### PR TITLE
SLF4J StaticMDCBinder implementation

### DIFF
--- a/subprojects/logging/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/subprojects/logging/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -1,0 +1,26 @@
+package org.slf4j.impl;
+
+import org.slf4j.helpers.NOPMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
+
+@SuppressWarnings("UnusedDeclaration")
+public class StaticMDCBinder {
+
+    public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+
+    private StaticMDCBinder() {
+    }
+
+    public static StaticMDCBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    public MDCAdapter getMDCA() {
+        return new NOPMDCAdapter();
+    }
+
+    public String getMDCAdapterClassStr() {
+        return NOPMDCAdapter.class.getName();
+    }
+
+}


### PR DESCRIPTION
Fixes #9491

If classpath doesn't have `org.slf4j.impl.StaticMDCBinder` class, slf4j displays a message about it. The message is sent to `System.err`. This implementation returns `NOPMDCAdapter` as MDC adapter.