### PR TITLE
Rename `ObjectFactory#container` to `domainObjectContainer`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -110,7 +110,7 @@ public interface ObjectFactory {
      * @return The container. Never returns null.
      * @since 5.5
      */
-    <T> NamedDomainObjectContainer<T> container(Class<T> elementType);
+    <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType);
 
     /**
      * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type. The given factory is used to create object instances.</p>
@@ -124,7 +124,7 @@ public interface ObjectFactory {
      * @return The container. Never returns null.
      * @since 5.5
      */
-    <T> NamedDomainObjectContainer<T> container(Class<T> elementType,  NamedDomainObjectFactory<T> factory);
+    <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory);
 
     /**
      * Creates a new {@link DomainObjectSet} for managing objects of the specified type.

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -510,7 +510,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
-            def container = project.objects.container(NamedThing)
+            def container = project.objects.domainObjectContainer(NamedThing)
             assert container != null
             def element = container.create('foo')
             assert element.name == 'foo'
@@ -531,7 +531,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
-            def container = project.objects.container(NamedThing) {
+            def container = project.objects.domainObjectContainer(NamedThing) {
                 return new NamedThing("prefix-" + it)
             }
             assert container != null

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -109,12 +109,12 @@ public class DefaultObjectFactory implements ObjectFactory {
     }
 
     @Override
-    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType) {
+    public <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType) {
         return domainObjectCollectionFactory.newNamedDomainObjectContainer(elementType);
     }
 
     @Override
-    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
+    public <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
         return domainObjectCollectionFactory.newNamedDomainObjectContainer(elementType, factory);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -55,12 +55,12 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
     }
 
     @Override
-    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType) {
+    public <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType) {
         throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object container");
     }
 
     @Override
-    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
+    public <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
         throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object container with factory");
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
@@ -62,7 +62,7 @@ public class GradlePluginDevelopmentExtension {
     }
 
     public GradlePluginDevelopmentExtension(Project project, SourceSet pluginSourceSet, SourceSet[] testSourceSets) {
-        this.plugins = project.getObjects().container(PluginDeclaration.class);
+        this.plugins = project.getObjects().domainObjectContainer(PluginDeclaration.class);
         this.pluginSourceSet = pluginSourceSet;
         testSourceSets(testSourceSets);
     }


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle/commit/dad5e02dc6047e0d4725ec14afb0d0d626577160#commitcomment-33635284

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Frename-factory-method)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
