### PR TITLE
Backed MethodSet with an actual Set

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ClassDetails.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ClassDetails.java
@@ -46,7 +46,7 @@ public interface ClassDetails {
      * Returns the non-private instance methods of this class that are not property getter or setter methods.
      * Includes inherited methods.
      */
-    List<Method> getInstanceMethods();
+    Collection<Method> getInstanceMethods();
 
     /**
      * The ordered super types of this type.

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MethodSet.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MethodSet.java
@@ -16,38 +16,64 @@
 
 package org.gradle.internal.reflect;
 
+import com.google.common.collect.Maps;
+
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.unmodifiableCollection;
 
 public class MethodSet implements Iterable<Method> {
-    private final List<Method> methods = new ArrayList<Method>();
+    private final Map<MethodKey, Method> methods = Maps.newLinkedHashMap();
 
-    /**
-     * @return true if the method was added, false if not
-     */
-    public boolean add(Method method) {
-        for (Method current : methods) {
-            if (current.getName().equals(method.getName()) && current.getReturnType().equals(method.getReturnType()) && Arrays.equals(current.getParameterTypes(), method.getParameterTypes())) {
-                return false;
-            }
-        }
-        methods.add(method);
-        return true;
+    public void add(Method method) {
+        methods.putIfAbsent(new MethodKey(method), method);
     }
 
     @Override
     public Iterator<Method> iterator() {
-        return methods.iterator();
+        return getValues().iterator();
     }
 
-    public List<Method> getValues() {
-        return methods;
+    public Collection<Method> getValues() {
+        return unmodifiableCollection(methods.values());
     }
 
     public boolean isEmpty() {
         return methods.isEmpty();
+    }
+
+    static class MethodKey {
+        private final Method method;
+        private final Class<?>[] parameterTypes;
+
+        private MethodKey(Method method) {
+            this.method = method;
+            this.parameterTypes = method.getParameterTypes(); // avoid clone
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+
+            MethodKey that = (MethodKey) obj;
+            return Objects.equals(method.getName(), that.method.getName())
+                && Objects.equals(method.getReturnType(), that.method.getReturnType())
+                && Arrays.equals(parameterTypes, that.parameterTypes);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(method.getName(), parameterTypes.length);
+        }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MutableClassDetails.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MutableClassDetails.java
@@ -44,7 +44,7 @@ class MutableClassDetails implements ClassDetails {
     }
 
     @Override
-    public List<Method> getInstanceMethods() {
+    public Collection<Method> getInstanceMethods() {
         return instanceMethods.getValues();
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MutablePropertyDetails.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MutablePropertyDetails.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.reflect;
 
 import java.lang.reflect.Method;
-import java.util.List;
+import java.util.Collection;
 
 class MutablePropertyDetails implements PropertyDetails {
     private final String name;
@@ -34,12 +34,12 @@ class MutablePropertyDetails implements PropertyDetails {
     }
 
     @Override
-    public List<Method> getGetters() {
+    public Collection<Method> getGetters() {
         return getters.getValues();
     }
 
     @Override
-    public List<Method> getSetters() {
+    public Collection<Method> getSetters() {
         return setters.getValues();
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/PropertyDetails.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/PropertyDetails.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.reflect;
 
 import java.lang.reflect.Method;
-import java.util.List;
+import java.util.Collection;
 
 public interface PropertyDetails {
 
@@ -37,12 +37,12 @@ public interface PropertyDetails {
      * The order of the methods follows the same precedence.
      * That is, the “nearer” declarations are earlier in the list.
      */
-    List<Method> getGetters();
+    Collection<Method> getGetters();
 
     /**
      * Similar to {@link #getGetters()}, but varies based on the param type instead of return type.
      *
      * Has identical ordering semantics.
      */
-    List<Method> getSetters();
+    Collection<Method> getSetters();
 }


### PR DESCRIPTION
Found this while investigating the cold daemon perf regressions.

Added ad-hoc perf test for [`cold daemon on largeMonolithicJavaProject`](https://builds.gradle.org/viewLog.html?buildId=23328311&buildTypeId=Gradle_Util_Performance_AdHocPerformanceScenarioLinux&tab=artifacts&branch_Gradle_Util_Performance=lorinc%2F2213%2Freflection-caching#%2Fresults%2Fperformance%2Fbuild%2Ftest-results-performanceAdhocTest.zip!%2Fflames
).

[Ready for release](https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Check_Stage_ReadyforRelease_Trigger&branch_Gradle_Check=lorinc%2F2213%2Freflection-caching&tab=buildTypeStatusDiv) build results are still running.

<img width="1556" alt="Screen Shot 2019-05-28 at 10 51 09" src="https://user-images.githubusercontent.com/1841944/58464744-8ae52180-8136-11e9-9418-dde11a33191f.png">
