### PR TITLE
Retry failed uploads with `ivy-publish`

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -147,7 +147,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
     }
 
     @Override
-    public ModuleVersionPublisher createPublisher() {
+    public IvyResolver createPublisher() {
         return createRealResolver();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -295,7 +295,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         }
     }
 
-    private void publish(ModuleComponentArtifactMetadata artifact, File src) {
+    public void publish(ModuleComponentArtifactMetadata artifact, File src) {
         ResourcePattern destinationPattern;
         if ("ivy".equals(artifact.getName().getType()) && !ivyPatterns.isEmpty()) {
             destinationPattern = ivyPatterns.get(0);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetry.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package org.gradle.api.publish.maven.internal.publisher;
+package org.gradle.api.internal.artifacts.repositories.transport;
 
-import org.gradle.api.internal.artifacts.repositories.transport.NetworkingIssueVerifier;
 import org.gradle.internal.UncheckedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetry.java
@@ -58,7 +58,8 @@ public class NetworkOperationBackOffAndRetry {
             if (!NetworkingIssueVerifier.isLikelyTransientNetworkingIssue(failure) || retries == maxDeployAttempts) {
                 throw UncheckedException.throwAsUncheckedException(failure);
             } else {
-                LOGGER.info("Error in '{}'. Waiting {}ms before next retry, {} retries left", operation, backoff, maxDeployAttempts - retries, failure);
+                LOGGER.info("Error in '{}'. Waiting {}ms before next retry, {} retries left", operation, backoff, maxDeployAttempts - retries);
+                LOGGER.debug("Network operation failed", failure);
                 try {
                     Thread.sleep(backoff);
                     backoff *= 2;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.api.publish.maven.internal.publisher
+package org.gradle.api.internal.artifacts.repositories.transport
 
 import org.apache.http.conn.HttpHostConnectException
 import org.gradle.api.UncheckedIOException
+import org.gradle.api.internal.artifacts.repositories.transport.NetworkOperationBackOffAndRetry
 import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException
 import org.gradle.testing.internal.util.Specification
 import spock.lang.Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetryTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.repositories.transport
 
 import org.apache.http.conn.HttpHostConnectException
 import org.gradle.api.UncheckedIOException
-import org.gradle.api.internal.artifacts.repositories.transport.NetworkOperationBackOffAndRetry
 import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException
 import org.gradle.testing.internal.util.Specification
 import spock.lang.Unroll
@@ -26,7 +25,7 @@ import spock.lang.Unroll
 @Unroll
 class NetworkOperationBackOffAndRetryTest extends Specification {
 
-    def 'retries operation if transient network issue - #ex'() {
+    def 'retries operation on transient network issue and fails after max attempts - #ex'() {
         when:
         int attempts = 0
         Runnable operation = {
@@ -54,7 +53,32 @@ class NetworkOperationBackOffAndRetryTest extends Specification {
         ]
     }
 
-    def 'does not retry operation if not transient network issue - #ex'() {
+    def 'retries operation on transient network issue and succeeds on subsequent attempt - #ex'() {
+        when:
+        int attempts = 0
+        Runnable operation = {
+            attempts++
+            if (attempts < 3) {
+                throw ex
+            }
+        }
+        NetworkOperationBackOffAndRetry executer = new NetworkOperationBackOffAndRetry(3, 1)
+        executer.withBackoffAndRetry(operation)
+
+        then:
+        attempts == 3
+        noExceptionThrown()
+
+        where:
+        ex << [
+                new SocketTimeoutException("something went wrong"),
+                new HttpHostConnectException(new IOException("something went wrong"), null, null),
+                new HttpErrorStatusCodeException("something", "something", 503, "something"),
+                new RuntimeException("with cause", new SocketTimeoutException("something went wrong"))
+        ]
+    }
+
+    def 'does not retry operation for non transient network issue - #ex'() {
         when:
         int attempts = 0
         Runnable operation = {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpResource.groovy
@@ -90,8 +90,8 @@ abstract class HttpResource extends AbstractHttpResource {
         server.expectPut(getPath(), getFile(), statusCode, credentials)
     }
 
-    void expectPutBroken(PasswordCredentials credentials = null) {
-        server.expectPut(getPath(), getFile(), 500, credentials)
+    void expectPutBroken(Integer statusCode = 500) {
+        server.expectPut(getPath(), getFile(), statusCode, null)
     }
 
     abstract TestFile getFile();

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
@@ -36,6 +36,7 @@ import static org.gradle.util.Matchers.matchesRegexp
 import static org.gradle.util.TestPrecondition.FIX_TO_WORK_ON_JAVA9
 
 class IvyPublishHttpIntegTest extends AbstractIvyPublishIntegTest {
+    private static final int HTTP_UNRECOVERABLE_ERROR = 415
     private static final String BAD_CREDENTIALS = '''
 credentials {
     username 'testuser'
@@ -375,7 +376,7 @@ credentials {
         """
 
         and:
-        module.jar.expectPutBroken(415)
+        module.jar.expectPutBroken(HTTP_UNRECOVERABLE_ERROR)
 
         when:
         fails ':publish'

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
@@ -375,7 +375,7 @@ credentials {
         """
 
         and:
-        module.jar.expectPutBroken()
+        module.jar.expectPutBroken(415)
 
         when:
         fails ':publish'
@@ -383,5 +383,44 @@ credentials {
         then:
         module.jarFile.assertExists()
         module.ivyFile.assertDoesNotExist()
+    }
+
+    def "retries artifact upload for transient network error"() {
+        given:
+        server.start()
+        settingsFile << 'rootProject.name = "publish"'
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'ivy-publish'
+
+            version = '2'
+            group = 'org.gradle'
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyHttpRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+
+        and:
+        module.jar.expectPutBroken()
+        module.jar.expectPut()
+        module.jar.sha1.expectPut()
+        module.ivy.expectPut(HttpStatus.ORDINAL_201_Created)
+        module.ivy.sha1.expectPut(HttpStatus.ORDINAL_201_Created)
+        module.moduleMetadata.expectPut()
+        module.moduleMetadata.sha1.expectPut()
+
+        when:
+        succeeds 'publish'
+
+        then:
+        module.assertMetadataAndJarFilePublished()
     }
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
@@ -411,10 +411,15 @@ credentials {
 
         and:
         module.jar.expectPutBroken()
+        module.jar.expectPutBroken()
         module.jar.expectPut()
         module.jar.sha1.expectPut()
+
+        module.ivy.expectPutBroken()
         module.ivy.expectPut(HttpStatus.ORDINAL_201_Created)
         module.ivy.sha1.expectPut(HttpStatus.ORDINAL_201_Created)
+
+        module.moduleMetadata.expectPutBroken()
         module.moduleMetadata.expectPut()
         module.moduleMetadata.sha1.expectPut()
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ContextualizingIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ContextualizingIvyPublisher.java
@@ -18,8 +18,8 @@ package org.gradle.api.publish.ivy.internal.publisher;
 
 import org.apache.ivy.Ivy;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
-import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
 
 public class ContextualizingIvyPublisher implements IvyPublisher {
     private final IvyPublisher ivyPublisher;
@@ -31,7 +31,7 @@ public class ContextualizingIvyPublisher implements IvyPublisher {
     }
 
     @Override
-    public void publish(final IvyNormalizedPublication publication, final PublicationAwareRepository repository) {
+    public void publish(final IvyNormalizedPublication publication, final IvyArtifactRepository repository) {
         ivyContextManager.withIvy(new Action<Ivy>() {
             @Override
             public void execute(Ivy ivy) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
@@ -50,6 +50,12 @@ public class DependencyResolverIvyPublisher implements IvyPublisher {
             public void run() {
                 publisher.publish(artifactMetadata, artifact.getFile());
             }
+
+            @Override
+            public String toString() {
+                return "Publish " + artifactMetadata;
+            }
+
         });
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
@@ -17,10 +17,12 @@
 package org.gradle.api.publish.ivy.internal.publisher;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
 import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
 import org.gradle.api.publish.ivy.IvyArtifact;
+import org.gradle.internal.Cast;
 import org.gradle.internal.component.external.ivypublish.DefaultIvyModulePublishMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
@@ -29,8 +31,8 @@ import org.gradle.internal.component.model.IvyArtifactName;
 public class DependencyResolverIvyPublisher implements IvyPublisher {
 
     @Override
-    public void publish(IvyNormalizedPublication publication, PublicationAwareRepository repository) {
-        ModuleVersionPublisher publisher = repository.createPublisher();
+    public void publish(IvyNormalizedPublication publication, IvyArtifactRepository repository) {
+        ModuleVersionPublisher publisher = Cast.cast(PublicationAwareRepository.class, repository).createPublisher();
         IvyPublicationIdentity projectIdentity = publication.getProjectIdentity();
         ModuleComponentIdentifier moduleVersionIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(projectIdentity.getOrganisation(), projectIdentity.getModule()), projectIdentity.getRevision());
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/DependencyResolverIvyPublisher.java
@@ -19,35 +19,41 @@ package org.gradle.api.publish.ivy.internal.publisher;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
-import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
-import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
+import org.gradle.api.internal.artifacts.repositories.DefaultIvyArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver;
+import org.gradle.api.internal.artifacts.repositories.transport.NetworkOperationBackOffAndRetry;
 import org.gradle.api.publish.ivy.IvyArtifact;
-import org.gradle.internal.Cast;
-import org.gradle.internal.component.external.ivypublish.DefaultIvyModulePublishMetadata;
+import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 public class DependencyResolverIvyPublisher implements IvyPublisher {
+    private final NetworkOperationBackOffAndRetry networkOperationBackOffAndRetry = new NetworkOperationBackOffAndRetry();
 
     @Override
     public void publish(IvyNormalizedPublication publication, IvyArtifactRepository repository) {
-        ModuleVersionPublisher publisher = Cast.cast(PublicationAwareRepository.class, repository).createPublisher();
+        IvyResolver publisher = ((DefaultIvyArtifactRepository) repository).createPublisher();
         IvyPublicationIdentity projectIdentity = publication.getProjectIdentity();
         ModuleComponentIdentifier moduleVersionIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(projectIdentity.getOrganisation(), projectIdentity.getModule()), projectIdentity.getRevision());
 
-        // Use the legacy metadata type so that we can leverage `ModuleVersionPublisher.publish()`
-        DefaultIvyModulePublishMetadata publishMetaData = new DefaultIvyModulePublishMetadata(moduleVersionIdentifier, "");
         for (IvyArtifact artifact : publication.getAllArtifacts()) {
-            publishMetaData.addArtifact(createIvyArtifact(artifact), artifact.getFile());
+            ModuleComponentArtifactMetadata artifactMetadata = new DefaultModuleComponentArtifactMetadata(moduleVersionIdentifier, createIvyArtifact(artifact));
+            publish(publisher, artifact, artifactMetadata);
         }
+    }
 
-        publisher.publish(publishMetaData);
+    private void publish(IvyResolver publisher, IvyArtifact artifact, ModuleComponentArtifactMetadata artifactMetadata) {
+        networkOperationBackOffAndRetry.withBackoffAndRetry(new Runnable() {
+            @Override
+            public void run() {
+                publisher.publish(artifactMetadata, artifact.getFile());
+            }
+        });
     }
 
     private IvyArtifactName createIvyArtifact(IvyArtifact artifact) {
         return new DefaultIvyArtifactName(artifact.getName(), artifact.getType(), artifact.getExtension(), artifact.getClassifier());
     }
-
-
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyPublisher.java
@@ -16,11 +16,11 @@
 
 package org.gradle.api.publish.ivy.internal.publisher;
 
-import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 
 /**
  * Used by the `ivy-publish` plugin to publish Ivy modules.
  */
 public interface IvyPublisher {
-    void publish(IvyNormalizedPublication publication, PublicationAwareRepository repository);
+    void publish(IvyNormalizedPublication publication, IvyArtifactRepository repository);
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
@@ -19,6 +19,7 @@ package org.gradle.api.publish.ivy.internal.publisher;
 import org.apache.commons.lang.ObjectUtils;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DescriptorParseContext;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DisconnectedDescriptorParseContext;
@@ -26,7 +27,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.Disconnect
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleDescriptorConverter;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParseException;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
-import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.publish.internal.PublicationFieldValidator;
 import org.gradle.api.publish.ivy.InvalidIvyPublicationException;
@@ -49,7 +49,7 @@ public class ValidatingIvyPublisher implements IvyPublisher {
     }
 
     @Override
-    public void publish(IvyNormalizedPublication publication, PublicationAwareRepository repository) {
+    public void publish(IvyNormalizedPublication publication, IvyArtifactRepository repository) {
         validateMetadata(publication);
         validateArtifacts(publication);
         checkNoDuplicateArtifacts(publication);

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
@@ -20,7 +20,6 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
 import org.gradle.api.publish.internal.PublishOperation;
 import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.ivy.internal.publication.IvyPublicationInternal;
@@ -29,7 +28,6 @@ import org.gradle.api.publish.ivy.internal.publisher.IvyPublisher;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.internal.Cast;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -148,7 +146,7 @@ public class PublishToIvyRepository extends DefaultTask {
             protected void publish() throws Exception {
                 IvyNormalizedPublication normalizedPublication = publication.asNormalisedPublication();
                 IvyPublisher publisher = getIvyPublisher();
-                publisher.publish(normalizedPublication, Cast.cast(PublicationAwareRepository.class, repository));
+                publisher.publish(normalizedPublication, repository);
             }
         }.run();
     }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.api.publish.ivy.internal.publisher
 
 import org.gradle.api.Action
 import org.gradle.api.XmlProvider
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.ivy.InvalidIvyPublicationException
@@ -47,6 +47,7 @@ class ValidatingIvyPublisherTest extends Specification {
     IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory())
 
     def publisher = new ValidatingIvyPublisher(delegate, moduleIdentifierFactory, TestFiles.fileRepository(), metadataFactory)
+    def repository = Mock(IvyArtifactRepository)
 
     def "delegates when publication is valid"() {
         when:
@@ -55,7 +56,6 @@ class ValidatingIvyPublisherTest extends Specification {
                             .withBranch("the-branch")
                             .withStatus("release")
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
-        def repository = Mock(PublicationAwareRepository)
 
         and:
         publisher.publish(publication, repository)
@@ -75,7 +75,6 @@ class ValidatingIvyPublisherTest extends Specification {
 
         and:
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity("the-group", "the-artifact", "the-version"), ivyFile, emptySet())
-        def repository = Mock(PublicationAwareRepository)
 
         and:
         publisher.publish(publication, repository)
@@ -88,7 +87,6 @@ class ValidatingIvyPublisherTest extends Specification {
         given:
         def projectIdentity = projectIdentity(group, name, version)
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(group, name, version), emptySet())
-        def repository = Mock(PublicationAwareRepository)
 
         when:
         publisher.publish(publication, repository)
@@ -117,7 +115,6 @@ class ValidatingIvyPublisherTest extends Specification {
                             .withBranch(branch)
                             .withStatus(status)
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
-        def repository = Stub(PublicationAwareRepository)
 
         when:
         publisher.publish(publication, repository)
@@ -148,7 +145,6 @@ class ValidatingIvyPublisherTest extends Specification {
                             .withBranch(branch)
                             .withStatus(status)
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
-        def repository = Stub(PublicationAwareRepository)
 
         when:
         publisher.publish(publication, repository)
@@ -170,7 +166,6 @@ class ValidatingIvyPublisherTest extends Specification {
         def generator = ivyGenerator("org", "module", "version")
         elements.each { generator.withExtraInfo(it, "${it}Value") }
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
-        def repository = Stub(PublicationAwareRepository)
 
         when:
         publisher.publish(publication, repository)
@@ -189,7 +184,6 @@ class ValidatingIvyPublisherTest extends Specification {
         given:
         def projectIdentity = projectIdentity("org", "module", "version")
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(organisation, module, version), emptySet())
-        def repository = Mock(PublicationAwareRepository)
 
         when:
         publisher.publish(publication, repository)
@@ -217,7 +211,6 @@ class ValidatingIvyPublisherTest extends Specification {
 
         and:
         def publication = new IvyNormalizedPublication("pub-name", identity, ivyFile, emptySet())
-        def repository = Mock(PublicationAwareRepository)
 
         when:
         publisher.publish(publication, repository)
@@ -242,7 +235,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity("org", "module", "version"), ivyFile("org", "module", "version"), toSet([ivyArtifact]))
 
         when:
-        publisher.publish(publication, Mock(PublicationAwareRepository))
+        publisher.publish(publication, repository)
 
         then:
         def t = thrown InvalidIvyPublicationException
@@ -273,7 +266,7 @@ class ValidatingIvyPublisherTest extends Specification {
         }
 
         when:
-        publisher.publish(publication, Mock(PublicationAwareRepository))
+        publisher.publish(publication, repository)
 
         then:
         ivyArtifact.name >> "name"
@@ -311,7 +304,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1, artifact2]))
 
         when:
-        publisher.publish(publication, Mock(PublicationAwareRepository))
+        publisher.publish(publication, repository)
 
         then:
         def t = thrown InvalidIvyPublicationException
@@ -331,7 +324,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1]))
 
         when:
-        publisher.publish(publication, Mock(PublicationAwareRepository))
+        publisher.publish(publication, repository)
 
         then:
         def t = thrown InvalidIvyPublicationException

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
@@ -260,7 +260,18 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
         buildFile << publicationBuild(version, group, mavenRemoteRepo.uri)
 
         module.artifact.expectPutBroken()
-        expectModulePublish(module)
+        module.artifact.expectPutBroken()
+        module.artifact.expectPublish()
+
+        module.rootMetaData.expectGetMissing()
+        module.rootMetaData.expectPutBroken()
+        module.rootMetaData.expectPublish()
+
+        module.pom.expectPutBroken()
+        module.pom.expectPublish()
+
+        module.moduleMetadata.expectPutBroken()
+        module.moduleMetadata.expectPublish()
 
         when:
         succeeds 'publish'

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -21,6 +21,7 @@ import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.api.internal.artifacts.repositories.transport.NetworkOperationBackOffAndRetry;
 import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;


### PR DESCRIPTION
This PR reuses the retry functionality developed for the `maven-publish` plugin in order to retry failed artifact uploads when publishing with `ivy-publish`.