### PR TITLE
Intern strings on write

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -41,6 +41,9 @@ class DefaultWriteContext(
     private
     val beanPropertyWriters = hashMapOf<Class<*>, BeanPropertyWriter>()
 
+    private
+    val writeStrings = WriteStrings()
+
     override fun beanPropertyWriterFor(beanType: Class<*>): BeanPropertyWriter =
         beanPropertyWriters.computeIfAbsent(beanType, ::BeanPropertyWriter)
 
@@ -51,9 +54,8 @@ class DefaultWriteContext(
         encodingFor(value)
     }
 
-    // TODO: consider interning strings
     override fun writeString(string: CharSequence) =
-        encoder.writeString(string)
+        writeStrings.writeString(string, encoder)
 
     override fun newIsolate(owner: Task): WriteIsolate =
         DefaultWriteIsolate(owner)
@@ -86,6 +88,9 @@ class DefaultReadContext(
     val beanPropertyReaders = hashMapOf<Class<*>, BeanPropertyReader>()
 
     private
+    val readStrings = ReadStrings()
+
+    private
     lateinit var projectProvider: ProjectProvider
 
     override lateinit var classLoader: ClassLoader
@@ -99,6 +104,9 @@ class DefaultReadContext(
     override fun read(): Any? = decoding.run {
         decode()
     }
+
+    override fun readString(): String =
+        readStrings.readString(decoder)
 
     override val isolate: ReadIsolate
         get() = getIsolate()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -46,13 +46,13 @@ class ReadStrings {
 
     fun readString(decoder: Decoder): String = decoder.run {
         when (readBoolean()) {
-            true -> strings[readSmallInt()]!!
+            true -> strings[readSmallInt()]
             else -> readString().also {
-                strings[strings.size] = it
+                strings.add(it)
             }
         }
     }
 
     private
-    val strings = HashMap<Int, String>()
+    val strings = mutableListOf<String>()
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -31,7 +31,6 @@ class WriteStrings {
             } else {
                 val newId = strings.size
                 writeBoolean(false)
-                writeSmallInt(newId)
                 writeString(string)
                 strings[string] = newId
             }
@@ -46,12 +45,10 @@ class WriteStrings {
 class ReadStrings {
 
     fun readString(decoder: Decoder): String = decoder.run {
-        val present = readBoolean()
-        val id = readSmallInt()
-        return when {
-            present -> strings[id]!!
+        when (readBoolean()) {
+            true -> strings[readSmallInt()]!!
             else -> readString().also {
-                strings[id] = it
+                strings[strings.size] = it
             }
         }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization
+
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
+
+
+class WriteStrings {
+
+    fun writeString(string: CharSequence, encoder: Encoder) = encoder.run {
+        string.toString().let { string ->
+            val id = strings[string]
+            if (id != null) {
+                writeBoolean(true)
+                writeSmallInt(id)
+            } else {
+                val newId = strings.size
+                writeBoolean(false)
+                writeSmallInt(newId)
+                writeString(string)
+                strings[string] = newId
+            }
+        }
+    }
+
+    private
+    val strings = HashMap<String, Int>()
+}
+
+
+class ReadStrings {
+
+    fun readString(decoder: Decoder): String = decoder.run {
+        val present = readBoolean()
+        val id = readSmallInt()
+        return when {
+            present -> strings[id]!!
+            else -> readString().also {
+                strings[id] = it
+            }
+        }
+    }
+
+    private
+    val strings = HashMap<Int, String>()
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Strings.kt
@@ -26,11 +26,10 @@ class WriteStrings {
         string.toString().let { string ->
             val id = strings[string]
             if (id != null) {
-                writeBoolean(true)
                 writeSmallInt(id)
             } else {
                 val newId = strings.size
-                writeBoolean(false)
+                writeSmallInt(-1)
                 writeString(string)
                 strings[string] = newId
             }
@@ -45,11 +44,9 @@ class WriteStrings {
 class ReadStrings {
 
     fun readString(decoder: Decoder): String = decoder.run {
-        when (readBoolean()) {
-            true -> strings[readSmallInt()]
-            else -> readString().also {
-                strings.add(it)
-            }
+        when (val index = readSmallInt()) {
+            -1 -> readString().also { strings.add(it) }
+            else -> strings[index]
         }
     }
 


### PR DESCRIPTION
By interning strings, each instant execution run from cache will require less memory to run.

By moving the interning of strings to the writer, each instant execution run from the cache benefits from smaller files to read and less processing to read them as all strings read from the file already have an unique id.