### PR TITLE
Let instant execution support running `build` on Groovy builds 

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.instantexecution
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 
 
 class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
@@ -29,5 +30,11 @@ class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
 
     protected InstantExecutionBuildOperationsFixture newInstantExecutionFixture() {
         return new InstantExecutionBuildOperationsFixture(executer, temporaryFolder)
+    }
+
+    protected void assertTestsExecuted(String testClass, String... testNames) {
+        new DefaultTestExecutionResult(testDirectory)
+            .testClass(testClass)
+            .assertTestsExecuted(testNames)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 
@@ -98,11 +97,5 @@ class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionInte
 
         and:
         assertTestsExecuted("ThingTest", "ok")
-    }
-
-    protected void assertTestsExecuted(String testClass, String... testNames) {
-        new DefaultTestExecutionResult(testDirectory)
-            .testClass(testClass)
-            .assertTestsExecuted(testNames)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -16,41 +16,93 @@
 
 package org.gradle.instantexecution
 
-import spock.lang.Ignore
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 
 
 class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
-    @Ignore
-    def "instant execution for compileGroovy on Groovy project with no dependencies"() {
+    def setup() {
+        executer.noDeprecationChecks()
+    }
+
+    def "build on Groovy build with JUnit tests"() {
 
         def instantExecution = newInstantExecutionFixture()
 
         given:
         buildFile << """
             plugins { id 'groovy' }
-        """
-        file("src/main/java/Thing.groovy") << """
-            class Thing {
+        
+            repositories {
+                ${jcenterRepository()}
+            }
+            
+            dependencies {
+                implementation(localGroovy())
+                testImplementation("junit:junit:4.12")
             }
         """
+        file("src/main/groovy/Thing.groovy") << """
+            class Thing {}
+        """
+        file("src/test/groovy/ThingTest.groovy") << """
+            import org.junit.*
+            class ThingTest {
+                @Test void ok() { new Thing() }
+            } 
+        """
+
+        and:
+        def expectedTasks = [
+            ":compileJava", ":compileGroovy", ":processResources", ":classes", ":jar", ":assemble",
+            ":compileTestJava", ":compileTestGroovy", ":processTestResources", ":testClasses", ":test", ":check",
+            ":build"
+        ]
+        def classFile = file("build/classes/groovy/main/Thing.class")
+        def testClassFile = file("build/classes/groovy/test/ThingTest.class")
+        def testResults = file("build/test-results/test")
 
         when:
-        instantRun "compileGroovy"
+        instantRun "build"
 
         then:
         instantExecution.assertStateStored()
-        result.assertTasksExecuted(":compileGroovy")
-        def classFile = file("build/classes/java/main/Thing.class")
+        result.assertTasksExecuted(*expectedTasks)
+
+        and:
         classFile.isFile()
+        testClassFile.isFile()
+        testResults.isDirectory()
+
+        and:
+        assertTestsExecuted("ThingTest", "ok")
 
         when:
         classFile.delete()
-        instantRun "compileGroovy"
+        testClassFile.delete()
+        testResults.delete()
+
+        and:
+        instantRun "build"
 
         then:
         instantExecution.assertStateLoaded()
-        result.assertTasksExecuted(":compileGroovy")
+        result.assertTasksExecuted(*expectedTasks)
+
+        and:
         classFile.isFile()
+        testClassFile.isFile()
+        testResults.isDirectory()
+
+        and:
+        assertTestsExecuted("ThingTest", "ok")
+    }
+
+    protected void assertTestsExecuted(String testClass, String... testNames) {
+        new DefaultTestExecutionResult(testDirectory)
+            .testClass(testClass)
+            .assertTestsExecuted(testNames)
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.junit.Test
 import spock.lang.Ignore
@@ -254,7 +253,7 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         testClassFile.isFile()
         def testResults = file("build/test-results/test")
         testResults.isDirectory()
-        new DefaultTestExecutionResult(testDirectory).testClass("ThingTest").assertTestsExecuted("ok")
+        assertTestsExecuted("ThingTest", "ok")
 
         when:
         classFile.delete()
@@ -268,7 +267,7 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         classFile.isFile()
         testClassFile.isFile()
         testResults.isDirectory()
-        new DefaultTestExecutionResult(testDirectory).testClass("ThingTest").assertTestsExecuted("ok")
+        assertTestsExecuted("ThingTest", "ok")
     }
 
     def "assemble on Java application build with no dependencies"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -54,10 +54,10 @@ import kotlin.reflect.KClass
 
 class Codecs(
     directoryFileTreeFactory: DirectoryFileTreeFactory,
-    private val fileCollectionFactory: FileCollectionFactory,
-    private val fileResolver: FileResolver,
-    private val instantiator: Instantiator,
-    private val listenerManager: ListenerManager
+    fileCollectionFactory: FileCollectionFactory,
+    fileResolver: FileResolver,
+    instantiator: Instantiator,
+    listenerManager: ListenerManager
 ) : EncodingProvider, DecodingProvider {
 
     private
@@ -95,6 +95,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
+        bind(ConfigurableFileCollectionCodec(fileSetSerializer, fileCollectionFactory))
         bind(FileCollectionCodec(fileSetSerializer, fileCollectionFactory))
         bind(ArtifactCollectionCodec)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.internal.serialize.SetSerializer
+import java.io.File
+
+
+internal
+class ConfigurableFileCollectionCodec(
+    private val fileSetSerializer: SetSerializer<File>,
+    private val fileCollectionFactory: FileCollectionFactory
+) : Codec<ConfigurableFileCollection> {
+
+    override fun WriteContext.encode(value: ConfigurableFileCollection) =
+        fileSetSerializer.write(this, value.files)
+
+    override fun ReadContext.decode(): ConfigurableFileCollection =
+        fileCollectionFactory.configurableFiles().also {
+            it.setFrom(fileSetSerializer.read(this))
+        }
+}


### PR DESCRIPTION
`GroovyCompile.compilerPluginClasspath` is a `ConfigurableFileCollection`. This PR adds an instant-execution codec for `ConfigurableFileCollection` and coverage for running `build` on a Groovy build with JUnit tests.