### PR TITLE
"gradle init" improvements for Kotlin projects

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -1369,7 +1369,7 @@ public class BuildScriptBuilder {
         @Override
         public String pluginDependencySpec(String pluginId, @Nullable String version) {
             if (version != null) {
-                return "id(\"" + pluginId + "\").version(\"" + version + "\")";
+                return "id(\"" + pluginId + "\") version \"" + version + "\"";
             }
             return pluginId.matches("[a-z]+") ? pluginId : "`" + pluginId + "`";
         }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinLibraryProjectInitDescriptor.java
@@ -61,7 +61,9 @@ public class KotlinLibraryProjectInitDescriptor extends JvmProjectInitDescriptor
 
         new KotlinProjectInitDescriptor(libraryVersionProvider).generate(buildScriptBuilder);
 
-        buildScriptBuilder.fileComment("This generated file contains a sample Kotlin library project to get you started.");
+        buildScriptBuilder
+            .fileComment("This generated file contains a sample Kotlin library project to get you started.")
+            .plugin("Apply the java-library plugin for API and implementation separation.", "java-library");
 
         TemplateOperation kotlinSourceTemplate = templateFactory.fromSourceTemplate("kotlinlibrary/Library.kt.template", "main");
         TemplateOperation kotlinTestTemplate = templateFactory.fromSourceTemplate("kotlinlibrary/LibraryTest.kt.template", "test");

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
@@ -72,6 +72,7 @@ see more at gradle.org""")
         when:
         builder.plugin("Add support for the Java language", "java")
         builder.plugin("Add support for Java libraries", "java-library")
+        builder.plugin("Add support for the Kotlin language", "org.jetbrains.kotlin.jvm", "1.3.31")
         builder.create().generate()
 
         then:
@@ -85,6 +86,9 @@ plugins {
 
     // Add support for Java libraries
     id 'java-library'
+
+    // Add support for the Kotlin language
+    id 'org.jetbrains.kotlin.jvm' version '1.3.31'
 }
 """)
     }

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
@@ -72,6 +72,7 @@ see more at gradle.org""")
         when:
         builder.plugin("Add support for the Java language", "java")
         builder.plugin("Add support for Java libraries", "java-library")
+        builder.plugin("Add support for the Kotlin language", "org.jetbrains.kotlin.jvm", "1.3.31")
         builder.create().generate()
 
         then:
@@ -85,6 +86,9 @@ plugins {
 
     // Add support for Java libraries
     `java-library`
+
+    // Add support for the Kotlin language
+    id("org.jetbrains.kotlin.jvm").version("1.3.31")
 }
 """)
     }

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
@@ -88,7 +88,7 @@ plugins {
     `java-library`
 
     // Add support for the Kotlin language
-    id("org.jetbrains.kotlin.jvm").version("1.3.31")
+    id("org.jetbrains.kotlin.jvm") version "1.3.31"
 }
 """)
     }


### PR DESCRIPTION
### Context

This improves the project templates generated by `gradle init --dsl kotlin` for more modern and simpler syntax.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
