### PR TITLE
WIP Changes in case for input files causes Sync tasks to fail

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -18,8 +18,6 @@ package org.gradle.api.internal.file.copy;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.specs.Spec;
@@ -31,8 +29,6 @@ import org.gradle.util.GFileUtils;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
 
 public class SyncCopyActionDecorator implements CopyAction {
     private final File baseDestDir;
@@ -40,7 +36,7 @@ public class SyncCopyActionDecorator implements CopyAction {
     private final PatternFilterable preserveSpec;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this(baseDestDir, delegate, null, directoryFileTreeFactory);
     }
 
@@ -52,39 +48,31 @@ public class SyncCopyActionDecorator implements CopyAction {
     }
 
     @Override
-    public WorkResult execute(final CopyActionProcessingStream stream) {
-        final Set<RelativePath> visited = new HashSet<RelativePath>();
+    public WorkResult execute(CopyActionProcessingStream stream) {
+        boolean cleanupDidWork = cleanup();
+        boolean copyDidWork = copy(stream);
 
-        WorkResult didWork = delegate.execute(new CopyActionProcessingStream() {
-            @Override
-            public void process(final CopyActionProcessingStreamAction action) {
-                stream.process(new CopyActionProcessingStreamAction() {
-                    @Override
-                    public void processFile(FileCopyDetailsInternal details) {
-                        visited.add(details.getRelativePath());
-                        action.processFile(details);
-                    }
-                });
-            }
-        });
-
-        SyncCopyActionDecoratorFileVisitor fileVisitor = new SyncCopyActionDecoratorFileVisitor(visited, preserveSpec);
-
-        MinimalFileTree walker = directoryFileTreeFactory.create(baseDestDir).postfix();
-        walker.visit(fileVisitor);
-        visited.clear();
-
-        return WorkResults.didWork(didWork.getDidWork() || fileVisitor.didWork);
+        return WorkResults.didWork(cleanupDidWork || copyDidWork);
     }
 
-    private static class SyncCopyActionDecoratorFileVisitor implements FileVisitor {
-        private final Set<RelativePath> visited;
+    private boolean cleanup() {
+        DeletingFileVisitor fileVisitor = new DeletingFileVisitor(preserveSpec);
+        MinimalFileTree walker = directoryFileTreeFactory.create(baseDestDir).postfix();
+        walker.visit(fileVisitor);
+        return fileVisitor.didWork;
+    }
+
+    private boolean copy(CopyActionProcessingStream stream) {
+        WorkResult result = delegate.execute(stream);
+        return result.getDidWork();
+    }
+
+    private static class DeletingFileVisitor implements FileVisitor {
         private final Spec<FileTreeElement> preserveSpec;
         private final PatternSet preserveSet;
         private boolean didWork;
 
-        private SyncCopyActionDecoratorFileVisitor(Set<RelativePath> visited, @Nullable PatternFilterable preserveSpec) {
-            this.visited = visited;
+        private DeletingFileVisitor(@Nullable PatternFilterable preserveSpec) {
             PatternSet preserveSet = new PatternSet();
             if (preserveSpec != null) {
                 preserveSet.include(preserveSpec.getIncludes());
@@ -96,21 +84,18 @@ public class SyncCopyActionDecorator implements CopyAction {
 
         @Override
         public void visitDir(FileVisitDetails dirDetails) {
-            maybeDelete(dirDetails, true);
+            maybeDelete(dirDetails);
         }
 
         @Override
         public void visitFile(FileVisitDetails fileDetails) {
-            maybeDelete(fileDetails, false);
+            maybeDelete(fileDetails);
         }
 
-        private void maybeDelete(FileVisitDetails fileDetails, boolean isDir) {
-            RelativePath path = fileDetails.getRelativePath();
-            if (!visited.contains(path)) {
-                if (preserveSet.isEmpty() || !preserveSpec.isSatisfiedBy(fileDetails)) {
-                    GFileUtils.forceDelete(fileDetails.getFile());
-                    didWork = true;
-                }
+        private void maybeDelete(FileVisitDetails fileDetails) {
+            if (preserveSet.isEmpty() || !preserveSpec.isSatisfiedBy(fileDetails)) {
+                GFileUtils.forceDelete(fileDetails.getFile());
+                didWork = true;
             }
         }
     }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -19,7 +19,6 @@ import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import org.gradle.util.ToBeImplemented
 import spock.lang.Issue
 
 class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
@@ -394,36 +393,70 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         ins.close()
     }
 
-    @ToBeImplemented
     @Issue("https://github.com/gradle/gradle/issues/9586")
-    @Requires(TestPrecondition.CASE_INSENSITIVE_FS)
-    def "change in case of input file still syncs properly"() {
+    def "change in case of input files and folders will still syncs properly"() {
         given:
-        buildFile << """
-            task writeFile {
-                def outputFile = new File(buildDir, project.hasProperty("capitalize") ? "OUTPUT" : "output")
-                outputs.file outputFile
-                doLast {
-                    outputFile.text = "hello"
-                }
+        buildFile << '''
+            task syncIt(type: Sync) {
+                from project.hasProperty("capitalizeFile") ? "FILE.TXT" : "file.txt"
+                from project.hasProperty("capitalizeDir") ? "DIR" : "dir"
+                into buildDir
             }
-            task sync(type: Sync) {
-                from writeFile
-                into new File(buildDir, "sync")
-            }
-        """
-        when:
-        succeeds("sync")
-        then:
-        file("build/output").assertExists()
-        file("build/sync/output").assertExists()
+        '''
+
+        def lowercaseFile = file('file.txt')
+        lowercaseFile.text = 'file'
+
+        file('dir').create {
+            file('file2.txt') << 'file2'
+            file('file3.txt') << 'file3'
+            file('file4.txt') << 'file4'
+        }
+
+        and:
+        run 'syncIt'
+        file('build').assertHasDescendants(
+            'file.txt',
+            'file2.txt',
+            'file3.txt',
+            'file4.txt'
+        )
+
+        and:
+        lowercaseFile.delete() // renameTo wouldn't change the case
+        def uppercaseFile = file('FILE.TXT')
+        uppercaseFile.text = 'FILE'
+        assert uppercaseFile.canonicalFile.name == 'FILE.TXT'
+        and:
+        file('dir/file3.txt').delete()
+
+        file('dir/file4.txt').delete()
+        file('dir/File4.txt') << 'File4'
 
         when:
-        succeeds("sync", "-Pcapitalize")
+        succeeds('syncIt', '-PcapitalizeFile')
+        def uppercaseOutputFile = file('build/FILE.TXT')
         then:
-        file("build/OUTPUT").assertExists()
-        // TODO: This should exist
-        file("build/sync/OUTPUT").assertDoesNotExist()
+        executedAndNotSkipped ':syncIt'
+        uppercaseOutputFile.parentFile.listFiles() != [].toArray()
+        uppercaseOutputFile.assertExists()
+        uppercaseOutputFile.text == 'FILE'
+        uppercaseOutputFile.canonicalFile.name == 'FILE.TXT'
+        and:
+        file('build/file2.txt').assertExists()
+        file('build/file3.txt').assertDoesNotExist()
+        file('build/File4.txt').canonicalFile.name == 'File4.txt'
+
+        when:
+        file('dir').deleteDir()
+        file('DIR').create {
+            file('file4.txt') << 'file4'
+        }
+        and:
+        succeeds('sync', '-PcapitalizeDir')
+        then:
+        executedAndNotSkipped ':syncIt'
+        file('build/file4.txt').canonicalFile.name == 'file4.txt'
     }
 
     def "sync from file tree"() {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/9586

Old implementation synchronized directories by copying stuff over first and deleting whatever wasn't visited.
This resulted in some just-copied files being deleted.

The fix was to purge the target folder first (delete all files) and do the copy afterwards.

Since the sync task is not incremental yet, it should work as expected.