### PR TITLE
Fix performance regression on instant-execution

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.security.CodeSource;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -54,6 +55,11 @@ public class ClasspathUtil {
 
     public static ClassPath getClasspath(ClassLoader classLoader) {
         final List<File> implementationClassPath = new ArrayList<File>();
+        collectClasspathOf(classLoader, implementationClassPath);
+        return DefaultClassPath.of(implementationClassPath);
+    }
+
+    public static void collectClasspathOf(ClassLoader classLoader, final Collection<File> implementationClassPath) {
         new ClassLoaderVisitor() {
             @Override
             public void visitClassPath(URL[] classPath) {
@@ -68,7 +74,6 @@ public class ClasspathUtil {
                 }
             }
         }.visit(classLoader);
-        return DefaultClassPath.of(implementationClassPath);
     }
 
     public static File getClasspathForClass(String targetClassName) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -59,14 +59,14 @@ public class ClasspathUtil {
         return DefaultClassPath.of(implementationClassPath);
     }
 
-    public static void collectClasspathOf(ClassLoader classLoader, final Collection<File> implementationClassPath) {
+    public static void collectClasspathOf(ClassLoader classLoader, final Collection<File> classpathFiles) {
         new ClassLoaderVisitor() {
             @Override
             public void visitClassPath(URL[] classPath) {
                 for (URL url : classPath) {
                     if (url.getProtocol() != null && url.getProtocol().equals("file")) {
                         try {
-                            implementationClassPath.add(new File(toURI(url)));
+                            classpathFiles.add(new File(toURI(url)));
                         } catch (URISyntaxException e) {
                             throw UncheckedException.throwAsUncheckedException(e);
                         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.initialization.InstantExecution
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
+import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.instantexecution.serialization.codecs.Codecs
 import org.gradle.instantexecution.serialization.codecs.TaskGraphCodec
 import org.gradle.instantexecution.serialization.readClassPath
@@ -107,7 +108,7 @@ class DefaultInstantExecution(
                     val tasksClassPath = classPathFor(scheduledTasks)
                     writeClassPath(tasksClassPath)
 
-                    TaskGraphCodec(filePropertyFactory).run {
+                    TaskGraphCodec().run {
                         writeTaskGraphOf(build, scheduledTasks)
                     }
                 }
@@ -121,7 +122,7 @@ class DefaultInstantExecution(
 
         buildOperationExecutor.withLoadOperation {
             KryoBackedDecoder(stateFileInputStream()).use { decoder ->
-                DefaultReadContext(codecs, decoder, logger).run {
+                DefaultReadContext(codecs, decoder, logger, BeanPropertyReader.factoryFor(filePropertyFactory)).run {
 
                     val rootProjectName = readString()
                     val build = host.createBuild(rootProjectName)
@@ -134,7 +135,7 @@ class DefaultInstantExecution(
                     val taskClassLoader = classLoaderFor(tasksClassPath)
                     initialize(build::getProject, taskClassLoader)
 
-                    val scheduledTasks = TaskGraphCodec(filePropertyFactory).run {
+                    val scheduledTasks = TaskGraphCodec().run {
                         readTaskGraph()
                     }
                     build.scheduleTasks(scheduledTasks)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -19,6 +19,7 @@ package org.gradle.instantexecution.serialization
 import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.logging.Logger
+import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 
@@ -54,6 +55,8 @@ interface ReadContext : IsolateContext, Decoder {
     override val isolate: ReadIsolate
 
     val classLoader: ClassLoader
+
+    fun beanPropertyReaderFor(beanType: Class<*>): BeanPropertyReader
 
     fun getProject(path: String): ProjectInternal
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -19,6 +19,7 @@ package org.gradle.instantexecution.serialization
 import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.logging.Logger
+import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 
@@ -67,9 +68,15 @@ class DefaultReadContext(
     private
     val decoder: Decoder,
 
-    override val logger: Logger
+    override val logger: Logger,
+
+    private
+    val beanPropertyReaderFactory: (Class<*>) -> BeanPropertyReader
 
 ) : AbstractIsolateContext<ReadIsolate>(), MutableReadContext, Decoder by decoder {
+
+    private
+    val beanPropertyReaders = hashMapOf<Class<*>, BeanPropertyReader>()
 
     private
     lateinit var projectProvider: ProjectProvider
@@ -88,6 +95,9 @@ class DefaultReadContext(
 
     override val isolate: ReadIsolate
         get() = getIsolate()
+
+    override fun beanPropertyReaderFor(beanType: Class<*>): BeanPropertyReader =
+        beanPropertyReaders.computeIfAbsent(beanType, beanPropertyReaderFactory)
 
     override fun getProject(path: String): ProjectInternal =
         projectProvider(path)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.beans
 
+import groovy.lang.GroovyObjectSupport
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -29,7 +30,9 @@ import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.logProperty
 import org.gradle.instantexecution.serialization.logPropertyWarning
 import org.gradle.internal.reflect.JavaReflectionUtil
+import sun.reflect.ReflectionFactory
 import java.io.File
+import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.util.function.Supplier
 
@@ -38,12 +41,40 @@ class BeanPropertyReader(
     private val beanType: Class<*>,
     private val filePropertyFactory: FilePropertyFactory
 ) {
+
+    companion object {
+
+        fun factoryFor(
+            filePropertyFactory: FilePropertyFactory
+        ): (Class<*>) -> BeanPropertyReader = { type ->
+            BeanPropertyReader(type, filePropertyFactory)
+        }
+    }
+
+    private
+    val setterByFieldName = relevantStateOf(beanType).associateBy(
+        { it.name },
+        { setterFor(it) }
+    )
+
+    private
+    val constructorForSerialization by lazy {
+        if (GroovyObjectSupport::class.java.isAssignableFrom(beanType)) {
+            // Run the `GroovyObjectSupport` constructor, to initialize the metadata field
+            newConstructorForSerialization(beanType, GroovyObjectSupport::class.java.getConstructor())
+        } else {
+            newConstructorForSerialization(beanType, Object::class.java.getConstructor())
+        }
+    }
+
+    fun newBean(): Any =
+        constructorForSerialization.newInstance()
+
     fun ReadContext.readFieldsOf(bean: Any) {
-        val fieldsByName = relevantStateOf(beanType).associateBy { it.name }
         while (true) {
             val (fieldName, fieldValue) = readNextProperty(PropertyKind.Field) ?: break
-            val field = fieldsByName.getValue(fieldName)
-            setFieldOf(bean, field, fieldValue)
+            val setter = setterByFieldName.getValue(fieldName)
+            setter(bean, fieldValue)
         }
     }
 
@@ -69,55 +100,57 @@ class BeanPropertyReader(
         return name to value
     }
 
+    @Suppress("unchecked_cast")
     private
-    fun ReadContext.setFieldOf(bean: Any, field: Field, value: Any?) {
+    fun setterFor(field: Field): ReadContext.(Any, Any?) -> Unit =
 
-        fun assign(value: Any?) = field.set(bean, value)
-
-        @Suppress("unchecked_cast")
         when (val type = field.type) {
-            DirectoryProperty::class.java -> {
-                assign(
-                    filePropertyFactory.newDirectoryProperty().apply {
-                        set(value as File?)
-                    }
-                )
+            DirectoryProperty::class.java -> { bean, value ->
+                field.set(bean, filePropertyFactory.newDirectoryProperty().apply {
+                    set(value as File?)
+                })
             }
-            RegularFileProperty::class.java -> {
-                assign(
-                    filePropertyFactory.newFileProperty().apply {
-                        set(value as File?)
-                    }
-                )
+            RegularFileProperty::class.java -> { bean, value ->
+                field.set(bean, filePropertyFactory.newFileProperty().apply {
+                    set(value as File?)
+                })
             }
-            Property::class.java -> {
-                assign(
-                    DefaultPropertyState(Any::class.java).apply {
-                        set(value)
-                    }
-                )
+            Property::class.java -> { bean, value ->
+                field.set(bean, DefaultPropertyState(Any::class.java).apply {
+                    set(value)
+                })
             }
-            Provider::class.java -> {
-                assign(when (value) {
+            Provider::class.java -> { bean, value ->
+                field.set(bean, when (value) {
                     null -> Providers.notDefined()
                     else -> Providers.of(value)
                 })
             }
-            Supplier::class.java -> assign(Supplier { value })
-            Function0::class.java -> assign({ value })
-            Lazy::class.java -> assign(lazyOf(value))
-            else -> {
+            Supplier::class.java -> { bean, value ->
+                field.set(bean, Supplier { value })
+            }
+            Function0::class.java -> { bean, value ->
+                field.set(bean, { value })
+            }
+            Lazy::class.java -> { bean, value ->
+                field.set(bean, lazyOf(value))
+            }
+            else -> { bean, value ->
                 if (isAssignableTo(type, value)) {
-                    assign(value)
+                    field.set(bean, value)
                 } else if (value != null) {
                     logPropertyWarning("deserialize", PropertyKind.Field, beanType, field.name, "value $value is not assignable to $type")
                 } // else null value -> ignore
             }
         }
-    }
 
     private
     fun isAssignableTo(type: Class<*>, value: Any?) =
         type.isInstance(value) ||
             type.isPrimitive && JavaReflectionUtil.getWrapperTypeForPrimitiveType(type).isInstance(value)
+
+    // TODO: What about the runtime decorations a serialized bean might have had at configuration time?
+    private
+    fun newConstructorForSerialization(beanType: Class<*>, constructor: Constructor<*>): Constructor<out Any> =
+        ReflectionFactory.getReflectionFactory().newConstructorForSerialization(beanType, constructor)
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -113,7 +113,7 @@ class Codecs(
         bind(ownerProjectService<FileOperations>())
         bind(ownerProjectService<BuildOperationExecutor>())
 
-        bind(BeanCodec(filePropertyFactory))
+        bind(BeanCodec())
     }
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -20,7 +20,6 @@ import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileOperations
-import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.invocation.Gradle
@@ -58,8 +57,7 @@ class Codecs(
     private val fileCollectionFactory: FileCollectionFactory,
     private val fileResolver: FileResolver,
     private val instantiator: Instantiator,
-    private val listenerManager: ListenerManager,
-    private val filePropertyFactory: FilePropertyFactory
+    private val listenerManager: ListenerManager
 ) : EncodingProvider, DecodingProvider {
 
     private
@@ -129,9 +127,7 @@ class Codecs(
         is Project -> unsupportedState(Project::class)
         is Gradle -> unsupportedState(Gradle::class)
         is Settings -> unsupportedState(Settings::class)
-        else -> candidate.javaClass.let { type ->
-            encodings.computeIfAbsent(type, ::computeEncoding)
-        }
+        else -> encodings.computeIfAbsent(candidate.javaClass, ::computeEncoding)
     }
 
     override fun ReadContext.decode(): Any? = when (val tag = readByte()) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -21,7 +21,6 @@ import org.gradle.api.Task
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.TaskInputsInternal
 import org.gradle.api.internal.TaskOutputsInternal
-import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType
 import org.gradle.api.internal.tasks.properties.OutputFilePropertyType
 import org.gradle.api.internal.tasks.properties.PropertyValue
@@ -47,9 +46,7 @@ import org.gradle.instantexecution.serialization.writeStrings
 
 
 internal
-class TaskGraphCodec(
-    private val filePropertyFactory: FilePropertyFactory
-) {
+class TaskGraphCodec {
 
     internal
     fun MutableWriteContext.writeTaskGraphOf(build: ClassicModeBuild, tasks: List<Task>) {
@@ -111,7 +108,7 @@ class TaskGraphCodec(
         val task = createTask(projectPath, taskName, taskType)
 
         withIsolate(task) {
-            BeanPropertyReader(taskType, filePropertyFactory).run {
+            beanPropertyReaderFor(taskType).run {
                 readFieldsOf(task)
                 readRegisteredPropertiesOf(task, this)
             }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -48,7 +48,6 @@ import org.gradle.instantexecution.serialization.writeStrings
 internal
 class TaskGraphCodec {
 
-    internal
     fun MutableWriteContext.writeTaskGraphOf(build: ClassicModeBuild, tasks: List<Task>) {
         writeCollection(tasks) { task ->
             try {
@@ -59,7 +58,6 @@ class TaskGraphCodec {
         }
     }
 
-    internal
     fun MutableReadContext.readTaskGraph(): List<Task> {
         val tasksWithDependencies = readTasksWithDependencies()
         wireTaskDependencies(tasksWithDependencies)


### PR DESCRIPTION
By caching some key data structures:
- the bean constructor used for deserialization per bean type
- the bean field schema per bean type
- the bean field assignment strategy per bean field
-  the encoding strategy per type

After the optimisations, instant-execution for `compileJava` in a 500 project build builder build is ~5x faster than classic execution and storing the task graph adds very little overhead.

![image](https://user-images.githubusercontent.com/51689/58818913-6345fb80-8605-11e9-8ea8-27e99d12b94a.png)
