### PR TITLE
Fix inconsistent serialization state when resolution cache expires

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -351,7 +351,7 @@ baz:1.0 requested
         useReason << [true, false]
     }
 
-    void "expired cache entry doesn't break reading reasons from cache"() {
+    void "expired cache entry doesn't break reading from cache"() {
         given:
         mavenRepo.module("org", "foo", "1.0").publish()
         mavenRepo.module("org", "bar", "1.0").publish()
@@ -365,12 +365,27 @@ baz:1.0 requested
             configurations {
                 conf
             }
+            
+            def attr = Attribute.of("myAttribute", String)
+            
             dependencies {
                 conf("org:foo:1.0") {
                     because 'first reason' // must have custom reasons to show the problem
                 }
-                conf("org:bar:1.0") {
+                conf("org:bar") {
                     because 'second reason'
+                    
+                    attributes {
+                        attribute(attr, 'val') // make sure attributes are properly serialized and read back
+                    }
+                }
+                constraints {
+                    conf("org:bar") {
+                        version {
+                            require "[0.1, 2.0["
+                            prefer "1.0"
+                        }
+                    }
                 }
             }
             

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -46,12 +46,16 @@ import java.util.List;
 import java.util.Map;
 
 public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSelector> {
-    private final AttributeContainerSerializer attributeContainerSerializer;
+    private final OptimizingAttributeContainerSerializer attributeContainerSerializer;
     private final BuildIdentifierSerializer buildIdentifierSerializer;
 
     public ComponentSelectorSerializer(AttributeContainerSerializer attributeContainerSerializer) {
         this.attributeContainerSerializer = new OptimizingAttributeContainerSerializer(attributeContainerSerializer);
         this.buildIdentifierSerializer = new BuildIdentifierSerializer();
+    }
+
+    void reset() {
+        attributeContainerSerializer.reset();
     }
 
     public ComponentSelector read(Decoder decoder) throws IOException {
@@ -240,6 +244,16 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             this.delegate = delegate;
         }
 
+        /**
+         * If the cache expired, or that it contains too many entries,
+         * it is possible for the same file to be read multiple times, in which
+         * case the internal state of the reader _must_ be reset.
+         */
+        public void reset() {
+            writeIndex.clear();
+            readIndex.clear();
+        }
+
         @Override
         public ImmutableAttributes read(Decoder decoder) throws IOException {
             boolean empty = decoder.readBoolean();
@@ -278,4 +292,5 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             }
         }
     }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -190,6 +190,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         }
 
         private ResolvedComponentResult deserialize(Decoder decoder) {
+            componentSelectorSerializer.reset();
             int valuesRead = 0;
             byte type = -1;
             Timer clock = Time.startTimer();


### PR DESCRIPTION
Resolution results are cached, but the cache may expire or entries
in the cache may be evicted, in case there are many configurations
resolved. This has the consequence that the streaming resolution
builder root factory may be called multiple times for the same
configuration, and therefore the file may be read several times
within a build.

This commit fixes a bug with attribute serialization where the state
of the serializer would make the 2d read incorrect.
