### PR TITLE
Fix ConcurrentGroupingQueueTest flakiness

### DIFF
--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ConcurrentGroupingQueueTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ConcurrentGroupingQueueTest.kt
@@ -70,7 +70,7 @@ class ConcurrentGroupingQueueTest {
         pushElementSignal.countDown()
 
         assertThat(
-            subject.nextGroup(200),
+            subject.nextGroup(defaultTestTimeoutMillis),
             equalTo(listOf(42))
         )
     }


### PR DESCRIPTION
on Windows, the hardcoded 200ms wait isn't always enough
use fixture longer default timeout instead
given the latch the test doesn't wait for the timeout to occur anyway
