### PR TITLE
Speed up HashCode's `equals` check via specialization and `hashCode` guard

### DIFF
--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashCodeBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashCodeBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.reflect;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Ints;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.HashFunction;
+import org.gradle.internal.hash.Hashing;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Benchmark                               Mode  Cnt   Score   Error  Units
+ * HashCodeBenchmark.hashCode_and_equals  thrpt   20  63.966 ± 5.416  ops/s
+ **/
+@Fork(2)
+@State(Scope.Benchmark)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = SECONDS)
+public class HashCodeBenchmark {
+    final List<HashCode> values = new ArrayList<HashCode>();
+
+    @Setup
+    public void prepare() {
+        HashFunction hashFunction = Hashing.md5();
+        for (int i = 0; i < 100000; i++) {
+            HashCode hashCode = hashFunction.hashBytes(Ints.toByteArray(i));
+            values.add(hashCode);
+        }
+    }
+
+    @Benchmark
+    public Object hashCode_and_equals() {
+        Set<HashCode> set = Sets.newHashSetWithExpectedSize(1); // we want many collisions
+        set.addAll(values);
+        set.addAll(values); // we need duplicates
+        Preconditions.checkArgument(set.size() == values.size());
+        return set;
+    }
+}

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashCodeBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashCodeBenchmark.java
@@ -37,7 +37,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Benchmark                               Mode  Cnt   Score   Error  Units
- * HashCodeBenchmark.hashCode_and_equals  thrpt   20  63.966 ± 5.416  ops/s
+ * HashCodeBenchmark.hashCode_and_equals  thrpt   20  83.162 ± 6.121  ops/s
  **/
 @Fork(2)
 @State(Scope.Benchmark)
@@ -52,6 +52,12 @@ public class HashCodeBenchmark {
         for (int i = 0; i < 100000; i++) {
             HashCode hashCode = hashFunction.hashBytes(Ints.toByteArray(i));
             values.add(hashCode);
+        }
+
+        int byteCount = hashFunction.byteCount();
+        System.out.println("Byte count: " + byteCount);
+        for (HashCode value : values) {
+            Preconditions.checkArgument(value.toByteArray().length == byteCount);
         }
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -181,7 +181,8 @@ class HashCode16 extends HashCode {
             return false;
         }
         HashCode16 that = (HashCode16) obj;
-        return long0 == that.long0
+        return hashCode == that.hashCode
+            && long0 == that.long0
             && long1 == that.long1;
     }
 
@@ -216,7 +217,8 @@ class HashCodeN extends HashCode {
             return false;
         }
         HashCodeN that = (HashCodeN) obj;
-        return Arrays.equals(bytes, that.bytes);
+        return hashCode == that.hashCode
+            && Arrays.equals(bytes, that.bytes);
     }
 
     @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashFunction.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashFunction.java
@@ -34,10 +34,12 @@ public interface HashFunction {
     /**
      * Hash the given bytes using the hash function.
      */
-    HashCode hashBytes(byte[] bytes);
+    HashCode hashBytes(byte... bytes);
 
     /**
      * Hash the given string using the hash function.
      */
     HashCode hashString(CharSequence string);
+
+    int byteCount();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashUtil.java
@@ -80,7 +80,7 @@ public class HashUtil {
     }
 
     public static String compactStringFor(HashCode hashCode) {
-        return compactStringFor(hashCode.getBytes());
+        return compactStringFor(hashCode.toByteArray());
     }
 
     public static String compactStringFor(byte[] digest) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -148,7 +148,7 @@ public class Hashing {
         }
 
         @Override
-        public HashCode hashBytes(byte[] bytes) {
+        public HashCode hashBytes(byte... bytes) {
             PrimitiveHasher hasher = newPrimitiveHasher();
             hasher.putBytes(bytes);
             return hasher.hash();
@@ -162,6 +162,8 @@ public class Hashing {
         }
 
         protected abstract MessageDigest createDigest();
+
+        public abstract int byteCount();
     }
 
     private static class CloningMessageDigestHashFunction extends MessageDigestHashFunction {
@@ -179,6 +181,11 @@ public class Hashing {
                 throw new AssertionError(e);
             }
         }
+
+        @Override
+        public int byteCount() {
+            return prototype.getDigestLength();
+        }
     }
 
     private static class RegularMessageDigestHashFunction extends MessageDigestHashFunction {
@@ -195,6 +202,11 @@ public class Hashing {
             } catch (NoSuchAlgorithmException e) {
                 throw new AssertionError(e);
             }
+        }
+
+        @Override
+        public int byteCount() {
+            return createDigest().getDigestLength();
         }
     }
 
@@ -263,14 +275,14 @@ public class Hashing {
 
         @Override
         public void putHash(HashCode hashCode) {
-            putBytes(hashCode.getBytes());
+            putBytes(hashCode.toByteArray());
         }
 
         @Override
         public HashCode hash() {
             byte[] bytes = getDigest().digest();
             digest = null;
-            return HashCode.fromBytesNoCopy(bytes);
+            return HashCode.fromBytes(bytes);
         }
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
@@ -31,12 +31,12 @@ class HashCodeTest extends Specification {
         hash.hashCode() == (int) hashCode
 
         where:
-        input          | length | toString       | hashCode   | bytes
-        "12345678"     | 4      | "12345678"     | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
-        "CAFEBABE"     | 4      | "cafebabe"     | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
-        "abbaabba"     | 4      | "abbaabba"     | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 2)
-        "abbaabbaabba" | 6      | "abbaabbaabba" | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 3)
-        "aB" * 255     | 255    | "ab" * 255     | 0xABABABAB | toBytes([0xAB] * 255)
+        input          | length | toString       | hashCode    | bytes
+        "12345678"     | 4      | "12345678"     | 1512517     | toBytes(0x12, 0x34, 0x56, 0x78)
+        "CAFEBABE"     | 4      | "cafebabe"     | -689351     | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
+        "abbaabba"     | 4      | "abbaabba"     | -1678689    | toBytes([0xAB, 0xBA] * 2)
+        "abbaabbaabba" | 6      | "abbaabbaabba" | -1613222834 | toBytes([0xAB, 0xBA] * 3)
+        "aB" * 100     | 100    | "ab" * 100     | 1556127809  | toBytes([0xAB] * 100)
     }
 
     def "can parse int: #input"() {
@@ -49,10 +49,10 @@ class HashCodeTest extends Specification {
         hash.hashCode() == (int) hashCode
 
         where:
-        input          | length | toString       | hashCode   | bytes
-        0x12345678     | 4      | "12345678"     | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
-        0xCAFEBABE     | 4      | "cafebabe"     | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
-        0xabbaabba     | 4      | "abbaabba"     | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 2)
+        input      | length | toString   | hashCode | bytes
+        0x12345678 | 4      | "12345678" | 1512517  | toBytes(0x12, 0x34, 0x56, 0x78)
+        0xCAFEBABE | 4      | "cafebabe" | -689351  | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
+        0xabbaabba | 4      | "abbaabba" | -1678689 | toBytes([0xAB, 0xBA] * 2)
     }
 
     def "can parse bytes: #input"() {
@@ -65,11 +65,11 @@ class HashCodeTest extends Specification {
         hash.hashCode() == (int) hashCode
 
         where:
-        input                           | length | toString       | hashCode   | bytes
-        toBytes(0x12, 0x34, 0x56, 0x78) | 4      | "12345678"     | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
-        toBytes(0xCA, 0xFE, 0xBA, 0xBE) | 4      | "cafebabe"     | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
-        toBytes([0xAB, 0xBA] * 3)       | 6      | "abbaabbaabba" | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 3)
-        toBytes([0xAB] * 255)           | 255    | "ab" * 255     | 0xABABABAB | toBytes([0xAB] * 255)
+        input                           | length | toString       | hashCode    | bytes
+        toBytes(0x12, 0x34, 0x56, 0x78) | 4      | "12345678"     | 1512517     | toBytes(0x12, 0x34, 0x56, 0x78)
+        toBytes(0xCA, 0xFE, 0xBA, 0xBE) | 4      | "cafebabe"     | -689351     | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
+        toBytes([0xAB, 0xBA] * 3)       | 6      | "abbaabbaabba" | -1613222834 | toBytes([0xAB, 0xBA] * 3)
+        toBytes([0xAB] * 100)           | 100    | "ab" * 100     | 1556127809  | toBytes([0xAB] * 100)
     }
 
     def "#a == #b: #equals"() {
@@ -87,23 +87,20 @@ class HashCodeTest extends Specification {
         "abcdef1234" | "abcdef12"   | false
     }
 
-    def "#a <=> #b: #expected"() {
-        def hashA = HashCode.fromString(a)
-        def hashB = HashCode.fromString(b)
-        def compareAB = hashA <=> hashB
-        def compareBA = hashB <=> hashA
+    def "a <=> b should be stable"() {
+        when:
+        def hashA = HashCode.fromInt(0)
+        def hashB = HashCode.fromInt(0)
 
-        expect:
-        Math.signum(compareAB) == expected
-        Math.signum(compareBA) == -expected
+        then:
+        Math.signum(hashA <=> hashB) == Math.signum(hashB <=> hashA)
 
-        where:
-        a            | b            | expected
-        "abcdef12"   | "abcdef12"   | 0
-        "abcdef12"   | "abcdef1234" | -1
-        "abcdef1234" | "abcdef12"   | 1
-        "abcdef1234" | "bcdef123"   | -1
-        "bcdef123"   | "abcdef12"   | 1
+        when:
+        def hashC = HashCode.fromInt(1)
+
+        then:
+        hashA != hashC
+        Math.signum(hashA <=> hashC) == -Math.signum(hashC <=> hashA)
     }
 
     def "not equals with null"() {


### PR DESCRIPTION
Speed improvements:
<img width="1562" alt="Screen Shot 2019-05-27 at 23 42 32" src="https://user-images.githubusercontent.com/1841944/58440273-33649880-80d9-11e9-8b2f-0f92335102e0.png">

Ad-hoc perf test for [`up-to-date assemble on largeJavaMultiProject with local build cache enabled (parallel true) `](https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Util_Performance_AdHocPerformanceScenarioLinux&tab=buildTypeStatusDiv&branch_Gradle_Util_Performance=lorinc%2FHashCode-equals)

The solution is similar to how [`UUID`](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/UUID.java) stores the 128 bit id.