### PR TITLE
Fix more TAPI cancellation flakiness

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/CancellationSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/CancellationSpec.groovy
@@ -75,9 +75,9 @@ latch.await()
         assert resultHandler.failure.message.startsWith(failureMessage)
 
         if (targetIsGradle51OrLater()) {
-            // https://github.com/gradle/gradle-private/issues/1760
-            assert resultHandler.failure.cause.message in ["Build cancelled.", "Daemon was stopped to handle build cancel request."]
+            verifyBuildCancelledExceptionMessage(resultHandler)
         }
+
         def failure = OutputScrapingExecutionFailure.from(stdout.toString(), stderr.toString())
         failure.assertHasDescription('Build cancelled.')
         assertHasBuildFailedLogging()
@@ -94,7 +94,7 @@ latch.await()
         // Verify there is a cause that explains that the build was cancelled (and where).
         // Some versions do not included this
         if (targetDist.toolingApiHasCauseOnCancel) {
-            assert resultHandler.failure.cause.message == "Build cancelled."
+            verifyBuildCancelledExceptionMessage(resultHandler)
         }
 
         // Verify that there is some logging output that explains that the build was cancelled.
@@ -104,6 +104,11 @@ latch.await()
             failure.assertHasDescription('Build cancelled.')
             assertHasConfigureFailedLogging()
         }
+    }
+
+    private static void verifyBuildCancelledExceptionMessage(TestResultHandler resultHandler) {
+        // https://github.com/gradle/gradle-private/issues/1760
+        assert resultHandler.failure.cause.message in ["Build cancelled.", "Daemon was stopped to handle build cancel request."]
     }
 
     void taskWasCancelled(TestResultHandler resultHandler, String taskPath) {


### PR DESCRIPTION
### Context

This is a leftover of https://github.com/gradle/gradle-private/issues/1760

Depending on the point when cancellation happens, the error message can be:

- Build cancelled
- Daemon was stopped to handle build cancel request

In previous fix we neglected one place. This PR fixes it.