### PR TITLE
Change ArrayLists, used as Queues to ArrayDeques and LinkedLists

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -17,7 +17,6 @@
 package org.gradle.composite.internal;
 
 import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import org.gradle.api.GradleException;
@@ -36,13 +35,14 @@ import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.service.scopes.BuildTreeScopeServices;
 import org.gradle.internal.logging.text.TreeFormatter;
+import org.gradle.internal.service.scopes.BuildTreeScopeServices;
 import org.gradle.util.Path;
 
 import java.io.File;
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.List;
+import java.util.Deque;
 import java.util.Map;
 import java.util.Set;
 
@@ -58,7 +58,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     private RootBuildState rootBuild;
     private final Map<BuildIdentifier, BuildState> builds = Maps.newHashMap();
     private final Map<File, IncludedBuildState> includedBuilds = Maps.newLinkedHashMap();
-    private final List<IncludedBuildState> pendingIncludedBuilds = Lists.newArrayList();
+    private final Deque<IncludedBuildState> pendingIncludedBuilds = new ArrayDeque<>();
 
     public DefaultIncludedBuildRegistry(IncludedBuildFactory includedBuildFactory, ProjectStateRegistry projectRegistry, IncludedBuildDependencySubstitutionsBuilder dependencySubstitutionsBuilder, GradleLauncherFactory gradleLauncherFactory, ListenerManager listenerManager, BuildTreeScopeServices rootServices) {
         this.includedBuildFactory = includedBuildFactory;
@@ -145,7 +145,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
         SettingsInternal settings = getRootBuild().getLoadedSettings();
         SetMultimap<String, IncludedBuildState> names = LinkedHashMultimap.create();
         while (!pendingIncludedBuilds.isEmpty()) {
-            IncludedBuildState build = pendingIncludedBuilds.remove(0);
+            IncludedBuildState build = pendingIncludedBuilds.removeFirst();
             build.loadSettings();
             String buildName = build.getName();
             names.put(buildName, build);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -69,6 +69,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -491,7 +492,7 @@ public class DependencyGraphBuilder {
         }
 
         // Collect the components to sort in consumer-first order
-        List<ComponentState> queue = Lists.newArrayListWithExpectedSize(resolveState.getNodeCount());
+        LinkedList<ComponentState> queue = Lists.newLinkedList();
         for (ModuleResolveState module : resolveState.getModules()) {
             if (module.getSelected() != null && !module.isVirtualPlatform()) {
                 queue.add(module.getSelected());
@@ -500,7 +501,7 @@ public class DependencyGraphBuilder {
 
         // Visit the edges after sorting the components in consumer-first order
         while (!queue.isEmpty()) {
-            ComponentState component = queue.get(0);
+            ComponentState component = queue.peekFirst();
             if (component.getVisitState() == VisitState.NotSeen) {
                 component.setVisitState(VisitState.Visiting);
                 int pos = 0;
@@ -519,7 +520,7 @@ public class DependencyGraphBuilder {
                 if (pos == 0) {
                     // have visited all consumers, so visit this node
                     component.setVisitState(VisitState.Visited);
-                    queue.remove(0);
+                    queue.removeFirst();
                     for (NodeState node : component.getNodes()) {
                         if (node.isSelected()) {
                             visitor.visitEdges(node);
@@ -529,7 +530,7 @@ public class DependencyGraphBuilder {
             } else if (component.getVisitState() == VisitState.Visiting) {
                 // have visited all consumers, so visit this node
                 component.setVisitState(VisitState.Visited);
-                queue.remove(0);
+                queue.removeFirst();
                 for (NodeState node : component.getNodes()) {
                     if (node.isSelected()) {
                         visitor.visitEdges(node);
@@ -537,7 +538,7 @@ public class DependencyGraphBuilder {
                 }
             } else {
                 // else, already visited previously, skip
-                queue.remove(0);
+                queue.removeFirst();
             }
         }
 

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/internal/RelativeFileNameTransformer.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/tasks/internal/RelativeFileNameTransformer.java
@@ -76,26 +76,24 @@ public class RelativeFileNameTransformer implements Transformer<String, File> {
     }
 
     private String findRelativePath(String from, String to) {
-        List<String> fromPath = splitPath(from);
-        List<String> toPath = splitPath(to);
+        LinkedList<String> fromPath = splitPath(from);
+        LinkedList<String> toPath = splitPath(to);
         List<String> relativePath = new ArrayList<String>();
 
         while (!fromPath.isEmpty() && !toPath.isEmpty() && fromPath.get(0).equals(toPath.get(0))) {
-            fromPath.remove(0);
-            toPath.remove(0);
+            fromPath.removeFirst();
+            toPath.removeFirst();
         }
         for (String ignored : fromPath) {
             relativePath.add("..");
         }
-        for (String entry : toPath) {
-            relativePath.add(entry);
-        }
+        relativePath.addAll(toPath);
         return Joiner.on(File.separatorChar).join(relativePath);
     }
 
-    private List<String> splitPath(String path) {
+    private LinkedList<String> splitPath(String path) {
         File pathFile = new File(path);
-        List<String> split = new LinkedList<String>();
+        LinkedList<String> split = new LinkedList<String>();
         while (pathFile != null) {
             split.add(0, pathFile.getName());
             pathFile = pathFile.getParentFile();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfRequestHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfRequestHandler.java
@@ -24,6 +24,7 @@ import org.gradle.internal.time.Time;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -37,7 +38,7 @@ class CyclicBarrierAnyOfRequestHandler implements TrackingHttpHandler, WaitPreco
     private final Condition condition;
     private final List<String> received = new ArrayList<String>();
     private final List<String> released = new ArrayList<String>();
-    private final List<ResourceHandlerWrapper> notReleased = new ArrayList<ResourceHandlerWrapper>();
+    private final LinkedList<ResourceHandlerWrapper> notReleased = new LinkedList<>();
     private final List<ResourceHandlerWrapper> notReceived = new ArrayList<ResourceHandlerWrapper>();
     private final int testId;
     private final int timeoutMs;
@@ -262,7 +263,7 @@ class CyclicBarrierAnyOfRequestHandler implements TrackingHttpHandler, WaitPreco
                 throw new IllegalStateException("Too few requests released, should wait for pending calls first.");
             }
             for (int i = 0; i < count; i++) {
-                ResourceHandlerWrapper resourceHandler = notReleased.remove(0);
+                ResourceHandlerWrapper resourceHandler = notReleased.removeFirst();
                 System.out.println(String.format("[%d] releasing %s", testId, resourceHandler.getPath()));
                 released.add(resourceHandler.getMethod() + " " + resourceHandler.getPath());
                 resourceHandler.released();

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/CollectingMacroLookup.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/CollectingMacroLookup.java
@@ -20,14 +20,14 @@ import com.google.common.collect.Iterators;
 import org.gradle.language.nativeplatform.internal.IncludeDirectives;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 public class CollectingMacroLookup implements MacroLookup {
-    private final List<MacroSource> uncollected = new ArrayList<MacroSource>();
+    private final Deque<MacroSource> uncollected = new ArrayDeque<>();
     private final IncludeDirectives includeDirectives;
     private Map<File, IncludeDirectives> visible;
 
@@ -84,7 +84,7 @@ public class CollectingMacroLookup implements MacroLookup {
 
     private void collectAll() {
         while (!uncollected.isEmpty()) {
-            MacroSource source = uncollected.remove(0);
+            MacroSource source = uncollected.removeFirst();
             source.collectInto(this);
         }
     }

--- a/subprojects/launcher-startup/src/main/java/org/gradle/launcher/daemon/server/api/DaemonCommandExecution.java
+++ b/subprojects/launcher-startup/src/main/java/org/gradle/launcher/daemon/server/api/DaemonCommandExecution.java
@@ -37,7 +37,7 @@ public class DaemonCommandExecution {
     final private Command command;
     final private DaemonContext daemonContext;
     final private DaemonStateControl daemonStateControl;
-    final private List<DaemonCommandAction> actions;
+    final private LinkedList<DaemonCommandAction> actions;
 
     private Object result;
 
@@ -101,7 +101,7 @@ public class DaemonCommandExecution {
         if (actions.isEmpty()) {
             return false;
         } else {
-            actions.remove(0).execute(this);
+            actions.removeFirst().execute(this);
             return true;
         }
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/queue/MultiEndPointQueue.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/queue/MultiEndPointQueue.java
@@ -20,14 +20,20 @@ import org.gradle.internal.dispatch.Dispatch;
 import org.gradle.internal.remote.internal.hub.protocol.EndOfStream;
 import org.gradle.internal.remote.internal.hub.protocol.InterHubMessage;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 
 // TODO - use circular buffers to avoid copying
 // TODO - share a single initializer with MultiChannelQueue
 public class MultiEndPointQueue implements Dispatch<InterHubMessage> {
     private final Set<EndPointQueue> endpoints = new HashSet<EndPointQueue>();
-    private final List<InterHubMessage> queue = new ArrayList<InterHubMessage>();
+    private final Deque<InterHubMessage> queue = new ArrayDeque<InterHubMessage>();
     private final List<EndPointQueue> waiting = new ArrayList<EndPointQueue>();
     private final Lock lock;
     private final QueueInitializer initializer = new QueueInitializer();
@@ -63,7 +69,7 @@ public class MultiEndPointQueue implements Dispatch<InterHubMessage> {
         // waiting endpoint, even if there are multiple waiting to do work
         EndPointQueue selected = waiting.isEmpty() ? null : waiting.get(0);
         while (!queue.isEmpty()) {
-            InterHubMessage message = queue.get(0);
+            InterHubMessage message = queue.peekFirst();
             switch (message.getDelivery()) {
                 case Stateful:
                 case AllHandlers:
@@ -76,14 +82,14 @@ public class MultiEndPointQueue implements Dispatch<InterHubMessage> {
                     for (EndPointQueue endpoint : endpoints) {
                         endpoint.dispatch(message);
                     }
-                    queue.remove(0);
+                    queue.removeFirst();
                     waiting.clear();
                     continue;
                 case SingleHandler:
                     if (selected == null) {
                         return;
                     }
-                    queue.remove(0);
+                    queue.removeFirst();
                     waiting.remove(selected);
                     selected.dispatch(message);
                     break;

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ClassInspector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ClassInspector.java
@@ -18,11 +18,11 @@ package org.gradle.internal.reflect;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class ClassInspector {
@@ -38,14 +38,14 @@ public class ClassInspector {
 
     private static void visitGraph(Class<?> type, MutableClassDetails classDetails) {
         Set<Class<?>> seen = new HashSet<Class<?>>();
-        List<Class<?>> queue = new ArrayList<Class<?>>();
+        Deque<Class<?>> queue = new ArrayDeque<Class<?>>();
 
         // fully visit the class hierarchy before any interfaces in order to meet the contract
         // of PropertyDetails.getGetters() etc.
         queue.add(type);
         superClasses(type, queue);
         while (!queue.isEmpty()) {
-            Class<?> current = queue.remove(0);
+            Class<?> current = queue.removeFirst();
             if (!seen.add(current)) {
                 continue;
             }

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/ModelGraph.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/ModelGraph.java
@@ -24,12 +24,10 @@ import org.gradle.model.internal.core.ModelPath;
 
 import javax.annotation.Nullable;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,7 +43,7 @@ class ModelGraph {
     private final SetMultimap<ModelPath, ModelListener> ancestorListeners = LinkedHashMultimap.create();
     private final Set<ModelListener> listeners = new LinkedHashSet<ModelListener>();
     private boolean notifying;
-    private final List<ModelListener> pendingListeners = new ArrayList<ModelListener>();
+    private final Deque<ModelListener> pendingListeners = new ArrayDeque<>();
     private final Map<ModelNodeInternal, PendingState> pendingNodes = Maps.newLinkedHashMap();
 
     public ModelGraph(ModelNodeInternal rootNode) {
@@ -193,7 +191,7 @@ class ModelGraph {
 
     private void flush() {
         while (!pendingListeners.isEmpty()) {
-            doAddListener(pendingListeners.remove(0));
+            doAddListener(pendingListeners.removeFirst());
         }
         while (!pendingNodes.isEmpty()) {
             Iterator<Map.Entry<ModelNodeInternal, PendingState>> iPendingNodes = pendingNodes.entrySet().iterator();


### PR DESCRIPTION
`ArrayList` has linear `remove(0)`, while `ArrayDeque` has amortised constant time.
Consuming a `Queue` therefore is quadratic in one case and linear in the other.

`ArrayDeque` was used when only the front and end was accessed, `LinkedList` when we're inserting/removing from random locations.

Found these while investigating perf regressions.

Ad-hoc perf test for [`assembleDebug on largeAndroidBuild`:](https://builds.gradle.org/viewLog.html?buildId=23330478&buildTypeId=Gradle_Util_Performance_AdHocPerformanceScenarioLinux&tab=artifacts&branch_Gradle_Util_Performance=lorinc%2Farraydeque-and-linkedlist-backed-queues#%2Fresults%2Fperformance%2Fbuild%2Ftest-results-performanceAdhocTest.zip!%2Fflames%2Fcurrent%2Fcpu%2Fsimplified)

<img width="1556" alt="Screen Shot 2019-05-28 at 10 47 41" src="https://user-images.githubusercontent.com/1841944/58464486-0f837000-8136-11e9-9b79-1cbc8e0f4a87.png">
