### PR TITLE
Fix documentation: task "jacocoTestReport" doesn't depend on "test" task

### DIFF
--- a/subprojects/docs/src/docs/userguide/jacoco_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jacoco_plugin.adoc
@@ -30,7 +30,7 @@ include::sample[dir="testing/jacoco/quickstart/groovy",files="build.gradle[tags=
 include::sample[dir="testing/jacoco/quickstart/kotlin",files="build.gradle.kts[tags=apply-plugin]"]
 ====
 
-If the Java plugin is also applied to your project, a new task named `jacocoTestReport` is created that depends on the `test` task. The report is available at `__$buildDir__/reports/jacoco/test`. By default, a HTML report is generated.
+If the Java plugin is also applied to your project, a new task named `jacocoTestReport` is created. Note that while tests should be executed before generation of report, `jacocoTestReport` task does not depend on the `test` task. By default, a HTML report is generated at `__$buildDir__/reports/jacoco/test`.
 
 [[sec:configuring_the_jacoco_plugin]]
 == Configuring the JaCoCo Plugin


### PR DESCRIPTION
While I tend to agree with #2921 that `jacocoTestReport` task should depend on `test` task, in any case IMO documentation should be fixed to match actual behavior, so propose this change.