### PR TITLE
Fix applying plugin by id in script plugins and init script

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
@@ -350,4 +350,26 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds "help"
     }
+
+    def "plugins can be applied with plugin id in script plugins"() {
+        given:
+        def jar = file("plugin.jar")
+        pluginBuilder.addPlugin("project.task('hello')")
+        pluginBuilder.publishTo(executer, jar)
+
+        buildScript """
+            apply from: "script.gradle"
+        """
+
+        file("script.gradle") << """
+            buildscript {
+                dependencies { classpath files("plugin.jar") }
+            }
+
+            apply plugin: "test-plugin"
+        """
+
+        expect:
+        succeeds "hello"
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
@@ -372,4 +372,27 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds "hello"
     }
+
+    def "plugins can be applied with plugin id in init script"() {
+        given:
+        def jar = file("plugin.jar")
+        pluginBuilder.addPlugin("project.task('hello')")
+        pluginBuilder.publishTo(executer, jar)
+
+        buildScript ''
+
+        file("init.gradle") << """
+            initscript {
+                dependencies { classpath files("plugin.jar") }
+            }
+
+            allprojects {
+                apply plugin: "test-plugin"
+            }
+        """
+
+        expect:
+        succeeds "hello", "-I", file("init.gradle").absolutePath
+    }
+
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/plugin/ScriptPluginClassLoadingIntegrationTest.groovy
@@ -351,6 +351,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         succeeds "help"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/1262")
     def "plugins can be applied with plugin id in script plugins"() {
         given:
         def jar = file("plugin.jar")
@@ -373,6 +374,7 @@ class ScriptPluginClassLoadingIntegrationTest extends AbstractIntegrationSpec {
         succeeds "hello"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/1322")
     def "plugins can be applied with plugin id in init script"() {
         given:
         def jar = file("plugin.jar")

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/AbstractClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/AbstractClassLoaderScope.java
@@ -82,4 +82,9 @@ public abstract class AbstractClassLoaderScope implements ClassLoaderScope {
     public ClassLoaderScope createLockedChild(String name, ClassPath localClasspath, @Nullable HashCode classpathImplementationHash, Function<ClassLoader, ClassLoader> localClassLoaderFactory) {
         return new ImmutableClassLoaderScope(id.child(name), this, localClasspath, classpathImplementationHash, localClassLoaderFactory, classLoaderCache, listener);
     }
+    
+    @Override
+    public boolean isUsable() {
+        return true;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
@@ -109,6 +109,8 @@ public interface ClassLoaderScope {
      */
     ClassLoaderScope lock();
 
+    boolean isUsable();
+
     boolean isLocked();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -107,7 +107,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
                     effectiveExportClassLoader = parent.getExportClassLoader();
                 }
             } else { // creating before locking, have to create the most flexible setup
-                if (Boolean.getBoolean(STRICT_MODE_PROPERTY)) {
+                if (isStrictModeEnabled()) {
                     throw new IllegalStateException("Attempt to define scope class loader before scope is locked, scope identifier is " + id);
                 }
 
@@ -120,6 +120,10 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
 
             exportLoaders = null;
         }
+    }
+
+    private boolean isStrictModeEnabled() {
+        return Boolean.getBoolean(STRICT_MODE_PROPERTY);
     }
 
     @Override
@@ -227,6 +231,11 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     @Override
     public boolean isLocked() {
         return locked;
+    }
+    
+    @Override
+    public boolean isUsable() {
+        return effectiveLocalClassLoader != null || isLocked() || !isStrictModeEnabled();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -165,4 +165,9 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         }
         return dynamicObject;
     }
+
+    @Override
+    public ClassLoaderScope getClassLoaderScope() {
+        return classLoaderScope;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ScriptHandlerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ScriptHandlerInternal.java
@@ -24,5 +24,5 @@ public interface ScriptHandlerInternal extends ScriptHandler {
 
     ClassPath getScriptClassPath();
 
-
+    ClassLoaderScope getClassLoaderScope();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
@@ -24,6 +24,7 @@ import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
+import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.plugins.InvalidPluginException;
 import org.gradle.api.plugins.PluginContainer;
@@ -129,7 +130,13 @@ public class DefaultPluginManager implements PluginManagerInternal {
 
     @Override
     public void apply(String pluginId) {
-        PluginImplementation<?> plugin = pluginRegistry.lookup(DefaultPluginId.unvalidated(pluginId));
+        apply(null, pluginId);
+    }
+
+    @Override
+    public void apply(ClassLoaderScope classLoaderScope, String pluginId) {
+        PluginRegistry pluginRegistryForScope = classLoaderScope != null ? pluginRegistry.createChild(classLoaderScope) : pluginRegistry;
+        PluginImplementation<?> plugin = pluginRegistryForScope.lookup(DefaultPluginId.unvalidated(pluginId));
         if (plugin == null) {
             throw new UnknownPluginException("Plugin with id '" + pluginId + "' not found.");
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
@@ -126,6 +126,10 @@ public class DefaultPluginRegistry implements PluginRegistry {
             }
         }
 
+        if (!classLoaderScope.isLocked()) {
+            // don't lookup in scope if it's not locked
+            return null;
+        }
         return lookup(pluginId, classLoaderScope.getLocalClassLoader());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginRegistry.java
@@ -126,8 +126,8 @@ public class DefaultPluginRegistry implements PluginRegistry {
             }
         }
 
-        if (!classLoaderScope.isLocked()) {
-            // don't lookup in scope if it's not locked
+        if (!classLoaderScope.isUsable()) {
+            // don't lookup in scope if it's not usable
             return null;
         }
         return lookup(pluginId, classLoaderScope.getLocalClassLoader());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginManagerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginManagerInternal.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.plugins;
 
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Plugin;
+import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.PluginManager;
@@ -31,6 +32,8 @@ public interface PluginManagerInternal extends PluginManager {
     <P extends Plugin> P addImperativePlugin(Class<P> plugin);
 
     PluginContainer getPluginContainer();
+
+    void apply(ClassLoaderScope classLoaderScope, String pluginId);
 
     DomainObjectSet<PluginWithId> pluginsForId(String id);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1289,7 +1289,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     protected DefaultObjectConfigurationAction createObjectConfigurationAction() {
         TextUriResourceLoader.Factory textUriResourceLoaderFactory = services.get(TextUriResourceLoader.Factory.class);
-        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getBaseClassLoaderScope(), textUriResourceLoaderFactory, this);
+        return new DefaultObjectConfigurationAction(getFileResolver(), getScriptPluginFactory(), getScriptHandlerFactory(), getBaseClassLoaderScope(), getClassLoaderScope(), textUriResourceLoaderFactory, this);
     }
 
     @Inject

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.HasScriptServices;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
+import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.logging.Logger;
@@ -109,6 +110,7 @@ public abstract class DefaultScript extends BasicScript {
             __scriptServices.get(ScriptPluginFactory.class),
             __scriptServices.get(ScriptHandlerFactory.class),
             classLoaderScope,
+            getBuildscript() instanceof ScriptHandlerInternal ? ((ScriptHandlerInternal) getBuildscript()).getClassLoaderScope() : null,
             __scriptServices.get(TextUriResourceLoader.Factory.class),
             getScriptTarget()
         );

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -246,7 +246,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
             getScriptPluginFactory(),
             getScriptHandlerFactory(),
             baseClassLoaderScope,
-            settingsClassLoaderScope,
+            classLoaderScope,
             getTextUriResourceLoaderFactory(),
             this);
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -246,6 +246,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
             getScriptPluginFactory(),
             getScriptHandlerFactory(),
             baseClassLoaderScope,
+            settingsClassLoaderScope,
             getTextUriResourceLoaderFactory(),
             this);
     }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -462,6 +462,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
             getScriptPluginFactory(),
             getScriptHandlerFactory(),
             getClassLoaderScope(),
+            getClassLoaderScope(),
             getResourceLoaderFactory(),
             this
         );

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -43,6 +43,7 @@ class DefaultScriptHandlerTest extends Specification {
     def baseClassLoader = new ClassLoader() {}
     def classLoaderScope = Stub(ClassLoaderScope) {
         getLocalClassLoader() >> baseClassLoader
+        isUsable() >> true
     }
     def classpathResolver = Mock(ScriptClassPathResolver)
     def instantiator = TestUtil.objectInstantiator()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
@@ -38,7 +38,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
     def textResourceLoaderFactory = Mock(TextUriResourceLoader.Factory)
     def configurer = Mock(ScriptPlugin)
 
-    DefaultObjectConfigurationAction action = new DefaultObjectConfigurationAction(resolver, scriptPluginFactory, scriptHandlerFactory, parentCompileScope, textResourceLoaderFactory, target)
+    DefaultObjectConfigurationAction action = new DefaultObjectConfigurationAction(resolver, scriptPluginFactory, scriptHandlerFactory, parentCompileScope, scriptCompileScope, textResourceLoaderFactory, target)
 
     def setup() {
        textResourceLoaderFactory.create(_) >> Mock(TextUriResourceLoader)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -346,6 +346,7 @@ class DefaultPluginContainerTest extends Specification {
     def scope(ClassLoader classLoader) {
         return Stub(ClassLoaderScope) {
             getLocalClassLoader() >> classLoader
+            isUsable() >> true
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
@@ -35,6 +35,7 @@ class DefaultPluginManagerTest extends Specification {
     def classLoader = new GroovyClassLoader(getClass().classLoader)
     def classLoaderScope = Stub(ClassLoaderScope) {
         getLocalClassLoader() >> classLoader
+        isUsable() >> true
     }
     def registry = new DefaultPluginRegistry(new PluginInspector(new ModelRuleSourceDetector()), classLoaderScope)
     def target = Mock(PluginTarget)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
@@ -34,6 +34,7 @@ class DefaultPluginRegistryTest extends Specification {
     def classLoader = Mock(ClassLoader)
     def classLoaderScope = Stub(ClassLoaderScope) {
         getLocalClassLoader() >> classLoader
+        isUsable() >> true
     }
     def pluginInspector = new PluginInspector(new ModelRuleSourceDetector())
     private DefaultPluginRegistry pluginRegistry = new DefaultPluginRegistry(pluginInspector, classLoaderScope)
@@ -298,6 +299,7 @@ class DefaultPluginRegistryTest extends Specification {
         given:
         PluginRegistry child = pluginRegistry.createChild(lookupScope)
         _ * lookupScope.localClassLoader >> childClassLoader
+        _ * lookupScope.isUsable() >> true
         _ * childClassLoader.getResource("META-INF/gradle-plugins/somePlugin.properties") >> url
         _ * childClassLoader.loadClass(TestPlugin1.name) >> TestPlugin1
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
@@ -172,12 +172,12 @@ class PluginBuilder {
         this
     }
 
-    PluginBuilder addPlugin(String impl, String id = "test-plugin", String className = "TestPlugin") {
+    PluginBuilder addPlugin(String impl, String id = "test-plugin", String className = "TestPlugin", Class pluginTypeClass = Project) {
         addPluginSource(id, className, """
             ${packageName ? "package $packageName" : ""}
 
-            class $className implements $Plugin.name<$Project.name> {
-                void apply($Project.name project) {
+            class $className implements $Plugin.name<$pluginTypeClass.name> {
+                void apply($pluginTypeClass.name ${pluginTypeClass.simpleName.toLowerCase()}) {
                     $impl
                 }
             }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
@@ -77,6 +77,7 @@ class KotlinScriptHost<out T : Any>(
             serviceRegistry.get(),
             serviceRegistry.get(),
             baseScope,
+            targetScope,
             serviceRegistry.get(),
             target)
 }

--- a/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
@@ -169,7 +169,11 @@ public class ConfigureUtil {
                 CURRENT_CONFIGURE_CLOSURE.set(configureClosure);
                 configure(configureClosure, t);
             } finally {
-                CURRENT_CONFIGURE_CLOSURE.set(previous);
+                if (previous != null) {
+                    CURRENT_CONFIGURE_CLOSURE.set(previous);
+                } else {
+                    CURRENT_CONFIGURE_CLOSURE.remove();
+                }
             }
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
@@ -156,6 +156,7 @@ public class ConfigureUtil {
 
     public static class WrappedConfigureAction<T> implements Action<T> {
         private final Closure configureClosure;
+        private final static ThreadLocal<Closure> CURRENT_CONFIGURE_CLOSURE = new ThreadLocal<>();
 
         WrappedConfigureAction(Closure configureClosure) {
             this.configureClosure = configureClosure;
@@ -163,11 +164,21 @@ public class ConfigureUtil {
 
         @Override
         public void execute(T t) {
-            configure(configureClosure, t);
+            Closure previous = CURRENT_CONFIGURE_CLOSURE.get();
+            try {
+                CURRENT_CONFIGURE_CLOSURE.set(configureClosure);
+                configure(configureClosure, t);
+            } finally {
+                CURRENT_CONFIGURE_CLOSURE.set(previous);
+            }
         }
 
         public Closure getConfigureClosure() {
             return configureClosure;
+        }
+
+        public static Closure getCurrentConfigureClosure() {
+            return CURRENT_CONFIGURE_CLOSURE.get();
         }
     }
 }


### PR DESCRIPTION
### Context
Fixes "Third-party plugins cannot be applied by ID from external build scripts" reported in #1262 and "Cannot apply plugin by id from init script (from outside distribution)" reported in #1322.

The changes here are more like a quick spike to investigate what could be a possible fix to the issue.
I didn't cover the Kotlin DSL and had to make a small change to get the code to compile after adding the `scriptClassLoaderScope` parameter to `DefaultObjectConfigurationAction` constructor. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
