### PR TITLE
WIP Delay Regex evaluation for ApiClassExtractor#isLocalClass

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/compile/ApiClassExtractor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/compile/ApiClassExtractor.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
  */
 public class ApiClassExtractor {
 
-    private static final Pattern LOCAL_CLASS_PATTERN = Pattern.compile(".+\\$[0-9]+(?:[\\p{Alnum}_$]+)?$");
+    private static final Pattern LOCAL_CLASS_PATTERN = Pattern.compile("\\d+(?:[\\p{Alnum}_$]+)?$");
 
     private final Set<String> exportedPackages;
     private final boolean apiIncludesPackagePrivateMembers;
@@ -93,6 +93,8 @@ public class ApiClassExtractor {
 
     // See JLS3 "Binary Compatibility" (13.1)
     private static boolean isLocalClass(String className) {
-        return LOCAL_CLASS_PATTERN.matcher(className).matches();
+        int localClassDelimiterPos = className.indexOf('$') + 1;
+        return localClassDelimiterPos > 0
+            && LOCAL_CLASS_PATTERN.matcher(className).find(localClassDelimiterPos);
     }
 }


### PR DESCRIPTION
Ad hoc perf test:[ `clean assemble on largeMonolithicJavaProject with rich console `](https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Util_Performance_AdHocPerformanceScenarioLinux&tab=buildTypeStatusDiv&branch_Gradle_Util_Performance=lorinc%2Fclass-extractor-pattern-optimization)