### PR TITLE
Improve validation in publishing plugins

### DIFF
--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -48,6 +48,10 @@ Previously, it was possible to pass `Task.dependsOn()` a `Provider<File>`, `Prov
 
 Note that it is still possible to to pass `dependsOn()` a `Provider` that returns a file and that represents a task output, for example `myTask.dependsOn(jar.archiveFile)` or `myTask.dependsOn(taskProvider.flatMap { it.outputDir })`.
 
+==== Enhanced validation of names for `publishing.publications` and `publishing.repositories`
+
+The repository and publication names are used to construct task names when publishing. Previously is was possible to supply a name that resulted in an invalid task name. These names are now restricted to `[A-Za-z0-9_\\-.]+`.
+
 [[changes_5.5]]
 == Upgrading from 5.4 and earlier
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -74,6 +74,7 @@ import org.gradle.api.publish.ivy.internal.dependency.IvyExcludeRule;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
@@ -127,7 +128,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final FeaturePreviews featurePreviews;
     private IvyArtifact ivyDescriptorArtifact;
-    private Task moduleDescriptorGenerator;
+    private TaskProvider<? extends Task> moduleDescriptorGenerator;
     private SingleOutputTaskIvyArtifact gradleModuleDescriptorArtifact;
     private SoftwareComponentInternal component;
     private boolean alias;
@@ -149,9 +150,9 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         this.versionMappingStrategy = versionMappingStrategy;
         this.featurePreviews = featurePreviews;
         this.mainArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, name, ivyArtifactNotationParser, fileCollectionFactory, collectionCallbackActionDecorator);
-        this.metadataArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
-        this.derivedArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
-        this.publishableArtifacts = new CompositePublicationArtifactSet<IvyArtifact>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
+        this.metadataArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.derivedArtifacts = new DefaultPublicationArtifactSet<>(IvyArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.publishableArtifacts = new CompositePublicationArtifactSet<>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         this.ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class, collectionCallbackActionDecorator);
         this.descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this, instantiator, objectFactory);
     }
@@ -183,7 +184,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     @Override
-    public void setIvyDescriptorGenerator(Task descriptorGenerator) {
+    public void setIvyDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator) {
         if (ivyDescriptorArtifact != null) {
             metadataArtifacts.remove(ivyDescriptorArtifact);
         }
@@ -193,7 +194,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     @Override
-    public void setModuleDescriptorGenerator(Task descriptorGenerator) {
+    public void setModuleDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator) {
         moduleDescriptorGenerator = descriptorGenerator;
         if (gradleModuleDescriptorArtifact != null) {
             metadataArtifacts.remove(gradleModuleDescriptorArtifact);

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
@@ -25,6 +25,7 @@ import org.gradle.api.publish.ivy.internal.dependency.IvyDependencyInternal;
 import org.gradle.api.publish.ivy.internal.dependency.IvyExcludeRule;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
+import org.gradle.api.tasks.TaskProvider;
 
 import java.util.Set;
 
@@ -35,9 +36,9 @@ public interface IvyPublicationInternal extends IvyPublication, PublicationInter
     @Override
     IvyModuleDescriptorSpecInternal getDescriptor();
 
-    void setIvyDescriptorGenerator(Task descriptorGenerator);
+    void setIvyDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator);
 
-    void setModuleDescriptorGenerator(Task descriptorGenerator);
+    void setModuleDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator);
 
     /**
      * @deprecated Kept to not break third-party plugins

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -166,8 +166,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
                 descriptorTask.setDestination(buildDir.file("publications/" + publicationName + "/ivy.xml"));
             }
         });
-        // TODO: Make lazy
-        publication.setIvyDescriptorGenerator(generatorTask.get());
+        publication.setIvyDescriptorGenerator(generatorTask);
     }
 
     private void createGenerateMetadataTask(final TaskContainer tasks, final IvyPublicationInternal publication, final Set<IvyPublicationInternal> publications, final DirectoryProperty buildDir) {
@@ -180,8 +179,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
             generateTask.getPublications().set(publications);
             generateTask.getOutputFile().convention(buildDir.file("publications/" + publicationName + "/module.json"));
         });
-        // TODO: Make lazy
-        publication.setModuleDescriptorGenerator(generatorTask.get());
+        publication.setModuleDescriptorGenerator(generatorTask);
     }
 
     private class IvyPublicationFactory implements NamedDomainObjectFactory<IvyPublication> {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy.plugins;
 
-import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectSet;
@@ -102,20 +101,17 @@ public class IvyPublishPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(PublishingPlugin.class);
 
-        project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
-            @Override
-            public void execute(PublishingExtension extension) {
-                extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider,
-                    instantiator,
-                    objectFactory,
-                    fileResolver,
-                    collectionCallbackActionDecorator,
-                    project.getConfigurations(),
-                    project.getPluginManager(),
-                    project.getExtensions(),
-                    (AttributesSchemaInternal) project.getDependencies().getAttributesSchema()));
-                createTasksLater(project, extension, project.getLayout().getBuildDirectory());
-            }
+        project.getExtensions().configure(PublishingExtension.class, extension -> {
+            extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider,
+                instantiator,
+                objectFactory,
+                fileResolver,
+                collectionCallbackActionDecorator,
+                project.getConfigurations(),
+                project.getPluginManager(),
+                project.getExtensions(),
+                (AttributesSchemaInternal) project.getDependencies().getAttributesSchema()));
+            createTasksLater(project, extension, project.getLayout().getBuildDirectory());
         });
     }
 
@@ -128,14 +124,11 @@ public class IvyPublishPlugin implements Plugin<Project> {
             publish.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
         }));
 
-        publications.all(new Action<IvyPublicationInternal>() {
-            @Override
-            public void execute(IvyPublicationInternal publication) {
-                final String publicationName = publication.getName();
-                createGenerateIvyDescriptorTask(tasks, publicationName, publication, buildDir, project);
-                createGenerateMetadataTask(project, tasks, publication, publications, buildDir);
-                createPublishTaskForEachRepository(tasks, publication, publicationName, repositories);
-            }
+        publications.all(publication -> {
+            final String publicationName = publication.getName();
+            createGenerateIvyDescriptorTask(tasks, publicationName, publication, buildDir);
+            createGenerateMetadataTask(tasks, publication, publications, buildDir);
+            createPublishTaskForEachRepository(tasks, publication, publicationName, repositories);
         });
     }
 
@@ -144,13 +137,10 @@ public class IvyPublishPlugin implements Plugin<Project> {
     }
 
     private void createPublishTaskForEachRepository(final TaskContainer tasks, final IvyPublicationInternal publication, final String publicationName, NamedDomainObjectList<IvyArtifactRepository> repositories) {
-        repositories.all(new Action<IvyArtifactRepository>() {
-            @Override
-            public void execute(IvyArtifactRepository repository) {
-                final String repositoryName = repository.getName();
-                final String publishTaskName = "publish" + capitalize(publicationName) + "PublicationTo" + capitalize(repositoryName) + "Repository";
-                createPublishToRepositoryTask(tasks, publication, publicationName, repository, repositoryName, publishTaskName);
-            }
+        repositories.all(repository -> {
+            final String repositoryName = repository.getName();
+            final String publishTaskName = "publish" + capitalize(publicationName) + "PublicationTo" + capitalize(repositoryName) + "Repository";
+            createPublishToRepositoryTask(tasks, publication, publicationName, repository, repositoryName, publishTaskName);
         });
     }
 
@@ -165,36 +155,30 @@ public class IvyPublishPlugin implements Plugin<Project> {
         tasks.named(publishAllToSingleRepoTaskName(repository), publish -> publish.dependsOn(publishTaskName));
     }
 
-    private void createGenerateIvyDescriptorTask(TaskContainer tasks, final String publicationName, final IvyPublicationInternal publication, @Path("buildDir") final DirectoryProperty buildDir, final Project project) {
+    private void createGenerateIvyDescriptorTask(TaskContainer tasks, final String publicationName, final IvyPublicationInternal publication, @Path("buildDir") final DirectoryProperty buildDir) {
         final String descriptorTaskName = "generateDescriptorFileFor" + capitalize(publicationName) + "Publication";
 
-        TaskProvider<GenerateIvyDescriptor> generatorTask = tasks.register(descriptorTaskName, GenerateIvyDescriptor.class, new Action<GenerateIvyDescriptor>() {
-            @Override
-            public void execute(final GenerateIvyDescriptor descriptorTask) {
-                descriptorTask.setDescription("Generates the Ivy Module Descriptor XML file for publication '" + publicationName + "'.");
-                descriptorTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                descriptorTask.setDescriptor(publication.getDescriptor());
-                if (descriptorTask.getDestination() == null) {
-                    descriptorTask.setDestination(buildDir.file("publications/" + publicationName + "/ivy.xml"));
-                }
+        TaskProvider<GenerateIvyDescriptor> generatorTask = tasks.register(descriptorTaskName, GenerateIvyDescriptor.class, descriptorTask -> {
+            descriptorTask.setDescription("Generates the Ivy Module Descriptor XML file for publication '" + publicationName + "'.");
+            descriptorTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+            descriptorTask.setDescriptor(publication.getDescriptor());
+            if (descriptorTask.getDestination() == null) {
+                descriptorTask.setDestination(buildDir.file("publications/" + publicationName + "/ivy.xml"));
             }
         });
         // TODO: Make lazy
         publication.setIvyDescriptorGenerator(generatorTask.get());
     }
 
-    private void createGenerateMetadataTask(Project project, final TaskContainer tasks, final IvyPublicationInternal publication, final Set<IvyPublicationInternal> publications, final DirectoryProperty buildDir) {
+    private void createGenerateMetadataTask(final TaskContainer tasks, final IvyPublicationInternal publication, final Set<IvyPublicationInternal> publications, final DirectoryProperty buildDir) {
         final String publicationName = publication.getName();
         String descriptorTaskName = "generateMetadataFileFor" + capitalize(publicationName) + "Publication";
-        TaskProvider<GenerateModuleMetadata> generatorTask = tasks.register(descriptorTaskName, GenerateModuleMetadata.class, new Action<GenerateModuleMetadata>() {
-            @Override
-            public void execute(final GenerateModuleMetadata generateTask) {
-                generateTask.setDescription("Generates the Gradle metadata file for publication '" + publicationName + "'.");
-                generateTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                generateTask.getPublication().set(publication);
-                generateTask.getPublications().set(publications);
-                generateTask.getOutputFile().convention(buildDir.file("publications/" + publicationName + "/module.json"));
-            }
+        TaskProvider<GenerateModuleMetadata> generatorTask = tasks.register(descriptorTaskName, GenerateModuleMetadata.class, generateTask -> {
+            generateTask.setDescription("Generates the Gradle metadata file for publication '" + publicationName + "'.");
+            generateTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+            generateTask.getPublication().set(publication);
+            generateTask.getPublications().set(publications);
+            generateTask.getOutputFile().convention(buildDir.file("publications/" + publicationName + "/module.json"));
         });
         // TODO: Make lazy
         publication.setModuleDescriptorGenerator(generatorTask.get());

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -39,6 +39,7 @@ import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
 import org.gradle.api.publish.ivy.IvyArtifact
 import org.gradle.api.tasks.TaskOutputs
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.AttributeTestUtil
@@ -384,10 +385,12 @@ class DefaultIvyPublicationTest extends Specification {
     }
 
     def createArtifactGenerator(File file) {
-        return Stub(Task) {
-            getOutputs() >> Stub(TaskOutputs) {
-                getFiles() >> Stub(FileCollection) {
-                    getSingleFile() >> file
+        return Stub(TaskProvider) {
+            get() >> Stub(Task) {
+                getOutputs() >> Stub(TaskOutputs) {
+                    getFiles() >> Stub(FileCollection) {
+                        getSingleFile() >> file
+                    }
                 }
             }
         }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomCustomizationIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomCustomizationIntegTest.groovy
@@ -371,7 +371,7 @@ class MavenPublishPomCustomizationIntegTest extends AbstractMavenPublishIntegTes
         then:
         failure.assertHasDescription("Execution failed for task ':publishMavenPublicationToMavenRepository'.")
         failure.assertHasCause("Failed to publish publication 'maven' to repository 'maven'")
-        failure.assertHasCause("Invalid publication 'maven': supplied version does not match POM file (cannot edit version directly in the POM file).")
+        failure.assertHasCause("Invalid publication 'maven': supplied version (1.0) does not match value from POM file (2.0). Cannot edit version directly in the POM file.")
     }
 
     def "withXml should not loose Gradle metadata marker"() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
@@ -16,29 +16,30 @@
 
 package org.gradle.api.publish.maven.internal.artifact;
 
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Task;
-import org.gradle.api.internal.tasks.DefaultTaskDependency;
+import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.tasks.TaskProvider;
 
 import java.io.File;
 
 public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
-    private final Task generator;
+    private final TaskProvider<? extends Task> generator;
     private final String extension;
     private final String classifier;
-    private final DefaultTaskDependency buildDependencies;
+    private final TaskDependencyInternal buildDependencies;
 
-    public SingleOutputTaskMavenArtifact(Task generator, String extension, String classifier) {
+    public SingleOutputTaskMavenArtifact(TaskProvider<? extends Task> generator, String extension, String classifier) {
         this.generator = generator;
         this.extension = extension;
         this.classifier = classifier;
-        this.buildDependencies = new DefaultTaskDependency(null, ImmutableSet.<Object>of(generator));
+        this.buildDependencies = new GeneratorTaskDependency();
     }
 
     @Override
     public File getFile() {
-        return generator.getOutputs().getFiles().getSingleFile();
+        return generator.get().getOutputs().getFiles().getSingleFile();
     }
 
     @Override
@@ -57,6 +58,13 @@ public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
     }
 
     public boolean isEnabled() {
-        return generator.getEnabled();
+        return generator.get().getEnabled();
+    }
+
+    private class GeneratorTaskDependency extends AbstractTaskDependency {
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            context.add(generator.get());
+        }
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -76,6 +76,7 @@ import org.gradle.api.publish.maven.internal.dependencies.MavenDependencyInterna
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
 import org.gradle.api.publish.maven.internal.publisher.MutableMavenProjectIdentity;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -143,7 +144,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private MavenArtifact pomArtifact;
     private SingleOutputTaskMavenArtifact moduleMetadataArtifact;
-    private Task moduleDescriptorGenerator;
+    private TaskProvider<? extends Task> moduleDescriptorGenerator;
     private SoftwareComponentInternal component;
     private boolean isPublishWithOriginalFileName;
     private boolean alias;
@@ -162,9 +163,9 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         this.immutableAttributesFactory = immutableAttributesFactory;
         this.versionMappingStrategy = versionMappingStrategy;
         this.mainArtifacts = instantiator.newInstance(DefaultMavenArtifactSet.class, name, mavenArtifactParser, fileCollectionFactory, collectionCallbackActionDecorator);
-        this.metadataArtifacts = new DefaultPublicationArtifactSet<MavenArtifact>(MavenArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
-        derivedArtifacts = new DefaultPublicationArtifactSet<MavenArtifact>(MavenArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
-        publishableArtifacts = new CompositePublicationArtifactSet<MavenArtifact>(MavenArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
+        this.metadataArtifacts = new DefaultPublicationArtifactSet<>(MavenArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        derivedArtifacts = new DefaultPublicationArtifactSet<>(MavenArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        publishableArtifacts = new CompositePublicationArtifactSet<>(MavenArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         pom = instantiator.newInstance(DefaultMavenPom.class, this, instantiator, objectFactory);
         this.featurePreviews = featurePreviews;
     }
@@ -196,7 +197,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     @Override
-    public void setPomGenerator(Task pomGenerator) {
+    public void setPomGenerator(TaskProvider<? extends Task> pomGenerator) {
         if (pomArtifact != null) {
             metadataArtifacts.remove(pomArtifact);
         }
@@ -205,7 +206,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     @Override
-    public void setModuleDescriptorGenerator(Task descriptorGenerator) {
+    public void setModuleDescriptorGenerator(TaskProvider<? extends Task> descriptorGenerator) {
         moduleDescriptorGenerator = descriptorGenerator;
         if (moduleMetadataArtifact != null) {
             metadataArtifacts.remove(moduleMetadataArtifact);

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -26,6 +26,7 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.dependencies.MavenDependencyInternal;
 import org.gradle.api.publish.maven.internal.publisher.MavenNormalizedPublication;
 import org.gradle.api.publish.maven.internal.publisher.MutableMavenProjectIdentity;
+import org.gradle.api.tasks.TaskProvider;
 
 import java.util.Set;
 
@@ -34,9 +35,9 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
     @Override
     MavenPomInternal getPom();
 
-    void setPomGenerator(Task pomGenerator);
+    void setPomGenerator(TaskProvider<? extends Task> pomGenerator);
 
-    void setModuleDescriptorGenerator(Task moduleMetadataGenerator);
+    void setModuleDescriptorGenerator(TaskProvider<? extends Task> moduleMetadataGenerator);
 
     /**
      * @deprecated Kept to not break third-party plugins

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -202,8 +202,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
                         .withRuntimeScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
             });
         });
-        // TODO: Make lazy
-        publication.setPomGenerator(generatorTask.get());
+        publication.setPomGenerator(generatorTask);
     }
 
     private void createGenerateMetadataTask(final TaskContainer tasks, final MavenPublicationInternal publication, final Set<? extends MavenPublicationInternal> publications, final DirectoryProperty buildDir) {
@@ -216,8 +215,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
             generateTask.getPublications().set(publications);
             generateTask.getOutputFile().convention(buildDir.file("publications/" + publication.getName() + "/module.json"));
         });
-        // TODO: Make lazy
-        publication.setModuleDescriptorGenerator(generatorTask.get());
+        publication.setModuleDescriptorGenerator(generatorTask);
     }
 
     private class MavenPublicationFactory implements NamedDomainObjectFactory<MavenPublication> {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven.plugins;
 
-import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectSet;
@@ -66,7 +65,6 @@ import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.inject.Inject;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import static org.apache.commons.lang.StringUtils.capitalize;
 
@@ -112,28 +110,22 @@ public class MavenPublishPlugin implements Plugin<Project> {
         project.getPluginManager().apply(PublishingPlugin.class);
 
         final TaskContainer tasks = project.getTasks();
-        tasks.register(PUBLISH_LOCAL_LIFECYCLE_TASK_NAME, new Action<Task>() {
-            @Override
-            public void execute(Task publish) {
-                publish.setDescription("Publishes all Maven publications produced by this project to the local Maven cache.");
-                publish.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-            }
+        tasks.register(PUBLISH_LOCAL_LIFECYCLE_TASK_NAME, publish -> {
+            publish.setDescription("Publishes all Maven publications produced by this project to the local Maven cache.");
+            publish.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
         });
 
-        project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
-            @Override
-            public void execute(PublishingExtension extension) {
-                extension.getPublications().registerFactory(MavenPublication.class, new MavenPublicationFactory(
-                        dependencyMetaDataProvider,
-                        instantiatorFactory.decorateLenient(),
-                        fileResolver,
-                        collectionCallbackActionDecorator,
-                        project.getConfigurations(),
-                        project.getPluginManager(),
-                        project.getExtensions(),
-                        (AttributesSchemaInternal) project.getDependencies().getAttributesSchema()));
-                realizePublishingTasksLater(project, extension);
-            }
+        project.getExtensions().configure(PublishingExtension.class, extension -> {
+            extension.getPublications().registerFactory(MavenPublication.class, new MavenPublicationFactory(
+                    dependencyMetaDataProvider,
+                    instantiatorFactory.decorateLenient(),
+                    fileResolver,
+                    collectionCallbackActionDecorator,
+                    project.getConfigurations(),
+                    project.getPluginManager(),
+                    project.getExtensions(),
+                    (AttributesSchemaInternal) project.getDependencies().getAttributesSchema()));
+            realizePublishingTasksLater(project, extension);
         });
     }
 
@@ -151,14 +143,11 @@ public class MavenPublishPlugin implements Plugin<Project> {
             publish.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
         }));
 
-        mavenPublications.all(new Action<MavenPublicationInternal>() {
-            @Override
-            public void execute(MavenPublicationInternal publication) {
-                createGenerateMetadataTask(tasks, publication, mavenPublications, buildDirectory);
-                createGeneratePomTask(tasks, publication, buildDirectory, project);
-                createLocalInstallTask(tasks, publishLocalLifecycleTask, publication);
-                createPublishTasksForEachMavenRepo(tasks, publishLifecycleTask, publication, repositories);
-            }
+        mavenPublications.all(publication -> {
+            createGenerateMetadataTask(tasks, publication, mavenPublications, buildDirectory);
+            createGeneratePomTask(tasks, publication, buildDirectory, project);
+            createLocalInstallTask(tasks, publishLocalLifecycleTask, publication);
+            createPublishTasksForEachMavenRepo(tasks, publishLifecycleTask, publication, repositories);
         });
     }
 
@@ -168,21 +157,18 @@ public class MavenPublishPlugin implements Plugin<Project> {
 
     private void createPublishTasksForEachMavenRepo(final TaskContainer tasks, final TaskProvider<Task> publishLifecycleTask, final MavenPublicationInternal publication, final NamedDomainObjectList<MavenArtifactRepository> repositories) {
         final String publicationName = publication.getName();
-        repositories.all(new Action<MavenArtifactRepository>() {
-            @Override
-            public void execute(final MavenArtifactRepository repository) {
-                final String repositoryName = repository.getName();
-                final String publishTaskName = "publish" + capitalize(publicationName) + "PublicationTo" + capitalize(repositoryName) + "Repository";
-                tasks.register(publishTaskName, PublishToMavenRepository.class, publishTask -> {
-                    publishTask.setPublication(publication);
-                    publishTask.setRepository(repository);
-                    publishTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                    publishTask.setDescription("Publishes Maven publication '" + publicationName + "' to Maven repository '" + repositoryName + "'.");
+        repositories.all(repository -> {
+            final String repositoryName = repository.getName();
+            final String publishTaskName = "publish" + capitalize(publicationName) + "PublicationTo" + capitalize(repositoryName) + "Repository";
+            tasks.register(publishTaskName, PublishToMavenRepository.class, publishTask -> {
+                publishTask.setPublication(publication);
+                publishTask.setRepository(repository);
+                publishTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+                publishTask.setDescription("Publishes Maven publication '" + publicationName + "' to Maven repository '" + repositoryName + "'.");
 
-                });
-                publishLifecycleTask.configure(task -> task.dependsOn(publishTaskName));
-                tasks.named(publishAllToSingleRepoTaskName(repository), publish -> publish.dependsOn(publishTaskName));
-            }
+            });
+            publishLifecycleTask.configure(task -> task.dependsOn(publishTaskName));
+            tasks.named(publishAllToSingleRepoTaskName(repository), publish -> publish.dependsOn(publishTaskName));
         });
     }
 
@@ -190,42 +176,31 @@ public class MavenPublishPlugin implements Plugin<Project> {
         final String publicationName = publication.getName();
         final String installTaskName = "publish" + capitalize(publicationName) + "PublicationToMavenLocal";
 
-        tasks.register(installTaskName, PublishToMavenLocal.class, new Action<PublishToMavenLocal>() {
-            @Override
-            public void execute(PublishToMavenLocal publishLocalTask) {
-                publishLocalTask.setPublication(publication);
-                publishLocalTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                publishLocalTask.setDescription("Publishes Maven publication '" + publicationName + "' to the local Maven repository.");
-            }
+        tasks.register(installTaskName, PublishToMavenLocal.class, publishLocalTask -> {
+            publishLocalTask.setPublication(publication);
+            publishLocalTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+            publishLocalTask.setDescription("Publishes Maven publication '" + publicationName + "' to the local Maven repository.");
         });
-        publishLocalLifecycleTask.configure(new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                task.dependsOn(installTaskName);
-            }
-        });
+        publishLocalLifecycleTask.configure(task -> task.dependsOn(installTaskName));
     }
 
     private void createGeneratePomTask(TaskContainer tasks, final MavenPublicationInternal publication, final DirectoryProperty buildDir, final Project project) {
         final String publicationName = publication.getName();
         String descriptorTaskName = "generatePomFileFor" + capitalize(publicationName) + "Publication";
-        TaskProvider<GenerateMavenPom> generatorTask = tasks.register(descriptorTaskName, GenerateMavenPom.class, new Action<GenerateMavenPom>() {
-            @Override
-            public void execute(final GenerateMavenPom generatePomTask) {
-                generatePomTask.setDescription("Generates the Maven POM file for publication '" + publicationName + "'.");
-                generatePomTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                generatePomTask.setPom(publication.getPom());
-                if (generatePomTask.getDestination() == null) {
-                    generatePomTask.setDestination(buildDir.file("publications/" + publication.getName() + "/pom-default.xml"));
-                }
-                project.getPluginManager().withPlugin("org.gradle.java", plugin -> {
-                    // If the Java plugin is applied, we want to express that the "compile" and "runtime" variants
-                    // are mapped to some attributes, which can be used in the version mapping strategy.
-                    // This is only required for POM publication, because the variants have _implicit_ attributes that we want explicit for matching
-                    generatePomTask.withCompileScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS)))
-                            .withRuntimeScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
-                });
+        TaskProvider<GenerateMavenPom> generatorTask = tasks.register(descriptorTaskName, GenerateMavenPom.class, generatePomTask -> {
+            generatePomTask.setDescription("Generates the Maven POM file for publication '" + publicationName + "'.");
+            generatePomTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+            generatePomTask.setPom(publication.getPom());
+            if (generatePomTask.getDestination() == null) {
+                generatePomTask.setDestination(buildDir.file("publications/" + publication.getName() + "/pom-default.xml"));
             }
+            project.getPluginManager().withPlugin("org.gradle.java", plugin -> {
+                // If the Java plugin is applied, we want to express that the "compile" and "runtime" variants
+                // are mapped to some attributes, which can be used in the version mapping strategy.
+                // This is only required for POM publication, because the variants have _implicit_ attributes that we want explicit for matching
+                generatePomTask.withCompileScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS)))
+                        .withRuntimeScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
+            });
         });
         // TODO: Make lazy
         publication.setPomGenerator(generatorTask.get());
@@ -234,15 +209,12 @@ public class MavenPublishPlugin implements Plugin<Project> {
     private void createGenerateMetadataTask(final TaskContainer tasks, final MavenPublicationInternal publication, final Set<? extends MavenPublicationInternal> publications, final DirectoryProperty buildDir) {
         final String publicationName = publication.getName();
         String descriptorTaskName = "generateMetadataFileFor" + capitalize(publicationName) + "Publication";
-        TaskProvider<GenerateModuleMetadata> generatorTask = tasks.register(descriptorTaskName, GenerateModuleMetadata.class, new Action<GenerateModuleMetadata>() {
-            @Override
-            public void execute(final GenerateModuleMetadata generateTask) {
-                generateTask.setDescription("Generates the Gradle metadata file for publication '" + publicationName + "'.");
-                generateTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
-                generateTask.getPublication().set(publication);
-                generateTask.getPublications().set(publications);
-                generateTask.getOutputFile().convention(buildDir.file("publications/" + publication.getName() + "/module.json"));
-            }
+        TaskProvider<GenerateModuleMetadata> generatorTask = tasks.register(descriptorTaskName, GenerateModuleMetadata.class, generateTask -> {
+            generateTask.setDescription("Generates the Gradle metadata file for publication '" + publicationName + "'.");
+            generateTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
+            generateTask.getPublication().set(publication);
+            generateTask.getPublications().set(publications);
+            generateTask.getOutputFile().convention(buildDir.file("publications/" + publication.getName() + "/module.json"));
         });
         // TODO: Make lazy
         publication.setModuleDescriptorGenerator(generatorTask.get());
@@ -318,24 +290,9 @@ public class MavenPublishPlugin implements Plugin<Project> {
         private MutableMavenProjectIdentity createProjectIdentity() {
             final Module module = dependencyMetaDataProvider.getModule();
             MutableMavenProjectIdentity projectIdentity = new WritableMavenProjectIdentity(objectFactory);
-            projectIdentity.getGroupId().set(providerFactory.provider(new Callable<String>() {
-                @Override
-                public String call() {
-                    return module.getGroup();
-                }
-            }));
-            projectIdentity.getArtifactId().set(providerFactory.provider(new Callable<String>() {
-                @Override
-                public String call() {
-                    return module.getName();
-                }
-            }));
-            projectIdentity.getVersion().set(providerFactory.provider(new Callable<String>() {
-                @Override
-                public String call() {
-                    return module.getVersion();
-                }
-            }));
+            projectIdentity.getGroupId().set(providerFactory.provider(module::getGroup));
+            projectIdentity.getArtifactId().set(providerFactory.provider(module::getName));
+            projectIdentity.getVersion().set(providerFactory.provider(module::getVersion));
             return projectIdentity;
         }
     }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -41,6 +41,7 @@ import org.gradle.api.publish.maven.MavenArtifact
 import org.gradle.api.publish.maven.internal.publisher.MutableMavenProjectIdentity
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.TaskOutputs
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -491,10 +492,12 @@ class DefaultMavenPublicationTest extends Specification {
     }
 
     def createArtifactGenerator(File file) {
-        return Stub(Task) {
-            getOutputs() >> Stub(TaskOutputs) {
-                getFiles() >> Stub(FileCollection) {
-                    getSingleFile() >> file
+        return Stub(TaskProvider) {
+            get() >> Stub(Task) {
+                getOutputs() >> Stub(TaskOutputs) {
+                    getFiles() >> Stub(FileCollection) {
+                        getSingleFile() >> file
+                    }
                 }
             }
         }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -16,10 +16,8 @@
 
 package org.gradle.api.publish.plugins;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
@@ -27,7 +25,6 @@ import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactPublicationServices;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.internal.DefaultPublicationContainer;
@@ -75,20 +72,14 @@ public class PublishingPlugin implements Plugin<Project> {
         RepositoryHandler repositories = publicationServices.createRepositoryHandler();
         PublicationContainer publications = instantiator.newInstance(DefaultPublicationContainer.class, instantiator, collectionCallbackActionDecorator);
         PublishingExtension extension = project.getExtensions().create(PublishingExtension.class, PublishingExtension.NAME, DefaultPublishingExtension.class, repositories, publications);
-        project.getTasks().register(PUBLISH_LIFECYCLE_TASK_NAME, new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                task.setDescription("Publishes all publications produced by this project.");
-                task.setGroup(PUBLISH_TASK_GROUP);
-            }
+        project.getTasks().register(PUBLISH_LIFECYCLE_TASK_NAME, task -> {
+            task.setDescription("Publishes all publications produced by this project.");
+            task.setGroup(PUBLISH_TASK_GROUP);
         });
-        extension.getPublications().all(new Action<Publication>() {
-            @Override
-            public void execute(Publication publication) {
-                PublicationInternal internalPublication = (PublicationInternal) publication;
-                ProjectInternal projectInternal = (ProjectInternal) project;
-                projectPublicationRegistry.registerPublication(projectInternal, internalPublication);
-            }
+        extension.getPublications().all(publication -> {
+            PublicationInternal internalPublication = (PublicationInternal) publication;
+            ProjectInternal projectInternal = (ProjectInternal) project;
+            projectPublicationRegistry.registerPublication(projectInternal, internalPublication);
         });
         bridgeToSoftwareModelIfNeeded((ProjectInternal) project);
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -16,15 +16,18 @@
 
 package org.gradle.api.publish.plugins;
 
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactPublicationServices;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.internal.DefaultPublicationContainer;
@@ -44,6 +47,7 @@ public class PublishingPlugin implements Plugin<Project> {
 
     public static final String PUBLISH_TASK_GROUP = "publishing";
     public static final String PUBLISH_LIFECYCLE_TASK_NAME = "publish";
+    private static final String VALID_NAME_REGEX = "[A-Za-z0-9_\\-.]+";
 
     private final Instantiator instantiator;
     private final ArtifactPublicationServices publicationServices;
@@ -82,6 +86,24 @@ public class PublishingPlugin implements Plugin<Project> {
             projectPublicationRegistry.registerPublication(projectInternal, internalPublication);
         });
         bridgeToSoftwareModelIfNeeded((ProjectInternal) project);
+        validatePublishingModelWhenComplete(project, extension);
+    }
+
+    private void validatePublishingModelWhenComplete(Project project, PublishingExtension extension) {
+        project.afterEvaluate(projectAfterEvaluate -> {
+            for (ArtifactRepository repository : extension.getRepositories()) {
+                String repositoryName = repository.getName();
+                if (!repositoryName.matches(VALID_NAME_REGEX)) {
+                    throw new InvalidUserDataException("Repository name '" + repositoryName + "' is not valid for publication. Must match regex " + VALID_NAME_REGEX + ".");
+                }
+            }
+            for (Publication publication : extension.getPublications()) {
+                String repositoryName = publication.getName();
+                if (!repositoryName.matches(VALID_NAME_REGEX)) {
+                    throw new InvalidUserDataException("Publication name '" + repositoryName + "' is not valid for publication. Must match regex " + VALID_NAME_REGEX + ".");
+                }
+            }
+        });
     }
 
     private void bridgeToSoftwareModelIfNeeded(ProjectInternal project) {


### PR DESCRIPTION
A number of tidy-ups and improvements to validation logic applied by the `maven-publish` and `ivy-publish` plugins.

- Refactored publishing plugins to make more use of Java8 features, and removed the need for eager task realization.
- Allow publishing a POM file with missing `groupId` and `version` values, when those values could be obtained from a parent POM file (#6009).
- Fail publishing early if a configured `Publication` or `Repository` has a name that would result in publishing plugins generating invalid task names (#5533). 

This PR is probably best reviewed commit-by-commit.

