### PR TITLE
Improve serialization of custom task state to instant execution cache

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -190,6 +190,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
                     bean = new SomeBean("default")
                     bean.parent = new SomeBean("parent")
                     bean.parent.child = bean
+                    bean.parent.parent = bean.parent
                 }
 
                 @TaskAction
@@ -267,6 +268,8 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         int.name               | "12"                     | "12"
         Long.name              | "12"                     | "12"
         long.name              | "12"                     | "12"
+        Double.name            | "12.1"                   | "12.1"
+        double.name            | "12.1"                   | "12.1"
         Class.name             | "SomeBean"               | "class SomeBean"
         "List<String>"         | "['a', 'b', 'c']"        | "[a, b, c]"
         "Set<String>"          | "['a', 'b', 'c'] as Set" | "[a, b, c]"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
@@ -21,7 +21,9 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.provider.DefaultPropertyState
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.internal.reflect.JavaReflectionUtil
 import org.gradle.internal.serialize.Decoder
 import java.io.File
@@ -62,6 +64,14 @@ class BeanFieldDeserializer(
                         val property = DefaultPropertyState<Any>(Any::class.java)
                         property.set(value)
                         field.set(bean, property)
+                    }
+                    Provider::class.java -> {
+                        val provider = if (value == null) {
+                            Providers.notDefined()
+                        } else {
+                            Providers.of(value)
+                        }
+                        field.set(bean, provider)
                     }
                     Supplier::class.java -> field.set(bean, Supplier { value })
                     Function0::class.java -> field.set(bean, { value })

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
@@ -65,6 +65,7 @@ class BeanFieldDeserializer(
                     }
                     Supplier::class.java -> field.set(bean, Supplier { value })
                     Function0::class.java -> field.set(bean, { value })
+                    Lazy::class.java -> field.set(bean, lazyOf(value))
                     else -> {
                         if (field.type.isInstance(value) || field.type.isPrimitive && JavaReflectionUtil.getWrapperTypeForPrimitiveType(field.type).isInstance(value)) {
                             field.set(bean, value)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldDeserializer.kt
@@ -36,7 +36,7 @@ class BeanFieldDeserializer(
     private val deserializer: StateDeserializer,
     private val filePropertyFactory: FilePropertyFactory
 ) {
-    fun deserialize(decoder: Decoder, listener: SerializationListener) {
+    fun deserialize(decoder: Decoder, listener: DeserializationContext) {
         val fieldsByName = relevantStateOf(beanType).associateBy { it.name }
         while (true) {
             val fieldName = decoder.readString()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
@@ -31,7 +31,7 @@ import java.util.function.Supplier
  * Serializes a bean by serializing the value of each of its fields.
  */
 class BeanFieldSerializer(private val bean: Any, private val beanType: Class<*>, private val stateSerializer: StateSerializer) : ValueSerializer {
-    override fun invoke(encoder: Encoder, listener: SerializationListener) {
+    override fun invoke(encoder: Encoder, listener: SerializationContext) {
         encoder.apply {
             for (field in relevantStateOf(beanType)) {
                 field.isAccessible = true

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
@@ -74,6 +74,7 @@ class BeanFieldSerializer(private val bean: Any, private val beanType: Class<*>,
         is Property<*> -> fieldValue.orNull
         is Supplier<*> -> fieldValue.get()
         is Function0<*> -> (fieldValue as (() -> Any?)).invoke()
+        is Lazy<*> -> fieldValue.value
         else -> fieldValue
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
@@ -22,6 +22,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.internal.serialize.Encoder
 import java.util.function.Supplier
 
@@ -72,6 +73,7 @@ class BeanFieldSerializer(private val bean: Any, private val beanType: Class<*>,
         is DirectoryProperty -> fieldValue.asFile.orNull
         is RegularFileProperty -> fieldValue.asFile.orNull
         is Property<*> -> fieldValue.orNull
+        is Provider<*> -> fieldValue.orNull
         is Supplier<*> -> fieldValue.get()
         is Function0<*> -> (fieldValue as (() -> Any?)).invoke()
         is Lazy<*> -> fieldValue.value

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/BeanFieldSerializer.kt
@@ -50,8 +50,8 @@ class BeanFieldSerializer(private val bean: Any, private val beanType: Class<*>,
                 writeString(field.name)
                 try {
                     valueSerializer(this, listener)
-                } catch (e: Exception) {
-                    throw GradleException("Could not save the value of field '${beanType.name}.${field.name}'.", e)
+                } catch (e: Throwable) {
+                    throw GradleException("Could not save the value of field '${beanType.name}.${field.name}' with type ${finalValue?.javaClass?.name}.", e)
                 }
                 listener.logFieldSerialization("serialize", beanType, field.name, finalValue)
             }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -115,7 +115,7 @@ class DefaultInstantExecution(
             encoder.serializeCollection(scheduledTasks) { task ->
                 try {
                     encoder.saveStateOf(task, build)
-                } catch (e: Exception) {
+                } catch (e: Throwable) {
                     throw GradleException("Could not save state of $task.", e)
                 }
             }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -197,7 +197,7 @@ class DefaultInstantExecution(
             writeString(it.path)
         }
 
-        BeanFieldSerializer(task, taskType, stateSerializer).invoke(this, SerializationListener(task, logger))
+        BeanFieldSerializer(task, taskType, stateSerializer).invoke(this, SerializationContext(task, logger))
     }
 
     private
@@ -209,8 +209,8 @@ class DefaultInstantExecution(
         val task = build.createTask(projectPath, taskName, taskClass)
         val taskDependencies = decoder.deserializeStrings()
         val deserializer = host.deserializerFor(taskClassLoader)
-        val listener = SerializationListener(task, logger)
-        BeanFieldDeserializer(task, taskClass, deserializer, filePropertyFactory).deserialize(decoder, listener)
+        val context = DeserializationContext(task, logger)
+        BeanFieldDeserializer(task, taskClass, deserializer, filePropertyFactory).deserialize(decoder, context)
         return task to taskDependencies
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DeserializationContext.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DeserializationContext.kt
@@ -16,18 +16,18 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.internal.serialize.Decoder
-import org.gradle.internal.serialize.Encoder
+import org.gradle.api.Task
+import org.slf4j.Logger
+import java.util.IdentityHashMap
 
 
-interface StateSerializer {
-    fun serializerFor(value: Any?): ValueSerializer?
-}
+class DeserializationContext(owner: Task, logger: Logger) : StateContext(owner, logger) {
+    private
+    val instanceIds = IdentityHashMap<Int, Any>()
 
+    fun getInstance(id: Int) = instanceIds[id]
 
-typealias ValueSerializer = (Encoder, SerializationContext) -> Unit
-
-
-interface StateDeserializer {
-    fun read(decoder: Decoder, context: DeserializationContext): Any?
+    fun putInstance(id: Int, instance: Any) {
+        instanceIds[id] = instance
+    }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -32,6 +32,7 @@ import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache
 import org.gradle.api.internal.project.IProjectFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.util.internal.PatternSpecFactory
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
 import org.gradle.groovy.scripts.StringScriptSource
@@ -84,6 +85,7 @@ class InstantExecutionHost internal constructor(
             getService(FileCollectionFactory::class.java),
             getService(FileResolver::class.java),
             getService(Instantiator::class.java),
+            getService(ObjectFactory::class.java),
             getService(PatternSpecFactory::class.java),
             getService(FilePropertyFactory::class.java)
         )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SerializationContext.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SerializationContext.kt
@@ -18,20 +18,18 @@ package org.gradle.instantexecution
 
 import org.gradle.api.Task
 import org.slf4j.Logger
+import java.util.IdentityHashMap
 
 
-class SerializationListener(private val owner: Task, private val logger: Logger) {
-    fun logFieldWarning(action: String, type: Class<*>, fieldName: String, message: String) {
-        logger.warn(
-            "instant-execution > task '{}' field '{}.{}' cannot be {}d because {}.",
-            owner.path, type.name, fieldName, action, message
-        )
-    }
+class SerializationContext(owner: Task, logger: Logger) : StateContext(owner, logger) {
+    private
+    val instanceIds = IdentityHashMap<Any, Int>()
 
-    fun logFieldSerialization(action: String, type: Class<*>, fieldName: String, value: Any?) {
-        logger.info(
-            "instant-execution > task '{}' field '{}.{}' {}d value {}",
-            owner.path, type.name, fieldName, action, value
-        )
+    fun getId(instance: Any) = instanceIds[instance]
+
+    fun putInstance(instance: Any): Int {
+        val id = instanceIds.size
+        instanceIds[instance] = id
+        return id
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateContext.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateContext.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.Task
+import org.slf4j.Logger
+
+
+open class StateContext(private val owner: Task, private val logger: Logger) {
+    fun logFieldWarning(action: String, type: Class<*>, fieldName: String, message: String) {
+        logger.warn(
+            "instant-execution > task '{}' field '{}.{}' cannot be {}d because {}.",
+            owner.path, type.name, fieldName, action, message
+        )
+    }
+
+    fun logFieldSerialization(action: String, type: Class<*>, fieldName: String, value: Any?) {
+        logger.info(
+            "instant-execution > task '{}' field '{}.{}' {}d value {}",
+            owner.path, type.name, fieldName, action, value
+        )
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerialization.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerialization.kt
@@ -79,6 +79,9 @@ class StateSerialization(
     val byteSerializer = BaseSerializerFactory.BYTE_SERIALIZER
 
     private
+    val doubleSerializer = BaseSerializerFactory.DOUBLE_SERIALIZER
+
+    private
     val booleanSerializer = BaseSerializerFactory.BOOLEAN_SERIALIZER
 
     private
@@ -111,6 +114,9 @@ class StateSerialization(
             }
             is Byte -> { encoder, _ ->
                 encoder.writeWithTag(BYTE_TYPE, byteSerializer, value)
+            }
+            is Double -> { encoder, _ ->
+                encoder.writeWithTag(DOUBLE_TYPE, doubleSerializer, value)
             }
             is FileTreeInternal -> { encoder, _ ->
                 encoder.writeWithTag(FILE_TREE_TYPE, fileTreeSerializer, value)
@@ -145,6 +151,9 @@ class StateSerialization(
             }
             is FileResolver -> { encoder, _ ->
                 encoder.writeByte(FILE_RESOLVER_TYPE)
+            }
+            is FileCollectionFactory -> { encoder, _ ->
+                encoder.writeByte(FILE_COLLECTION_FACTORY_TYPE)
             }
             is DefaultCopySpec -> defaultCopySpecSerializerFor(value)
             is DestinationRootCopySpec -> destinationRootCopySpecSerializerFor(value)
@@ -227,6 +236,7 @@ class StateSerialization(
             INT_TYPE -> integerSerializer.read(decoder)
             LONG_TYPE -> longSerializer.read(decoder)
             BYTE_TYPE -> byteSerializer.read(decoder)
+            DOUBLE_TYPE -> doubleSerializer.read(decoder)
             FILE_TYPE -> BaseSerializerFactory.FILE_SERIALIZER.read(decoder)
             CLASS_TYPE -> beanClassLoader.loadClass(decoder.readString())
             LIST_TYPE -> deserializeCollection(decoder, context) { ArrayList<Any?>(it) }
@@ -241,6 +251,7 @@ class StateSerialization(
             OBJECT_FACTORY_TYPE -> objectFactory
             FILE_RESOLVER_TYPE -> fileResolver
             PATTERN_SPEC_FACTORY_TYPE -> patternSpecFactory
+            FILE_COLLECTION_FACTORY_TYPE -> fileCollectionFactory
             DEFAULT_COPY_SPEC -> deserializeDefaultCopySpec(decoder, context)
             DESTINATION_ROOT_COPY_SPEC -> deserializeDestinationRootCopySpec(decoder, context)
             BEAN -> deserializeBean(decoder, context, beanClassLoader)
@@ -349,27 +360,29 @@ class StateSerialization(
         const val BYTE_TYPE: Byte = 3
         const val INT_TYPE: Byte = 4
         const val LONG_TYPE: Byte = 5
-        const val LIST_TYPE: Byte = 6
-        const val SET_TYPE: Byte = 7
-        const val MAP_TYPE: Byte = 8
-        const val FILE_TYPE: Byte = 9
-        const val CLASS_TYPE: Byte = 10
-        const val BEAN: Byte = 11
+        const val DOUBLE_TYPE: Byte = 6
+        const val LIST_TYPE: Byte = 7
+        const val SET_TYPE: Byte = 8
+        const val MAP_TYPE: Byte = 9
+        const val FILE_TYPE: Byte = 10
+        const val CLASS_TYPE: Byte = 11
+        const val BEAN: Byte = 12
 
         // Logging type
-        const val LOGGER_TYPE: Byte = 12
+        const val LOGGER_TYPE: Byte = 13
 
         // Gradle types
-        const val FILE_TREE_TYPE: Byte = 13
-        const val FILE_COLLECTION_TYPE: Byte = 14
-        const val ARTIFACT_COLLECTION_TYPE: Byte = 15
-        const val OBJECT_FACTORY_TYPE: Byte = 16
+        const val FILE_TREE_TYPE: Byte = 14
+        const val FILE_COLLECTION_TYPE: Byte = 15
+        const val ARTIFACT_COLLECTION_TYPE: Byte = 16
+        const val OBJECT_FACTORY_TYPE: Byte = 17
 
         // Internal Gradle types
-        const val FILE_RESOLVER_TYPE: Byte = 17
-        const val PATTERN_SPEC_FACTORY_TYPE: Byte = 18
-        const val DEFAULT_COPY_SPEC: Byte = 19
-        const val DESTINATION_ROOT_COPY_SPEC: Byte = 20
+        const val FILE_RESOLVER_TYPE: Byte = 18
+        const val PATTERN_SPEC_FACTORY_TYPE: Byte = 19
+        const val FILE_COLLECTION_FACTORY_TYPE: Byte = 20
+        const val DEFAULT_COPY_SPEC: Byte = 21
+        const val DESTINATION_ROOT_COPY_SPEC: Byte = 22
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerialization.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateSerialization.kt
@@ -76,6 +76,9 @@ class StateSerialization(
     val longSerializer = BaseSerializerFactory.LONG_SERIALIZER
 
     private
+    val byteSerializer = BaseSerializerFactory.BYTE_SERIALIZER
+
+    private
     val booleanSerializer = BaseSerializerFactory.BOOLEAN_SERIALIZER
 
     private
@@ -105,6 +108,9 @@ class StateSerialization(
             }
             is Long -> { encoder, _ ->
                 encoder.writeWithTag(LONG_TYPE, longSerializer, value)
+            }
+            is Byte -> { encoder, _ ->
+                encoder.writeWithTag(BYTE_TYPE, byteSerializer, value)
             }
             is FileTreeInternal -> { encoder, _ ->
                 encoder.writeWithTag(FILE_TREE_TYPE, fileTreeSerializer, value)
@@ -214,6 +220,7 @@ class StateSerialization(
             BOOLEAN_TYPE -> booleanSerializer.read(decoder)
             INT_TYPE -> integerSerializer.read(decoder)
             LONG_TYPE -> longSerializer.read(decoder)
+            BYTE_TYPE -> byteSerializer.read(decoder)
             FILE_TYPE -> BaseSerializerFactory.FILE_SERIALIZER.read(decoder)
             CLASS_TYPE -> beanClassLoader.loadClass(decoder.readString())
             LIST_TYPE -> deserializeCollection(decoder, listener) { ArrayList<Any?>(it) }
@@ -327,29 +334,30 @@ class StateSerialization(
         const val NULL_VALUE: Byte = 0
         const val STRING_TYPE: Byte = 1
         const val BOOLEAN_TYPE: Byte = 2
-        const val INT_TYPE: Byte = 3
-        const val LONG_TYPE: Byte = 4
-        const val LIST_TYPE: Byte = 5
-        const val SET_TYPE: Byte = 6
-        const val MAP_TYPE: Byte = 7
-        const val FILE_TYPE: Byte = 8
-        const val CLASS_TYPE: Byte = 9
-        const val BEAN: Byte = 10
+        const val BYTE_TYPE: Byte = 3
+        const val INT_TYPE: Byte = 4
+        const val LONG_TYPE: Byte = 5
+        const val LIST_TYPE: Byte = 6
+        const val SET_TYPE: Byte = 7
+        const val MAP_TYPE: Byte = 8
+        const val FILE_TYPE: Byte = 9
+        const val CLASS_TYPE: Byte = 10
+        const val BEAN: Byte = 11
 
         // Logging type
-        const val LOGGER_TYPE: Byte = 11
+        const val LOGGER_TYPE: Byte = 12
 
         // Gradle types
-        const val FILE_TREE_TYPE: Byte = 12
-        const val FILE_COLLECTION_TYPE: Byte = 13
-        const val ARTIFACT_COLLECTION_TYPE: Byte = 14
-        const val OBJECT_FACTORY_TYPE: Byte = 15
+        const val FILE_TREE_TYPE: Byte = 13
+        const val FILE_COLLECTION_TYPE: Byte = 14
+        const val ARTIFACT_COLLECTION_TYPE: Byte = 15
+        const val OBJECT_FACTORY_TYPE: Byte = 16
 
         // Internal Gradle types
-        const val FILE_RESOLVER_TYPE: Byte = 16
-        const val PATTERN_SPEC_FACTORY_TYPE: Byte = 17
-        const val DEFAULT_COPY_SPEC: Byte = 18
-        const val DESTINATION_ROOT_COPY_SPEC: Byte = 19
+        const val FILE_RESOLVER_TYPE: Byte = 17
+        const val PATTERN_SPEC_FACTORY_TYPE: Byte = 18
+        const val DEFAULT_COPY_SPEC: Byte = 19
+        const val DESTINATION_ROOT_COPY_SPEC: Byte = 20
     }
 }
 


### PR DESCRIPTION
### Context

This PR adds support for serializing more task state to the instant execution cache:

- Handle cycles in a "bean" object graph. Also preserve identity of "bean" instances for a given task instance. Identity is not preserved across task instances, to keep tasks isolated from each other.
- Handle fields with type `Byte`, `byte`, `Double`, `double` or `Class`
- Handle fields with `Logger` and `ObjectFactory` service types
- Handle fields with `Provider<T>` type.
- Handle lazy kotlin properties.

Nested "lazy" types are not handled particularly well (eg a lazy kotlin property of type `Provider<T>`) nor are broken lazy types (eg a `Provider<T>` whose `get()` method fails).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
