### PR TITLE
Replace jmh to jmhImplementation in build scripts

### DIFF
--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation(library("commons_io"))
     implementation(library("asm"))
 
-    jmh(library("bouncycastle_provider")) {
+    jmhImplementation(library("bouncycastle_provider")) {
         version {
             prefer(libraryVersion("bouncycastle_provider"))
         }
@@ -40,9 +40,7 @@ testFixtures {
 }
 
 jmh {
-    withGroovyBuilder {
-        setProperty("include", listOf("HashingAlgorithmsBenchmark"))
-    }
+    include = listOf("HashingAlgorithmsBenchmark")
 }
 
 val buildReceiptPackage: String by rootProject.extra

--- a/subprojects/build-cache/build-cache.gradle.kts
+++ b/subprojects/build-cache/build-cache.gradle.kts
@@ -35,21 +35,21 @@ dependencies {
     implementation(library("commons_io"))
     implementation(library("inject"))
 
-    jmh(library("ant")) {
+    jmhImplementation(library("ant")) {
         version {
             prefer(libraryVersion("ant"))
         }
     }
 
-    jmh(library("commons_compress")) {
+    jmhImplementation(library("commons_compress")) {
         version {
             prefer(libraryVersion("commons_compress"))
         }
     }
 
-    jmh("io.airlift:aircompressor:0.8")
-    jmh("org.iq80.snappy:snappy:0.4")
-    jmh("org.kamranzafar:jtar:2.3")
+    jmhImplementation("io.airlift:aircompressor:0.8")
+    jmhImplementation("org.iq80.snappy:snappy:0.4")
+    jmhImplementation("org.kamranzafar:jtar:2.3")
 
     testImplementation(project(":modelCore"))
     testImplementation(project(":files"))


### PR DESCRIPTION
Running JMH for any Gradle module (e.g. `./gradlew jmh`) gives the following error now for every JMH benchmark (we don't actively use these micro-benchmarks):
```
# Fork: 1 of 1
<forked VM failed with exit code 1>
<stdout last='20 lines'>
</stdout>
<stderr last='20 lines'>
Error: Could not find or load main class org.openjdk.jmh.runner.ForkedMain
Caused by: java.lang.ClassNotFoundException: org.openjdk.jmh.runner.ForkedMain
</stderr>
```

Based on the [recent dependency changes](https://github.com/gradle/gradle/commit/8ab371109b8d75117edcb1fa93a3bf92ee764dad#diff-301adb492b5b298f395902bcf5bc06aa) by @jjohannes, we've changed `jmh` to `jmhImplementation` in the build scripts (the problem is not fully fixed, though)

There are two snapshots for that day, the second one broke it:
• gradle-5.5-20190528232623+0000-bin.zip - bad
• gradle-5.5-20190528142438+0000-bin.zip - good
