### PR TITLE
Validate repository name when publishing

### DIFF
--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIdentifierValidationIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIdentifierValidationIntegTest.groovy
@@ -140,4 +140,33 @@ class MavenPublishIdentifierValidationIntegTest extends AbstractMavenPublishInte
         failure.assertHasCause "Failed to publish publication 'maven' to repository 'maven'"
         failure.assertHasCause "Invalid publication 'maven': groupId cannot be empty"
     }
+
+    def "fails with reasonable error message for invalid repository name"() {
+        settingsFile << "rootProject.name = 'invalid-repo'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java'
+
+            group = 'org.test'
+            version = '1.0'
+
+            publishing {
+                repositories {
+                    maven { 
+                        name 'bad:name'
+                        url "${mavenRepo.uri}" 
+                    }
+                }
+                publications {
+                    maven(MavenPublication)
+                }
+            }
+        """
+        when:
+        fails 'publish'
+
+        then:
+        failure.assertHasDescription "A problem occurred evaluating root project 'invalid-repo'"
+        failure.assertHasCause "Repository name 'bad:name' is not valid for publication"
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisher.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.maven.internal.publisher;
 
 import org.apache.commons.lang.ObjectUtils;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.publish.PublicationArtifact;
@@ -39,6 +40,12 @@ public class ValidatingMavenPublisher implements MavenPublisher {
 
     public ValidatingMavenPublisher(MavenPublisher delegate) {
         this.delegate = delegate;
+    }
+
+    public static void validateRepositoryName(String name) {
+        if (!name.matches(ID_REGEX)) {
+            throw new InvalidUserDataException("Repository name " + name + " is not valid for publishing");
+        }
     }
 
     public void publish(MavenNormalizedPublication publication, MavenArtifactRepository artifactRepository) {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -17,10 +17,12 @@
 package org.gradle.api.publish.plugins;
 
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.FeaturePreviews;
@@ -47,6 +49,7 @@ public class PublishingPlugin implements Plugin<Project> {
 
     public static final String PUBLISH_TASK_GROUP = "publishing";
     public static final String PUBLISH_LIFECYCLE_TASK_NAME = "publish";
+    private static final String REPOSITORY_NAME_REGEX = "[A-Za-z0-9_\\-.]+";
 
     private final Instantiator instantiator;
     private final ArtifactPublicationServices publicationServices;
@@ -74,19 +77,19 @@ public class PublishingPlugin implements Plugin<Project> {
         RepositoryHandler repositories = publicationServices.createRepositoryHandler();
         PublicationContainer publications = instantiator.newInstance(DefaultPublicationContainer.class, instantiator, collectionCallbackActionDecorator);
         PublishingExtension extension = project.getExtensions().create(PublishingExtension.class, PublishingExtension.NAME, DefaultPublishingExtension.class, repositories, publications);
-        project.getTasks().register(PUBLISH_LIFECYCLE_TASK_NAME, new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                task.setDescription("Publishes all publications produced by this project.");
-                task.setGroup(PUBLISH_TASK_GROUP);
-            }
+        project.getTasks().register(PUBLISH_LIFECYCLE_TASK_NAME, task -> {
+            task.setDescription("Publishes all publications produced by this project.");
+            task.setGroup(PUBLISH_TASK_GROUP);
         });
-        extension.getPublications().all(new Action<Publication>() {
-            @Override
-            public void execute(Publication publication) {
-                PublicationInternal internalPublication = (PublicationInternal) publication;
-                ProjectInternal projectInternal = (ProjectInternal) project;
-                projectPublicationRegistry.registerPublication(projectInternal, internalPublication);
+        extension.getPublications().all(publication -> {
+            PublicationInternal internalPublication = (PublicationInternal) publication;
+            ProjectInternal projectInternal = (ProjectInternal) project;
+            projectPublicationRegistry.registerPublication(projectInternal, internalPublication);
+        });
+        extension.getRepositories().all(artifactRepository -> {
+            String repositoryName = artifactRepository.getName();
+            if (!repositoryName.matches(REPOSITORY_NAME_REGEX)) {
+                throw new InvalidUserDataException("Repository name '" + repositoryName + "' is not valid for publication");
             }
         });
         bridgeToSoftwareModelIfNeeded((ProjectInternal) project);


### PR DESCRIPTION
The `repository.name` value is used to construct task names when publishing.
This change adds validation to prevent invalid names such as "bad:name"
being used for repositories configured for publication.

Fixes #5533