### PR TITLE
Revert `libA0:dependentComponents on nativeDependents` regression

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/RuleBindings.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/RuleBindings.java
@@ -284,7 +284,7 @@ class RuleBindings {
         private List<RuleBinder> getByPath(Map<String, List<RuleBinder>> byState, String path) {
             List<RuleBinder> ruleBinders = byState.get(path);
             if (ruleBinders == null) {
-                ruleBinders = new LinkedList<RuleBinder>();
+                ruleBinders = new ArrayList<>();
                 byState.put(path, ruleBinders);
             }
             return ruleBinders;

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/RuleBindings.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/RuleBindings.java
@@ -18,18 +18,11 @@ package org.gradle.model.internal.registry;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.gradle.model.internal.core.ModelNode;
 import org.gradle.model.internal.core.ModelPath;
 import org.gradle.model.internal.type.ModelType;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 class RuleBindings {
     private final NodeAtStateIndex rulesBySubject;
@@ -249,7 +242,7 @@ class RuleBindings {
     }
 
     private static class NodeAtStateIndex {
-        private final EnumMap<ModelNode.State, Map<String, Set<RuleBinder>>> boundAtState = Maps.newEnumMap(ModelNode.State.class);
+        private final EnumMap<ModelNode.State, Map<String, List<RuleBinder>>> boundAtState = Maps.newEnumMap(ModelNode.State.class);
 
         private final String name;
 
@@ -257,10 +250,10 @@ class RuleBindings {
             this.name = name;
         }
 
-        private Map<String, Set<RuleBinder>> getByState(ModelNode.State state) {
-            Map<String, Set<RuleBinder>> map = boundAtState.get(state);
+        private Map<String, List<RuleBinder>> getByState(ModelNode.State state) {
+            Map<String, List<RuleBinder>> map = boundAtState.get(state);
             if (map == null) {
-                map = new HashMap<String, Set<RuleBinder>>(64);
+                map = new HashMap<String, List<RuleBinder>>(64);
                 boundAtState.put(state, map);
             }
             return map;
@@ -269,8 +262,8 @@ class RuleBindings {
         public void nodeRemoved(ModelNodeInternal node) {
             // This could be more efficient; assume that removal happens much less often than addition
             for (ModelNode.State state : ModelNode.State.values()) {
-                Map<String, Set<RuleBinder>> byState = getByState(state);
-                Set<RuleBinder> remove = byState.remove(node.getPath().toString());
+                Map<String, List<RuleBinder>> byState = getByState(state);
+                List<RuleBinder> remove = byState.remove(node.getPath().toString());
                 if (remove != null) {
                     for (RuleBinder rule : remove) {
                         unbind(rule, node);
@@ -280,16 +273,18 @@ class RuleBindings {
         }
 
         public void put(NodeAtState nodeAtState, RuleBinder binder) {
-            Map<String, Set<RuleBinder>> byState = getByState(nodeAtState.state);
+            Map<String, List<RuleBinder>> byState = getByState(nodeAtState.state);
             String path = nodeAtState.path.toString();
-            Set<RuleBinder> byPath = getByPath(byState, path);
-            byPath.add(binder);
+            List<RuleBinder> byPath = getByPath(byState, path);
+            if (!byPath.contains(binder)) {
+                byPath.add(binder);
+            }
         }
 
-        private Set<RuleBinder> getByPath(Map<String, Set<RuleBinder>> byState, String path) {
-            Set<RuleBinder> ruleBinders = byState.get(path);
+        private List<RuleBinder> getByPath(Map<String, List<RuleBinder>> byState, String path) {
+            List<RuleBinder> ruleBinders = byState.get(path);
             if (ruleBinders == null) {
-                ruleBinders = Sets.newLinkedHashSet();
+                ruleBinders = new LinkedList<RuleBinder>();
                 byState.put(path, ruleBinders);
             }
             return ruleBinders;
@@ -305,7 +300,7 @@ class RuleBindings {
         public void remove(ModelNodeInternal node, RuleBinder ruleBinder) {
             unbind(ruleBinder, node);
             for (ModelNode.State state : ModelNode.State.values()) {
-                Map<String, Set<RuleBinder>> byState = getByState(state);
+                Map<String, List<RuleBinder>> byState = getByState(state);
                 getByPath(byState, node.getPath().toString()).clear();
             }
         }


### PR DESCRIPTION
See:
https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/23524031:id/report-performance-performance-tests.zip%21/report/tests/libA0%3AdependentComponents-on-nativeDependents.html#result771268383

Showed a regression because of https://github.com/gradle/gradle/commit/8ceab2330db86ab45196480d65cc2bae7d818e02#diff-efe576ec56ef8ef9f40791e8cc6ef053R292

Reverted the change and used an `ArrayList` instead of the linked list or linked set.

<img width="1484" alt="Screen Shot 2019-06-03 at 13 28 13" src="https://user-images.githubusercontent.com/1841944/58798657-79eb5300-8603-11e9-81ab-f8433e48e60e.png">

Ad-hoc perf test, with flames: https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Util_Performance_AdHocPerformanceScenarioLinux&tab=buildTypeStatusDiv&branch_Gradle_Util_Performance=lorinc%2Frevert-RuleBindings