### PR TITLE
Re-enable production environment check

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -65,9 +65,9 @@ for (project in rootProject.children) {
 
 fun remoteBuildCacheEnabled(settings: Settings) = settings.buildCache.remote?.isEnabled == true
 
-fun isOpenJDK() = true == System.getProperty("java.vm.name")?.contains("OpenJDK")
+fun isAdoptOpenJDK() = true == System.getProperty("java.vendor")?.contains("AdoptOpenJDK")
 
-fun isOpenJDK11() = isOpenJDK() && JavaVersion.current().isJava11
+fun isAdoptOpenJDK11() = isAdoptOpenJDK() && JavaVersion.current().isJava11
 
 fun getBuildJavaHome() = System.getProperty("java.home")
 
@@ -76,7 +76,7 @@ gradle.settingsEvaluated {
         return@settingsEvaluated
     }
 
-    if (remoteBuildCacheEnabled(this) && !isOpenJDK11()) {
+    if (remoteBuildCacheEnabled(this) && !isAdoptOpenJDK11()) {
         throw GradleException("Remote cache is enabled, which requires OpenJDK 11 to perform this build. It's currently ${getBuildJavaHome()}.")
     }
 

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -54,7 +54,7 @@ const val testJavaHomePropertyName = "testJavaHome"
 
 
 private
-const val productionJdkName = "OpenJDK 11"
+const val productionJdkName = "AdoptOpenJDK 11"
 
 
 open class AvailableJavaInstallations(private val project: Project, private val javaInstallationProbe: JavaInstallationProbe, private val jvmVersionDetector: JvmVersionDetector) {
@@ -84,7 +84,7 @@ open class AvailableJavaInstallations(private val project: Project, private val 
     }
 
     fun validateForProductionEnvironment() {
-//        validate(validateProductionJdks())
+        validate(validateProductionJdks())
     }
 
     private


### PR DESCRIPTION
### Context

Previously we disabled production check after upgrading to AdoptOpenJDK 11.0.3. Now we re-enable the check and forbid users to use other JDK if remote cache is enabled.