### PR TITLE
Only start logging on worker once the logging manager is connected

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -31,7 +31,9 @@ import org.gradle.process.internal.worker.DefaultWorkerProcessFactory
 import org.gradle.process.internal.worker.WorkerProcess
 import org.gradle.process.internal.worker.WorkerProcessBuilder
 import org.gradle.process.internal.worker.WorkerProcessContext
+import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
+import spock.lang.Requires
 import spock.lang.Timeout
 import spock.lang.Unroll
 
@@ -224,6 +226,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         ! stdout.stdErr.contains("java.lang.IllegalStateException")
     }
 
+    @Requires({TestPrecondition.NOT_WINDOWS})
     def "handles output when worker fails before logging is started"() {
         when:
         execute(worker(new RemoteProcess()).jvmArgs("-Dorg.gradle.native.dir=/dev/null").expectStartFailure())

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -54,12 +54,12 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
 
     void execute(ChildProcess... processes) throws Throwable {
         for (ChildProcess process : processes) {
-            process.start();
+            process.start()
         }
         for (ChildProcess process : processes) {
-            process.waitForStop();
+            process.waitForStop()
         }
-        exceptionListener.rethrow();
+        exceptionListener.rethrow()
     }
 
     def workerProcessStdoutAndStderrIsForwardedToThisProcess() {
@@ -224,26 +224,35 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         ! stdout.stdErr.contains("java.lang.IllegalStateException")
     }
 
+    def "handles output when worker fails before logging is started"() {
+        when:
+        execute(worker(new RemoteProcess()).jvmArgs("-Dorg.gradle.native.dir=/dev/null").expectStartFailure())
+
+        then:
+        noExceptionThrown()
+        stdout.stdErr.contains("net.rubygrapefruit.platform.NativeException: Failed to load native library")
+    }
+
     private class ChildProcess {
-        private boolean stopFails;
-        private boolean startFails;
-        private WorkerProcess proc;
-        private Action<? super WorkerProcessContext> action;
-        private List<String> jvmArgs = Collections.emptyList();
-        private Action<ObjectConnectionBuilder> serverAction;
+        private boolean stopFails
+        private boolean startFails
+        private WorkerProcess proc
+        private Action<? super WorkerProcessContext> action
+        private List<String> jvmArgs = Collections.emptyList()
+        private Action<ObjectConnectionBuilder> serverAction
 
         public ChildProcess(Action<? super WorkerProcessContext> action) {
-            this.action = action;
+            this.action = action
         }
 
         ChildProcess expectStopFailure() {
-            stopFails = true;
-            return this;
+            stopFails = true
+            return this
         }
 
         ChildProcess expectStartFailure() {
-            startFails = true;
-            return this;
+            startFails = true
+            return this
         }
 
         public void start() {
@@ -253,9 +262,9 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
             builder.javaCommand.systemProperty("test.system.property", "value")
             builder.javaCommand.environment("TEST_ENV_VAR", "value")
 
-            builder.javaCommand.jvmArgs(jvmArgs);
+            builder.javaCommand.jvmArgs(jvmArgs)
 
-            proc = builder.build();
+            proc = builder.build()
             try {
                 proc.start()
                 assertFalse(startFails)
@@ -263,7 +272,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
                 if (!startFails) {
                     throw new AssertionError(e)
                 }
-                return;
+                return
             }
             proc.connection.addIncoming(TestListenerInterface.class, exceptionListener)
             if (serverAction != null) {
@@ -303,7 +312,7 @@ class StdOutSerializableLogAction extends SerializableLogAction {
     }
 
     void execute() {
-        System.out.println(message);
+        System.out.println(message)
     }
 }
 
@@ -313,7 +322,7 @@ class StdErrSerializableLogAction extends SerializableLogAction {
     }
 
     void execute() {
-        System.err.println(message);
+        System.err.println(message)
     }
 }
 
@@ -338,5 +347,5 @@ abstract class SerializableLogAction implements Serializable {
         this.message = message
     }
 
-    abstract void execute();
+    abstract void execute()
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/WorkerProcessIntegrationTest.groovy
@@ -31,9 +31,9 @@ import org.gradle.process.internal.worker.DefaultWorkerProcessFactory
 import org.gradle.process.internal.worker.WorkerProcess
 import org.gradle.process.internal.worker.WorkerProcessBuilder
 import org.gradle.process.internal.worker.WorkerProcessContext
+import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
-import spock.lang.Requires
 import spock.lang.Timeout
 import spock.lang.Unroll
 
@@ -226,7 +226,7 @@ class WorkerProcessIntegrationTest extends AbstractWorkerProcessIntegrationSpec 
         ! stdout.stdErr.contains("java.lang.IllegalStateException")
     }
 
-    @Requires({TestPrecondition.NOT_WINDOWS})
+    @Requires(TestPrecondition.NOT_WINDOWS)
     def "handles output when worker fails before logging is started"() {
         when:
         execute(worker(new RemoteProcess()).jvmArgs("-Dorg.gradle.native.dir=/dev/null").expectStartFailure())

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -84,8 +84,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
         // Read logging config and setup logging
         int logLevel = decoder.readSmallInt();
         LoggingServiceRegistry loggingServiceRegistry = LoggingServiceRegistry.newEmbeddableLogging();
-        LoggingManagerInternal loggingManager = createLoggingManager(loggingServiceRegistry);
-        loggingManager.setLevelInternal(LogLevel.values()[logLevel]).start();
+        LoggingManagerInternal loggingManager = createLoggingManager(loggingServiceRegistry).setLevelInternal(LogLevel.values()[logLevel]);
 
         // Read whether process info should be published
         boolean shouldPublishJvmMemoryInfo = decoder.readBoolean();
@@ -124,6 +123,8 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
             connection = messagingServices.get(MessagingClient.class).getConnection(serverAddress);
             connection.addUnrecoverableErrorHandler(unrecoverableErrorHandler);
             workerLogEventListener = configureLogging(loggingManager, connection);
+            // start logging now that the logging manager is connected
+            loggingManager.start();
             if (shouldPublishJvmMemoryInfo) {
                 configureWorkerJvmMemoryInfoEvents(workerServices, connection);
             }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.jvm.Jvm
+import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.workers.IsolationMode
-import spock.lang.Requires
 import spock.lang.Unroll
 
 import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
@@ -291,7 +291,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         isolationMode << [IsolationMode.CLASSLOADER, IsolationMode.NONE]
     }
 
-    @Requires({TestPrecondition.NOT_WINDOWS})
+    @Requires(TestPrecondition.NOT_WINDOWS)
     def "produces a sensible error when worker fails before logging is initialized"() {
         fixture.withRunnableClassInBuildScript()
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.jvm.Jvm
+import org.gradle.util.TestPrecondition
 import org.gradle.workers.IsolationMode
+import spock.lang.Requires
 import spock.lang.Unroll
 
 import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
@@ -289,6 +291,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         isolationMode << [IsolationMode.CLASSLOADER, IsolationMode.NONE]
     }
 
+    @Requires({TestPrecondition.NOT_WINDOWS})
     def "produces a sensible error when worker fails before logging is initialized"() {
         fixture.withRunnableClassInBuildScript()
 


### PR DESCRIPTION
This way, the worker will continue to print to standard out/err until it actually can send messages to the daemon.