### PR TITLE
Don't use classloader registry in worker daemons

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderRegistry.java
@@ -44,7 +44,14 @@ public interface ClassLoaderRegistry {
     ClassLoader getWorkerPluginsClassLoader();
 
     /**
-     * Returns a copy of the filter spec for the Gradle API Classloader
+     * Returns a copy of the filter spec for the Gradle API Classloader.  This is expensive to calculate, so we create it once in
+     * the build process and provide it to the worker.
      */
     FilteringClassLoader.Spec getGradleApiFilterSpec();
+
+    /**
+     * Returns the extension classloader spec for use in worker processes.  This is expensive to calculate, so we create it once in
+     * the build process and provide it to the worker.
+     */
+    MixInLegacyTypesClassLoader.Spec getGradleWorkerExtensionSpec();
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderRegistry.java
@@ -39,11 +39,6 @@ public interface ClassLoaderRegistry {
     ClassLoader getGradleCoreApiClassLoader();
 
     /**
-     * Returns the implementation class loader for the built-in plugins, constructed for use in a worker process.
-     */
-    ClassLoader getWorkerPluginsClassLoader();
-
-    /**
      * Returns a copy of the filter spec for the Gradle API Classloader.  This is expensive to calculate, so we create it once in
      * the build process and provide it to the worker.
      */

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultClassLoaderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultClassLoaderRegistry.java
@@ -18,14 +18,12 @@ package org.gradle.initialization;
 
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.internal.classloader.FilteringClassLoader;
-import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.reflect.Instantiator;
 
 public class DefaultClassLoaderRegistry implements ClassLoaderRegistry {
     private final ClassLoader apiOnlyClassLoader;
     private final ClassLoader apiAndPluginsClassLoader;
     private final ClassLoader pluginsClassLoader;
-    private final ClassLoader workerPluginsClassLoader;
     private final FilteringClassLoader.Spec gradleApiSpec;
     private final MixInLegacyTypesClassLoader.Spec workerExtensionSpec;
     private final Instantiator instantiator;
@@ -35,10 +33,8 @@ public class DefaultClassLoaderRegistry implements ClassLoaderRegistry {
         ClassLoader runtimeClassLoader = getClass().getClassLoader();
         this.apiOnlyClassLoader = restrictToGradleApi(runtimeClassLoader);
         this.pluginsClassLoader = new MixInLegacyTypesClassLoader(runtimeClassLoader, classPathRegistry.getClassPath("GRADLE_EXTENSIONS"), legacyTypesSupport);
-        ClassPath workerExtensionClassPath = classPathRegistry.getClassPath("GRADLE_WORKER_EXTENSIONS");
-        this.workerPluginsClassLoader = new MixInLegacyTypesClassLoader(runtimeClassLoader, workerExtensionClassPath, legacyTypesSupport);
         this.gradleApiSpec = apiSpecFor(pluginsClassLoader);
-        this.workerExtensionSpec = new MixInLegacyTypesClassLoader.Spec("legacy-mixin-loader", workerExtensionClassPath.getAsURLs());
+        this.workerExtensionSpec = new MixInLegacyTypesClassLoader.Spec("legacy-mixin-loader", classPathRegistry.getClassPath("GRADLE_WORKER_EXTENSIONS").getAsURLs());
         this.apiAndPluginsClassLoader = restrictTo(gradleApiSpec, pluginsClassLoader);
     }
 
@@ -86,11 +82,6 @@ public class DefaultClassLoaderRegistry implements ClassLoaderRegistry {
     @Override
     public ClassLoader getGradleCoreApiClassLoader() {
         return apiOnlyClassLoader;
-    }
-
-    @Override
-    public ClassLoader getWorkerPluginsClassLoader() {
-        return workerPluginsClassLoader;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/FlatClassLoaderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/FlatClassLoaderRegistry.java
@@ -55,4 +55,9 @@ public class FlatClassLoaderRegistry implements ClassLoaderRegistry {
     public FilteringClassLoader.Spec getGradleApiFilterSpec() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public MixInLegacyTypesClassLoader.Spec getGradleWorkerExtensionSpec() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/FlatClassLoaderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/FlatClassLoaderRegistry.java
@@ -47,11 +47,6 @@ public class FlatClassLoaderRegistry implements ClassLoaderRegistry {
     }
 
     @Override
-    public ClassLoader getWorkerPluginsClassLoader() {
-        return classLoader;
-    }
-
-    @Override
     public FilteringClassLoader.Spec getGradleApiFilterSpec() {
         throw new UnsupportedOperationException();
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -23,6 +23,7 @@ import groovy.lang.MetaClassRegistry;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.classanalysis.AsmConstants;
 import org.gradle.internal.classloader.TransformingClassLoader;
+import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.reflect.PropertyAccessorType;
 import org.objectweb.asm.ClassReader;
@@ -35,11 +36,13 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import javax.annotation.Nullable;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -83,6 +86,11 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
 
     public MixInLegacyTypesClassLoader(ClassLoader parent, ClassPath classPath, LegacyTypesSupport legacyTypesSupport) {
         super("legacy-mixin-loader", parent, classPath);
+        this.legacyTypesSupport = legacyTypesSupport;
+    }
+
+    public MixInLegacyTypesClassLoader(ClassLoader parent, Collection<URL> urls, LegacyTypesSupport legacyTypesSupport) {
+        super("legacy-mixin-loader", parent, urls);
         this.legacyTypesSupport = legacyTypesSupport;
     }
 
@@ -333,6 +341,17 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
             mv.visitLocalVariable("this", "L" + className + ";", null, l0, l1, 0);
             mv.visitMaxs(1, 1);
             mv.visitEnd();
+        }
+    }
+
+    public static class Spec extends VisitableURLClassLoader.Spec {
+        public Spec(String name, List<URL> classpath) {
+            super(name, classpath);
+        }
+
+        @Override
+        public String toString() {
+            return "{legacy-mixin-class-loader name:" + super.getName() + ", classpath:" + getClasspath() + "}";
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -19,10 +19,18 @@ package org.gradle.internal.service.scopes;
 import com.google.common.collect.Iterables;
 import org.gradle.api.execution.internal.DefaultTaskInputsListener;
 import org.gradle.api.execution.internal.TaskInputsListener;
+import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DefaultClassPathProvider;
+import org.gradle.api.internal.DefaultClassPathRegistry;
+import org.gradle.api.internal.DynamicModulesClassPathProvider;
 import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.api.internal.classpath.DefaultModuleRegistry;
+import org.gradle.api.internal.classpath.DefaultPluginModuleRegistry;
+import org.gradle.api.internal.classpath.ModuleRegistry;
+import org.gradle.api.internal.classpath.PluginModuleRegistry;
 import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
@@ -46,10 +54,13 @@ import org.gradle.cli.CommandLineConverter;
 import org.gradle.configuration.DefaultImportsReader;
 import org.gradle.configuration.ImportsReader;
 import org.gradle.initialization.ClassLoaderRegistry;
+import org.gradle.initialization.DefaultClassLoaderRegistry;
 import org.gradle.initialization.DefaultCommandLineConverter;
 import org.gradle.initialization.DefaultJdkToolsInitializer;
 import org.gradle.initialization.DefaultParallelismConfigurationManager;
+import org.gradle.initialization.FlatClassLoaderRegistry;
 import org.gradle.initialization.JdkToolsInitializer;
+import org.gradle.initialization.LegacyTypesSupport;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
@@ -64,6 +75,8 @@ import org.gradle.internal.filewatch.DefaultFileWatcherFactory;
 import org.gradle.internal.filewatch.FileWatcherFactory;
 import org.gradle.internal.hash.DefaultStreamHasher;
 import org.gradle.internal.hash.StreamHasher;
+import org.gradle.internal.installation.CurrentGradleInstallation;
+import org.gradle.internal.installation.GradleRuntimeShadedJarDetector;
 import org.gradle.internal.instantiation.DefaultInstantiatorFactory;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -72,6 +85,7 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.DefaultBuildOperationListenerManager;
+import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.remote.MessagingServer;
 import org.gradle.internal.remote.services.MessagingServices;
@@ -110,6 +124,7 @@ import java.util.List;
  */
 public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
 
+    protected final ClassPath additionalModuleClassPath;
     private GradleBuildEnvironment environment;
 
     public GlobalScopeServices(final boolean longLiving) {
@@ -117,7 +132,8 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
     }
 
     public GlobalScopeServices(final boolean longLiving, ClassPath additionalModuleClassPath) {
-        super(additionalModuleClassPath);
+        super();
+        this.additionalModuleClassPath = additionalModuleClassPath;
         this.environment = new GradleBuildEnvironment() {
             public boolean isLongLivingProcess() {
                 return longLiving;
@@ -289,5 +305,33 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
 
     ExecutionStateChangeDetector createExecutionStateChangeDetector() {
         return new DefaultExecutionStateChangeDetector();
+    }
+
+    ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, PluginModuleRegistry pluginModuleRegistry) {
+        return new DefaultClassPathRegistry(
+            new DefaultClassPathProvider(moduleRegistry),
+            new DynamicModulesClassPathProvider(moduleRegistry,
+                pluginModuleRegistry));
+    }
+
+    DefaultModuleRegistry createModuleRegistry(CurrentGradleInstallation currentGradleInstallation) {
+        return new DefaultModuleRegistry(additionalModuleClassPath, currentGradleInstallation.getInstallation());
+    }
+
+    CurrentGradleInstallation createCurrentGradleInstallation() {
+        return CurrentGradleInstallation.locate();
+    }
+
+    PluginModuleRegistry createPluginModuleRegistry(ModuleRegistry moduleRegistry) {
+        return new DefaultPluginModuleRegistry(moduleRegistry);
+    }
+
+    ClassLoaderRegistry createClassLoaderRegistry(ClassPathRegistry classPathRegistry, LegacyTypesSupport legacyTypesSupport) {
+        if (GradleRuntimeShadedJarDetector.isLoadedFrom(getClass())) {
+            return new FlatClassLoaderRegistry(getClass().getClassLoader());
+        }
+
+        // Use DirectInstantiator here to avoid setting up the instantiation infrastructure early
+        return new DefaultClassLoaderRegistry(classPathRegistry, legacyTypesSupport, DirectInstantiator.INSTANCE);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -16,81 +16,28 @@
 
 package org.gradle.internal.service.scopes;
 
-import org.gradle.api.internal.ClassPathRegistry;
-import org.gradle.api.internal.DefaultClassPathProvider;
-import org.gradle.api.internal.DefaultClassPathRegistry;
-import org.gradle.api.internal.DynamicModulesClassPathProvider;
-import org.gradle.api.internal.classpath.DefaultModuleRegistry;
-import org.gradle.api.internal.classpath.DefaultPluginModuleRegistry;
-import org.gradle.api.internal.classpath.ModuleRegistry;
-import org.gradle.api.internal.classpath.PluginModuleRegistry;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.internal.CacheFactory;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.DefaultCacheFactory;
 import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
-import org.gradle.initialization.ClassLoaderRegistry;
-import org.gradle.initialization.DefaultClassLoaderRegistry;
 import org.gradle.initialization.DefaultLegacyTypesSupport;
-import org.gradle.initialization.FlatClassLoaderRegistry;
 import org.gradle.initialization.LegacyTypesSupport;
-import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.installation.CurrentGradleInstallation;
-import org.gradle.internal.installation.GradleRuntimeShadedJarDetector;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.logging.services.ProgressLoggingBridge;
 import org.gradle.internal.operations.BuildOperationIdFactory;
 import org.gradle.internal.operations.DefaultBuildOperationIdFactory;
-import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
 
 public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
 
-    protected final ClassPath additionalModuleClassPath;
-
-    public WorkerSharedGlobalScopeServices() {
-        this(ClassPath.EMPTY);
-    }
-
-    public WorkerSharedGlobalScopeServices(ClassPath additionalModuleClassPath) {
-        this.additionalModuleClassPath = additionalModuleClassPath;
-    }
-
-    ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, PluginModuleRegistry pluginModuleRegistry) {
-        return new DefaultClassPathRegistry(
-            new DefaultClassPathProvider(moduleRegistry),
-            new DynamicModulesClassPathProvider(moduleRegistry,
-                pluginModuleRegistry));
-    }
-
-    DefaultModuleRegistry createModuleRegistry(CurrentGradleInstallation currentGradleInstallation) {
-        return new DefaultModuleRegistry(additionalModuleClassPath, currentGradleInstallation.getInstallation());
-    }
-
-    CurrentGradleInstallation createCurrentGradleInstallation() {
-        return CurrentGradleInstallation.locate();
-    }
-
-    PluginModuleRegistry createPluginModuleRegistry(ModuleRegistry moduleRegistry) {
-        return new DefaultPluginModuleRegistry(moduleRegistry);
-    }
-
     protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
         return new DefaultCacheFactory(fileLockManager, executorFactory, progressLoggerFactory);
-    }
-
-    ClassLoaderRegistry createClassLoaderRegistry(ClassPathRegistry classPathRegistry, LegacyTypesSupport legacyTypesSupport) {
-        if (GradleRuntimeShadedJarDetector.isLoadedFrom(getClass())) {
-            return new FlatClassLoaderRegistry(getClass().getClassLoader());
-        }
-
-        // Use DirectInstantiator here to avoid setting up the instantiation infrastructure early
-        return new DefaultClassLoaderRegistry(classPathRegistry, legacyTypesSupport, DirectInstantiator.INSTANCE);
     }
 
     LegacyTypesSupport createLegacyTypesSupport() {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.compile.daemon.DaemonGroovyCompiler;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.GroovyCompileOptions;
+import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -42,8 +43,9 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
     private final JvmVersionDetector jvmVersionDetector;
     private final WorkerDirectoryProvider workerDirectoryProvider;
     private final ClassPathRegistry classPathRegistry;
+    private final ClassLoaderRegistry classLoaderRegistry;
 
-    public GroovyCompilerFactory(WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, AnnotationProcessorDetector processorDetector, JvmVersionDetector jvmVersionDetector, WorkerDirectoryProvider workerDirectoryProvider, ClassPathRegistry classPathRegistry) {
+    public GroovyCompilerFactory(WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, AnnotationProcessorDetector processorDetector, JvmVersionDetector jvmVersionDetector, WorkerDirectoryProvider workerDirectoryProvider, ClassPathRegistry classPathRegistry, ClassLoaderRegistry classLoaderRegistry) {
         this.workerDaemonFactory = workerDaemonFactory;
         this.inProcessWorkerFactory = inProcessWorkerFactory;
         this.forkOptionsFactory = forkOptionsFactory;
@@ -51,6 +53,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
         this.jvmVersionDetector = jvmVersionDetector;
         this.workerDirectoryProvider = workerDirectoryProvider;
         this.classPathRegistry = classPathRegistry;
+        this.classLoaderRegistry = classLoaderRegistry;
     }
 
     @Override
@@ -62,7 +65,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
         } else {
             workerFactory = inProcessWorkerFactory;
         }
-        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(workerDirectoryProvider.getWorkingDirectory(), DaemonSideCompiler.class, classPathRegistry, workerFactory, forkOptionsFactory, jvmVersionDetector);
+        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(workerDirectoryProvider.getWorkingDirectory(), DaemonSideCompiler.class, classPathRegistry, workerFactory, classLoaderRegistry, forkOptionsFactory, jvmVersionDetector);
         return new AnnotationProcessorDiscoveringCompiler<GroovyJavaJointCompileSpec>(new NormalizingGroovyCompiler(groovyCompiler), processorDetector);
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -41,6 +41,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.jvm.toolchain.JavaToolChain;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -87,7 +88,8 @@ public class GroovyCompile extends AbstractCompile {
             JvmVersionDetector jvmVersionDetector = getServices().get(JvmVersionDetector.class);
             WorkerDirectoryProvider workerDirectoryProvider = getServices().get(WorkerDirectoryProvider.class);
             ClassPathRegistry classPathRegistry = getServices().get(ClassPathRegistry.class);
-            GroovyCompilerFactory groovyCompilerFactory = new GroovyCompilerFactory(workerDaemonFactory, inProcessWorkerFactory, forkOptionsFactory, processorDetector, jvmVersionDetector, workerDirectoryProvider, classPathRegistry);
+            ClassLoaderRegistry classLoaderRegistry = getServices().get(ClassLoaderRegistry.class);
+            GroovyCompilerFactory groovyCompilerFactory = new GroovyCompilerFactory(workerDaemonFactory, inProcessWorkerFactory, forkOptionsFactory, processorDetector, jvmVersionDetector, workerDirectoryProvider, classPathRegistry, classLoaderRegistry);
             Compiler<GroovyJavaJointCompileSpec> delegatingCompiler = groovyCompilerFactory.newCompiler(spec);
             compiler = new CleaningGroovyCompiler(delegatingCompiler, getOutputs());
         }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -78,7 +78,8 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
 
         ClassPath compilerClasspath = classPathRegistry.getClassPath("SCALA-COMPILER").plus(DefaultClassPath.of(zincClasspath));
 
-        HierarchicalClassLoaderStructure classLoaderStructure = new HierarchicalClassLoaderStructure(getScalaFilterSpec())
+        HierarchicalClassLoaderStructure classLoaderStructure = new HierarchicalClassLoaderStructure(classLoaderRegistry.getGradleWorkerExtensionSpec())
+                .withChild(getScalaFilterSpec())
                 .withChild(new VisitableURLClassLoader.Spec("compiler", compilerClasspath.getAsURLs()));
 
         return new DaemonForkOptionsBuilder(forkOptionsFactory)

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
@@ -61,7 +61,8 @@ public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemo
 
         ClassPath playCompilerClasspath = classPathRegistry.getClassPath("PLAY-COMPILER").plus(DefaultClassPath.of(compilerClasspath));
 
-        HierarchicalClassLoaderStructure classLoaderStructure = new HierarchicalClassLoaderStructure(getPlayFilterSpec())
+        HierarchicalClassLoaderStructure classLoaderStructure = new HierarchicalClassLoaderStructure(classLoaderRegistry.getGradleWorkerExtensionSpec())
+                .withChild(getPlayFilterSpec())
                 .withChild(new VisitableURLClassLoader.Spec("compiler", playCompilerClasspath.getAsURLs()));
 
         return new DaemonForkOptionsBuilder(forkOptionsFactory)

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderStructureProvider.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderStructureProvider.java
@@ -16,36 +16,59 @@
 
 package org.gradle.workers.internal;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import org.gradle.initialization.ClassLoaderRegistry;
+import org.gradle.initialization.MixInLegacyTypesClassLoader;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.DefaultClassPath;
 
 import java.io.File;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 public class ClassLoaderStructureProvider {
-    private final LoadingCache<Iterable<File>, ClassLoaderStructure> knownClassLoaderStructures;
+    private final ClassLoaderRegistry classLoaderRegistry;
+    private final Cache<Iterable<File>, ClassLoaderStructure> knownClassLoaderStructures;
 
     public ClassLoaderStructureProvider(final ClassLoaderRegistry classLoaderRegistry) {
-        this.knownClassLoaderStructures = CacheBuilder.newBuilder().softValues().build(new CacheLoader<Iterable<File>, ClassLoaderStructure>() {
-            @Override
-            public ClassLoaderStructure load(Iterable<File> userClasspathFiles) throws Exception {
-                FilteringClassLoader.Spec gradleApiFilter = classLoaderRegistry.getGradleApiFilterSpec();
-                VisitableURLClassLoader.Spec userSpec = new VisitableURLClassLoader.Spec("worker-loader", DefaultClassPath.of(userClasspathFiles).getAsURLs());
-                // Add the Gradle API filter between the user classloader and the worker infrastructure classloader
-                return new HierarchicalClassLoaderStructure(gradleApiFilter).withChild(userSpec);
-            }
-        });
+        this.classLoaderRegistry = classLoaderRegistry;
+        this.knownClassLoaderStructures = CacheBuilder.newBuilder().softValues().build();
     }
 
-    public ClassLoaderStructure getDefaultClassLoaderStructure(Iterable<File> userClasspathFiles) {
+    public ClassLoaderStructure getWorkerProcessClassLoaderStructure(final Iterable<File> userClasspathFiles) {
         try {
-            return knownClassLoaderStructures.get(userClasspathFiles);
+            return knownClassLoaderStructures.get(userClasspathFiles, new Callable<ClassLoaderStructure>() {
+                @Override
+                public ClassLoaderStructure call() throws Exception {
+                    MixInLegacyTypesClassLoader.Spec workerExtensionSpec = classLoaderRegistry.getGradleWorkerExtensionSpec();
+                    FilteringClassLoader.Spec gradleApiFilter = classLoaderRegistry.getGradleApiFilterSpec();
+                    VisitableURLClassLoader.Spec userSpec = new VisitableURLClassLoader.Spec("worker-loader", DefaultClassPath.of(userClasspathFiles).getAsURLs());
+                    // Add the Gradle API filter between the user classloader and the worker infrastructure classloader
+                    return new HierarchicalClassLoaderStructure(workerExtensionSpec)
+                            .withChild(gradleApiFilter)
+                            .withChild(userSpec);
+                }
+            });
+        } catch (ExecutionException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    public ClassLoaderStructure getInProcessClassLoaderStructure(final Iterable<File> userClasspathFiles) {
+        try {
+            return knownClassLoaderStructures.get(userClasspathFiles, new Callable<ClassLoaderStructure>() {
+                @Override
+                public ClassLoaderStructure call() throws Exception {
+                    FilteringClassLoader.Spec gradleApiFilter = classLoaderRegistry.getGradleApiFilterSpec();
+                    VisitableURLClassLoader.Spec userSpec = new VisitableURLClassLoader.Spec("worker-loader", DefaultClassPath.of(userClasspathFiles).getAsURLs());
+                    // Add the Gradle API filter between the user classloader and the worker infrastructure classloader
+                    return new HierarchicalClassLoaderStructure(gradleApiFilter)
+                            .withChild(userSpec);
+                }
+            });
         } catch (ExecutionException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -232,7 +232,11 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
 
             Iterable<File> daemonClasspath = classpathBuilder.build();
 
-            builder.withClassLoaderStructure(classLoaderStructureProvider.getDefaultClassLoaderStructure(daemonClasspath));
+            if (isolationMode == IsolationMode.PROCESS) {
+                builder.withClassLoaderStructure(classLoaderStructureProvider.getWorkerProcessClassLoaderStructure(daemonClasspath));
+            } else {
+                builder.withClassLoaderStructure(classLoaderStructureProvider.getInProcessClassLoaderStructure(daemonClasspath));
+            }
         }
 
         return builder.build();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/VisitableURLClassLoaderSpecSerializer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/VisitableURLClassLoaderSpecSerializer.java
@@ -17,6 +17,7 @@
 package org.gradle.workers.internal;
 
 import com.google.common.collect.Lists;
+import org.gradle.initialization.MixInLegacyTypesClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -26,8 +27,17 @@ import java.net.URL;
 import java.util.List;
 
 public class VisitableURLClassLoaderSpecSerializer implements Serializer<VisitableURLClassLoader.Spec> {
+    private static final byte VISITABLE_URL_CLASSLOADER_SPEC = (byte) 0;
+    private static final byte MIXIN_CLASSLOADER_SPEC = (byte) 1;
+
     @Override
     public void write(Encoder encoder, VisitableURLClassLoader.Spec spec) throws Exception {
+        if (spec instanceof MixInLegacyTypesClassLoader.Spec) {
+            encoder.writeByte(MIXIN_CLASSLOADER_SPEC);
+        } else {
+            encoder.writeByte(VISITABLE_URL_CLASSLOADER_SPEC);
+        }
+
         encoder.writeString(spec.getName());
         encoder.writeInt(spec.getClasspath().size());
         for (URL url : spec.getClasspath()) {
@@ -37,12 +47,21 @@ public class VisitableURLClassLoaderSpecSerializer implements Serializer<Visitab
 
     @Override
     public VisitableURLClassLoader.Spec read(Decoder decoder) throws Exception {
+        byte typeTag = decoder.readByte();
         String name = decoder.readString();
         List<URL> classpath = Lists.newArrayList();
         int classpathSize = decoder.readInt();
         for (int i=0; i<classpathSize; i++) {
             classpath.add(new URL(decoder.readString()));
         }
-        return new VisitableURLClassLoader.Spec(name, classpath);
+
+        switch(typeTag) {
+            case VISITABLE_URL_CLASSLOADER_SPEC:
+                return new VisitableURLClassLoader.Spec(name, classpath);
+            case MIXIN_CLASSLOADER_SPEC:
+                return new MixInLegacyTypesClassLoader.Spec(name, classpath);
+            default:
+                throw new IllegalArgumentException("Unexpected payload type.");
+        }
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -17,7 +17,6 @@
 package org.gradle.workers.internal;
 
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
-import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.instantiation.DefaultInstantiatorFactory;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -64,8 +63,7 @@ public class WorkerDaemonServer implements WorkerProtocol {
             if (classLoaderStructure instanceof FlatClassLoaderStructure) {
                 isolatedClassloaderWorker = new FlatClassLoaderWorker(this.getClass().getClassLoader(), serviceRegistry);
             } else {
-                ClassLoaderRegistry classLoaderRegistry = serviceRegistry.get(ClassLoaderRegistry.class);
-                isolatedClassloaderWorker = new IsolatedClassloaderWorker(classLoaderStructure, classLoaderRegistry.getWorkerPluginsClassLoader(), serviceRegistry, true);
+                isolatedClassloaderWorker = new IsolatedClassloaderWorker(classLoaderStructure, this.getClass().getClassLoader(), serviceRegistry, true);
             }
         }
         return isolatedClassloaderWorker;

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -128,7 +128,7 @@ class DefaultWorkerExecutorTest extends Specification {
         DaemonForkOptions daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration)
 
         then:
-        1 * classLoaderStructureProvider.getDefaultClassLoaderStructure(_) >> { args -> new HierarchicalClassLoaderStructure(new VisitableURLClassLoader.Spec("test", args[0].collect { it.toURI().toURL() }))}
+        1 * classLoaderStructureProvider.getInProcessClassLoaderStructure(_) >> { args -> new HierarchicalClassLoaderStructure(new VisitableURLClassLoader.Spec("test", args[0].collect { it.toURI().toURL() }))}
 
         and:
         daemonForkOptions.classLoaderStructure.spec.classpath.contains(foo.toURI().toURL())


### PR DESCRIPTION
This resolves a performance regression with worker daemons.  Rather than construct a classloader registry in the worker daemon to calculate the plugins classloader (which is expensive), we just construct it once in the build process and then pass a spec to worker daemons instead.