### PR TITLE
Capture more custom task state in the instant execution cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -514,7 +514,7 @@ public class DefaultCopySpec implements CopySpecInternal {
         return this.new DefaultCopySpecResolver(null);
     }
 
-    // TODO:instant-execution
+    // TODO:instant-execution - remove this
     public Set<File> resolveSourceFiles() {
         return fileResolver.resolveFiles(sourcePaths).getFiles();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DestinationRootCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DestinationRootCopySpec.java
@@ -48,7 +48,7 @@ public class DestinationRootCopySpec extends DelegatingCopySpecInternal {
         return destinationDir == null ? null : fileResolver.resolve(destinationDir);
     }
 
-    // TODO:instant-execution
+    // TODO:instant-execution - remove this
     public CopySpecInternal getDelegate() {
         return delegate;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
@@ -241,13 +242,17 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         return new DefaultMemoryManager(osMemoryInfo, jvmMemoryInfo, listenerManager, executorFactory);
     }
 
-    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory) {
+    FilePropertyFactory createFilePropertyFactory(FileResolver fileResolver) {
+        return new DefaultFilePropertyFactory(fileResolver);
+    }
+
+    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory, FilePropertyFactory filePropertyFactory) {
         return new DefaultObjectFactory(
             instantiatorFactory.injectAndDecorate(services),
             NamedObjectInstantiator.INSTANCE,
             fileResolver,
             directoryFileTreeFactory,
-            new DefaultFilePropertyFactory(fileResolver),
+            filePropertyFactory,
             fileCollectionFactory);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
@@ -44,7 +44,7 @@ class ImplementationDependencyRelocator extends Remapper {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     line = line.trim();
-                    // TODO:instant-execution remove kotlin predicate after updating the wrapper
+                    // TODO:instant-execution - remove kotlin predicate after updating the wrapper
                     if (line.length() > 0 && !line.startsWith("kotlin")) {
                         builder.addWord(line);
                     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.internal.reflect.JavaReflectionUtil
 import org.gradle.internal.serialize.Decoder
 import java.io.File
 import java.util.function.Supplier
@@ -46,7 +47,7 @@ class BeanFieldDeserializer(private val bean: Any, private val beanType: Class<*
                     Supplier::class.java -> field.set(bean, Supplier { value })
                     Function0::class.java -> field.set(bean, { value })
                     else -> {
-                        if (field.type.isAssignableFrom(value.javaClass)) {
+                        if (field.type.isInstance(value) || field.type.isPrimitive && JavaReflectionUtil.getWrapperTypeForPrimitiveType(field.type).isInstance(value)) {
                             field.set(bean, value)
                         } else {
                             listener.logFieldWarning("deserialize", beanType, fieldName, "${field.type} != ${value.javaClass}")

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
@@ -36,10 +36,14 @@ class BeanFieldSerializer(private val bean: Any, private val beanType: Class<*>,
                 field.isAccessible = true
                 val fieldValue = field.get(bean)
                 val conventionalValue = fieldValue ?: conventionalValueOf(bean, field.name)
-                val finalValue = unpack(conventionalValue) ?: continue
+                val finalValue = unpack(conventionalValue)
                 val valueSerializer = stateSerializer.serializerFor(finalValue)
                 if (valueSerializer == null) {
-                    listener.logFieldWarning("serialize", beanType, field.name, "there's no serializer for type '${GeneratedSubclasses.unpackType(finalValue).name}'")
+                    if (finalValue == null) {
+                        listener.logFieldWarning("serialize", beanType, field.name, "there's no serializer for null values")
+                    } else {
+                        listener.logFieldWarning("serialize", beanType, field.name, "there's no serializer for type '${GeneratedSubclasses.unpackType(finalValue).name}'")
+                    }
                     continue
                 }
                 writeString(field.name)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -22,6 +22,7 @@ import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.initialization.ClassLoaderIds
@@ -31,16 +32,17 @@ import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache
 import org.gradle.api.internal.project.IProjectFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.tasks.util.internal.PatternSpecFactory
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.initialization.BuildLoader
+import org.gradle.initialization.BuildOperatingFiringSettingsPreparer
+import org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer
 import org.gradle.initialization.BuildOperationSettingsProcessor
 import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.NotifyingBuildLoader
-import org.gradle.initialization.BuildOperatingFiringSettingsPreparer
-import org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer
 import org.gradle.initialization.SettingsLocation
 import org.gradle.initialization.SettingsPreparer
 import org.gradle.initialization.SettingsProcessor
@@ -81,7 +83,9 @@ class InstantExecutionHost internal constructor(
             getService(DirectoryFileTreeFactory::class.java),
             getService(FileCollectionFactory::class.java),
             getService(FileResolver::class.java),
-            getService(Instantiator::class.java)
+            getService(Instantiator::class.java),
+            getService(PatternSpecFactory::class.java),
+            getService(FilePropertyFactory::class.java)
         )
     }
 
@@ -133,7 +137,7 @@ class InstantExecutionHost internal constructor(
                 // Fire build operation required by build scan to determine startup duration and settings evaluated duration
                 val settingsPreparer = BuildOperatingFiringSettingsPreparer(SettingsPreparer {
                     // Nothing to do
-                    // TODO - instant-execution: instead, create and attach the settings object
+                    // TODO:instant-execution - instead, create and attach the settings object
                 }, getService(BuildOperationExecutor::class.java), getService(BuildDefinition::class.java).fromBuild)
                 settingsPreparer.prepareSettings(this)
 
@@ -238,7 +242,7 @@ class InstantExecutionHost internal constructor(
             // This might be better done as a new build operation type
             BuildOperatingFiringTaskExecutionPreparer(TaskExecutionPreparer {
                 // Nothing to do
-                // TODO - instant-execution: prehaps move this so it wraps loading tasks from cache file
+                // TODO:instant-execution - perhaps move this so it wraps loading tasks from cache file
             }, getService(BuildOperationExecutor::class.java)).prepareForTaskExecution(gradle)
         }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SerializationListener.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SerializationListener.kt
@@ -30,7 +30,7 @@ class SerializationListener(private val owner: Task, private val logger: Logger)
 
     fun logFieldSerialization(action: String, type: Class<*>, fieldName: String, value: Any?) {
         logger.info(
-            "instant-execution > task '{}' field '{}.{}' {}d value '{}'",
+            "instant-execution > task '{}' field '{}.{}' {}d value {}",
             owner.path, type.name, fieldName, action, value
         )
     }


### PR DESCRIPTION
### Context

This PR changes task state for the instant execution cache, so that objects of any unrecognized type are treated as "beans" and their fields serialized. Previously only objects whose type has a zero-args constructor were treated as "beans".

While this change means more stuff can be serialized, it also is broken for a bunch of types (e.g. `Class` or most Gradle services), and cycles are not supported (but were not previously either). These will be fixed in later PRs, as needed.

Also:
- Handle fields with `Integer`, `Long`, `Boolean` and associated primitive types.
- Handle fields with `Set` and some `Map` implementations.
- Better handle fields with `Property`, `DirectoryProperty` and `RegularFileProperty` type, including those with no value.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
