### PR TITLE
Improvements to task state serialization to instant execution cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -20,7 +20,10 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
+import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.reflect.Instantiator;
+
+import javax.annotation.Nullable;
 
 /**
  * A {@link ITaskFactory} which determines task actions, inputs and outputs based on annotation attached to the task properties. Also provides some validation based on these annotations.
@@ -37,13 +40,13 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
     }
 
     @Override
-    public ITaskFactory createChild(ProjectInternal project, Instantiator childInstantiator) {
-        return new AnnotationProcessingTaskFactory(instantiator, taskClassInfoStore, taskFactory.createChild(project, childInstantiator));
+    public ITaskFactory createChild(ProjectInternal project, InstantiationScheme instantiationScheme) {
+        return new AnnotationProcessingTaskFactory(instantiator, taskClassInfoStore, taskFactory.createChild(project, instantiationScheme));
     }
 
     @Override
-    public <S extends Task> S create(TaskIdentity<S> taskIdentity, Object... args) {
-        return process(taskFactory.create(taskIdentity, args));
+    public <S extends Task> S create(TaskIdentity<S> taskIdentity, @Nullable Object[] constructorArgs) {
+        return process(taskFactory.create(taskIdentity, constructorArgs));
     }
 
     private <S extends Task> S process(S task) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/ITaskFactory.java
@@ -17,10 +17,15 @@ package org.gradle.api.internal.project.taskfactory;
 
 import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.instantiation.InstantiationScheme;
+
+import javax.annotation.Nullable;
 
 public interface ITaskFactory {
-    ITaskFactory createChild(ProjectInternal project, Instantiator instantiator);
+    ITaskFactory createChild(ProjectInternal project, InstantiationScheme instantiationScheme);
 
-    <S extends Task> S create(TaskIdentity<S> taskIdentity, Object... args);
+    /**
+     * @param constructorArgs null == do not invoke constructor, empty == invoke constructor with no args, non-empty = invoke constructor with args
+     */
+    <S extends Task> S create(TaskIdentity<S> taskIdentity, @Nullable Object[] constructorArgs);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/PropertyAssociationTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/PropertyAssociationTaskFactory.java
@@ -26,7 +26,7 @@ import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.tasks.FileNormalizer;
-import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.instantiation.InstantiationScheme;
 
 import javax.annotation.Nullable;
 
@@ -40,13 +40,13 @@ public class PropertyAssociationTaskFactory implements ITaskFactory {
     }
 
     @Override
-    public ITaskFactory createChild(ProjectInternal project, Instantiator instantiator) {
-        return new PropertyAssociationTaskFactory(delegate.createChild(project, instantiator), propertyWalker);
+    public ITaskFactory createChild(ProjectInternal project, InstantiationScheme instantiationScheme) {
+        return new PropertyAssociationTaskFactory(delegate.createChild(project, instantiationScheme), propertyWalker);
     }
 
     @Override
-    public <S extends Task> S create(TaskIdentity<S> taskIdentity, Object... args) {
-        final S task = delegate.create(taskIdentity, args);
+    public <S extends Task> S create(TaskIdentity<S> taskIdentity, @Nullable Object[] constructorArgs) {
+        final S task = delegate.create(taskIdentity, constructorArgs);
         TaskPropertyUtils.visitProperties(propertyWalker, (TaskInternal) task, new Listener(task));
         return task;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskFactory.java
@@ -22,31 +22,32 @@ import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.api.tasks.TaskInstantiationException;
-import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.util.NameValidator;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 
 public class TaskFactory implements ITaskFactory {
     private final ProjectInternal project;
-    private final Instantiator instantiator;
+    private final InstantiationScheme instantiationScheme;
 
     public TaskFactory() {
         this(null, null);
     }
 
-    private TaskFactory(ProjectInternal project, Instantiator instantiator) {
+    private TaskFactory(ProjectInternal project, InstantiationScheme instantiationScheme) {
         this.project = project;
-        this.instantiator = instantiator;
+        this.instantiationScheme = instantiationScheme;
     }
 
     @Override
-    public ITaskFactory createChild(ProjectInternal project, Instantiator instantiator) {
-        return new TaskFactory(project, instantiator);
+    public ITaskFactory createChild(ProjectInternal project, InstantiationScheme instantiationScheme) {
+        return new TaskFactory(project, instantiationScheme);
     }
 
     @Override
-    public <S extends Task> S create(final TaskIdentity<S> identity, final Object... args) {
+    public <S extends Task> S create(final TaskIdentity<S> identity, @Nullable final Object[] constructorArgs) {
         if (!Task.class.isAssignableFrom(identity.type)) {
             throw new InvalidUserDataException(String.format(
                 "Cannot create task of type '%s' as it does not implement the Task interface.",
@@ -55,18 +56,24 @@ public class TaskFactory implements ITaskFactory {
 
         NameValidator.validate(identity.name, "task name", "");
 
-        final Class<? extends Task> implType;
+        final Class<? extends AbstractTask> implType;
         if (identity.type.isAssignableFrom(DefaultTask.class)) {
             implType = DefaultTask.class;
         } else {
-            implType = identity.type;
+            implType = identity.type.asSubclass(AbstractTask.class);
         }
 
         return AbstractTask.injectIntoNewInstance(project, identity, new Callable<S>() {
             @Override
             public S call() {
                 try {
-                    return identity.type.cast(instantiator.newInstance(implType, args));
+                    Task instance;
+                    if (constructorArgs != null) {
+                        instance = instantiationScheme.instantiator().newInstance(implType, constructorArgs);
+                    } else {
+                        instance = instantiationScheme.deserializationInstantiator().newInstance(implType, AbstractTask.class);
+                    }
+                    return identity.type.cast(instance);
                 } catch (ObjectInstantiationException e) {
                     throw new TaskInstantiationException(String.format("Could not create task of type '%s'.", identity.type.getSimpleName()),
                         e.getCause());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskInstantiator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskInstantiator.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.model.internal.core.NamedEntityInstantiator;
 
 public class TaskInstantiator implements NamedEntityInstantiator<Task> {
+    private static final Object[] NO_PARAMS = new Object[0];
     private final ITaskFactory taskFactory;
     private final ProjectInternal project;
 
@@ -31,6 +32,6 @@ public class TaskInstantiator implements NamedEntityInstantiator<Task> {
 
     @Override
     public <S extends Task> S create(String name, Class<S> type) {
-        return taskFactory.create(TaskIdentity.create(name, type, project));
+        return taskFactory.create(TaskIdentity.create(name, type, project), NO_PARAMS);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskContainerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskContainerInternal.java
@@ -58,4 +58,11 @@ public interface TaskContainerInternal extends TaskContainer, TaskResolver, Poly
      * Adds a previously constructed task into the container.  For internal use with software model bridging.
      */
     boolean addAllInternal(Collection<? extends Task> task);
+
+    /**
+     * Creates an instance of the given task type without invoking its constructors. This is used to recreate a task instance from the instant execution cache.
+     *
+     * TODO:instant-execution - review this
+     */
+    <T extends Task> T createWithoutConstructor(String name, Class<T> type);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -1493,7 +1493,7 @@ class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerS
         thrown(UnsupportedOperationException)
     }
 
-    def factory = new TaskInstantiator(new TaskFactory().createChild(project, TestUtil.instantiatorFactory().decorateLenient()), project)
+    def factory = new TaskInstantiator(new TaskFactory().createChild(project, TestUtil.instantiatorFactory().decorateScheme()), project)
     final SomeTask a = factory.create("a", SomeTask)
     final SomeTask b = factory.create("b", SomeTask)
     final SomeTask c = factory.create("c", SomeTask)

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.api.internal.project.taskfactory.TaskFactory
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.instantiation.InstantiationScheme
 import org.gradle.nativeplatform.internal.DefaultFlavorContainer
 import spock.lang.Shared
 import spock.lang.Specification
@@ -65,7 +65,7 @@ class NameValidatorTest extends Specification {
                 getIdentityPath() >> Path.path(":build:foo:bar")
             }
         }
-        new TaskInstantiator(new TaskFactory(project, Mock(Instantiator)), project).create(name, DefaultTask)
+        new TaskInstantiator(new TaskFactory(project, Mock(InstantiationScheme)), project).create(name, DefaultTask)
 
         then:
         def exception = thrown(InvalidUserDataException)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractSpockTaskTest.groovy
@@ -48,12 +48,12 @@ abstract class AbstractSpockTaskTest extends AbstractProjectBuilderSpec {
         return createTask(type, project, TEST_TASK_NAME)
     }
 
-    Task createTask(Project project, String name) {
+    Task createTask(ProjectInternal project, String name) {
         return createTask(getTask().getClass(), project, name)
     }
 
-    def <T extends AbstractTask> T createTask(Class<T> type, Project project, String name) {
-        Task task = new TaskInstantiator(taskFactory.createChild(project, TestUtil.instantiatorFactory().decorateLenient()), project).create(name, type)
+    def <T extends AbstractTask> T createTask(Class<T> type, ProjectInternal project, String name) {
+        Task task = new TaskInstantiator(taskFactory.createChild(project, TestUtil.instantiatorFactory().decoratingLenientScheme), project).create(name, type)
         assert type.isAssignableFrom(task.getClass())
         return type.cast(task)
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -85,7 +85,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         if (parameterType == TransformParameters.class) {
             throw new VariantTransformConfigurationException(String.format("Could not register transform: must use a sub-type of %s as parameter type. Use %s for transforms without parameters.", ModelType.of(TransformParameters.class).getDisplayName(), ModelType.of(TransformParameters.None.class).getDisplayName()));
         }
-        T parameterObject = parameterType == TransformParameters.None.class ? null : parametersInstantiationScheme.withServices(services).newInstance(parameterType);
+        T parameterObject = parameterType == TransformParameters.None.class ? null : parametersInstantiationScheme.withServices(services).instantiator().newInstance(parameterType);
         TypedRegistration<T> registration = Cast.uncheckedNonnullCast(instantiatorFactory.decorateLenient().newInstance(TypedRegistration.class, parameterObject, immutableAttributesFactory));
         registrationAction.execute(registration);
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -216,7 +216,7 @@ class DefaultInstantExecution(
 
     private
     fun InstantExecutionBuild.createTask(projectPath: String, taskName: String, taskClass: Class<out Task>) =
-        getProject(projectPath).tasks.create(taskName, taskClass)
+        getProject(projectPath).tasks.createWithoutConstructor(taskName, taskClass)
 
     private
     val isInstantExecutionEnabled: Boolean

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateContext.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/StateContext.kt
@@ -20,7 +20,7 @@ import org.gradle.api.Task
 import org.slf4j.Logger
 
 
-open class StateContext(private val owner: Task, private val logger: Logger) {
+open class StateContext(val owner: Task, private val logger: Logger) {
     fun logFieldWarning(action: String, type: Class<*>, fieldName: String, message: String) {
         logger.warn(
             "instant-execution > task '{}' field '{}.{}' cannot be {}d because {}.",

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
@@ -411,6 +411,11 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             }
 
             @Override
+            public Class<?> getGeneratedClass() {
+                return constructor.getDeclaringClass();
+            }
+
+            @Override
             public Class<?>[] getParameterTypes() {
                 return constructor.getParameterTypes();
             }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ClassGenerator.java
@@ -58,6 +58,9 @@ interface ClassGenerator {
          */
         boolean serviceInjectionTriggeredByAnnotation(Class<? extends Annotation> serviceAnnotation);
 
+        //TODO:instant-execution: remove this
+        Class<?> getGeneratedClass();
+
         Class<?>[] getParameterTypes();
 
         Type[] getGenericParameterTypes();

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiatorFactory.java
@@ -57,7 +57,7 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
 
     @Override
     public Instantiator inject(ServiceLookup services) {
-        return injectOnlyScheme.withServices(services);
+        return injectOnlyScheme.withServices(services).instantiator();
     }
 
     @Override
@@ -94,7 +94,7 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
 
     @Override
     public Instantiator injectLenient(ServiceLookup services) {
-        return injectOnlyLenientScheme.withServices(services);
+        return injectOnlyLenientScheme.withServices(services).instantiator();
     }
 
     @Override
@@ -104,7 +104,7 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
 
     @Override
     public Instantiator injectAndDecorateLenient(ServiceLookup services) {
-        return decoratingLenientScheme.withServices(services);
+        return decoratingLenientScheme.withServices(services).instantiator();
     }
 
     @Override
@@ -114,7 +114,7 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
 
     @Override
     public Instantiator injectAndDecorate(ServiceLookup services) {
-        return decoratingScheme.withServices(services);
+        return decoratingScheme.withServices(services).instantiator();
     }
 
     private void assertKnownAnnotation(Class<? extends Annotation> annotation) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DeserializationInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DeserializationInstantiator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instantiation;
+
+import org.gradle.api.reflect.ObjectInstantiationException;
+
+/**
+ * Creates instance of objects in preparation for deserialization of their state.
+ */
+public interface DeserializationInstantiator {
+    /**
+     * Creates an instance of the given type without invoking its constructor. Invokes the constructor of the given base class.
+     *
+     * @throws ObjectInstantiationException On failure to create the new instance.
+     */
+    <T> T newInstance(Class<T> implType, Class<? super T> baseClass) throws ObjectInstantiationException;
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstanceFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstanceFactory.java
@@ -21,7 +21,8 @@ import org.gradle.internal.service.ServiceLookup;
 import java.lang.annotation.Annotation;
 
 /**
- * Creates instances of the given type. This is similar to {@link org.gradle.internal.reflect.Instantiator}, but produces instances of the given type only. This allows it to provides some additional metadata about the type, such as which services it requires, and can potentially produce instances more quickly due to the extra context it holds.
+ * Creates instances of the given type. This is similar to {@link org.gradle.internal.reflect.Instantiator}, but produces instances of the given type only. This allows it to provides some
+ * additional metadata about the type, such as which services it requires, and may be more performant at creating instances due to the extra context it holds.
  */
 public interface InstanceFactory<T> {
     /**

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiationScheme.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 public interface InstantiationScheme {
     /**
-     * Returns the set of annotations that are used by this instantiation scheme for dependency injection.
+     * Returns the set of annotations that are supported by this instantiation scheme for dependency injection.
      */
     Set<Class<? extends Annotation>> getInjectionAnnotations();
 
@@ -39,12 +39,17 @@ public interface InstantiationScheme {
     <T> InstanceFactory<T> forType(Class<T> type);
 
     /**
-     * Creates a new {@link Instantiator} which creates instances using the given services, based on the configuration of this scheme.
+     * Creates a new {@link InstantiationScheme} which creates instances using the given services, based on the configuration of this scheme.
      */
-    Instantiator withServices(ServiceLookup services);
+    InstantiationScheme withServices(ServiceLookup services);
 
     /**
-     * Returns the instantiator which creates instances using a default set of services (usually empty), based on the configuration of this scheme.
+     * Returns the instantiator which creates instances using a default set of services, based on the configuration of this scheme.
      */
     Instantiator instantiator();
+
+    /**
+     * Returns an instantiator that creates instances to be deserialized, based on the configuration of this scheme.
+     */
+    DeserializationInstantiator deserializationInstantiator();
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiationSchemeTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiationSchemeTest.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instantiation
+
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
+import org.gradle.internal.service.DefaultServiceRegistry
+import org.gradle.internal.service.ServiceLookup
+import spock.lang.Specification
+
+import javax.inject.Inject
+import java.lang.reflect.Type
+
+
+class DefaultInstantiationSchemeTest extends Specification {
+    def scheme = new DefaultInstantiationScheme(new Jsr330ConstructorSelector(new IdentityClassGenerator(), new TestCrossBuildInMemoryCacheFactory.TestCache<Class<?>, Jsr330ConstructorSelector.CachedConstructor>()), new DefaultServiceRegistry(), [] as Set)
+
+    def "can specify a set of services to inject"() {
+        def services = Mock(ServiceLookup)
+        _ * services.find((Type) String) >> "value"
+
+        when:
+        def value = scheme.withServices(services).instantiator().newInstance(WithServices)
+
+        then:
+        value.prop == "value"
+    }
+
+    def "can create instances without invoking their constructor"() {
+        when:
+        def value = scheme.deserializationInstantiator().newInstance(Impl, Base)
+
+        then:
+        value.prop == "default"
+    }
+
+    static class Base {
+        String prop
+
+        Base() {
+            prop = "default"
+        }
+    }
+
+    static class Impl extends Base {
+        Impl() {
+            throw new RuntimeException("should not be called")
+        }
+    }
+
+    static class WithServices {
+        String prop
+
+        @Inject
+        WithServices(String value) {
+            prop = value
+        }
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/IdentityClassGenerator.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/IdentityClassGenerator.java
@@ -69,6 +69,11 @@ class IdentityClassGenerator implements ClassGenerator {
                         }
 
                         @Override
+                        public Class<?> getGeneratedClass() {
+                            return constructor.getDeclaringClass();
+                        }
+
+                        @Override
                         public Class<?>[] getParameterTypes() {
                             return constructor.getParameterTypes();
                         }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -199,7 +199,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
             @Override
             public void execute(ProcessResources resourcesTask) {
                 resourcesTask.setDescription("Processes " + resourceSet + ".");
-                new DslObject(resourcesTask).getConventionMapping().map("destinationDir", new Callable<File>() {
+                new DslObject(resourcesTask.getRootSpec()).getConventionMapping().map("destinationDir", new Callable<File>() {
                     @Override
                     public File call() {
                         return sourceSet.getOutput().getResourcesDir();


### PR DESCRIPTION
### Context

This PR changes the instant execution implementation, so that the task constructors are not executed when restoring from the cache. This avoid running any of the task code before its state has been restored, for example, the task registering inputs via the runtime API during deserialization.

Also allow a task to reference itself, and handle short and float types.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
