### PR TITLE
Serialize the fields of a bean to the instant execution cache

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
+
+    void instantRun(String... args) {
+        run(INSTANT_EXECUTION_PROPERTY, *args)
+    }
+
+    static final String INSTANT_EXECUTION_PROPERTY = "-Dorg.gradle.unsafe.instant-execution"
+
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+
+import spock.lang.Ignore
+
+class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+
+    @Ignore
+    def "instant execution for compileGroovy on Groovy project with no dependencies"() {
+        given:
+        buildFile << """
+            plugins { id 'groovy' }
+            
+            println "running build script"
+        """
+        file("src/main/java/Thing.groovy") << """
+            class Thing {
+            }
+        """
+
+        expect:
+        instantRun "compileGroovy"
+        outputContains("running build script")
+        result.assertTasksExecuted(":compileGroovy")
+        def classFile = file("build/classes/java/main/Thing.class")
+        classFile.isFile()
+
+        when:
+        classFile.delete()
+        instantRun "compileGroovy"
+
+        then:
+        outputDoesNotContain("running build script")
+        result.assertTasksExecuted(":compileGroovy")
+        classFile.isFile()
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -171,6 +171,11 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
             class SomeBean {
                 String value 
                 SomeBean parent
+                
+                SomeBean() {
+                    println("creating bean")
+                    value = "default"
+                }
             }
 
             class SomeTask extends DefaultTask {
@@ -194,9 +199,15 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         when:
         instantRun "ok"
+
+        then:
+        result.output.count("creating bean") == 2
+
+        when:
         instantRun "ok"
 
         then:
+        result.output.count("creating bean") == 2 // still running the task constructor, which creates values that are then discarded
         outputContains("bean.value = child")
         outputContains("bean.parent.value = parent")
     }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -17,19 +17,13 @@
 package org.gradle.instantexecution
 
 import org.gradle.initialization.LoadProjectsBuildOperationType
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Ignore
 
-class InstantExecutionIntegrationTest extends AbstractIntegrationSpec {
-
-    def setup() {
-        executer.noDeprecationChecks()
-    }
+class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
     def "instant execution for help on empty project"() {
         given:
@@ -104,70 +98,6 @@ class InstantExecutionIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksExecuted(":a")
     }
 
-    def "instant execution for compileJava on Java project with no dependencies"() {
-        given:
-        buildFile << """
-            plugins { id 'java' }
-            
-            println "running build script"
-        """
-        file("src/main/java/Thing.java") << """
-            class Thing {
-            }
-        """
-
-        expect:
-        instantRun "compileJava"
-        outputContains("running build script")
-        result.assertTasksExecuted(":compileJava")
-        def classFile = file("build/classes/java/main/Thing.class")
-        classFile.isFile()
-
-        when:
-        classFile.delete()
-        instantRun "compileJava"
-
-        then:
-        outputDoesNotContain("running build script")
-        result.assertTasksExecuted(":compileJava")
-        classFile.isFile()
-    }
-
-    def "instant execution for assemble on Java project with multiple source directories"() {
-        given:
-        buildFile << """
-            plugins { id 'java' }
-            
-            sourceSets.main.java.srcDir("src/common/java") 
-            
-            println "running build script"
-        """
-        file("src/common/java/OtherThing.java") << """
-            class OtherThing {
-            }
-        """
-        file("src/main/java/Thing.java") << """
-            class Thing extends OtherThing {
-            }
-        """
-
-        expect:
-        instantRun "assemble"
-        outputContains("running build script")
-        result.assertTasksExecuted(":compileJava", ":processResources", ":classes", ":jar", ":assemble")
-        def classFile = file("build/classes/java/main/Thing.class")
-        classFile.isFile()
-
-        when:
-        classFile.delete()
-        instantRun "assemble"
-
-        then:
-        outputDoesNotContain("running build script")
-        result.assertTasksExecuted(":compileJava", ":processResources", ":classes", ":jar", ":assemble")
-        classFile.isFile()
-    }
-
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
@@ -232,36 +162,6 @@ class InstantExecutionIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Ignore
-    def "instant execution for compileGroovy on Groovy project with no dependencies"() {
-        given:
-        buildFile << """
-            plugins { id 'groovy' }
-            
-            println "running build script"
-        """
-        file("src/main/java/Thing.groovy") << """
-            class Thing {
-            }
-        """
-
-        expect:
-        instantRun "compileGroovy"
-        outputContains("running build script")
-        result.assertTasksExecuted(":compileGroovy")
-        def classFile = file("build/classes/java/main/Thing.class")
-        classFile.isFile()
-
-        when:
-        classFile.delete()
-        instantRun "compileGroovy"
-
-        then:
-        outputDoesNotContain("running build script")
-        result.assertTasksExecuted(":compileGroovy")
-        classFile.isFile()
-    }
-
-    @Ignore
     def "android"() {
 
         given:
@@ -271,44 +171,4 @@ class InstantExecutionIntegrationTest extends AbstractIntegrationSpec {
         instantRun 'mainApkListPersistenceDebug', 'compileDebugAidl'
         instantRun 'mainApkListPersistenceDebug', 'compileDebugAidl'
     }
-
-    def "multi-project java build"() {
-        given:
-        settingsFile << """
-            include("a", "b")
-        """
-        buildFile << """
-            allprojects { apply plugin: 'java' }
-            project(":b") {
-                dependencies {
-                    implementation(project(":a"))
-                }
-            }
-        """
-        file("a/src/main/java/a/A.java") << """
-            package a;
-            public class A {}
-        """
-        file("b/src/main/java/b/B.java") << """
-            package b;
-            public class B extends a.A {}
-        """
-
-        when:
-        instantRun ":b:assemble", "-s"
-
-        and:
-        file("b/build/classes/java/main/b/B.class").delete()
-        instantRun ":b:assemble", "-s"
-
-        then:
-        new ZipTestFixture(file("b/build/libs/b.jar")).assertContainsFile("b/B.class")
-    }
-
-    private void instantRun(String... args) {
-        run(INSTANT_EXECUTION_PROPERTY, *args)
-    }
-
-    private static final String INSTANT_EXECUTION_PROPERTY = "-Dorg.gradle.unsafe.instant-execution"
-
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.test.fixtures.archive.ZipTestFixture
+
+class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+    def setup() {
+        executer.noDeprecationChecks()
+    }
+
+    def "instant execution for compileJava on Java project with no dependencies"() {
+        given:
+        buildFile << """
+            plugins { id 'java' }
+            
+            println "running build script"
+        """
+        file("src/main/java/Thing.java") << """
+            class Thing {
+            }
+        """
+
+        expect:
+        instantRun "compileJava"
+        outputContains("running build script")
+        result.assertTasksExecuted(":compileJava")
+        def classFile = file("build/classes/java/main/Thing.class")
+        classFile.isFile()
+
+        when:
+        classFile.delete()
+        instantRun "compileJava"
+
+        then:
+        outputDoesNotContain("running build script")
+        result.assertTasksExecuted(":compileJava")
+        classFile.isFile()
+    }
+
+    def "instant execution for assemble on Java project with multiple source directories"() {
+        given:
+        buildFile << """
+            plugins { id 'java' }
+            
+            sourceSets.main.java.srcDir("src/common/java") 
+            
+            println "running build script"
+        """
+        file("src/common/java/OtherThing.java") << """
+            class OtherThing {
+            }
+        """
+        file("src/main/java/Thing.java") << """
+            class Thing extends OtherThing {
+            }
+        """
+
+        expect:
+        instantRun "assemble"
+        outputContains("running build script")
+        result.assertTasksExecuted(":compileJava", ":processResources", ":classes", ":jar", ":assemble")
+        def classFile = file("build/classes/java/main/Thing.class")
+        classFile.isFile()
+
+        when:
+        classFile.delete()
+        instantRun "assemble"
+
+        then:
+        outputDoesNotContain("running build script")
+        result.assertTasksExecuted(":compileJava", ":processResources", ":classes", ":jar", ":assemble")
+        classFile.isFile()
+    }
+
+    def "multi-project java build"() {
+        given:
+        settingsFile << """
+            include("a", "b")
+        """
+        buildFile << """
+            allprojects { apply plugin: 'java' }
+            project(":b") {
+                dependencies {
+                    implementation(project(":a"))
+                }
+            }
+        """
+        file("a/src/main/java/a/A.java") << """
+            package a;
+            public class A {}
+        """
+        file("b/src/main/java/b/B.java") << """
+            package b;
+            public class B extends a.A {}
+        """
+
+        when:
+        instantRun ":b:assemble", "-s"
+
+        and:
+        file("b/build/classes/java/main/b/B.class").delete()
+        instantRun ":b:assemble", "-s"
+
+        then:
+        new ZipTestFixture(file("b/build/libs/b.jar")).assertContainsFile("b/B.class")
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.internal.serialize.Decoder
+import java.io.File
+import java.util.function.Supplier
+
+
+class BeanFieldDeserializer(private val bean: Any, private val beanType: Class<*>, private val deserializer: StateDeserializer) {
+    fun deserialize(decoder: Decoder, listener: SerializationListener) {
+        val fieldsByName = relevantStateOf(beanType).associateBy { it.name }
+        while (true) {
+            val fieldName = decoder.readString()
+            if (fieldName.isEmpty()) {
+                break
+            }
+            try {
+                val value = deserializer.read(decoder, listener) ?: continue
+                val field = fieldsByName.getValue(fieldName)
+                field.isAccessible = true
+                listener.logFieldSerialization("deserialize", beanType, fieldName, value)
+                @Suppress("unchecked_cast")
+                when (field.type) {
+                    DirectoryProperty::class.java -> (field.get(bean) as? DirectoryProperty)?.set(value as File)
+                    RegularFileProperty::class.java -> (field.get(bean) as? RegularFileProperty)?.set(value as File)
+                    Property::class.java -> (field.get(bean) as? Property<Any>)?.set(value)
+                    Supplier::class.java -> field.set(bean, Supplier { value })
+                    Function0::class.java -> field.set(bean, { value })
+                    else -> {
+                        if (field.type.isAssignableFrom(value.javaClass)) {
+                            field.set(bean, value)
+                        } else {
+                            listener.logFieldWarning("deserialize", beanType, fieldName, "${field.type} != ${value.javaClass}")
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                throw GradleException("Could not load the value of field '${beanType.name}.$fieldName'.", e)
+            }
+        }
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.IConventionAware
+import org.gradle.api.provider.Property
+import org.gradle.internal.serialize.Encoder
+import java.lang.reflect.Field
+import java.util.function.Supplier
+
+
+/**
+ * Serializes a bean by serializing the value of each of its fields.
+ */
+class BeanFieldSerializer(private val bean: Any, private val fields: Sequence<Field>, private val stateSerializer: StateSerializer) : ValueSerializer {
+    override fun invoke(encoder: Encoder, listener: SerializationListener) {
+        encoder.apply {
+            for (field in fields) {
+                field.isAccessible = true
+                val fieldValue = field.get(bean)
+                val conventionalValue = fieldValue ?: conventionalValueOf(bean, field.name)
+                val finalValue = unpack(conventionalValue) ?: continue
+                val valueSerializer = stateSerializer.serializerFor(finalValue)
+                if (valueSerializer == null) {
+                    listener.logFieldWarning("serialize", bean.javaClass, field.name, "there's no serializer for type '${finalValue.javaClass.name}'")
+                    continue
+                }
+                writeString(field.name)
+                try {
+                    valueSerializer(this, listener)
+                } catch (e: Exception) {
+                    throw GradleException("Could not save the value of field '${bean.javaClass.name}.${field.name}'.", e)
+                }
+                listener.logFieldSerialization("serialize", bean.javaClass, field.name, finalValue)
+            }
+            writeString("")
+        }
+    }
+
+    private
+    fun conventionalValueOf(task: Any, fieldName: String): Any? {
+        if (task is IConventionAware) {
+            return task.conventionMapping.getConventionValue(null, fieldName, false)
+        } else {
+            return null
+        }
+    }
+
+    private
+    fun unpack(fieldValue: Any?) = when (fieldValue) {
+        is DirectoryProperty -> fieldValue.asFile.orNull
+        is RegularFileProperty -> fieldValue.asFile.orNull
+        is Property<*> -> fieldValue.orNull
+        is Supplier<*> -> fieldValue.get()
+        is Function0<*> -> (fieldValue as (() -> Any?)).invoke()
+        else -> fieldValue
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -101,6 +101,7 @@ class DefaultInstantExecution(
         KryoBackedDecoder(instantExecutionStateFile.inputStream()).use { decoder ->
             val rootProjectName = decoder.readString()
             val build = host.createBuild(rootProjectName)
+            loadRelevantProjects(decoder, build)
             build.autoApplyPlugins()
             build.scheduleTasks(loadTasksFor(decoder, build))
         }
@@ -112,9 +113,9 @@ class DefaultInstantExecution(
         KryoBackedEncoder(instantExecutionStateFile.outputStream()).use { encoder ->
             encoder.writeString(build.rootProject.name)
             val scheduledTasks = build.scheduledTasks
+            saveRelevantProjectsFor(scheduledTasks, encoder)
             val relevantClassPath = classPathFor(scheduledTasks)
             encoder.serializeClassPath(relevantClassPath)
-            saveRelevantProjectsFor(scheduledTasks, encoder)
             encoder.serializeCollection(scheduledTasks) { task ->
                 encoder.saveStateOf(task, build)
             }
@@ -122,7 +123,7 @@ class DefaultInstantExecution(
     }
 
     private
-    fun saveRelevantProjectsFor(tasks: List<Task>, encoder: KryoBackedEncoder) {
+    fun saveRelevantProjectsFor(tasks: List<Task>, encoder: Encoder) {
         encoder.serializeCollection(fillTheGapsOf(relevantProjectsFor(tasks))) {
             encoder.writeString(it.path)
         }
@@ -133,6 +134,13 @@ class DefaultInstantExecution(
         tasks.mapNotNull { task ->
             task.project.takeIf { it.parent != null }?.path?.let(Path::path)
         }.toSortedSet()
+
+    private
+    fun loadRelevantProjects(decoder: Decoder, build: InstantExecutionBuild) {
+        decoder.deserializeCollection {
+            build.createProject(decoder.readString())
+        }
+    }
 
     private
     fun loadTasksFor(decoder: Decoder, build: InstantExecutionBuild): List<Task> {
@@ -155,9 +163,6 @@ class DefaultInstantExecution(
     fun loadTasksWithDependenciesFor(decoder: Decoder, build: InstantExecutionBuild): List<Pair<Task, List<String>>> {
         val classPath = decoder.deserializeClassPath()
         val taskClassLoader = classLoaderFor(classPath)
-        decoder.deserializeCollection {
-            build.createProject(decoder.readString())
-        }
 
         build.registerProjects()
 
@@ -180,7 +185,7 @@ class DefaultInstantExecution(
         task.javaClass.classLoader.let(ClasspathUtil::getClasspath)
 
     private
-    fun KryoBackedEncoder.saveStateOf(task: Task, build: ClassicModeBuild) {
+    fun Encoder.saveStateOf(task: Task, build: ClassicModeBuild) {
         val taskType = GeneratedSubclasses.unpack(task.javaClass)
         writeString(task.project.path)
         writeString(task.name)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -25,7 +25,6 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.internal.GeneratedSubclasses
-import org.gradle.api.internal.IConventionAware
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
@@ -194,38 +193,7 @@ class DefaultInstantExecution(
             writeString(it.path)
         }
 
-        for (field in relevantStateOf(taskType)) {
-            val fieldValue = field.getFieldValue(task)
-            val conventionalValue = fieldValue ?: conventionalValueOf(task, field.name)
-            val finalValue = unpack(conventionalValue) ?: continue
-            val valueSerializer = stateSerializer.serializerFor(finalValue)
-            if (valueSerializer == null) {
-                logFieldWarning("serialize", task.path, taskType.name, field.name, "there's no serializer for type '${finalValue.javaClass.name}'")
-                continue
-            }
-            writeString(field.name)
-            try {
-                valueSerializer(this)
-            } catch (e: Exception) {
-                throw GradleException("Could not save the value of field '${taskType.name}.${field.name}' of task ${task.path}.", e)
-            }
-            logFieldSerialization("serialize", task.path, taskType.name, field.name, finalValue)
-        }
-        writeString("")
-    }
-
-    private
-    fun conventionalValueOf(task: Task, fieldName: String): Any? =
-        (task as IConventionAware).conventionMapping.getConventionValue(null, fieldName, false)
-
-    private
-    fun unpack(fieldValue: Any?) = when (fieldValue) {
-        is DirectoryProperty -> fieldValue.asFile.orNull
-        is RegularFileProperty -> fieldValue.asFile.orNull
-        is Property<*> -> fieldValue.orNull
-        is Supplier<*> -> fieldValue.get()
-        is Function0<*> -> (fieldValue as (() -> Any?)).invoke()
-        else -> fieldValue
+        BeanFieldSerializer(task, relevantStateOf(taskType), stateSerializer).invoke(this, SerializationListener(task, logger))
     }
 
     private
@@ -244,6 +212,7 @@ class DefaultInstantExecution(
         val task = build.createTask(projectPath, taskName, taskClass)
         val taskDependencies = decoder.deserializeStrings()
         val deserializer = host.deserializerFor(taskClassLoader)
+        val listener = SerializationListener(task, logger)
         while (true) {
             val fieldName = decoder.readString()
             if (fieldName.isEmpty()) {
@@ -252,7 +221,7 @@ class DefaultInstantExecution(
             try {
                 val value = deserializer.read(decoder) ?: continue
                 val field = taskFieldsByName.getValue(fieldName)
-                logFieldSerialization("deserialize", task.path, typeName, fieldName, value)
+                listener.logFieldSerialization("deserialize", taskClass, fieldName, value)
                 @Suppress("unchecked_cast")
                 when (field.type) {
                     DirectoryProperty::class.java -> (field.getFieldValue(task) as? DirectoryProperty)?.set(value as File)
@@ -264,7 +233,7 @@ class DefaultInstantExecution(
                         if (field.type.isAssignableFrom(value.javaClass)) {
                             field.setValue(task, value)
                         } else {
-                            logFieldWarning("deserialize", "$projectPath:$taskName", typeName, fieldName, "${field.type} != ${value.javaClass}")
+                            listener.logFieldWarning("deserialize", taskClass, fieldName, "${field.type} != ${value.javaClass}")
                         }
                     }
                 }
@@ -316,20 +285,6 @@ class DefaultInstantExecution(
         AbstractTask::class.java,
         ConventionTask::class.java
     )
-
-    private
-    fun logFieldSerialization(actionName: String, taskPath: String, taskType: String, fieldName: String?, value: Any?) =
-        logger.info(
-            "instant-execution > task '{}' field '{}.{}' {}d value '{}'",
-            taskPath, taskType, fieldName, actionName, value
-        )
-
-    private
-    fun logFieldWarning(actionName: String, taskPath: String, taskType: String, fieldName: String?, reason: String) =
-        logger.warn(
-            "instant-execution > task '{}' field '{}.{}' cannot be {}d because {}.",
-            taskPath, taskType, fieldName, actionName, reason
-        )
 
     private
     val isInstantExecutionEnabled: Boolean

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SerializationListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SerializationListener.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.Task
+import org.slf4j.Logger
+
+
+class SerializationListener(private val owner: Task, private val logger: Logger) {
+    fun logFieldWarning(action: String, type: Class<*>, fieldName: String, message: String) {
+        logger.warn(
+            "instant-execution > task '{}' field '{}.{}' cannot be {}d because {}.",
+            owner.path, type.name, fieldName, action, message
+        )
+    }
+
+    fun logFieldSerialization(action: String, type: Class<*>, fieldName: String, value: Any?) {
+        logger.info(
+            "instant-execution > task '{}' field '{}.{}' {}d value '{}'",
+            owner.path, type.name, fieldName, action, value
+        )
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerialization.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerialization.kt
@@ -16,8 +16,11 @@
 
 package org.gradle.instantexecution
 
+import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.file.FileCollection
+import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.file.DefaultCompositeFileTree
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
@@ -30,6 +33,7 @@ import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.internal.file.copy.DestinationRootCopySpec
+import org.gradle.api.invocation.Gradle
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.serialize.BaseSerializerFactory
@@ -38,13 +42,12 @@ import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.ListSerializer
 import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.serialize.SetSerializer
-
+import org.slf4j.LoggerFactory
 import java.io.File
-
 import java.lang.reflect.Modifier
-
 import java.util.ArrayList
 import java.util.LinkedHashSet
+import kotlin.reflect.KClass
 
 
 class StateSerialization(
@@ -107,7 +110,17 @@ class StateSerialization(
             }
             is DefaultCopySpec -> defaultCopySpecSerializerFor(value)
             is DestinationRootCopySpec -> destinationRootCopySpecSerializerFor(value)
+            is Project -> projectStateType(Project::class)
+            is Gradle -> projectStateType(Gradle::class)
+            is Settings -> projectStateType(Settings::class)
+            is Task -> projectStateType(Task::class)
             else -> if (isBean(value.javaClass)) beanSerializerFor(value) else null
+        }
+
+        private
+        fun projectStateType(type: KClass<*>): ValueSerializer? {
+            LoggerFactory.getLogger(StateSerialization::class.java).warn("instant-execution > Cannot serialize object of type ${type.java.name} as these are not supported with instant execution.")
+            return null
         }
 
         private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerializer.kt
@@ -25,7 +25,7 @@ interface StateSerializer {
 }
 
 
-typealias ValueSerializer = (Encoder) -> Unit
+typealias ValueSerializer = (Encoder, SerializationListener) -> Unit
 
 
 interface StateDeserializer {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerializer.kt
@@ -29,5 +29,5 @@ typealias ValueSerializer = (Encoder, SerializationListener) -> Unit
 
 
 interface StateDeserializer {
-    fun read(decoder: Decoder): Any?
+    fun read(decoder: Decoder, listener: SerializationListener): Any?
 }


### PR DESCRIPTION
### Context

This PR improves the serialization used to write task state to the instant execution cache, to better handle arbitrary objects:

- Write the fields of a "bean" object to the cache.
- Do not run the constructor of a "bean" object when reading.
- Do not write `Project`, `Gradle`, `Settings` or `Task` instances to the cache, but instead emit a warning, as these things hold (or represent part of) the shared project state and should not be referenced by tasks. Later this might become an error.

Only objects whose type has a zero-args constructor are considered "beans". Other unrecognized types are still ignored. This isn't intended to be complete, just an increment.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
