### PR TITLE
Time out wait when waiting for RETRY on state lock

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
@@ -48,7 +48,7 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
                         case RETRY:
                             resourceLockState.releaseLocks();
                             try {
-                                lock.wait();
+                                lock.wait(5000);
                             } catch (InterruptedException e) {
                                 throw UncheckedException.throwAsUncheckedException(e);
                             }


### PR DESCRIPTION
This way, when we miss an update, at least after 5 seconds we try again
to see if something changed. This is a temporary measure until we found
the root cause why the build does not finish.