### PR TITLE
Reimplement `maven-publish` internals to avoid use of `maven-aether`

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,4 +1,10 @@
 {
     "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.publish.maven.tasks.PublishToMavenLocal",
+            "member": "Method org.gradle.api.publish.maven.tasks.PublishToMavenLocal.getRepositoryTransportFactory()",
+            "acceptation": "Injected service",
+            "changes": []
+        }
     ]
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -34,7 +34,6 @@ import org.gradle.test.fixtures.gradle.VariantMetadataSpec
 import java.text.SimpleDateFormat
 
 abstract class AbstractMavenModule extends AbstractModule implements MavenModule {
-    protected static final String MAVEN_METADATA_FILE = "maven-metadata.xml"
     private final TestFile rootDir
     final TestFile moduleDir
     final String groupId
@@ -336,12 +335,12 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
     @Override
     DefaultRootMavenMetaData getRootMetaData() {
-        new DefaultRootMavenMetaData("$moduleRootPath/${MAVEN_METADATA_FILE}", rootMetaDataFile)
+        new DefaultRootMavenMetaData("$moduleRootPath/${metadataFileName}", rootMetaDataFile)
     }
 
     @Override
     DefaultSnapshotMavenMetaData getSnapshotMetaData() {
-        new DefaultSnapshotMavenMetaData("$path/${MAVEN_METADATA_FILE}", snapshotMetaDataFile)
+        new DefaultSnapshotMavenMetaData("$path/${metadataFileName}", snapshotMetaDataFile)
     }
 
     @Override
@@ -370,15 +369,19 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
     @Override
     TestFile getMetaDataFile() {
-        moduleDir.file(MAVEN_METADATA_FILE)
+        moduleDir.file(metadataFileName)
     }
 
     TestFile getRootMetaDataFile() {
-        moduleDir.parentFile.file(MAVEN_METADATA_FILE)
+        moduleDir.parentFile.file(metadataFileName)
     }
 
     TestFile getSnapshotMetaDataFile() {
-        moduleDir.file(MAVEN_METADATA_FILE)
+        moduleDir.file(metadataFileName)
+    }
+
+    protected String getMetadataFileName() {
+        "maven-metadata.xml"
     }
 
     TestFile artifactFile(Map<String, ?> options) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultRootMavenMetaData.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultRootMavenMetaData.groovy
@@ -29,6 +29,7 @@ class DefaultRootMavenMetaData implements RootMavenMetaData {
     String artifactId
 
     String releaseVersion
+    String latestVersion
 
     List<String> versions = []
     String lastUpdated
@@ -52,6 +53,7 @@ class DefaultRootMavenMetaData implements RootMavenMetaData {
 
         lastUpdated = versioning.lastUpdated[0]?.text()
         releaseVersion = versioning.release[0]?.text()
+        latestVersion = versioning.latest[0]?.text()
 
         versioning.versions[0].version.each {
             versions << it.text()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultSnapshotMavenMetaData.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DefaultSnapshotMavenMetaData.groovy
@@ -28,6 +28,7 @@ class DefaultSnapshotMavenMetaData implements SnapshotMavenMetaData {
     String artifactId
     String version
 
+    boolean localSnapshot
     String snapshotTimestamp
     String snapshotBuildNumber
     List<String> snapshotVersions = []
@@ -55,6 +56,7 @@ class DefaultSnapshotMavenMetaData implements SnapshotMavenMetaData {
         lastUpdated = versioning.lastUpdated[0]?.text()
         snapshotTimestamp =  versioning.snapshot.timestamp[0]?.text()
         snapshotBuildNumber =  versioning.snapshot.buildNumber[0]?.text()
+        localSnapshot = versioning.snapshot.localCopy[0]?.text() == 'true'
 
         def snapshotVersionCollector = new LinkedHashSet<String>()
         versioning.snapshotVersions.snapshotVersion.value.each {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenLocalModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenLocalModule.groovy
@@ -36,6 +36,11 @@ class MavenLocalModule extends MavenFileModule {
     }
 
     @Override
+    protected String getMetadataFileName() {
+        return "maven-metadata-local.xml"
+    }
+
+    @Override
     String getMetaDataFileContent() {
         """
 <metadata>

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenLocalModuleTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenLocalModuleTest.groovy
@@ -26,6 +26,7 @@ class MavenLocalModuleTest extends Specification {
     TestFile testFile
     MavenModule mavenLocalModule
     MavenModule snapshotMavenLocalModule
+    private String mavenMetadataFileName = 'maven-metadata-local.xml'
 
     def setup() {
         testFile = tmpDir.file("file")
@@ -168,7 +169,7 @@ class MavenLocalModuleTest extends Specification {
         then:
         mavenModule != null
         publishedFiles*.name.containsAll('my-artifact-1.0.jar', 'my-artifact-1.0.pom')
-        !publishedFiles.find { it.name == 'maven-metadata.xml' }
+        !publishedFiles.find { it.name == mavenMetadataFileName }
         mavenLocalModule.assertArtifactsPublished('my-artifact-1.0.jar', 'my-artifact-1.0.pom')
     }
 
@@ -180,9 +181,9 @@ class MavenLocalModuleTest extends Specification {
         then:
         mavenModule != null
         publishedFiles*.name.containsAll('my-artifact-1.0-SNAPSHOT.jar', 'my-artifact-1.0-SNAPSHOT.pom')
-        publishedFiles.find { it.name == 'maven-metadata.xml' }.exists()
-        new XmlSlurper().parseText(publishedFiles.find { it.name == 'maven-metadata.xml' }.text).versioning.snapshot.localCopy.text() == 'true'
-        snapshotMavenLocalModule.assertArtifactsPublished('maven-metadata.xml', 'my-artifact-1.0-SNAPSHOT.jar', 'my-artifact-1.0-SNAPSHOT.pom')
+        publishedFiles.find { it.name == mavenMetadataFileName }.exists()
+        new XmlSlurper().parseText(publishedFiles.find { it.name == mavenMetadataFileName }.text).versioning.snapshot.localCopy.text() == 'true'
+        snapshotMavenLocalModule.assertArtifactsPublished(mavenMetadataFileName, 'my-artifact-1.0-SNAPSHOT.jar', 'my-artifact-1.0-SNAPSHOT.pom')
     }
 
     def "Publish artifacts for non-unique snapshot"() {
@@ -196,8 +197,8 @@ class MavenLocalModuleTest extends Specification {
         then:
         mavenModule != null
         publishedFiles*.name.containsAll('my-artifact-1.0-SNAPSHOT.jar', 'my-artifact-1.0-SNAPSHOT.pom')
-        publishedFiles.find { it.name == 'maven-metadata.xml' }.exists()
-        new XmlSlurper().parseText(publishedFiles.find { it.name == 'maven-metadata.xml' }.text).versioning.snapshot.localCopy.text() == 'true'
-        snapshotMavenLocalModule.assertArtifactsPublished('maven-metadata.xml', 'my-artifact-1.0-SNAPSHOT.jar', 'my-artifact-1.0-SNAPSHOT.pom')
+        publishedFiles.find { it.name == mavenMetadataFileName }.exists()
+        new XmlSlurper().parseText(publishedFiles.find { it.name == mavenMetadataFileName }.text).versioning.snapshot.localCopy.text() == 'true'
+        snapshotMavenLocalModule.assertArtifactsPublished(mavenMetadataFileName, 'my-artifact-1.0-SNAPSHOT.jar', 'my-artifact-1.0-SNAPSHOT.pom')
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -142,6 +142,7 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         repoModule.rootMetaData.artifactId == "root"
         repoModule.rootMetaData.versions == ["1.0"]
         repoModule.rootMetaData.releaseVersion == "1.0"
+        repoModule.rootMetaData.latestVersion == "1.0"
 
         when:
         succeeds 'publishToMavenLocal'
@@ -154,6 +155,7 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         localModule.rootMetaData.artifactId == "root"
         localModule.rootMetaData.versions == ["1.0"]
         localModule.rootMetaData.releaseVersion == "1.0"
+        localModule.rootMetaData.latestVersion == "1.0"
 
         and:
         resolveArtifacts(repoModule) {
@@ -203,12 +205,14 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         repoModule.rootMetaData.artifactId == "root"
         repoModule.rootMetaData.versions == ["1.0", "2.0"]
         repoModule.rootMetaData.releaseVersion == "2.0"
+        repoModule.rootMetaData.latestVersion == "2.0"
 
         and:
         localModule.rootMetaData.groupId == "group"
         localModule.rootMetaData.artifactId == "root"
         localModule.rootMetaData.versions == ["1.0", "2.0"]
         localModule.rootMetaData.releaseVersion == "2.0"
+        localModule.rootMetaData.latestVersion == "2.0"
     }
 
     def "can publish to custom maven local repo defined in settings.xml"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBuildOperationIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBuildOperationIntegrationTest.groovy
@@ -93,7 +93,7 @@ class MavenPublishBuildOperationIntegrationTest extends AbstractMavenPublishInte
         writes2.size() == 12
 
         def reads2 = buildOperations.all(ExternalResourceReadBuildOperationType)
-        reads2.size() == 3
+        reads2.size() == 1
     }
 
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
@@ -126,8 +126,6 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
 
         server.authenticationScheme = authScheme
         module.artifact.expectPut(401, credentials)
-        module.pom.expectPut(401, credentials)
-        module.moduleMetadata.expectPut(401, credentials)
 
         when:
         fails 'publish'
@@ -147,8 +145,6 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
         buildFile << publicationBuild(version, group, mavenRemoteRepo.uri)
         server.authenticationScheme = authScheme
         module.artifact.expectPut(401)
-        module.pom.expectPut(401)
-        module.moduleMetadata.expectPut(401)
 
         when:
         fails 'publish'
@@ -239,9 +235,9 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
 
         and:
         module.rootMetaData.expectGet()
-        module.rootMetaData.sha1.expectGet()
-        module.rootMetaData.expectGet()
-        module.rootMetaData.sha1.expectGet()
+//        module.rootMetaData.sha1.expectGet()
+//        module.rootMetaData.expectGet()
+//        module.rootMetaData.sha1.expectGet()
         module.rootMetaData.expectPublish()
 
         and:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
@@ -260,9 +260,6 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
         buildFile << publicationBuild(version, group, mavenRemoteRepo.uri)
 
         module.artifact.expectPutBroken()
-        module.pom.expectPublish()
-        module.moduleMetadata.expectPublish()
-
         expectModulePublish(module)
 
         when:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
@@ -235,9 +235,6 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
 
         and:
         module.rootMetaData.expectGet()
-//        module.rootMetaData.sha1.expectGet()
-//        module.rootMetaData.expectGet()
-//        module.rootMetaData.sha1.expectGet()
         module.rootMetaData.expectPublish()
 
         and:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishLoggingIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishLoggingIntegTest.groovy
@@ -48,22 +48,6 @@ class MavenPublishLoggingIntegTest extends AbstractMavenPublishIntegTest {
         """
     }
 
-    def "logs missing metadata as info and not error"() {
-        when:
-        succeeds 'publish'
-
-        then:
-        !errorOutput.contains("Could not find metadata")
-        !output.contains("Could not find metadata")
-
-        when:
-        mavenRepo.rootDir.deleteDir()
-        succeeds 'publish', "-i"
-
-        then:
-        output.contains("Could not find metadata")
-    }
-
     def "logging is associated to task"() {
         when:
         succeeds 'publish', "-i"
@@ -72,14 +56,10 @@ class MavenPublishLoggingIntegTest extends AbstractMavenPublishIntegTest {
         def output = result.groupedOutput.task(":publishMavenPublicationToMavenRepository").output
 
         output.contains("Publishing to repository 'maven'")
-        // Logging from LoggingMavenTransferListener
-        output.contains("Deploying to")
-        output.contains("Uploading: group/root/1.0/root-1.0.jar")
-        output.contains("Uploading: group/root/1.0/root-1.0.pom")
-        output.contains("group/root/1.0/root-1.0.module")
-        output.contains("Downloading: group/root/maven-metadata.xml from repository")
-        output.contains("Could not find metadata")
-        output.contains("Uploading: group/root/maven-metadata.xml to repository")
+        output.contains("Uploading root-1.0.jar to ")
+        output.contains("Uploading root-1.0.pom to ")
+        output.contains("Uploading root-1.0.module to ")
+        output.contains("Uploading maven-metadata.xml to ")
     }
 
     def "does not log uploads when installing to mavenLocal"() {
@@ -88,6 +68,6 @@ class MavenPublishLoggingIntegTest extends AbstractMavenPublishIntegTest {
 
         then:
         output.contains("Publishing to maven local repository")
-        !output.contains("Uploading:")
+        !output.contains("Uploading")
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishLoggingIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishLoggingIntegTest.groovy
@@ -71,6 +71,7 @@ class MavenPublishLoggingIntegTest extends AbstractMavenPublishIntegTest {
         then:
         def output = result.groupedOutput.task(":publishMavenPublicationToMavenRepository").output
 
+        output.contains("Publishing to repository 'maven'")
         // Logging from LoggingMavenTransferListener
         output.contains("Deploying to")
         output.contains("Uploading: group/root/1.0/root-1.0.jar")
@@ -81,4 +82,12 @@ class MavenPublishLoggingIntegTest extends AbstractMavenPublishIntegTest {
         output.contains("Uploading: group/root/maven-metadata.xml to repository")
     }
 
+    def "does not log uploads when installing to mavenLocal"() {
+        when:
+        succeeds 'publishToMavenLocal', '-i'
+
+        then:
+        output.contains("Publishing to maven local repository")
+        !output.contains("Uploading:")
+    }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
@@ -58,6 +58,7 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
             groupId == "org.gradle"
             artifactId == "snapshotPublish"
             releaseVersion == null
+            latestVersion == '1.0-SNAPSHOT'
             versions == ['1.0-SNAPSHOT']
         }
 
@@ -189,6 +190,7 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
             groupId == "org.gradle"
             artifactId == "snapshotInstall"
             releaseVersion == null
+            latestVersion == '1.0-SNAPSHOT'
             versions == ['1.0-SNAPSHOT']
         }
 
@@ -220,6 +222,7 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
             groupId == "org.gradle"
             artifactId == "snapshotInstall"
             releaseVersion == null
+            latestVersion == '1.0-SNAPSHOT'
             versions == ['1.0-SNAPSHOT']
         }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
@@ -68,6 +68,7 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
 
             snapshotTimestamp != null
             snapshotBuildNumber == '1'
+            localSnapshot == false
             lastUpdated == snapshotTimestamp.replace('.', '')
 
             snapshotVersions == ["1.0-${snapshotTimestamp}-${snapshotBuildNumber}"]
@@ -152,5 +153,88 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
 
         and:
         resolveArtifacts(module) { expectFiles "snapshotPublish-${secondVersion}.jar" }
+    }
+
+    def "can install snapshot versions"() {
+        using m2
+
+        settingsFile << 'rootProject.name = "snapshotInstall"'
+        buildFile << """
+    apply plugin: 'java'
+    apply plugin: 'maven-publish'
+
+    group = 'org.gradle'
+    version = '1.0-SNAPSHOT'
+
+    publishing {
+        publications {
+            pub(MavenPublication) {
+                from components.java
+            }
+        }
+    }
+"""
+        def module = getM2().mavenRepo().module('org.gradle', 'snapshotInstall', '1.0-SNAPSHOT')
+
+        when:
+        succeeds 'publishToMavenLocal'
+
+        then:
+        module.assertArtifactsPublished("maven-metadata-local.xml", "snapshotInstall-1.0-SNAPSHOT.module", "snapshotInstall-1.0-SNAPSHOT.jar", "snapshotInstall-1.0-SNAPSHOT.pom")
+
+        and:
+        module.parsedPom.version == '1.0-SNAPSHOT'
+
+        with (module.rootMetaData) {
+            groupId == "org.gradle"
+            artifactId == "snapshotInstall"
+            releaseVersion == null
+            versions == ['1.0-SNAPSHOT']
+        }
+
+        with (module.snapshotMetaData) {
+            groupId == "org.gradle"
+            artifactId == "snapshotInstall"
+            version == "1.0-SNAPSHOT"
+
+            snapshotTimestamp == null
+            snapshotBuildNumber == null
+            localSnapshot == true
+
+            lastUpdated != null
+
+            snapshotVersions == ["1.0-SNAPSHOT"]
+        }
+
+        // Install a second time
+        when:
+        succeeds 'publishToMavenLocal'
+
+        then:
+        module.assertArtifactsPublished("maven-metadata-local.xml", "snapshotInstall-1.0-SNAPSHOT.module", "snapshotInstall-1.0-SNAPSHOT.jar", "snapshotInstall-1.0-SNAPSHOT.pom")
+
+        and:
+        module.parsedPom.version == '1.0-SNAPSHOT'
+
+        with (module.rootMetaData) {
+            groupId == "org.gradle"
+            artifactId == "snapshotInstall"
+            releaseVersion == null
+            versions == ['1.0-SNAPSHOT']
+        }
+
+        with (module.snapshotMetaData) {
+            groupId == "org.gradle"
+            artifactId == "snapshotInstall"
+            version == "1.0-SNAPSHOT"
+
+            snapshotTimestamp == null
+            snapshotBuildNumber == null
+            localSnapshot == true
+
+            lastUpdated != null
+
+            snapshotVersions == ["1.0-SNAPSHOT"]
+        }
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -582,7 +582,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                 return true;
             }
         });
-        return new MavenNormalizedPublication(name, pom.getPackaging(), getPomArtifact(), projectIdentity, artifactsToBePublished, determineMainArtifact());
+        return new MavenNormalizedPublication(name, projectIdentity, pom.getPackaging(), getPomArtifact(), determineMainArtifact(), artifactsToBePublished);
     }
 
     private MavenArtifact getPomArtifact() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -36,6 +36,8 @@ import org.gradle.internal.resource.ExternalResourceRepository;
 import org.gradle.internal.resource.local.ByteArrayReadableContent;
 import org.gradle.internal.resource.local.FileReadableContent;
 import org.gradle.internal.xml.XmlTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +49,8 @@ import java.net.URI;
 import static org.apache.maven.artifact.ArtifactUtils.isSnapshot;
 
 abstract class AbstractMavenPublisher implements MavenPublisher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenPublisher.class);
+
     private static final String POM_FILE_ENCODING = "UTF-8";
     private final Factory<File> temporaryDirFactory;
     protected final RepositoryTransportFactory repositoryTransportFactory;
@@ -224,6 +228,9 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
         }
 
         public void publish(ExternalResourceName externalResource, File content) {
+            if (!localRepo) {
+                LOGGER.info("Uploading {} to {}", externalResource.getShortDisplayName(), externalResource.getPath());
+            }
             repository.withProgressLogging().resource(externalResource).put(new FileReadableContent(content));
             if (!localRepo) {
                 publishChecksums(repository, content, externalResource);

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -41,12 +41,12 @@ public abstract class AbstractMavenPublisher implements MavenPublisher {
             LOGGER.info("Publishing to repository '{}' ({})", artifactRepository.getName(), artifactRepository.getUrl());
         }
 
-        MavenPublishAction deployTask = createDeployTask(publication.getPackaging(), publication.getProjectIdentity(), mavenRepositoryLocator, artifactRepository);
+        MavenPublishAction deployTask = createDeployTask(publication, mavenRepositoryLocator, artifactRepository);
         addPomAndArtifacts(deployTask, publication);
         execute(deployTask);
     }
 
-    abstract protected MavenPublishAction createDeployTask(String packaging, MavenProjectIdentity projectIdentity, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository);
+    abstract protected MavenPublishAction createDeployTask(MavenNormalizedPublication publication, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository);
 
     private void addPomAndArtifacts(MavenPublishAction publishAction, MavenNormalizedPublication publication) {
         MavenArtifact pomArtifact = publication.getPomArtifact();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -101,6 +101,7 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
         if (!versioning.getVersions().contains(version)) {
             versioning.addVersion(version);
         }
+        versioning.setLatest(version);
         if (!isSnapshot(version)) {
             versioning.setRelease(version);
         }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,56 +16,209 @@
 
 package org.gradle.api.publish.maven.internal.publisher;
 
-import com.google.common.base.Strings;
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
-import org.gradle.api.publication.maven.internal.action.MavenPublishAction;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
+import org.gradle.api.Action;
+import org.gradle.api.Transformer;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.publish.maven.MavenArtifact;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.gradle.internal.Factory;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.resource.ExternalResourceName;
+import org.gradle.internal.resource.ExternalResourceReadResult;
+import org.gradle.internal.resource.ExternalResourceRepository;
+import org.gradle.internal.resource.local.ByteArrayReadableContent;
+import org.gradle.internal.resource.local.FileReadableContent;
+import org.gradle.internal.xml.XmlTransformer;
 
-public abstract class AbstractMavenPublisher implements MavenPublisher {
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.net.URI;
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(AbstractMavenPublisher.class);
-    private final LocalMavenRepositoryLocator mavenRepositoryLocator;
+import static org.apache.maven.artifact.ArtifactUtils.isSnapshot;
 
-    public AbstractMavenPublisher(LocalMavenRepositoryLocator mavenRepositoryLocator) {
-        this.mavenRepositoryLocator = mavenRepositoryLocator;
+abstract class AbstractMavenPublisher implements MavenPublisher {
+    private static final String POM_FILE_ENCODING = "UTF-8";
+    private final Factory<File> temporaryDirFactory;
+    protected final RepositoryTransportFactory repositoryTransportFactory;
+    private final XmlTransformer xmlTransformer = new XmlTransformer();
+
+    public AbstractMavenPublisher(Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory) {
+        this.temporaryDirFactory = temporaryDirFactory;
+        this.repositoryTransportFactory = repositoryTransportFactory;
     }
 
-    @Override
-    public void publish(MavenNormalizedPublication publication, MavenArtifactRepository artifactRepository) {
-        if (artifactRepository == null) {
-            LOGGER.info("Publishing to maven local repository");
-        } else {
-            LOGGER.info("Publishing to repository '{}' ({})", artifactRepository.getName(), artifactRepository.getUrl());
+    protected void publish(MavenNormalizedPublication publication, ExternalResourceRepository repository, URI rootUri, boolean localRepo) {
+        MavenProjectIdentity projectIdentity = publication.getProjectIdentity();
+        String groupId = projectIdentity.getGroupId().get();
+        String artifactId = projectIdentity.getArtifactId().get();
+        String version = projectIdentity.getVersion().get();
+
+        ModuleArtifactPublisher artifactPublisher = new ModuleArtifactPublisher(repository, localRepo, rootUri, groupId, artifactId, version);
+
+        if (publication.getMainArtifact() != null) {
+            artifactPublisher.publish(null, publication.getPackaging(), publication.getMainArtifact().getFile());
+        }
+        artifactPublisher.publish(null, "pom", publication.getPomArtifact().getFile());
+        for (MavenArtifact artifact : publication.getAdditionalArtifacts()) {
+            artifactPublisher.publish(artifact.getClassifier(), artifact.getExtension(), artifact.getFile());
         }
 
-        MavenPublishAction deployTask = createDeployTask(publication, mavenRepositoryLocator, artifactRepository);
-        addPomAndArtifacts(deployTask, publication);
-        execute(deployTask);
+        ExternalResourceName externalResource = artifactPublisher.getMetadataPath();
+        Metadata metadata = createMetadata(groupId, artifactId, version, repository, externalResource);
+        artifactPublisher.publish(externalResource, writeMetadataToTmpFile(metadata, "module-maven-metadata.xml"));
     }
 
-    abstract protected MavenPublishAction createDeployTask(MavenNormalizedPublication publication, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository);
-
-    private void addPomAndArtifacts(MavenPublishAction publishAction, MavenNormalizedPublication publication) {
-        MavenArtifact pomArtifact = publication.getPomArtifact();
-        publishAction.setPomArtifact(pomArtifact.getFile());
-
-        MavenArtifact mainArtifact = publication.getMainArtifact();
-        if (mainArtifact != null) {
-            publishAction.setMainArtifact(mainArtifact.getFile());
+    private Metadata createMetadata(String groupId, String artifactId, String version, ExternalResourceRepository repository, ExternalResourceName metadataResource) {
+        Versioning versioning = getExistingVersioning(repository, metadataResource);
+        if (!versioning.getVersions().contains(version)) {
+            versioning.addVersion(version);
         }
+        if (!isSnapshot(version)) {
+            versioning.setRelease(version);
+        }
+        versioning.updateTimestamp();
 
-        for (MavenArtifact artifact : publication.getAllArtifacts()) {
-            if (artifact == mainArtifact || artifact == pomArtifact) {
-                continue;
+        Metadata metadata = new Metadata();
+        metadata.setGroupId(groupId);
+        metadata.setArtifactId(artifactId);
+        metadata.setVersioning(versioning);
+        return metadata;
+    }
+
+    private Versioning getExistingVersioning(ExternalResourceRepository repository, ExternalResourceName metadataResource) {
+        ExternalResourceReadResult<Metadata> existing = readExistingMetadata(repository, metadataResource);
+
+        if (existing != null) {
+            Metadata recessive = existing.getResult();
+            if (recessive.getVersioning() != null) {
+                return recessive.getVersioning();
             }
-            publishAction.addAdditionalArtifact(artifact.getFile(), Strings.nullToEmpty(artifact.getExtension()), Strings.nullToEmpty(artifact.getClassifier()));
         }
+        return new Versioning();
     }
 
-    private void execute(MavenPublishAction publishAction) {
-        publishAction.publish();
+    protected ExternalResourceReadResult<Metadata> readExistingMetadata(ExternalResourceRepository repository, ExternalResourceName metadataResource) {
+        return repository.resource(metadataResource).withContentIfPresent(new Transformer<Metadata, InputStream>() {
+            @Override
+            public Metadata transform(InputStream inputStream) {
+                try {
+                    return new MetadataXpp3Reader().read(inputStream, false);
+                } catch (Exception e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
+        });
+    }
+
+    private File writeMetadataToTmpFile(Metadata metadata, String fileName) {
+        File metadataFile = new File(temporaryDirFactory.create(), fileName);
+        xmlTransformer.transform(metadataFile, POM_FILE_ENCODING, new Action<Writer>() {
+            public void execute(Writer writer) {
+                try {
+                    new MetadataXpp3Writer().write(writer, metadata);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        });
+        return metadataFile;
+    }
+
+    private static class ModuleArtifactPublisher {
+        private final ExternalResourceRepository repository;
+        private final boolean localRepo;
+        private final URI rootUri;
+        private final String groupId;
+        private final String artifactId;
+        private final String moduleVersion;
+        private String artifactVersion;
+
+        public ModuleArtifactPublisher(ExternalResourceRepository repository, boolean localRepo, URI rootUri, String groupId, String artifactId, String moduleVersion) {
+            this.repository = repository;
+            this.localRepo = localRepo;
+            this.rootUri = rootUri;
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.moduleVersion = moduleVersion;
+            this.artifactVersion = moduleVersion;
+        }
+
+        public ExternalResourceName getArtifactPath(String classifier, String extension) {
+            return new ExternalResourceName(rootUri, getArtifactPath(groupId, artifactId, moduleVersion, artifactVersion, classifier, extension));
+        }
+
+        public ExternalResourceName getMetadataPath() {
+            StringBuilder path = new StringBuilder(128);
+            path.append(groupId.replace('.', '/')).append('/');
+            path.append(artifactId).append('/');
+            path.append(getMetadataFileName());
+
+            return new ExternalResourceName(rootUri, path.toString());
+        }
+
+        private String getMetadataFileName() {
+            if (localRepo) {
+                return "maven-metadata-local.xml";
+            }
+            return "maven-metadata.xml";
+        }
+
+        private String getArtifactPath(String groupId, String artifactId, String moduleVersion, String artifactVersion, String classifier, String extension) {
+            StringBuilder path = new StringBuilder(128);
+            path.append(groupId.replace('.', '/')).append('/');
+            path.append(artifactId).append('/');
+            path.append(moduleVersion).append('/');
+
+            path.append(artifactId).append('-').append(artifactVersion);
+
+            if (classifier != null) {
+                path.append('-').append(classifier);
+            }
+
+            if (extension.length() > 0) {
+                path.append('.').append(extension);
+            }
+
+            return path.toString();
+        }
+
+        public void publish(String classifier, String extension, File content) {
+            ExternalResourceName externalResource = getArtifactPath(classifier, extension);
+            publish(externalResource, content);
+        }
+
+        public void publish(ExternalResourceName externalResource, File content) {
+            repository.withProgressLogging().resource(externalResource).put(new FileReadableContent(content));
+            if (!localRepo) {
+                publishChecksums(repository, content, externalResource);
+            }
+        }
+
+        private void publishChecksums(ExternalResourceRepository repository, File source, ExternalResourceName destination) {
+            byte[] sha1 = createChecksumFile(source, "SHA1", 40);
+            repository.resource(destination.append(".sha1")).put(new ByteArrayReadableContent(sha1));
+
+            byte[] md5 = createChecksumFile(source, "MD5", 32);
+            repository.resource(destination.append(".md5")).put(new ByteArrayReadableContent(md5));
+        }
+
+        private byte[] createChecksumFile(File src, String algorithm, int checksumLength) {
+            HashValue hash = HashUtil.createHash(src, algorithm);
+            String formattedHashString = hash.asZeroPaddedHexString(checksumLength);
+            try {
+                return formattedHashString.getBytes("US-ASCII");
+            } catch (UnsupportedEncodingException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+        }
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
@@ -50,4 +50,33 @@ public class MavenLocalPublisher extends AbstractMavenPublisher {
 
         publish(publication, repository, rootUri, true);
     }
+
+    @Override
+    protected Metadata createSnapshotMetadata(MavenNormalizedPublication publication, String groupId, String artifactId, String version, ExternalResourceRepository repository, ExternalResourceName metadataResource) {
+        Metadata metadata = new Metadata();
+        metadata.setModelVersion("1.1.0");
+        metadata.setGroupId(groupId);
+        metadata.setArtifactId(artifactId);
+        metadata.setVersion(version);
+
+        Snapshot snapshot = new Snapshot();
+        snapshot.setLocalCopy(true);
+        Versioning versioning = new Versioning();
+        versioning.updateTimestamp();
+        versioning.setSnapshot(snapshot);
+
+        for (MavenArtifact artifact : publication.getAllArtifacts()) {
+            SnapshotVersion sv = new SnapshotVersion();
+            sv.setClassifier(artifact.getClassifier());
+            sv.setExtension(artifact.getExtension());
+            sv.setVersion(version);
+            sv.setUpdated(versioning.getLastUpdated());
+
+            versioning.getSnapshotVersions().add(sv);
+        }
+
+        metadata.setVersioning(versioning);
+
+        return metadata;
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
@@ -28,12 +28,16 @@ import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.internal.Factory;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URI;
 import java.util.Collections;
 
 public class MavenLocalPublisher extends AbstractMavenPublisher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenLocalPublisher.class);
+
     private final LocalMavenRepositoryLocator mavenRepositoryLocator;
 
     public MavenLocalPublisher(Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory, LocalMavenRepositoryLocator mavenRepositoryLocator) {
@@ -43,6 +47,8 @@ public class MavenLocalPublisher extends AbstractMavenPublisher {
 
     @Override
     public void publish(MavenNormalizedPublication publication, MavenArtifactRepository artifactRepository) {
+        LOGGER.info("Publishing to maven local repository");
+
         URI rootUri = mavenRepositoryLocator.getLocalMavenRepository().toURI();
         String protocol = rootUri.getScheme().toLowerCase();
         RepositoryTransport transport = repositoryTransportFactory.createTransport(protocol, "mavenLocal", Collections.emptyList());

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
@@ -38,10 +38,12 @@ import java.util.Collections;
 public class MavenLocalPublisher extends AbstractMavenPublisher {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenLocalPublisher.class);
 
+    private final RepositoryTransportFactory repositoryTransportFactory;
     private final LocalMavenRepositoryLocator mavenRepositoryLocator;
 
     public MavenLocalPublisher(Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory, LocalMavenRepositoryLocator mavenRepositoryLocator) {
-        super(temporaryDirFactory, repositoryTransportFactory);
+        super(temporaryDirFactory);
+        this.repositoryTransportFactory = repositoryTransportFactory;
         this.mavenRepositoryLocator = mavenRepositoryLocator;
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
@@ -26,8 +26,8 @@ public class MavenLocalPublisher extends AbstractMavenPublisher {
     }
 
     @Override
-    protected MavenInstallAction createDeployTask(String packaging, MavenProjectIdentity projectIdentity, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
-        MavenInstallAction mavenInstallTask = new MavenInstallAction(packaging, projectIdentity);
+    protected MavenInstallAction createDeployTask(MavenNormalizedPublication publication, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
+        MavenInstallAction mavenInstallTask = new MavenInstallAction(publication.getPackaging(), publication.getProjectIdentity());
         mavenInstallTask.setLocalMavenRepositoryLocation(mavenRepositoryLocator.getLocalMavenRepository());
         return mavenInstallTask;
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenLocalPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,38 @@
 
 package org.gradle.api.publish.maven.internal.publisher;
 
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Snapshot;
+import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
+import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
-import org.gradle.api.publication.maven.internal.action.MavenInstallAction;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
+import org.gradle.api.publish.maven.MavenArtifact;
+import org.gradle.internal.Factory;
+import org.gradle.internal.resource.ExternalResourceName;
+import org.gradle.internal.resource.ExternalResourceRepository;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Collections;
 
 public class MavenLocalPublisher extends AbstractMavenPublisher {
-    public MavenLocalPublisher(LocalMavenRepositoryLocator mavenRepositoryLocator) {
-        super(mavenRepositoryLocator);
+    private final LocalMavenRepositoryLocator mavenRepositoryLocator;
+
+    public MavenLocalPublisher(Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory, LocalMavenRepositoryLocator mavenRepositoryLocator) {
+        super(temporaryDirFactory, repositoryTransportFactory);
+        this.mavenRepositoryLocator = mavenRepositoryLocator;
     }
 
     @Override
-    protected MavenInstallAction createDeployTask(MavenNormalizedPublication publication, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
-        MavenInstallAction mavenInstallTask = new MavenInstallAction(publication.getPackaging(), publication.getProjectIdentity());
-        mavenInstallTask.setLocalMavenRepositoryLocation(mavenRepositoryLocator.getLocalMavenRepository());
-        return mavenInstallTask;
+    public void publish(MavenNormalizedPublication publication, MavenArtifactRepository artifactRepository) {
+        URI rootUri = mavenRepositoryLocator.getLocalMavenRepository().toURI();
+        String protocol = rootUri.getScheme().toLowerCase();
+        RepositoryTransport transport = repositoryTransportFactory.createTransport(protocol, "mavenLocal", Collections.emptyList());
+        ExternalResourceRepository repository = transport.getRepository();
+
+        publish(publication, repository, rootUri, true);
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenNormalizedPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenNormalizedPublication.java
@@ -20,27 +20,50 @@ import org.gradle.api.publish.maven.MavenArtifact;
 
 import java.io.File;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MavenNormalizedPublication {
 
     private final String name;
+    private final MavenProjectIdentity projectIdentity;
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
     private final String packaging;
     private final MavenArtifact pomArtifact;
-    private final MavenProjectIdentity projectIdentity;
-    private final Set<MavenArtifact> allArtifacts;
     private final MavenArtifact mainArtifact;
+    private final Set<MavenArtifact> allArtifacts;
 
-    public MavenNormalizedPublication(String name, String packaging, MavenArtifact pomArtifact, MavenProjectIdentity projectIdentity, Set<MavenArtifact> allArtifacts, MavenArtifact mainArtifact) {
+    public MavenNormalizedPublication(String name, MavenProjectIdentity projectIdentity, String packaging, MavenArtifact pomArtifact, MavenArtifact mainArtifact, Set<MavenArtifact> allArtifacts) {
         this.name = name;
+        this.projectIdentity = projectIdentity;
+        this.groupId = projectIdentity.getGroupId().get();
+        this.artifactId = projectIdentity.getArtifactId().get();
+        this.version = projectIdentity.getVersion().get();
         this.packaging = packaging;
         this.pomArtifact = pomArtifact;
-        this.projectIdentity = projectIdentity;
-        this.allArtifacts = allArtifacts;
         this.mainArtifact = mainArtifact;
+        this.allArtifacts = allArtifacts;
     }
 
     public String getName() {
         return name;
+    }
+
+    public MavenProjectIdentity getProjectIdentity() {
+        return projectIdentity;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     public String getPackaging() {
@@ -59,16 +82,17 @@ public class MavenNormalizedPublication {
         return pomArtifact;
     }
 
-    public Set<MavenArtifact> getAllArtifacts() {
-        return allArtifacts;
-    }
-
-    public MavenProjectIdentity getProjectIdentity() {
-        return projectIdentity;
-    }
-
     public MavenArtifact getMainArtifact() {
         return mainArtifact;
     }
 
+    public Set<MavenArtifact> getAdditionalArtifacts() {
+        return allArtifacts.stream()
+                .filter(artifact -> artifact != pomArtifact && artifact != mainArtifact)
+                .collect(Collectors.toSet());
+    }
+
+    public Set<MavenArtifact> getAllArtifacts() {
+        return allArtifacts;
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,85 +16,31 @@
 
 package org.gradle.api.publish.maven.internal.publisher;
 
-import org.apache.maven.artifact.ant.RemoteRepository;
-import org.apache.maven.wagon.Wagon;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
-import org.gradle.api.publication.maven.internal.action.MavenDeployAction;
-import org.gradle.api.publication.maven.internal.action.MavenPublishAction;
-import org.gradle.api.publication.maven.internal.wagon.RepositoryTransportDeployWagon;
-import org.gradle.api.publication.maven.internal.wagon.RepositoryTransportWagonAdapter;
 import org.gradle.internal.Factory;
 import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInternal;
+import org.gradle.internal.resource.ExternalResourceRepository;
 
 import java.io.File;
 import java.net.URI;
 
 public class MavenRemotePublisher extends AbstractMavenPublisher {
-    private final Factory<File> temporaryDirFactory;
-    private final RepositoryTransportFactory repositoryTransportFactory;
 
-    public MavenRemotePublisher(LocalMavenRepositoryLocator mavenRepositoryLocator, Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory) {
-        super(mavenRepositoryLocator);
-        this.temporaryDirFactory = temporaryDirFactory;
-        this.repositoryTransportFactory = repositoryTransportFactory;
+    public MavenRemotePublisher(Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory) {
+        super(temporaryDirFactory, repositoryTransportFactory);
     }
 
     @Override
-    protected MavenPublishAction createDeployTask(MavenNormalizedPublication publication, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
-        GradleWagonMavenDeployAction deployTask = new GradleWagonMavenDeployAction(publication.getPackaging(), publication.getProjectIdentity(), artifactRepository, repositoryTransportFactory);
-        deployTask.setLocalMavenRepositoryLocation(temporaryDirFactory.create());
-        deployTask.setRepositories(createMavenRemoteRepository(artifactRepository), null);
-        return deployTask;
-    }
+    public void publish(MavenNormalizedPublication publication, MavenArtifactRepository artifactRepository) {
+        String protocol = artifactRepository.getUrl().getScheme().toLowerCase();
+        RepositoryTransport transport = repositoryTransportFactory.createTransport(protocol, artifactRepository.getName(),
+                ((AuthenticationSupportedInternal) artifactRepository).getConfiguredAuthentication());
+        ExternalResourceRepository repository = transport.getRepository();
 
-    private RemoteRepository createMavenRemoteRepository(MavenArtifactRepository repository) {
-        RemoteRepository remoteRepository = new RemoteRepository();
-        remoteRepository.setUrl(repository.getUrl().toString());
-        return remoteRepository;
-    }
+        URI rootUri = artifactRepository.getUrl();
 
-    /**
-     * A deploy action that uses a Gradle provided wagon implementation.
-     */
-    private static class GradleWagonMavenDeployAction extends MavenDeployAction {
-        private final MavenArtifactRepository artifactRepository;
-        private final RepositoryTransportFactory repositoryTransportFactory;
-
-        public GradleWagonMavenDeployAction(String packaging, MavenProjectIdentity projectIdentity, MavenArtifactRepository artifactRepository, RepositoryTransportFactory repositoryTransportFactory) {
-            super(packaging, projectIdentity, null);
-            this.artifactRepository = artifactRepository;
-            this.repositoryTransportFactory = repositoryTransportFactory;
-
-            registerWagonProtocols();
-        }
-
-        private void registerWagonProtocols() {
-            Wagon wagon = new RepositoryTransportDeployWagon();
-            for (String protocol : repositoryTransportFactory.getRegisteredProtocols()) {
-                getContainer().addComponent(wagon, Wagon.class, protocol);
-            }
-        }
-
-        @Override
-        public void publish() {
-            String protocol = artifactRepository.getUrl().getScheme().toLowerCase();
-            RepositoryTransportWagonAdapter adapter = createAdapter(protocol, artifactRepository, repositoryTransportFactory);
-            RepositoryTransportDeployWagon.contextualize(adapter);
-            try {
-                super.publish();
-            } finally {
-                RepositoryTransportDeployWagon.decontextualize();
-            }
-        }
-
-        private RepositoryTransportWagonAdapter createAdapter(String protocol, MavenArtifactRepository artifactRepository, RepositoryTransportFactory repositoryTransportFactory) {
-            RepositoryTransport transport = repositoryTransportFactory.createTransport(protocol, artifactRepository.getName(),
-                    ((AuthenticationSupportedInternal)artifactRepository).getConfiguredAuthentication());
-            URI rootUri = artifactRepository.getUrl();
-            return new RepositoryTransportWagonAdapter(transport, rootUri);
-        }
+        publish(publication, repository, rootUri, false);
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
@@ -43,8 +43,8 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
     }
 
     @Override
-    protected MavenPublishAction createDeployTask(String packaging, MavenProjectIdentity projectIdentity, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
-        GradleWagonMavenDeployAction deployTask = new GradleWagonMavenDeployAction(packaging, projectIdentity, artifactRepository, repositoryTransportFactory);
+    protected MavenPublishAction createDeployTask(MavenNormalizedPublication publication, LocalMavenRepositoryLocator mavenRepositoryLocator, MavenArtifactRepository artifactRepository) {
+        GradleWagonMavenDeployAction deployTask = new GradleWagonMavenDeployAction(publication.getPackaging(), publication.getProjectIdentity(), artifactRepository, repositoryTransportFactory);
         deployTask.setLocalMavenRepositoryLocation(temporaryDirFactory.create());
         deployTask.setRepositories(createMavenRemoteRepository(artifactRepository), null);
         return deployTask;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
@@ -29,6 +29,8 @@ import org.gradle.internal.artifacts.repositories.AuthenticationSupportedInterna
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceReadResult;
 import org.gradle.internal.resource.ExternalResourceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URI;
@@ -38,6 +40,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 public class MavenRemotePublisher extends AbstractMavenPublisher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenRemotePublisher.class);
 
     public MavenRemotePublisher(Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory) {
         super(temporaryDirFactory, repositoryTransportFactory);
@@ -45,6 +48,8 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
 
     @Override
     public void publish(MavenNormalizedPublication publication, MavenArtifactRepository artifactRepository) {
+        LOGGER.info("Publishing to repository '{}' ({})", artifactRepository.getName(), artifactRepository.getUrl());
+
         String protocol = artifactRepository.getUrl().getScheme().toLowerCase();
         RepositoryTransport transport = repositoryTransportFactory.createTransport(protocol, artifactRepository.getName(),
                 ((AuthenticationSupportedInternal) artifactRepository).getConfiguredAuthentication());

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenRemotePublisher.java
@@ -41,9 +41,11 @@ import java.util.TimeZone;
 
 public class MavenRemotePublisher extends AbstractMavenPublisher {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenRemotePublisher.class);
+    private final RepositoryTransportFactory repositoryTransportFactory;
 
     public MavenRemotePublisher(Factory<File> temporaryDirFactory, RepositoryTransportFactory repositoryTransportFactory) {
-        super(temporaryDirFactory, repositoryTransportFactory);
+        super(temporaryDirFactory);
+        this.repositoryTransportFactory = repositoryTransportFactory;
     }
 
     @Override
@@ -73,7 +75,7 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
         String timestamp = utcDateFormatter.format(new Date());
 
         Snapshot snapshot = new Snapshot();
-        snapshot.setBuildNumber(getPreviousBuildNumber(repository, metadataResource) + 1);
+        snapshot.setBuildNumber(getNextBuildNumber(repository, metadataResource));
         snapshot.setTimestamp(timestamp);
 
         Versioning versioning = new Versioning();
@@ -96,7 +98,7 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
         return metadata;
     }
 
-    private int getPreviousBuildNumber(ExternalResourceRepository repository, ExternalResourceName metadataResource) {
+    private int getNextBuildNumber(ExternalResourceRepository repository, ExternalResourceName metadataResource) {
         ExternalResourceReadResult<Metadata> existing = readExistingMetadata(repository, metadataResource);
 
         if (existing != null) {
@@ -105,10 +107,10 @@ public class MavenRemotePublisher extends AbstractMavenPublisher {
             if (versioning != null) {
                 Snapshot snapshot = versioning.getSnapshot();
                 if (snapshot != null && snapshot.getBuildNumber() > 0) {
-                    return snapshot.getBuildNumber();
+                    return snapshot.getBuildNumber() + 1;
                 }
             }
         }
-        return 0;
+        return 1;
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/NetworkOperationBackOffAndRetry.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/NetworkOperationBackOffAndRetry.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven.internal.publisher;
+
+import org.gradle.api.internal.artifacts.repositories.transport.NetworkingIssueVerifier;
+import org.gradle.internal.UncheckedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class NetworkOperationBackOffAndRetry {
+    private final static String MAX_ATTEMPTS = "org.gradle.internal.network.retry.max.attempts";
+    private final static String INITIAL_BACKOFF_MS = "org.gradle.internal.network.retry.initial.backOff";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NetworkOperationBackOffAndRetry.class);
+    private final int maxDeployAttempts;
+    private final int initialBackOff;
+
+    public NetworkOperationBackOffAndRetry() {
+        this(Integer.getInteger(MAX_ATTEMPTS, 3), Integer.getInteger(INITIAL_BACKOFF_MS, 1000));
+    }
+
+    public NetworkOperationBackOffAndRetry(int maxDeployAttempts, int initialBackOff) {
+        this.maxDeployAttempts = maxDeployAttempts;
+        this.initialBackOff = initialBackOff;
+        assert maxDeployAttempts > 0;
+        assert initialBackOff > 0;
+    }
+
+    public void withBackoffAndRetry(Runnable operation) {
+        int backoff = initialBackOff;
+        int retries = 0;
+        while (retries < maxDeployAttempts) {
+            retries++;
+            Throwable failure;
+            try {
+                operation.run();
+                if (retries > 1) {
+                    LOGGER.info("Successfully ran '{}' after {} retries", operation, retries - 1);
+                }
+                break;
+            } catch (Exception throwable) {
+                failure = throwable;
+            }
+            if (!NetworkingIssueVerifier.isLikelyTransientNetworkingIssue(failure) || retries == maxDeployAttempts) {
+                throw UncheckedException.throwAsUncheckedException(failure);
+            } else {
+                LOGGER.info("Error in '{}'. Waiting {}ms before next retry, {} retries left", operation, backoff, maxDeployAttempts - retries, failure);
+                try {
+                    Thread.sleep(backoff);
+                    backoff *= 2;
+                } catch (InterruptedException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
+        }
+    }
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.maven.tasks;
 
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.publish.internal.PublishOperation;
 import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
 import org.gradle.api.publish.maven.internal.publisher.MavenLocalPublisher;
@@ -24,6 +25,8 @@ import org.gradle.api.publish.maven.internal.publisher.MavenPublisher;
 import org.gradle.api.publish.maven.internal.publisher.StaticLockingMavenPublisher;
 import org.gradle.api.publish.maven.internal.publisher.ValidatingMavenPublisher;
 import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
 
 /**
  * Publishes a {@link org.gradle.api.publish.maven.MavenPublication} to the Maven Local repository.
@@ -42,11 +45,16 @@ public class PublishToMavenLocal extends AbstractPublishToMaven {
         new PublishOperation(publication, "mavenLocal") {
             @Override
             protected void publish() throws Exception {
-                MavenPublisher localPublisher = new MavenLocalPublisher(getMavenRepositoryLocator());
+                MavenPublisher localPublisher = new MavenLocalPublisher(getTemporaryDirFactory(), getRepositoryTransportFactory(), getMavenRepositoryLocator());
                 MavenPublisher staticLockingPublisher = new StaticLockingMavenPublisher(localPublisher);
                 MavenPublisher validatingPublisher = new ValidatingMavenPublisher(staticLockingPublisher);
                 validatingPublisher.publish(publication.asNormalisedPublication(), null);
             }
         }.run();
+    }
+
+    @Inject
+    protected RepositoryTransportFactory getRepositoryTransportFactory() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
@@ -22,7 +22,6 @@ import org.gradle.api.publish.internal.PublishOperation;
 import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
 import org.gradle.api.publish.maven.internal.publisher.MavenLocalPublisher;
 import org.gradle.api.publish.maven.internal.publisher.MavenPublisher;
-import org.gradle.api.publish.maven.internal.publisher.StaticLockingMavenPublisher;
 import org.gradle.api.publish.maven.internal.publisher.ValidatingMavenPublisher;
 import org.gradle.api.tasks.TaskAction;
 
@@ -46,8 +45,7 @@ public class PublishToMavenLocal extends AbstractPublishToMaven {
             @Override
             protected void publish() throws Exception {
                 MavenPublisher localPublisher = new MavenLocalPublisher(getTemporaryDirFactory(), getRepositoryTransportFactory(), getMavenRepositoryLocator());
-                MavenPublisher staticLockingPublisher = new StaticLockingMavenPublisher(localPublisher);
-                MavenPublisher validatingPublisher = new ValidatingMavenPublisher(staticLockingPublisher);
+                MavenPublisher validatingPublisher = new ValidatingMavenPublisher(localPublisher);
                 validatingPublisher.publish(publication.asNormalisedPublication(), null);
             }
         }.run();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -77,7 +77,7 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
         new PublishOperation(publication, repository.getName()) {
             @Override
             protected void publish() throws Exception {
-                MavenPublisher remotePublisher = new MavenRemotePublisher(getMavenRepositoryLocator(), getTemporaryDirFactory(), getRepositoryTransportFactory());
+                MavenPublisher remotePublisher = new MavenRemotePublisher(getTemporaryDirFactory(), getRepositoryTransportFactory());
                 MavenPublisher staticLockingPublisher = new StaticLockingMavenPublisher(remotePublisher);
                 MavenPublisher validatingPublisher = new ValidatingMavenPublisher(staticLockingPublisher);
                 validatingPublisher.publish(publication.asNormalisedPublication(), repository);

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -23,7 +23,6 @@ import org.gradle.api.publish.internal.PublishOperation;
 import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
 import org.gradle.api.publish.maven.internal.publisher.MavenPublisher;
 import org.gradle.api.publish.maven.internal.publisher.MavenRemotePublisher;
-import org.gradle.api.publish.maven.internal.publisher.StaticLockingMavenPublisher;
 import org.gradle.api.publish.maven.internal.publisher.ValidatingMavenPublisher;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
@@ -78,8 +77,7 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
             @Override
             protected void publish() throws Exception {
                 MavenPublisher remotePublisher = new MavenRemotePublisher(getTemporaryDirFactory(), getRepositoryTransportFactory());
-                MavenPublisher staticLockingPublisher = new StaticLockingMavenPublisher(remotePublisher);
-                MavenPublisher validatingPublisher = new ValidatingMavenPublisher(staticLockingPublisher);
+                MavenPublisher validatingPublisher = new ValidatingMavenPublisher(remotePublisher);
                 validatingPublisher.publish(publication.asNormalisedPublication(), repository);
             }
         }.run();

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/NetworkOperationBackOffAndRetryTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/NetworkOperationBackOffAndRetryTest.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven.internal.publisher
+
+import org.apache.http.conn.HttpHostConnectException
+import org.gradle.api.UncheckedIOException
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException
+import org.gradle.testing.internal.util.Specification
+import spock.lang.Unroll
+
+@Unroll
+class NetworkOperationBackOffAndRetryTest extends Specification {
+
+    def 'retries operation if transient network issue - #ex'() {
+        when:
+        int attempts = 0
+        Runnable operation = {
+            attempts++
+            throw ex
+        }
+        NetworkOperationBackOffAndRetry executer = new NetworkOperationBackOffAndRetry(3, 1)
+        executer.withBackoffAndRetry(operation)
+
+        then:
+        attempts == 3
+        Exception failure = thrown()
+        if (failure instanceof UncheckedIOException) {
+            assert failure.cause == ex
+        } else {
+            assert failure == ex
+        }
+
+        where:
+        ex << [
+            new SocketTimeoutException("something went wrong"),
+            new HttpHostConnectException(new IOException("something went wrong"), null, null),
+            new HttpErrorStatusCodeException("something", "something", 503, "something"),
+            new RuntimeException("with cause", new SocketTimeoutException("something went wrong"))
+        ]
+    }
+
+    def 'does not retry operation if not transient network issue - #ex'() {
+        when:
+        int attempts = 0
+        Runnable operation = {
+            attempts++
+            throw ex
+        }
+        NetworkOperationBackOffAndRetry executer = new NetworkOperationBackOffAndRetry(3, 1)
+        executer.withBackoffAndRetry(operation)
+
+        then:
+        attempts == 1
+        Exception failure = thrown()
+        failure == ex
+
+        where:
+        ex << [
+            new RuntimeException("non network issue"),
+            new HttpErrorStatusCodeException("something", "something", 400, "something")
+        ]
+    }
+}

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
@@ -48,7 +48,7 @@ class ValidatingMavenPublisherTest extends Specification {
     def "delegates when publication is valid"() {
         when:
         def projectIdentity = makeProjectIdentity("the-group", "the-artifact", "the-version")
-        def publication = new MavenNormalizedPublication("pub-name", "pom", createPomFile(projectIdentity, null, marker), projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", createPomFile(projectIdentity, null, marker), null, emptySet())
 
         and:
         publisher.publish(publication, repository)
@@ -63,7 +63,7 @@ class ValidatingMavenPublisherTest extends Specification {
     def "validates project coordinates"() {
         given:
         def projectIdentity = makeProjectIdentity(groupId, artifactId, version)
-        def publication = new MavenNormalizedPublication("pub-name", "pom", createPomFile(projectIdentity), projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", createPomFile(projectIdentity), null, emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -90,7 +90,7 @@ class ValidatingMavenPublisherTest extends Specification {
         given:
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(makeProjectIdentity(groupId, artifactId, version))
-        def publication = new MavenNormalizedPublication("pub-name", "pom", pomFile, projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", pomFile, null, emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -113,7 +113,7 @@ class ValidatingMavenPublisherTest extends Specification {
             getExtension() >> extension
             getClassifier() >> classifier
         }
-        def publication = new MavenNormalizedPublication("pub-name", "pom", pomFile, projectIdentity, toSet([mavenArtifact]), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", pomFile, null, toSet([mavenArtifact]))
 
         when:
         publisher.publish(publication, repository)
@@ -137,7 +137,7 @@ class ValidatingMavenPublisherTest extends Specification {
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(projectIdentity)
         def mavenArtifact = Mock(MavenArtifact)
-        def publication = new MavenNormalizedPublication("pub-name", "pom", pomFile, projectIdentity, toSet([mavenArtifact]), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", pomFile, null, toSet([mavenArtifact]))
 
         File theFile = new TestFile(testDir.testDirectory, "testFile")
         if (createDir) {
@@ -175,7 +175,7 @@ class ValidatingMavenPublisherTest extends Specification {
         }
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(projectIdentity)
-        def publication = new MavenNormalizedPublication("pub-name", "pom", pomFile, projectIdentity, toSet([artifact1, artifact2]), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", pomFile, null, toSet([artifact1, artifact2]))
 
         when:
         publisher.publish(publication, repository)
@@ -194,7 +194,7 @@ class ValidatingMavenPublisherTest extends Specification {
         }
         def projectIdentity = makeProjectIdentity("group", "artifact", "version")
         def pomFile = createPomFile(projectIdentity)
-        def publication = new MavenNormalizedPublication("pub-name", "pom", pomFile, projectIdentity, toSet([artifact1, pomFile]), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", pomFile, null, toSet([artifact1, pomFile]))
 
         when:
         publisher.publish(publication, repository)
@@ -212,7 +212,7 @@ class ValidatingMavenPublisherTest extends Specification {
                 xml.asNode().appendNode("invalid", "This is not a valid pomFile element")
             }
         })
-        def publication = new MavenNormalizedPublication("pub-name", "pom", pomFile, projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", projectIdentity, "pom", pomFile, null, emptySet())
 
         when:
         publisher.publish(publication, repository)

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenPublishGcsErrorsIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenPublishGcsErrorsIntegrationTest.groovy
@@ -71,7 +71,6 @@ class MavenPublishGcsErrorsIntegrationTest extends AbstractMavenPublishIntegTest
         when:
         def module = mavenGcsRepo.module("org.gradle", "publishGcsTest", "1.45")
         module.artifact.expectPutAuthenticationError()
-        module.pom.expectPutAuthenticationError()
 
         then:
         fails 'publish'

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
@@ -70,7 +70,6 @@ class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest 
         when:
         def module = mavenS3Repo.module("org.gradle", "publishS3Test", "1.45")
         module.artifact.expectPutAuthenticationError()
-        module.pom.expectPutAuthenticationError()
 
         then:
         fails 'publish'

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r47/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r47/BuildProgressCrossVersionSpec.groovy
@@ -23,9 +23,9 @@ import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.gradle.tooling.ProjectConnection
+import org.gradle.util.GradleVersion
 
-@TargetGradleVersion(">=4.7 <5.6")
-// As of 5.6, we no longer rely on the Maven Aether libraries for `maven-publish`
+@TargetGradleVersion(">=4.7")
 class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
 
     public RepositoryHttpServer server
@@ -43,6 +43,14 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         given:
         toolingApi.requireIsolatedUserHome()
 
+        int metadataDownloads = 1
+        int metadataChecksumDownloads = 0
+        // Older versions of Gradle use maven-aether for maven-publish, and perform additional downloads
+        if (targetVersion.compareTo(GradleVersion.version("5.6")) < 0) {
+            metadataDownloads = 2
+            metadataChecksumDownloads = 2
+        }
+
         def module = mavenHttpRepo.module('group', 'publish', '1')
 
         // module is published
@@ -51,10 +59,12 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         // module will be published a second time via 'maven-publish'
         module.artifact.expectPublish()
         module.pom.expectPublish()
-        module.rootMetaData.expectGet()
-        module.rootMetaData.sha1.expectGet()
-        module.rootMetaData.expectGet()
-        module.rootMetaData.sha1.expectGet()
+        metadataDownloads.times {
+            module.rootMetaData.expectGet()
+        }
+        metadataChecksumDownloads.times {
+            module.rootMetaData.sha1.expectGet()
+        }
         module.rootMetaData.expectPublish()
 
         settingsFile << 'rootProject.name = "publish"'
@@ -87,8 +97,8 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
 
         then:
         def publishTask = events.operation('Task :publishMavenPublicationToMavenRepository')
-        publishTask.descendants { it.descriptor.displayName == "Download ${module.rootMetaData.uri}" }.size() == 2
-        publishTask.descendants { it.descriptor.displayName == "Download ${module.rootMetaData.sha1.uri}" }.size() == 2
+        publishTask.descendants { it.descriptor.displayName == "Download ${module.rootMetaData.uri}" }.size() == metadataDownloads
+        publishTask.descendants { it.descriptor.displayName == "Download ${module.rootMetaData.sha1.uri}" }.size() == metadataChecksumDownloads
     }
 
     MavenHttpRepository getMavenHttpRepo() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r47/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r47/BuildProgressCrossVersionSpec.groovy
@@ -24,7 +24,8 @@ import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.gradle.tooling.ProjectConnection
 
-@TargetGradleVersion(">=4.7")
+@TargetGradleVersion(">=4.7 <5.6")
+// As of 5.6, we no longer rely on the Maven Aether libraries for `maven-publish`
 class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
 
     public RepositoryHttpServer server


### PR DESCRIPTION
This changeset re-implements the core Maven publishing functionality, using Maven libraries to produce the `maven-metadata.xml` files directly, but without giving control to the aether `DefaultDeployer` and `DefaultInstaller` implementations.

The use of `aether` and other Maven libraries was problematic:
- Static state prevented us from running publishing tasks in parallel, even in separate projects (#8950)
- A Gradle `RepositoryTransport` was wired into aether via a custom Wagon implementation: this mechanism relied on `ThreadLocal` state and was difficult to understand or change.
- The generation of `maven-metadata.xml` files was abstracted away so as to make bugfixes and changes very difficult.
- Multiple layers of indirection (Gradle->Maven->Gradle->Maven) made the functionality difficult to comprehend and modify.

With this change, the `maven-publish` implementation is quite separate from the legacy `maven` plugin. Once the latter is deprecated and removed, it will permit the remove of a substantial amount of code and dependencies.

This PR fixes:
- #8950 : Allow `maven-publish` tasks to run in parallel
- #9141 : Update the `latest` version for `maven-metadata.xml`