### PR TITLE
Collect all JFR recordings for cold daemon performance tests

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/JfrProfiler.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/JfrProfiler.groovy
@@ -98,6 +98,13 @@ class JfrProfiler extends Profiler implements Stoppable {
     }
 
     void start(BuildExperimentSpec spec) {
+        // Remove any profiles created during warmup
+        def jfrOutputDir = getJfrOutputDirectory(spec)
+        jfrOutputDir.listFiles()
+            .findAll { it.name.endsWith(".jfr") }
+            .forEach { File file ->
+                file.delete()
+            }
         if (useDaemon(spec)) {
             jCmd.execute(pid.pid, "JFR.start", "name=profile", "settings=$config")
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/JfrProfiler.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/JfrProfiler.groovy
@@ -21,6 +21,7 @@ import com.google.common.io.Files
 import com.google.common.io.Resources
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
+import org.apache.commons.io.FileUtils
 import org.gradle.api.JavaVersion
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.performance.util.JCmd
@@ -99,12 +100,8 @@ class JfrProfiler extends Profiler implements Stoppable {
 
     void start(BuildExperimentSpec spec) {
         // Remove any profiles created during warmup
-        def jfrOutputDir = getJfrOutputDirectory(spec)
-        jfrOutputDir.listFiles()
-            .findAll { it.name.endsWith(".jfr") }
-            .forEach { File file ->
-                file.delete()
-            }
+        // TODO Should not run warmup runs with the profiler enabled for no daemon cases – https://github.com/gradle/gradle/issues/9458
+        FileUtils.cleanDirectory(getJfrOutputDirectory(spec))
         if (useDaemon(spec)) {
             jCmd.execute(pid.pid, "JFR.start", "name=profile", "settings=$config")
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/JfrToStacksConverter.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/JfrToStacksConverter.java
@@ -40,6 +40,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,14 +54,15 @@ import java.util.stream.StreamSupport;
  * Converts JFR recordings to the collapsed stacks format used by the FlameGraph tool.
  */
 class JfrToStacksConverter {
-    public void convertToStacks(IItemCollection recording, File targetFile, Options options) {
-        Map<String, Long> foldedStacks = foldStacks(recording, options);
+    public void convertToStacks(Collection<IItemCollection> recordings, File targetFile, Options options) {
+        Map<String, Long> foldedStacks = foldStacks(recordings, options);
         writeFoldedStacks(foldedStacks, targetFile);
     }
 
-    private Map<String, Long> foldStacks(IItemCollection recording, Options options) {
+    private Map<String, Long> foldStacks(Collection<IItemCollection> recordings, Options options) {
         StackFolder folder = new StackFolder(options);
-        StreamSupport.stream(recording.spliterator(), false)
+        recordings.stream()
+            .flatMap(recording -> StreamSupport.stream(recording.spliterator(), false))
             .flatMap(eventStream -> StreamSupport.stream(eventStream.spliterator(), false))
             .filter(options.eventType::matches)
             .filter(event -> getStackTrace(event) != null)


### PR DESCRIPTION
Instead of producing a single `profile.jfr` we now produces a series of them, and process all of them when generating stacks.txt files.
