### PR TITLE
Up-to-date check throws NPE when run from filesystem root

### DIFF
--- a/subprojects/build-cache/src/jmh/java/org/gradle/OptionalBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/OptionalBenchmark.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/*
+ * Benchmark                     Mode  Cnt          Score         Error  Units
+ * OptionalBenchmark.nullCheck  thrpt   20  107887111.061 ±  882182.482  ops/s
+ * OptionalBenchmark.optional   thrpt   20   86746312.090 ± 1150860.296  ops/s
+ **/
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = SECONDS)
+@State(Scope.Benchmark)
+public class OptionalBenchmark {
+
+    final Path path = Paths.get(".");
+    final Path pathRoot = Paths.get(".").toAbsolutePath().getRoot();
+
+    @Benchmark
+    public void nullCheck(Blackhole bh) {
+        bh.consume(nullCheck(path));
+        bh.consume(nullCheck(pathRoot));
+    }
+
+    private static Object nullCheck(Path path) {
+        Path fileName = path.getFileName();
+        if (fileName != null) {
+            return fileName.toString();
+        } else {
+            return "";
+        }
+    }
+
+    @Benchmark
+    public void optional(Blackhole bh) {
+        bh.consume(optional(path));
+        bh.consume(optional(pathRoot));
+    }
+
+    private static Object optional(Path path) {
+        return Optional.ofNullable(path.getFileName())
+            .map(Object::toString)
+            .orElse("");
+    }
+}

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SubstIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SubstIntegrationTest.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import org.gradle.util.TextUtil
+
+@Requires(TestPrecondition.WINDOWS)
+class SubstIntegrationTest extends AbstractIntegrationSpec {
+    def "up to date check works from filesystem's root - intput folder to output file"() {
+        def drive = 'X:'.toUpperCase()
+        def root = substRoot(drive)
+
+        def inputFileName = "input.txt"
+        root.file(inputFileName) << 'content'
+
+        def outputFile = file("output.txt")
+
+        def taskName = 'inputFromFilesystemRoot'
+        def script = /*language=Groovy*/ """
+            class InputDirectoryContentToOutputFileAction extends DefaultTask {
+                @InputDirectory File inputDirectory
+                @OutputFile File output
+                
+                @TaskAction def execute() {
+                    output.text = inputDirectory.list().join()
+                }
+            }
+            
+            task ${taskName}(type: InputDirectoryContentToOutputFileAction) {
+                inputDirectory = new File("${drive}\\\\") 
+                output = file("${TextUtil.escapeString(outputFile.absolutePath)}")
+            }
+        """
+        when:
+        buildScript script
+
+        then:
+        succeeds taskName
+        outputFile.text.contains inputFileName
+
+        cleanup:
+        cleanupSubst(drive)
+    }
+
+    def "up to date check works from filesystem's root - intput file to output folder copy"() {
+        def drive = 'Y:'.toUpperCase()
+        substRoot(drive)
+
+        def inputFileName = "input.txt"
+        def inputFile = file(inputFileName)
+        inputFile << 'content'
+
+        def outputDirectory = new File(drive)
+
+        def taskName = 'outputFromFilesystemRoot'
+        def script = /*language=Groovy*/ """
+            class InputFileToOutputDirectoryCopyAction extends DefaultTask {
+                @InputFile File input
+                @OutputDirectory File outputDirectory
+                
+                @TaskAction def execute() {
+                    new File(outputDirectory, "${inputFileName}") << input.text
+                }
+            }
+            
+            task ${taskName}(type: InputFileToOutputDirectoryCopyAction) {
+                input = file("${TextUtil.escapeString(inputFile.absolutePath)}") 
+                outputDirectory = new File("${drive}\\\\")
+            }
+        """
+        when:
+        buildScript script
+
+        then:
+        succeeds taskName
+        outputDirectory.list().contains inputFileName
+
+        cleanup:
+        cleanupSubst(drive)
+    }
+
+    private substRoot(String drive) {
+        assert !isPresent(drive): "Drive ${drive} already in use!"
+        def substRoot = temporaryFolder.createDir("root").createDir()
+        ['subst', drive, substRoot].execute().waitForProcessOutput()
+        assert isPresent(drive): "Can't subst ${drive}!"
+        substRoot
+    }
+
+    static isPresent(String drive) {
+        File.listRoots().any { "${it}".toUpperCase().startsWith(drive) }
+    }
+
+    def cleanupSubst(String drive) {
+        ['subst', '/d', drive].execute()
+    }
+}

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SubstIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SubstIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.TextUtil
 @Requires(TestPrecondition.WINDOWS)
 class SubstIntegrationTest extends AbstractIntegrationSpec {
     def "up to date check works from filesystem's root - intput folder to output file"() {
-        def drive = 'X:'.toUpperCase()
+        def drive = 'X:'
         def root = substRoot(drive)
 
         def inputFileName = "input.txt"
@@ -59,7 +59,7 @@ class SubstIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "up to date check works from filesystem's root - intput file to output folder copy"() {
-        def drive = 'Y:'.toUpperCase()
+        def drive = 'Y:'
         substRoot(drive)
 
         def inputFileName = "input.txt"
@@ -104,7 +104,7 @@ class SubstIntegrationTest extends AbstractIntegrationSpec {
     }
 
     static isPresent(String drive) {
-        File.listRoots().any { "${it}".toUpperCase().startsWith(drive) }
+        File.listRoots().any { "${it}".toUpperCase().startsWith(drive.toUpperCase()) }
     }
 
     def cleanupSubst(String drive) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -55,6 +55,7 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 
 public class DirectorySnapshotter {
     private final FileHasher hasher;
@@ -252,13 +253,20 @@ public class DirectorySnapshotter {
 
         @Override
         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-            String name = stringInterner.intern(dir.getFileName().toString());
+            String fileName = getFilename(dir);
+            String name = stringInterner.intern(fileName);
             if (builder.isRoot() || isAllowed(dir, name, true, attrs, builder.getRelativePath())) {
                 builder.preVisitDirectory(internedAbsolutePath(dir), name);
                 return FileVisitResult.CONTINUE;
             } else {
                 return FileVisitResult.SKIP_SUBTREE;
             }
+        }
+
+        private String getFilename(Path dir) {
+            return Optional.ofNullable(dir.getFileName())
+                .map(Object::toString)
+                .orElse("");
         }
 
         @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -75,91 +75,7 @@ public class DirectorySnapshotter {
         final MerkleDirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.sortingRequired();
 
         try {
-            Files.walkFileTree(rootPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new java.nio.file.FileVisitor<Path>() {
-                @Override
-                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-                    String name = stringInterner.intern(dir.getFileName().toString());
-                    if (builder.isRoot() || isAllowed(dir, name, true, attrs, builder.getRelativePath())) {
-                        builder.preVisitDirectory(internedAbsolutePath(dir), name);
-                        return FileVisitResult.CONTINUE;
-                    } else {
-                        return FileVisitResult.SKIP_SUBTREE;
-                    }
-                }
-
-                @Override
-                public FileVisitResult visitFile(Path file, @Nullable BasicFileAttributes attrs) {
-                    String name = stringInterner.intern(file.getFileName().toString());
-                    if (isAllowed(file, name, false, attrs, builder.getRelativePath())) {
-                        if (attrs == null) {
-                            throw new GradleException(String.format("Cannot read file '%s': not authorized.", file));
-                        }
-                        if (attrs.isSymbolicLink()) {
-                            // when FileVisitOption.FOLLOW_LINKS, we only get here when link couldn't be followed
-                            throw new GradleException(String.format("Could not list contents of '%s'. Couldn't follow symbolic link.", file));
-                        }
-                        addFileSnapshot(file, name, attrs);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult visitFileFailed(Path file, IOException exc) {
-                    // File loop exceptions are ignored. When we encounter a loop (via symbolic links), we continue
-                    // so we include all the other files apart from the loop.
-                    // This way, we include each file only once.
-                    if (isNotFileSystemLoopException(exc) && isAllowed(file, file.getFileName().toString(), false, null, builder.getRelativePath())) {
-                        throw new GradleException(String.format("Could not read path '%s'.", file), exc);
-                    }
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult postVisitDirectory(Path dir, @Nullable IOException exc) {
-                    // File loop exceptions are ignored. When we encounter a loop (via symbolic links), we continue
-                    // so we include all the other files apart from the loop.
-                    // This way, we include each file only once.
-                    if (isNotFileSystemLoopException(exc)) {
-                        throw new GradleException(String.format("Could not read directory path '%s'.", dir), exc);
-                    }
-                    builder.postVisitDirectory();
-                    return FileVisitResult.CONTINUE;
-                }
-
-                private boolean isNotFileSystemLoopException(@Nullable IOException e) {
-                    return e != null && !(e instanceof FileSystemLoopException);
-                }
-
-                private void addFileSnapshot(Path file, String name, BasicFileAttributes attrs) {
-                    Preconditions.checkNotNull(attrs, "Unauthorized access to %", file);
-                    DefaultFileMetadata metadata = new DefaultFileMetadata(FileType.RegularFile, attrs.lastModifiedTime().toMillis(), attrs.size());
-                    HashCode hash = hasher.hash(file.toFile(), metadata);
-                    RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(internedAbsolutePath(file), name, hash, metadata.getLastModified());
-                    builder.visit(fileSnapshot);
-                }
-
-                private String internedAbsolutePath(Path file) {
-                    return stringInterner.intern(file.toString());
-                }
-
-                private boolean isAllowed(Path path, String name, boolean isDirectory, @Nullable BasicFileAttributes attrs, Iterable<String> relativePath) {
-                    if (isDirectory) {
-                        if (defaultExcludes.excludeDir(name)) {
-                            return false;
-                        }
-                    } else if (defaultExcludes.excludeFile(name)) {
-                        return false;
-                    }
-                    if (spec == null) {
-                        return true;
-                    }
-                    boolean allowed = spec.isSatisfiedBy(new PathBackedFileTreeElement(path, name, isDirectory, attrs, relativePath, fileSystem));
-                    if (!allowed) {
-                        hasBeenFiltered.set(true);
-                    }
-                    return allowed;
-                }
-            });
+            Files.walkFileTree(rootPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new PathVisitor(builder, spec, hasBeenFiltered));
         } catch (IOException e) {
             throw new GradleException(String.format("Could not list contents of directory '%s'.", rootPath), e);
         }
@@ -320,6 +236,102 @@ public class DirectorySnapshotter {
         @Override
         public int getMode() {
             return stat.getUnixMode(path.toFile());
+        }
+    }
+
+    private class PathVisitor implements java.nio.file.FileVisitor<Path> {
+        private final MerkleDirectorySnapshotBuilder builder;
+        private final Spec<FileTreeElement> spec;
+        private final MutableBoolean hasBeenFiltered;
+
+        public PathVisitor(MerkleDirectorySnapshotBuilder builder, @Nullable Spec<FileTreeElement> spec, MutableBoolean hasBeenFiltered) {
+            this.builder = builder;
+            this.spec = spec;
+            this.hasBeenFiltered = hasBeenFiltered;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            String name = stringInterner.intern(dir.getFileName().toString());
+            if (builder.isRoot() || isAllowed(dir, name, true, attrs, builder.getRelativePath())) {
+                builder.preVisitDirectory(internedAbsolutePath(dir), name);
+                return FileVisitResult.CONTINUE;
+            } else {
+                return FileVisitResult.SKIP_SUBTREE;
+            }
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, @Nullable BasicFileAttributes attrs) {
+            String name = stringInterner.intern(file.getFileName().toString());
+            if (isAllowed(file, name, false, attrs, builder.getRelativePath())) {
+                if (attrs == null) {
+                    throw new GradleException(String.format("Cannot read file '%s': not authorized.", file));
+                }
+                if (attrs.isSymbolicLink()) {
+                    // when FileVisitOption.FOLLOW_LINKS, we only get here when link couldn't be followed
+                    throw new GradleException(String.format("Could not list contents of '%s'. Couldn't follow symbolic link.", file));
+                }
+                addFileSnapshot(file, name, attrs);
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFileFailed(Path file, IOException exc) {
+            // File loop exceptions are ignored. When we encounter a loop (via symbolic links), we continue
+            // so we include all the other files apart from the loop.
+            // This way, we include each file only once.
+            if (isNotFileSystemLoopException(exc) && isAllowed(file, file.getFileName().toString(), false, null, builder.getRelativePath())) {
+                throw new GradleException(String.format("Could not read path '%s'.", file), exc);
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, @Nullable IOException exc) {
+            // File loop exceptions are ignored. When we encounter a loop (via symbolic links), we continue
+            // so we include all the other files apart from the loop.
+            // This way, we include each file only once.
+            if (isNotFileSystemLoopException(exc)) {
+                throw new GradleException(String.format("Could not read directory path '%s'.", dir), exc);
+            }
+            builder.postVisitDirectory();
+            return FileVisitResult.CONTINUE;
+        }
+
+        private boolean isNotFileSystemLoopException(@Nullable IOException e) {
+            return e != null && !(e instanceof FileSystemLoopException);
+        }
+
+        private void addFileSnapshot(Path file, String name, BasicFileAttributes attrs) {
+            Preconditions.checkNotNull(attrs, "Unauthorized access to %", file);
+            DefaultFileMetadata metadata = new DefaultFileMetadata(FileType.RegularFile, attrs.lastModifiedTime().toMillis(), attrs.size());
+            HashCode hash = hasher.hash(file.toFile(), metadata);
+            RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(internedAbsolutePath(file), name, hash, metadata.getLastModified());
+            builder.visit(fileSnapshot);
+        }
+
+        private String internedAbsolutePath(Path file) {
+            return stringInterner.intern(file.toString());
+        }
+
+        private boolean isAllowed(Path path, String name, boolean isDirectory, @Nullable BasicFileAttributes attrs, Iterable<String> relativePath) {
+            if (isDirectory) {
+                if (defaultExcludes.excludeDir(name)) {
+                    return false;
+                }
+            } else if (defaultExcludes.excludeFile(name)) {
+                return false;
+            }
+            if (spec == null) {
+                return true;
+            }
+            boolean allowed = spec.isSatisfiedBy(new PathBackedFileTreeElement(path, name, isDirectory, attrs, relativePath, fileSystem));
+            if (!allowed) {
+                hasBeenFiltered.set(true);
+            }
+            return allowed;
         }
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
@@ -30,6 +30,8 @@ import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+import java.nio.file.Paths
+
 @UsesNativeServices
 class DirectorySnapshotterTest extends Specification {
     @Rule
@@ -83,6 +85,20 @@ class DirectorySnapshotterTest extends Specification {
             'subdir1', 'subdir1/a', 'subdir1/a/b', 'subdir1/a/b/c.html',
             'a.txt'
         ].collect { 'root/' + it }) as Set
+    }
+
+    def "should snapshot file system root"() {
+        given:
+        def fileSystemRoot = fileSystemRoot()
+        def patterns = new PatternSet().exclude("*")
+        def actuallyFiltered = new MutableBoolean(false)
+
+        when:
+        def snapshot = directorySnapshotter.snapshot(fileSystemRoot, patterns, actuallyFiltered)
+
+        then:
+        snapshot.absolutePath == fileSystemRoot
+        snapshot.name == ""
     }
 
     def "should snapshot with filters"() {
@@ -151,6 +167,10 @@ class DirectorySnapshotterTest extends Specification {
 
         !defaultExcludes.excludeFile('.svnsomething')
         !defaultExcludes.excludeFile('#some')
+    }
+
+    private static String fileSystemRoot() {
+        "${Paths.get("").toAbsolutePath().root}"
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/7885

Unit test failure before the fix:
<img width="1344" alt="Screen Shot 2019-05-31 at 20 51 30" src="https://user-images.githubusercontent.com/1841944/58728536-6d8aae80-83e7-11e9-904f-fe848a9734c9.png">

Integration test failure, before the fix (VM):
<img width="1679" alt="Screen Shot 2019-06-04 at 18 00 41" src="https://user-images.githubusercontent.com/1841944/58894697-c06bab00-86f2-11e9-8a5d-f83883f18269.png">

After fix, on real Windows:
![Fix](https://user-images.githubusercontent.com/1841944/58728596-8dba6d80-83e7-11e9-83fa-4772ce6aae1d.PNG)

Please review [commit-by-commit](https://github.com/gradle/gradle/pull/9592/commits).