### PR TITLE
Don't run `buildSrc` tasks when running from instant execution cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
@@ -120,25 +120,24 @@ class TaskTypeUpToDateIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when: succeeds "copy"
-        then: skippedTasks.empty
+        then: result.ignoreBuildSrc.assertTasksSkipped()
 
         file("output.txt").makeOlder()
 
         when: succeeds "copy"
-        then: skippedTasks == ([":copy"] as Set)
+        then: result.ignoreBuildSrc.assertTasksSkipped(":copy")
 
         when:
         file("buildSrc/src/main/groovy/SimpleCopyTask.groovy").text = declareSimpleCopyTaskType(true)
 
         succeeds "copy"
 
-        then:
-        skippedTasks.empty
+        then: result.ignoreBuildSrc.assertTasksSkipped()
 
         when:
         succeeds "copy"
 
-        then: skippedTasks == ([":copy"] as Set)
+        then: result.ignoreBuildSrc.assertTasksSkipped(":copy")
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-1910")
@@ -157,25 +156,24 @@ class TaskTypeUpToDateIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when: succeeds "copy"
-        then: skippedTasks.empty
+        then: result.ignoreBuildSrc.assertTasksSkipped()
 
         file("output.txt").makeOlder()
 
         when: succeeds "copy"
-        then: skippedTasks == ([":copy"] as Set)
+        then: result.ignoreBuildSrc.assertTasksSkipped(":copy")
 
         when:
         file("buildSrc/build.gradle").text = guavaDependency("19.0")
 
         succeeds "copy"
 
-        then:
-        skippedTasks.empty
+        then: result.ignoreBuildSrc.assertTasksSkipped()
 
         when:
         succeeds "copy"
 
-        then: skippedTasks == ([":copy"] as Set)
+        then: result.ignoreBuildSrc.assertTasksSkipped(":copy")
     }
 
     private static String declareSimpleCopyTask(boolean modification = false) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
@@ -39,7 +39,7 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
         when:
         execute "test"
         then:
-        skippedTasks.empty
+        result.assertTaskNotSkipped(":test")
 
         when:
         assert file("sources/input.txt").renameTo(file("sources/input-renamed.txt"))
@@ -48,14 +48,14 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
 
         execute "test"
         then:
-        skippedTasks.empty == !expectSkipped
+        result.groupedOutput.task(":test").outcome == expectedOutcome
 
         where:
-        pathSensitive | expectSkipped
-        ABSOLUTE      | false
-        RELATIVE      | false
-        NAME_ONLY     | false
-        NONE          | true
+        pathSensitive | expectedOutcome
+        ABSOLUTE      | null
+        RELATIVE      | null
+        NAME_ONLY     | null
+        NONE          | statusForReusedOutput
     }
 
     def "single source file moved within hierarchy with #pathSensitive as input is loaded from cache: #expectSkipped"() {
@@ -75,7 +75,7 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
         when:
         execute "test"
         then:
-        skippedTasks.empty
+        result.assertTaskNotSkipped(":test")
 
         when:
         assert file("src/data1/input.txt").renameTo(file("src/data2/input.txt"))
@@ -83,14 +83,14 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
 
         execute "test"
         then:
-        skippedTasks.empty == !expectSkipped
+        result.groupedOutput.task(":test").outcome == expectedOutcome
 
         where:
-        pathSensitive | expectSkipped
-        ABSOLUTE      | false
-        RELATIVE      | false
-        NAME_ONLY     | true
-        NONE          | true
+        pathSensitive | expectedOutcome
+        ABSOLUTE      | null
+        RELATIVE      | null
+        NAME_ONLY     | statusForReusedOutput
+        NONE          | statusForReusedOutput
     }
 
     def "source file hierarchy moved with #pathSensitive as input is loaded from cache: #expectSkipped"() {
@@ -108,7 +108,7 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
         when:
         execute "test"
         then:
-        skippedTasks.empty
+        result.assertTaskNotSkipped(":test")
 
         when:
         assert file("src").renameTo(file("source"))
@@ -122,19 +122,21 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
 
         execute "test"
         then:
-        skippedTasks.empty == !expectSkipped
+        result.groupedOutput.task(":test").outcome == expectSkipped
 
         where:
         pathSensitive | expectSkipped
-        ABSOLUTE      | false
-        RELATIVE      | true
-        NAME_ONLY     | true
-        NONE          | true
+        ABSOLUTE      | null
+        RELATIVE      | statusForReusedOutput
+        NAME_ONLY     | statusForReusedOutput
+        NONE          | statusForReusedOutput
     }
 
     abstract void execute(String... tasks)
 
     abstract void cleanWorkspace()
+
+    abstract String getStatusForReusedOutput()
 
     private void declareTestTaskWithPathSensitivity(PathSensitivity pathSensitivity) {
         file("buildSrc/src/main/groovy/TestTask.groovy") << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
@@ -41,6 +41,11 @@ class CachedPathSensitivityIntegrationTest extends AbstractPathSensitivityIntegr
         run "clean"
     }
 
+    @Override
+    String getStatusForReusedOutput() {
+        return "FROM-CACHE"
+    }
+
     def "single #pathSensitivity input file loaded from cache can be used as input"() {
         file("src/data/input.txt").text = "data"
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UpToDatePathSensitivityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UpToDatePathSensitivityIntegrationTest.groovy
@@ -25,4 +25,9 @@ class UpToDatePathSensitivityIntegrationTest extends AbstractPathSensitivityInte
     @Override
     void cleanWorkspace() {
     }
+
+    @Override
+    String getStatusForReusedOutput() {
+        return "UP-TO-DATE"
+    }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcIntegrationTest.groovy
@@ -49,9 +49,16 @@ class InstantExecutionBuildSrcIntegrationTest extends AbstractInstantExecutionIn
 
         when:
         instantRun("greeting")
+
+        then:
+        result.assertTaskExecuted(":buildSrc:build")
+        result.assertTaskExecuted(":greeting")
+
+        when:
         instantRun("greeting")
 
         then:
+        result.assertTasksExecuted(":greeting")
         outputContains("yo instant execution")
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildSrcIntegrationTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.TaskAction
+
+class InstantExecutionBuildSrcIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+    def "can use tasks defined in buildSrc"() {
+        file("buildSrc/src/main/java/CustomTask.java") << """
+            import ${DefaultTask.name};
+            import ${TaskAction.name};
+            import ${Property.name};
+
+            public class CustomTask extends DefaultTask {
+                private final Property<String> greeting = getProject().getObjects().property(String.class);
+                 
+                public Property<String> getGreeting() {
+                    return greeting;
+                }
+
+                @TaskAction
+                public void run() {
+                    System.out.println(getGreeting().get());
+                }
+            }
+        """
+
+        buildFile << """
+            task greeting(type: CustomTask) {
+                greeting = 'yo instant execution'
+            }
+        """
+
+        when:
+        instantRun("greeting")
+        instantRun("greeting")
+
+        then:
+        outputContains("yo instant execution")
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -92,6 +92,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         instantExecution.assertStateStored()
+        outputContains("Calculating task graph as no instant execution cache is available for tasks: a")
         outputContains("running build script")
         outputContains("create task")
         outputContains("configure task")
@@ -102,6 +103,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         instantExecution.assertStateLoaded()
+        outputContains("Reusing instant execution cache. This is not guaranteed to work in any way.")
         outputDoesNotContain("running build script")
         outputDoesNotContain("create task")
         outputDoesNotContain("configure task")
@@ -112,6 +114,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         instantExecution.assertStateStored()
+        outputContains("Calculating task graph as no instant execution cache is available for tasks: b")
         outputContains("running build script")
         outputContains("create task")
         outputContains("configure task")
@@ -122,6 +125,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         instantExecution.assertStateLoaded()
+        outputContains("Reusing instant execution cache. This is not guaranteed to work in any way.")
         outputDoesNotContain("running build script")
         outputDoesNotContain("create task")
         outputDoesNotContain("configure task")

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
@@ -21,6 +21,7 @@ import org.gradle.api.internal.project.ProjectInternal
 
 
 interface ClassicModeBuild {
+    val buildSrc: Boolean
 
     val rootProject: ProjectInternal
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -65,7 +65,7 @@ class DefaultInstantExecution(
 
     interface Host {
 
-        val isSkipLoadingState: Boolean
+        val skipLoadingStateReason: String?
 
         val currentBuild: ClassicModeBuild
 
@@ -86,8 +86,8 @@ class DefaultInstantExecution(
         !isInstantExecutionEnabled -> {
             false
         }
-        host.isSkipLoadingState -> {
-            logger.lifecycle("Calculating task graph as skipping instant execution cache was requested")
+        host.skipLoadingStateReason != null -> {
+            logger.lifecycle("Calculating task graph as instant execution cache cannot be reused due to ${host.skipLoadingStateReason}")
             false
         }
         !instantExecutionStateFile.isFile -> {
@@ -293,9 +293,11 @@ class DefaultInstantExecution(
         Files.createDirectories(parentFile.toPath())
     }
 
+    // Skip instant execution for buildSrc for now. Should instead collect up the inputs of its tasks and treat as task graph cache inputs
     private
     val isInstantExecutionEnabled: Boolean
-        get() = host.getSystemProperty("org.gradle.unsafe.instant-execution") != null
+        get() = host.getSystemProperty("org.gradle.unsafe.instant-execution") != null && !host.currentBuild.buildSrc
+
 
     private
     val instantExecutionStateFile by lazy {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -66,8 +66,12 @@ class InstantExecutionHost internal constructor(
     private
     val startParameter = gradle.startParameter
 
-    override val isSkipLoadingState: Boolean
-        get() = gradle.startParameter.isRefreshDependencies
+    override val skipLoadingStateReason: String?
+        get() = if (gradle.startParameter.isRefreshDependencies) {
+            "--refresh-dependencies"
+        } else {
+            null
+        }
 
     override val currentBuild: ClassicModeBuild =
         DefaultClassicModeBuild()
@@ -94,6 +98,8 @@ class InstantExecutionHost internal constructor(
         )
 
     inner class DefaultClassicModeBuild : ClassicModeBuild {
+        override val buildSrc: Boolean
+            get() = gradle.parent != null && gradle.publicBuildPath.buildPath.name == "buildSrc"
 
         override val scheduledTasks: List<Task>
             get() = gradle.taskGraph.allTasks

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
@@ -108,8 +108,8 @@ class BuildSourceBuilderIntegrationTest extends AbstractIntegrationSpec {
         def blockingResult = runBlockingHandle.waitForFinish()
 
         then:
-        blockingResult.assertTasksExecuted(":build1")
-        releaseResult.assertTasksExecuted(":build2")
+        blockingResult.ignoreBuildSrc.assertTasksExecuted(":build1")
+        releaseResult.ignoreBuildSrc.assertTasksExecuted(":build2")
 
         cleanup:
         runReleaseHandle?.abort()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
@@ -63,7 +63,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractPluginIntegration
         when:
         withBuildCache().run "customTask"
         then:
-        skippedTasks.empty
+        result.assertTaskNotSkipped(":customTask")
 
         when:
         file("buildSrc/build").deleteDir()
@@ -72,12 +72,12 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractPluginIntegration
 
         withBuildCache().run "customTask"
         then:
-        skippedTasks.contains ":customTask"
+        result.groupedOutput.task(":customTask").outcome == "FROM-CACHE"
     }
 
     @IgnoreIf({GradleContextualExecuter.parallel})
     @LeaksFileHandles
-    def "changing custom Kotlin task implementation in buildSrc doesn't invalidate built-in task"() {
+    def "changing custom Kotlin task implementation in buildSrc invalidates cached result"() {
         withKotlinBuildSrc()
         def taskSourceFile = file("buildSrc/src/main/kotlin/CustomTask.kt")
         taskSourceFile << customKotlinTask()
@@ -91,7 +91,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractPluginIntegration
         when:
         withBuildCache().run "customTask"
         then:
-        skippedTasks.empty
+        result.assertTaskNotSkipped(":customTask")
         file("build/output.txt").text == "input"
 
         when:
@@ -100,7 +100,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractPluginIntegration
         cleanBuildDir()
         withBuildCache().run "customTask"
         then:
-        nonSkippedTasks.contains ":customTask"
+        result.assertTaskNotSkipped(":customTask")
         file("build/output.txt").text == "input modified"
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionFailure.java
@@ -27,6 +27,11 @@ public class ErrorsOnStdoutScrapingExecutionFailure extends ErrorsOnStdoutScrapi
     }
 
     @Override
+    public ExecutionFailure getIgnoreBuildSrc() {
+        return new ErrorsOnStdoutScrapingExecutionFailure(delegate.getIgnoreBuildSrc());
+    }
+
+    @Override
     public ExecutionFailure assertHasLineNumber(int lineNumber) {
         delegate.assertHasLineNumber(lineNumber);
         return this;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
@@ -29,6 +29,11 @@ public class ErrorsOnStdoutScrapingExecutionResult implements ExecutionResult {
     }
 
     @Override
+    public ExecutionResult getIgnoreBuildSrc() {
+        return new ErrorsOnStdoutScrapingExecutionResult(delegate.getIgnoreBuildSrc());
+    }
+
+    @Override
     public String getOutput() {
         return delegate.getOutput();
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionFailure.java
@@ -18,6 +18,12 @@ package org.gradle.integtests.fixtures.executer;
 import org.hamcrest.Matcher;
 
 public interface ExecutionFailure extends ExecutionResult {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ExecutionFailure getIgnoreBuildSrc();
+
     ExecutionFailure assertHasLineNumber(int lineNumber);
 
     ExecutionFailure assertHasFileName(String filename);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -22,6 +22,11 @@ import java.util.Set;
 
 public interface ExecutionResult {
     /**
+     * Returns a copy of this result that ignores `buildSrc` tasks.
+     */
+    ExecutionResult getIgnoreBuildSrc();
+
+    /**
      * Stdout of the Gradle execution, normalized to use new-line char as line separator.
      *
      * <p>You should avoid using this method as it couples the tests to a particular layout for the console. Instead use the more descriptive assertion methods on this class.</p>
@@ -111,36 +116,36 @@ public interface ExecutionResult {
     ExecutionResult assertHasPostBuildOutput(String expectedOutput);
 
     /**
-     * Returns the tasks have been executed in order started (includes tasks that were skipped). Asserts that each task appears once only. Note: ignores buildSrc tasks.
+     * Returns the tasks have been executed in order started (includes tasks that were skipped). Asserts that each task appears once only.
      *
      * <p>You should avoid using this method, as as doing so not provide useful context on assertion failure. Instead, use the more descriptive assertion methods
      */
     List<String> getExecutedTasks();
 
     /**
-     * Asserts that exactly the given set of tasks have been executed in the given order. Note: ignores buildSrc tasks.
+     * Asserts that exactly the given set of tasks have been executed in the given order.
      * Each task path can be either a String or a {@link TaskOrderSpec}.  See {@link TaskOrderSpecs} for common assertions
      * and an explanation of their usage.  Defaults to a {@link TaskOrderSpecs#exact(Object[])} assertion.
      */
     ExecutionResult assertTasksExecutedInOrder(Object... taskPaths);
 
     /**
-     * Asserts that exactly the given set of tasks have been executed in any order. Note: ignores buildSrc tasks.
+     * Asserts that exactly the given set of tasks have been executed in any order.
      */
     ExecutionResult assertTasksExecuted(Object... taskPaths);
 
     /**
-     * Asserts that the given task has been executed. Note: ignores buildSrc tasks.
+     * Asserts that the given task has been executed.
      */
     ExecutionResult assertTaskExecuted(String taskPath);
 
     /**
-     * Asserts that exactly the given set of tasks have been executed in any order and none of the tasks were skipped. Note: ignores buildSrc tasks.
+     * Asserts that exactly the given set of tasks have been executed in any order and none of the tasks were skipped.
      */
     ExecutionResult assertTasksExecutedAndNotSkipped(Object... taskPaths);
 
     /**
-     * Asserts that the given task has not been executed. Note: ignores buildSrc tasks.
+     * Asserts that the given task has not been executed.
      */
     ExecutionResult assertTaskNotExecuted(String taskPath);
 
@@ -152,29 +157,29 @@ public interface ExecutionResult {
     ExecutionResult assertTaskOrder(Object... taskPaths);
 
     /**
-     * Returns the tasks that were skipped, in an undefined order. Note: ignores buildSrc tasks.
+     * Returns the tasks that were skipped, in an undefined order.
      *
      * <p>You should avoid using this method, as as doing so not provide useful context on assertion failure. Instead, use the more descriptive assertion methods
      */
     Set<String> getSkippedTasks();
 
     /**
-     * Asserts that exactly the given set of tasks have been skipped. Note: ignores buildSrc tasks.
+     * Asserts that exactly the given set of tasks have been skipped.
      */
     ExecutionResult assertTasksSkipped(Object... taskPaths);
 
     /**
-     * Asserts the given task has been skipped. Note: ignores buildSrc tasks.
+     * Asserts the given task has been skipped.
      */
     ExecutionResult assertTaskSkipped(String taskPath);
 
     /**
-     * Asserts that exactly the given set of tasks have not been skipped. Note: ignores buildSrc tasks.
+     * Asserts that exactly the given set of tasks have not been skipped.
      */
     ExecutionResult assertTasksNotSkipped(Object... taskPaths);
 
     /**
-     * Asserts that the given task has not been skipped. Note: ignores buildSrc tasks.
+     * Asserts that the given task has not been skipped.
      */
     ExecutionResult assertTaskNotSkipped(String taskPath);
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.file.DefaultFileCollectionFactory;
 import org.gradle.api.internal.file.TestFiles;
 import org.gradle.api.logging.configuration.ConsoleOutput;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskState;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.configuration.GradleLauncherMetaData;
@@ -461,20 +462,12 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
             }
 
             String taskPath = path(task);
-            if (taskPath.startsWith(":buildSrc:")) {
-                return;
-            }
-
             executedTasks.add(taskPath);
         }
 
         @Override
         public void afterExecute(Task task, TaskState state) {
             String taskPath = path(task);
-            if (taskPath.startsWith(":buildSrc:")) {
-                return;
-            }
-
             if (state.getSkipped()) {
                 skippedTasks.add(taskPath);
             }
@@ -486,14 +479,22 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
     }
 
     public static class InProcessExecutionResult implements ExecutionResult {
-        private final List<String> executedTasks;
-        private final Set<String> skippedTasks;
-        private final OutputScrapingExecutionResult outputResult;
+        protected static final Spec<String> NOT_BUILD_SRC_TASK = t -> !t.startsWith(":buildSrc:");
+        protected final List<String> executedTasks;
+        protected final Set<String> skippedTasks;
+        private final ExecutionResult outputResult;
 
-        InProcessExecutionResult(List<String> executedTasks, Set<String> skippedTasks, OutputScrapingExecutionResult outputResult) {
+        InProcessExecutionResult(List<String> executedTasks, Set<String> skippedTasks, ExecutionResult outputResult) {
             this.executedTasks = executedTasks;
             this.skippedTasks = skippedTasks;
             this.outputResult = outputResult;
+        }
+
+        @Override
+        public ExecutionResult getIgnoreBuildSrc() {
+            List<String> executedTasks = CollectionUtils.filter(this.executedTasks, NOT_BUILD_SRC_TASK);
+            Set<String> skippedTasks = CollectionUtils.filter(this.skippedTasks, NOT_BUILD_SRC_TASK);
+            return new InProcessExecutionResult(executedTasks, skippedTasks, outputResult.getIgnoreBuildSrc());
         }
 
         @Override
@@ -662,13 +663,13 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
 
     private static class InProcessExecutionFailure extends InProcessExecutionResult implements ExecutionFailure {
         private static final Pattern LOCATION_PATTERN = Pattern.compile("(?m)^((\\w+ )+'.+') line: (\\d+)$");
-        private final OutputScrapingExecutionFailure outputFailure;
+        private final ExecutionFailure outputFailure;
         private final Throwable failure;
         private final List<String> fileNames = new ArrayList<String>();
         private final List<String> lineNumbers = new ArrayList<String>();
         private final List<String> descriptions = new ArrayList<String>();
 
-        InProcessExecutionFailure(List<String> tasks, Set<String> skippedTasks, OutputScrapingExecutionFailure outputFailure, Throwable failure) {
+        InProcessExecutionFailure(List<String> tasks, Set<String> skippedTasks, ExecutionFailure outputFailure, Throwable failure) {
             super(tasks, skippedTasks, outputFailure);
             this.outputFailure = outputFailure;
             this.failure = failure;
@@ -692,6 +693,13 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
             } else {
                 descriptions.add(failureMessage.trim());
             }
+        }
+
+        @Override
+        public InProcessExecutionFailure getIgnoreBuildSrc() {
+            List<String> executedTasks = CollectionUtils.filter(this.executedTasks, NOT_BUILD_SRC_TASK);
+            Set<String> skippedTasks = CollectionUtils.filter(this.skippedTasks, NOT_BUILD_SRC_TASK);
+            return new InProcessExecutionFailure(executedTasks, skippedTasks, outputFailure.getIgnoreBuildSrc(), failure);
         }
 
         @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
@@ -57,11 +57,11 @@ public class OutputScrapingExecutionFailure extends OutputScrapingExecutionResul
      * @return A {@link OutputScrapingExecutionResult} for a successful build, or a {@link OutputScrapingExecutionFailure} for a failed build.
      */
     public static OutputScrapingExecutionFailure from(String output, String error) {
-        return new OutputScrapingExecutionFailure(output, error);
+        return new OutputScrapingExecutionFailure(output, error, true);
     }
 
-    protected OutputScrapingExecutionFailure(String output, String error) {
-        super(LogContent.of(output), LogContent.of(error));
+    protected OutputScrapingExecutionFailure(String output, String error, boolean includeBuildSrc) {
+        super(LogContent.of(output), LogContent.of(error), includeBuildSrc);
 
         LogContent withoutDebug = LogContent.of(output).ansiCharsToPlainText().removeDebugPrefix();
 
@@ -114,6 +114,11 @@ public class OutputScrapingExecutionFailure extends OutputScrapingExecutionResul
         } else {
             resolution = matcher.group(1).trim();
         }
+    }
+
+    @Override
+    public ExecutionFailure getIgnoreBuildSrc() {
+        return new OutputScrapingExecutionFailure(getOutput(), getError(), false);
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -49,6 +49,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
 
     private final LogContent output;
     private final LogContent error;
+    private boolean includeBuildSrc;
     private final LogContent mainContent;
     private final LogContent postBuild;
     private final LogContent errorContent;
@@ -69,18 +70,19 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     public static OutputScrapingExecutionResult from(String output, String error) {
         // Should provide a Gradle version as parameter so this check can be more precise
         if (output.contains("BUILD FAILED") || output.contains("FAILURE: Build failed with an exception.") || error.contains("BUILD FAILED")) {
-            return new OutputScrapingExecutionFailure(output, error);
+            return new OutputScrapingExecutionFailure(output, error, true);
         }
-        return new OutputScrapingExecutionResult(LogContent.of(output), LogContent.of(error));
+        return new OutputScrapingExecutionResult(LogContent.of(output), LogContent.of(error), true);
     }
 
     /**
      * @param output The build stdout content.
      * @param error The build stderr content. Must have normalized line endings.
      */
-    protected OutputScrapingExecutionResult(LogContent output, LogContent error) {
+    protected OutputScrapingExecutionResult(LogContent output, LogContent error, boolean includeBuildSrc) {
         this.output = output;
         this.error = error;
+        this.includeBuildSrc = includeBuildSrc;
 
         // Split out up the output into main content and post build content
         LogContent filteredOutput = this.output.ansiCharsToPlainText().removeDebugPrefix();
@@ -93,6 +95,11 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
             this.postBuild = match.getRight().drop(1);
         }
         this.errorContent = error.ansiCharsToPlainText();
+    }
+
+    @Override
+    public ExecutionResult getIgnoreBuildSrc() {
+        return new OutputScrapingExecutionResult(output, error, false);
     }
 
     @Override
@@ -351,20 +358,22 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
                 if (matcher.matches()) {
                     String taskStatusLine = matcher.group().replace(TASK_PREFIX, "");
                     String taskName = matcher.group(2);
-                    if (!taskName.contains(":buildSrc:")) {
-                        // The task status line may appear twice - once for the execution, once for the UP-TO-DATE/SKIPPED/etc
-                        // So don't add to the task list if this is an update to a previously added task.
-
-                        // Find the status line for the previous record of this task
-                        String previousTaskStatusLine = tasks.contains(taskName) ? taskStatusLines.get(tasks.lastIndexOf(taskName)) : "";
-                        // Don't add if our last record has a `:taskName` status, and this one is `:taskName SOMETHING`
-                        if (previousTaskStatusLine.equals(taskName) && !taskStatusLine.equals(taskName)) {
-                            return;
-                        }
-
-                        taskStatusLines.add(taskStatusLine);
-                        tasks.add(taskName);
+                    if (!includeBuildSrc && taskName.startsWith(":buildSrc:")) {
+                        return;
                     }
+
+                    // The task status line may appear twice - once for the execution, once for the UP-TO-DATE/SKIPPED/etc
+                    // So don't add to the task list if this is an update to a previously added task.
+
+                    // Find the status line for the previous record of this task
+                    String previousTaskStatusLine = tasks.contains(taskName) ? taskStatusLines.get(tasks.lastIndexOf(taskName)) : "";
+                    // Don't add if our last record has a `:taskName` status, and this one is `:taskName SOMETHING`
+                    if (previousTaskStatusLine.equals(taskName) && !taskStatusLine.equals(taskName)) {
+                        return;
+                    }
+
+                    taskStatusLines.add(taskStatusLine);
+                    tasks.add(taskName);
                 }
             }
         });

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ParallelForkingGradleHandle.java
@@ -46,7 +46,7 @@ public class ParallelForkingGradleHandle extends ForkingGradleHandle {
      */
     private static class ParallelExecutionResult extends OutputScrapingExecutionFailure {
         public ParallelExecutionResult(String output, String error) {
-            super(output, error);
+            super(output, error, true);
         }
 
         @Override

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
@@ -64,7 +64,7 @@ Binaries
         succeeds "assemble"
 
         then:
-        executedTasks == [":compileDocsExplodedReference", ":compileDocsExplodedUserguide", ":docsExploded", ":assemble"]
+        result.ignoreBuildSrc.assertTasksExecuted(":compileDocsExplodedReference", ":compileDocsExplodedUserguide", ":docsExploded", ":assemble")
 
         and:
         languageTypeSample.dir.file("build/docs/exploded").assertHasDescendants(

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/CachedCustomPluginIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/CachedCustomPluginIntegrationTest.groovy
@@ -68,14 +68,14 @@ class CachedCustomPluginIntegrationTest extends AbstractIntegrationSpec implemen
         executer.inDirectory(originalProjectDir)
         withBuildCache().run "customTask"
         then:
-        skippedTasks.empty
+        result.assertTaskNotSkipped(":customTask")
 
         when:
         setupProjectInDirectory(newProjectDir)
         executer.inDirectory(newProjectDir)
         withBuildCache().run "customTask"
         then:
-        skippedTasks.contains ":customTask"
+        result.groupedOutput.task(":customTask").outcome == "FROM-CACHE"
     }
 
     private static String customGroovyTask(String suffix = "") {

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
@@ -255,7 +255,7 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
 
         then:
-        result.assertTasksExecutedInOrder(":second:generate", ":first:generate", ":resolve")
+        result.ignoreBuildSrc.assertTasksExecutedInOrder(":second:generate", ":first:generate", ":resolve")
         outputContains("Hello from root build's plugin")
     }
 


### PR DESCRIPTION
### Context

The content of `buildSrc` (and other local builds that contribute build logic) is relatively static, at least while a developer is focussed on production code. As part of the instant execution experiment we want to see if it is practical to avoid running any `buildSrc` tasks and instead just capture the result.

This PR simply switches off `buildSrc` when running from the instant execution cache. Later we can capture the inputs of `buildSrc`, so that the cache is invalidated when something in `buildSrc` changes, and also handle included builds that produce build logic.

Also, this PR changes the `ExecutionResult` fixture so that it does not ignore `buildSrc` tasks, at least by default.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
