### PR TITLE
Fix tooling api task execution when running from the instant execution cache

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -77,7 +77,7 @@ gradle.settingsEvaluated {
     }
 
     if (remoteBuildCacheEnabled(this) && !isAdoptOpenJDK11()) {
-        throw GradleException("Remote cache is enabled, which requires OpenJDK 11 to perform this build. It's currently ${getBuildJavaHome()}.")
+        throw GradleException("Remote cache is enabled, which requires AdoptOpenJDK 11 to perform this build. It's currently ${getBuildJavaHome()}.")
     }
 
     if (!JavaVersion.current().isJava9Compatible) {

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -18,9 +18,13 @@ dependencies {
     implementation(library("slf4j_api"))
     implementation(futureKotlin("stdlib-jdk8"))
 
+    integTestImplementation(project(":toolingApi"))
+
     integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))
     integTestImplementation(library("inject"))
+
+    integTestRuntimeOnly(project(":toolingApiBuilders"))
 }
 
 gradlebuildJava {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionToolingApiInvocationIntegrationTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
+import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
+import org.gradle.tooling.GradleConnector
+
+class InstantExecutionToolingApiInvocationIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+    def "can run tasks via tooling api when instant execution is enabled"() {
+        buildFile << """
+            plugins {
+                id("java")
+            }    
+        """
+
+        when:
+        runWithInstantExecutionViaToolingApi("assemble")
+        runWithInstantExecutionViaToolingApi("assemble")
+
+        then:
+        outputContains("Reusing instant execution cache. This is not guaranteed to work in any way.")
+    }
+
+    ExecutionResult runWithInstantExecutionViaToolingApi(String... tasks) {
+        def output = new ByteArrayOutputStream()
+        def error = new ByteArrayOutputStream()
+        def context = new IntegrationTestBuildContext()
+        def connector = GradleConnector
+            .newConnector()
+            .forProjectDirectory(testDirectory)
+            .useGradleUserHomeDir(context.gradleUserHomeDir)
+            .searchUpwards(false)
+        if (GradleContextualExecuter.embedded) {
+            connector.embedded(true).useClasspathDistribution()
+        } else {
+            connector.embedded(false).useInstallation(context.gradleHomeDir)
+        }
+        def connection = connector.connect()
+        try {
+            connection.newBuild()
+                .forTasks(tasks)
+                .withArguments(INSTANT_EXECUTION_PROPERTY)
+                .setStandardOutput(output)
+                .setStandardError(error)
+                .run()
+        } finally {
+            connection.close()
+        }
+        result = OutputScrapingExecutionResult.from(output.toString(), error.toString())
+        return result
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -132,6 +132,7 @@ class InstantExecutionHost internal constructor(
                 settingsPreparer.prepareSettings(this)
 
                 rootProject = createProject(null, rootProjectName)
+                defaultProject = rootProject
             }
         }
 


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
