### PR TITLE
Remove usage of Factory from DefaultFileSystemSnapshotter

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryIndexedCache.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/InMemoryIndexedCache.java
@@ -18,7 +18,6 @@ package org.gradle.testfixtures.internal;
 import org.gradle.api.Transformer;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.ProducerGuard;
-import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.serialize.InputStreamBackedDecoder;
 import org.gradle.internal.serialize.OutputStreamBackedEncoder;
@@ -29,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * A simple in-memory cache, used by the testing fixtures.
@@ -59,13 +59,13 @@ public class InMemoryIndexedCache<K, V> implements PersistentIndexedCache<K, V> 
 
     @Override
     public V get(final K key, final Transformer<? extends V, ? super K> producer) {
-        return producerGuard.guardByKey(key, new Factory<V>() {
+        return producerGuard.guardByKey(key, new Supplier<V>() {
             @Override
-            public V create() {
+            public V get() {
                 if (!entries.containsKey(key)) {
                     put(key, producer.transform(key));
                 }
-                return get(key);
+                return InMemoryIndexedCache.this.get(key);
             }
         });
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessor.java
@@ -50,6 +50,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.function.Supplier;
 
 public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExternalResourceAccessor {
 
@@ -77,10 +78,10 @@ public class DefaultCacheAwareExternalResourceAccessor implements CacheAwareExte
 
     @Nullable
     @Override
-    public LocallyAvailableExternalResource getResource(final ExternalResourceName location, @Nullable String baseName, final ResourceFileStore fileStore, @Nullable final LocallyAvailableResourceCandidates additionalCandidates) throws IOException {
-        return producerGuard.guardByKey(location, new Factory<LocallyAvailableExternalResource>() {
+    public LocallyAvailableExternalResource getResource(final ExternalResourceName location, @Nullable String baseName, final ResourceFileStore fileStore, @Nullable final LocallyAvailableResourceCandidates additionalCandidates) {
+        return producerGuard.guardByKey(location, new Supplier<LocallyAvailableExternalResource>() {
             @Override
-            public LocallyAvailableExternalResource create() {
+            public LocallyAvailableExternalResource get() {
                 LOGGER.debug("Constructing external resource: {}", location);
                 CachedExternalResource cached = cachedExternalResourceIndex.lookup(location.toString());
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -56,8 +56,8 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
     final cachePolicy = new DefaultExternalResourceCachePolicy()
     final ProducerGuard<URI> producerGuard = Stub() {
         guardByKey(_, _) >> { args ->
-            def (key, factory) = args
-            factory.create()
+            def (key, supplier) = args
+            supplier.get()
         }
     }
     final cache = new DefaultCacheAwareExternalResourceAccessor(repository, index, timeProvider, temporaryFileProvider, cacheLockingManager, cachePolicy, producerGuard, fileRepository)

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/ProducerGuardTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/ProducerGuardTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.internal.Factory
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Supplier
 
 class ProducerGuardTest extends ConcurrentSpec {
 
@@ -31,9 +31,9 @@ class ProducerGuardTest extends ConcurrentSpec {
         async {
             100.times {
                 start {
-                    guard.guardByKey("foo", new Factory() {
+                    guard.guardByKey("foo", new Supplier() {
                         @Override
-                        Object create() {
+                        Object get() {
                             return calls.getAndIncrement()
                         }
                     })
@@ -55,9 +55,9 @@ class ProducerGuardTest extends ConcurrentSpec {
         async {
             100.times {
                 start {
-                    guard.guardByKey("foo", new Factory() {
+                    guard.guardByKey("foo", new Supplier() {
                         @Override
-                        Object create() {
+                        Object get() {
                             if (concurrentCalls.getAndIncrement() != 0) {
                                 throw new IllegalStateException("Factory called concurrently")
                             }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DefaultFileSystemSnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DefaultFileSystemSnapshotter.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.cache.internal.ProducerGuard;
-import org.gradle.internal.Factory;
 import org.gradle.internal.MutableBoolean;
 import org.gradle.internal.file.FileMetadataSnapshot;
 import org.gradle.internal.file.FileType;
@@ -46,6 +45,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Responsible for snapshotting various aspects of the file system.
@@ -90,10 +90,10 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
                 return snapshot.getHash();
             }
         }
-        return producingSnapshots.guardByKey(absolutePath, new Factory<HashCode>() {
+        return producingSnapshots.guardByKey(absolutePath, new Supplier<HashCode>() {
             @Nullable
             @Override
-            public HashCode create() {
+            public HashCode get() {
                 InternableString internableAbsolutePath = new InternableString(absolutePath);
                 FileMetadataSnapshot metadata = statAndCache(internableAbsolutePath, file);
                 if (metadata.getType() != FileType.RegularFile) {
@@ -110,9 +110,9 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
         final String absolutePath = file.getAbsolutePath();
         FileSystemLocationSnapshot result = fileSystemMirror.getSnapshot(absolutePath);
         if (result == null) {
-            result = producingSnapshots.guardByKey(absolutePath, new Factory<FileSystemLocationSnapshot>() {
+            result = producingSnapshots.guardByKey(absolutePath, new Supplier<FileSystemLocationSnapshot>() {
                 @Override
-                public FileSystemLocationSnapshot create() {
+                public FileSystemLocationSnapshot get() {
                     return snapshotAndCache(file, null);
                 }
             });
@@ -187,9 +187,9 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
         if (snapshot != null) {
             return filterSnapshot(snapshot, patterns);
         }
-        return producingSnapshots.guardByKey(path, new Factory<FileSystemSnapshot>() {
+        return producingSnapshots.guardByKey(path, new Supplier<FileSystemSnapshot>() {
             @Override
-            public FileSystemSnapshot create() {
+            public FileSystemSnapshot get() {
                 FileSystemLocationSnapshot snapshot = fileSystemMirror.getSnapshot(path);
                 if (snapshot == null) {
                     snapshot = snapshotAndCache(root, patterns);

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/OncePerBuildInvocationVcsVersionWorkingDirResolver.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/OncePerBuildInvocationVcsVersionWorkingDirResolver.java
@@ -18,12 +18,12 @@ package org.gradle.vcs.internal.resolver;
 
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.cache.internal.ProducerGuard;
-import org.gradle.internal.Factory;
 import org.gradle.vcs.internal.VersionControlRepositoryConnection;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
+import java.util.function.Supplier;
 
 /**
  * Ensures that a given resolution from (repo + selector) -> working dir is performed once per build invocation. Allows resolution for different repos to happen in parallel.
@@ -43,10 +43,10 @@ public class OncePerBuildInvocationVcsVersionWorkingDirResolver implements VcsVe
     @Override
     public File selectVersion(final ModuleComponentSelector selector, final VersionControlRepositoryConnection repository) {
         // Perform the work per repository
-        return perRepoGuard.guardByKey(repository.getUniqueId(), new Factory<File>() {
+        return perRepoGuard.guardByKey(repository.getUniqueId(), new Supplier<File>() {
             @Nullable
             @Override
-            public File create() {
+            public File get() {
                 File workingDir = inMemoryCache.getWorkingDirForSelector(repository, selector.getVersionConstraint());
                 if (workingDir == null) {
                     workingDir = delegate.selectVersion(selector, repository);


### PR DESCRIPTION
Using a `Supplier` does not require any Gradle base services types.