### PR TITLE
Add support for Java test fixtures

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -543,4 +543,23 @@ public interface DependencyHandler extends ExtensionAware {
      */
     @Incubating
     Dependency enforcedPlatform(Object notation, Action<? super Dependency> configureAction);
+
+    /**
+     * Declares a dependency on the test fixtures of a component.
+     * @param notation the coordinates of the component to use test fixtures for
+     *
+     * @since 5.6
+     */
+    @Incubating
+    Dependency testFixtures(Object notation);
+
+    /**
+     * Declares a dependency on the test fixtures of a component and allows configuring
+     * the resulting dependency.
+     * @param notation the coordinates of the component to use test fixtures for
+     *
+     * @since 5.6
+     */
+    @Incubating
+    Dependency testFixtures(Object notation, Action<? super Dependency> configureAction);
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -55,5 +55,26 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
    Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(compileClasspath)]""")
     }
 
+    def 'fails to resolve undeclared test fixture'() {
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            dependencies {
+                implementation(testFixtures(project(':')))
+            }
+            
+            task resolve {
+                doLast {
+                    println configurations.compileClasspath.incoming.files.files
+                }
+            }
+"""
+
+        when:
+        succeeds 'dependencyInsight', '--configuration', 'compileClasspath', '--dependency', ':'
+
+        then:
+        outputContains("Could not resolve project :.")
+    }
 }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -22,6 +22,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
@@ -38,7 +40,9 @@ import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.component.external.model.ProjectTestFixtures;
 import org.gradle.internal.Factory;
+import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.internal.metaobject.MethodMixIn;
 import org.gradle.util.ConfigureUtil;
@@ -47,6 +51,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT;
+import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURES_CAPABILITY_APPENDIX;
 
 public abstract class DefaultDependencyHandler implements DependencyHandler, MethodMixIn {
     private final ConfigurationContainer configurationContainer;
@@ -263,6 +268,31 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         Dependency dep = enforcedPlatform(notation);
         configureAction.execute(dep);
         return dep;
+    }
+
+    @Override
+    public Dependency testFixtures(Object notation) {
+        Dependency testFixturesDependency = create(notation);
+        if (testFixturesDependency instanceof ProjectDependency) {
+            ProjectDependency projectDependency = (ProjectDependency) testFixturesDependency;
+            projectDependency.capabilities(new ProjectTestFixtures(projectDependency.getDependencyProject()));
+        } else if (testFixturesDependency instanceof ModuleDependency) {
+            ModuleDependency moduleDependency = (ModuleDependency) testFixturesDependency;
+            moduleDependency.capabilities(capabilities -> {
+                capabilities.requireCapability(new ImmutableCapability(
+                    moduleDependency.getGroup(),
+                    moduleDependency.getName() + TEST_FIXTURES_CAPABILITY_APPENDIX,
+                    null));
+            });
+        }
+        return testFixturesDependency;
+    }
+
+    @Override
+    public Dependency testFixtures(Object notation, Action<? super Dependency> configureAction) {
+        Dependency testFixturesDependency = testFixtures(notation);
+        configureAction.execute(testFixturesDependency);
+        return testFixturesDependency;
     }
 
     private Category toCategory(String category) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
+import org.gradle.api.capabilities.Capability;
 
 public class ImmutableCapability implements CapabilityInternal {
 
@@ -77,13 +78,13 @@ public class ImmutableCapability implements CapabilityInternal {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Capability)) {
             return false;
         }
-        ImmutableCapability that = (ImmutableCapability) o;
-        return Objects.equal(group, that.group)
-            && Objects.equal(name, that.name)
-            && Objects.equal(version, that.version);
+        Capability that = (Capability) o;
+        return Objects.equal(group, that.getGroup())
+            && Objects.equal(name, that.getName())
+            && Objects.equal(version, that.getVersion());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.component.external.model;
 
+import com.google.common.base.Objects;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
 import org.gradle.api.capabilities.Capability;
@@ -44,6 +45,21 @@ public class ProjectDerivedCapability implements Capability {
         return notNull("version", project.getVersion());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Capability)) {
+            return false;
+        }
+
+        Capability that = (Capability) o;
+        return Objects.equal(getGroup(), that.getGroup())
+            && Objects.equal(getName(), that.getName())
+            && Objects.equal(getVersion(), that.getVersion());
+
+    }
 
     private static String notNull(String id, Object o) {
         if (o == null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.util.TextUtil;
+
+public class ProjectDerivedCapability implements Capability {
+    private final Project project;
+    private final String featureName;
+
+    public ProjectDerivedCapability(Project project, String featureName) {
+        this.project = project;
+        this.featureName = featureName;
+    }
+
+    @Override
+    public String getGroup() {
+        return notNull("group", project.getGroup());
+    }
+
+    @Override
+    public String getName() {
+        return notNull("name", project.getName()) + "-" + TextUtil.camelToKebabCase(featureName);
+    }
+
+    @Override
+    public String getVersion() {
+        return notNull("version", project.getVersion());
+    }
+
+
+    private static String notNull(String id, Object o) {
+        if (o == null) {
+            throw new InvalidUserDataException(id + " must not be null");
+        }
+        return o.toString();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectDerivedCapability.java
@@ -46,6 +46,11 @@ public class ProjectDerivedCapability implements Capability {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hashCode(getGroup(), getName(), getVersion());
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectTestFixtures.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ProjectTestFixtures.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
+
+import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURES_FEATURE_NAME;
+
+public class ProjectTestFixtures implements Action<ModuleDependencyCapabilitiesHandler> {
+    private final Project project;
+
+    public ProjectTestFixtures(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void execute(ModuleDependencyCapabilitiesHandler capabilities) {
+        capabilities.requireCapability(new ProjectDerivedCapability(project, TEST_FIXTURES_FEATURE_NAME));
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/TestFixturesSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/TestFixturesSupport.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+public abstract class TestFixturesSupport {
+    public final static String TEST_FIXTURE_SOURCESET_NAME = "testFixtures";
+    public final static String TEST_FIXTURES_FEATURE_NAME = "testFixtures";
+    public final static String TEST_FIXTURES_API = "testFixturesApi";
+    public final static String TEST_FIXTURES_CAPABILITY_APPENDIX = "-test-fixtures";
+}

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -49,6 +49,12 @@
             "member": "Method org.gradle.api.publish.ivy.tasks.PublishToIvyRepository.getDuplicatePublicationTracker()",
             "acceptation": "Injected service",
             "changes": []
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaLibraryPlugin",
+            "member": "Constructor org.gradle.api.plugins.JavaLibraryPlugin()",
+            "acceptation": "Removed old injecting constructor",
+            "changes": []
         }
     ]
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -111,7 +111,7 @@ allprojects {
         assert actualRoot.startsWith(expectedRoot)
 
         def expectedFirstLevel = graph.root.deps.findAll { !it.constraint }.collect { d ->
-            def configs = d.selected.configurations.collect {
+            def configs = d.selected.firstLevelConfigurations.collect {
                 "[${d.selected.moduleVersionId}:${it}]"
             }
             if (configs.empty) {
@@ -558,6 +558,7 @@ allprojects {
         final String module
         final String version
         final Set<String> configurations = []
+        Set<String> firstLevelConfigurations
         private boolean implicitArtifact = true
         final List<String> files = []
         private final Set<ExpectedArtifact> artifacts = new LinkedHashSet<>()
@@ -797,6 +798,14 @@ allprojects {
 
         void configuration(String configuration) {
             configurations << configuration
+        }
+
+        void setFirstLevelConfigurations(Collection<String> firstLevelConfigurations) {
+            this.firstLevelConfigurations = firstLevelConfigurations as Set
+        }
+
+        Set<String> getFirstLevelConfigurations() {
+            firstLevelConfigurations == null ? configurations : firstLevelConfigurations
         }
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -127,4 +127,10 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
 
     override fun enforcedPlatform(notation: Any, configureAction: Action<in Dependency>): Dependency =
         delegate.enforcedPlatform(notation, configureAction)
+
+    override fun testFixtures(notation: Any): Dependency =
+        delegate.testFixtures(notation)
+
+    override fun testFixtures(notation: Any, configureAction: Action<in Dependency>): Dependency =
+        delegate.testFixtures(notation, configureAction)
 }

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -65,6 +65,10 @@ dependencies {
     testImplementation(testLibrary("jsoup"))
 
     integTestRuntimeOnly(project(":maven"))
+
+    testImplementation(library("gson")) {
+        because("for unknown reason (bug in the Groovy/Spock compiler?) requires it to be present to use the Gradle Module Metadata test fixtures")
+    }
 }
 
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.fixtures
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.test.fixtures.GradleModuleMetadata
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.maven.MavenPom
+
+abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrationSpec {
+    abstract String getPluginName()
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+
+        buildFile << """
+            allprojects {
+                apply plugin: '${pluginName}'
+
+                ${mavenCentralRepository()}
+                
+                dependencies { testImplementation 'junit:junit:4.12' }
+            }
+        """
+    }
+
+    def "can compile test fixtures"() {
+        buildFile << """
+            java {
+                enableTestFixtures()
+            }
+
+        """
+        addPersonDomainClass()
+        addPersonTestFixture()
+        addPersonTestUsingTestFixtures()
+
+        when:
+        succeeds 'compileTestJava'
+
+        then:
+        def skippedJars = pluginName == 'java' ? [':testFixturesJar'] : [':jar', ':testFixturesJar']
+        def producedJars = pluginName == 'java' ? [':jar'] : []
+        executedAndNotSkipped(
+            ":compileJava",
+            ":compileTestFixturesJava",
+            ":compileTestJava",
+            *producedJars
+        )
+        notExecuted(*skippedJars)
+
+        when:
+        succeeds "test"
+
+        then:
+        def expectedJars = [':jar', ':testFixturesJar'] - producedJars
+        executedAndNotSkipped(*expectedJars)
+    }
+
+    def "test fixtures can use their own dependencies"() {
+        buildFile << """
+            java {
+                enableTestFixtures()
+            }
+        
+            dependencies {
+                testFixturesImplementation 'org.apache.commons:commons-lang3:3.9'
+            }
+        """
+        addPersonDomainClass()
+        addPersonTestFixtureUsingApacheCommons()
+        addPersonTestUsingTestFixtures()
+
+        when:
+        succeeds 'compileTestJava'
+
+        then:
+        def skippedJars = pluginName == 'java' ? [':testFixturesJar'] : [':jar', ':testFixturesJar']
+        def producedJars = pluginName == 'java' ? [':jar'] : []
+        executedAndNotSkipped(
+            ":compileJava",
+            ":compileTestFixturesJava",
+            ":compileTestJava",
+            *producedJars
+        )
+        notExecuted(*skippedJars)
+
+        when:
+        succeeds "test"
+
+        then:
+        def expectedJars = [':jar', ':testFixturesJar'] - producedJars
+        executedAndNotSkipped(*expectedJars)
+    }
+
+    def "test fixtures implementation dependencies to not leak into the test compile classpath"() {
+        buildFile << """
+            java {
+                enableTestFixtures()
+            }
+        
+            dependencies {
+                testFixturesImplementation 'org.apache.commons:commons-lang3:3.9'
+            }
+        """
+        addPersonDomainClass()
+        addPersonTestFixtureUsingApacheCommons()
+        addPersonTestUsingTestFixtures()
+        file("src/test/java/org/Leaking.java") << """
+            package org;
+            import org.apache.commons.lang3.StringUtils;
+            
+            public class Leaking {
+            }
+        """
+        when:
+        fails 'compileTestJava'
+
+        then:
+        failure.assertHasCause("Compilation failed")
+        errorOutput.contains("package org.apache.commons.lang3 does not exist")
+    }
+
+    def "test fixtures api dependencies are visible on the test compile classpath"() {
+        buildFile << """
+            java {
+                enableTestFixtures()
+            }
+        
+            dependencies {
+                testFixturesApi 'org.apache.commons:commons-lang3:3.9'
+            }
+        """
+        addPersonDomainClass()
+        addPersonTestFixtureUsingApacheCommons()
+        addPersonTestUsingTestFixtures()
+        file("src/test/java/org/Leaking.java") << """
+            package org;
+            import org.apache.commons.lang3.StringUtils;
+            
+            public class Leaking {
+            }
+        """
+
+        expect:
+        succeeds 'compileTestJava'
+    }
+
+    def "can consume test fixtures of subproject"() {
+        settingsFile << """
+            include 'sub'
+        """
+        file("sub/build.gradle") << """
+            java {
+                enableTestFixtures()
+            }
+        """
+        buildFile << """
+            java {
+                usesTestFixturesOf(project(":sub"))
+            }           
+        """
+        addPersonDomainClass("sub")
+        addPersonTestFixture("sub")
+        // the test will live in the current project, instead of "sub"
+        // which demonstrates that the test fixtures are exposed
+        addPersonTestUsingTestFixtures()
+
+        when:
+        succeeds ':compileTestJava'
+
+        then:
+        executedAndNotSkipped(
+            ":sub:compileTestFixturesJava"
+        )
+    }
+
+    def "can publish test fixtures"() {
+        FeaturePreviewsFixture.enableGradleMetadata(settingsFile)
+
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            java {
+                enableTestFixtures()
+            }
+
+            dependencies {
+                testFixturesImplementation 'org.apache.commons:commons-lang3:3.9'
+            }
+
+            publishing {
+                repositories {
+                    maven {
+                        url "\${buildDir}/repo"
+                    }
+                    publications {
+                        maven(MavenPublication) {
+                            from components.java
+                        }
+                    }
+                }
+            }
+
+            group = 'com.acme'
+            version = '1.3'
+        """
+        addPersonDomainClass()
+        addPersonTestFixtureUsingApacheCommons()
+        addPersonTestUsingTestFixtures()
+
+        when:
+        succeeds 'publish'
+
+        then: "a test fixtures jar is published"
+        file("build/repo/com/acme/root/1.3/root-1.3-test-fixtures.jar").exists()
+
+        and: "appears as optional dependency in Maven POM"
+        MavenPom pom = new MavenPom(file("build/repo/com/acme/root/1.3/root-1.3.pom"))
+        pom.scope("compile") {
+            assertOptionalDependencies(
+                "com.acme:root:1.3",
+                "org.apache.commons:commons-lang3:3.9"
+            )
+        }
+
+        and: "appears as a variant in Gradle Module metadata"
+        GradleModuleMetadata gmm = new GradleModuleMetadata(file("build/repo/com/acme/root/1.3/root-1.3.module"))
+        gmm.variant("testFixturesApiElements") {
+            dependency("com.acme:root:1.3")
+            noMoreDependencies()
+        }
+        gmm.variant("testFixturesRuntimeElements") {
+            dependency("com.acme:root:1.3")
+            dependency("org.apache.commons:commons-lang3:3.9")
+            noMoreDependencies()
+        }
+    }
+
+    def "can consume test fixtures of an external module"() {
+        mavenRepo.module("com.acme", "external-module", "1.3")
+            .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api-jars']) {
+                capability('com.acme', 'external-module-test-fixtures', '1.3')
+                dependsOn("com.acme:external-module:1.3")
+                artifact("external-module-1.3-test-fixtures.jar")
+            }
+            .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime-jars']) {
+                capability('com.acme', 'external-module-test-fixtures', '1.3')
+                dependsOn("com.acme:external-module:1.3")
+                dependsOn("org.apache.commons:commons-lang3:3.9")
+                artifact("external-module-1.3-test-fixtures.jar")
+            }
+            .withGradleMetadataRedirection()
+            .withModuleMetadata()
+            .publish()
+        buildFile << """
+            java {
+                usesTestFixturesOf('com.acme:external-module:1.3')
+            }
+            repositories {
+                maven {
+                    url "${mavenRepo.uri}"
+                }
+            }           
+        """
+        when:
+        def resolve = new ResolveTestFixture(buildFile, "testCompileClasspath")
+        resolve.prepare()
+        succeeds ':checkdeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":root:unspecified") {
+                module('junit:junit:4.12') {
+                    configuration = 'compile' // external POM
+                    module("org.hamcrest:hamcrest-core:1.3")
+                }
+                module('com.acme:external-module:1.3') {
+                    variant("testFixturesApiElements", [
+                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-api-jars'
+                    ])
+                    firstLevelConfigurations = ['testFixturesApiElements']
+                    module('com.acme:external-module:1.3') {
+                        variant("api", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api-jars'])
+                        artifact(name: 'external-module', version:'1.3')
+                    }
+                    artifact(name: 'external-module', version:'1.3', classifier:'test-fixtures')
+                }
+            }
+        }
+
+        when:
+        resolve = new ResolveTestFixture(buildFile, "testRuntimeClasspath")
+        resolve.prepare()
+        succeeds ':checkdeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":root:unspecified") {
+                module('junit:junit:4.12') {
+                    configuration = 'runtime' // external POM
+                    module("org.hamcrest:hamcrest-core:1.3")
+                }
+                module('com.acme:external-module:1.3') {
+                    variant("testFixturesRuntimeElements", [
+                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime-jars'
+                    ])
+                    firstLevelConfigurations = ['testFixturesRuntimeElements']
+                    module('com.acme:external-module:1.3') {
+                        variant("runtime", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime-jars'])
+                        artifact(name: 'external-module', version:'1.3')
+                    }
+                    module("org.apache.commons:commons-lang3:3.9") {
+                        configuration = 'runtime' // external POM
+                    }
+                    artifact(name: 'external-module', version:'1.3', classifier:'test-fixtures')
+                }
+            }
+        }
+    }
+
+    private TestFile addPersonTestUsingTestFixtures(String subproject = "") {
+        file("${subproject ? "${subproject}/" : ""}src/test/java/org/PersonTest.java") << """
+            import org.PersonFixture;
+            import org.Person;
+            import org.junit.Test;
+            import static org.junit.Assert.*;
+            
+            public class PersonTest {
+                @Test
+                public void testAny() {
+                    Person anyone = PersonFixture.anyone();
+                    assertEquals("John", anyone.getFirstName());
+                    assertEquals("Doe", anyone.getLastName());
+                }
+            }
+        """
+    }
+
+    private TestFile addPersonDomainClass(String subproject = "") {
+        file("${subproject ? "${subproject}/" : ""}src/main/java/org/Person.java") << """
+            package org;
+            
+            public class Person {
+                private final String firstName;
+                private final String lastName;
+                
+                public Person(String first, String last) {
+                    this.firstName = first;
+                    this.lastName = last;
+                }
+                
+                public String getFirstName() {
+                    return firstName;
+                }
+                
+                public String getLastName() {
+                    return lastName;
+                }
+            }
+        """
+    }
+
+    private TestFile addPersonTestFixture(String subproject = "") {
+        file("${subproject ? "${subproject}/" : ""}src/testFixtures/java/org/PersonFixture.java") << """
+            package org;
+            
+            public class PersonFixture {
+                public static Person anyone() {
+                    return new Person("John", "Doe");
+                }
+            }
+        """
+    }
+
+    private TestFile addPersonTestFixtureUsingApacheCommons(String subproject = "") {
+        file("${subproject ? "${subproject}/" : ""}src/testFixtures/java/org/PersonFixture.java") << """
+            package org;
+            import org.apache.commons.lang3.StringUtils;
+            
+            public class PersonFixture {
+                public static Person anyone() {
+                    return new Person(StringUtils.capitalize("john"), StringUtils.capitalize("doe"));
+                }
+            }
+        """
+    }
+
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -44,10 +44,7 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
 
     def "can compile test fixtures"() {
         buildFile << """
-            java {
-                enableTestFixtures()
-            }
-
+            apply plugin: 'java-test-fixtures'
         """
         addPersonDomainClass()
         addPersonTestFixture()
@@ -77,9 +74,7 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
 
     def "test fixtures can use their own dependencies"() {
         buildFile << """
-            java {
-                enableTestFixtures()
-            }
+            apply plugin: 'java-test-fixtures'
         
             dependencies {
                 testFixturesImplementation 'org.apache.commons:commons-lang3:3.9'
@@ -113,9 +108,7 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
 
     def "test fixtures implementation dependencies to not leak into the test compile classpath"() {
         buildFile << """
-            java {
-                enableTestFixtures()
-            }
+            apply plugin: 'java-test-fixtures'
         
             dependencies {
                 testFixturesImplementation 'org.apache.commons:commons-lang3:3.9'
@@ -141,9 +134,7 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
 
     def "test fixtures api dependencies are visible on the test compile classpath"() {
         buildFile << """
-            java {
-                enableTestFixtures()
-            }
+            apply plugin: 'java-test-fixtures'
         
             dependencies {
                 testFixturesApi 'org.apache.commons:commons-lang3:3.9'
@@ -169,13 +160,11 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
             include 'sub'
         """
         file("sub/build.gradle") << """
-            java {
-                enableTestFixtures()
-            }
+            apply plugin: 'java-test-fixtures'
         """
         buildFile << """
-            java {
-                usesTestFixturesOf(project(":sub"))
+            dependencies {
+                testImplementation(testFixtures(project(":sub")))
             }           
         """
         addPersonDomainClass("sub")
@@ -198,10 +187,7 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
 
         buildFile << """
             apply plugin: 'maven-publish'
-
-            java {
-                enableTestFixtures()
-            }
+            apply plugin: 'java-test-fixtures'
 
             dependencies {
                 testFixturesImplementation 'org.apache.commons:commons-lang3:3.9'
@@ -272,8 +258,8 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
             .withModuleMetadata()
             .publish()
         buildFile << """
-            java {
-                usesTestFixturesOf('com.acme:external-module:1.3')
+            dependencies {
+                testImplementation(testFixtures('com.acme:external-module:1.3'))
             }
             repositories {
                 maven {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.fixtures
+
+class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaTestFixturesIntegrationTest {
+    @Override
+    String getPluginName() {
+        'java-library'
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.fixtures
+
+class JavaTestFixturesIntegrationTest extends AbstractJavaTestFixturesIntegrationTest {
+    @Override
+    String getPluginName() {
+        'java'
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -40,6 +40,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.javadoc.Groovydoc;
+import org.gradle.internal.component.external.model.TestFixturesSupport;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -127,7 +128,7 @@ public class GroovyBasePlugin implements Plugin<Project> {
                     }
                 }));
 
-                if (SourceSet.MAIN_SOURCE_SET_NAME.equals(sourceSet.getName())) {
+                if (SourceSet.MAIN_SOURCE_SET_NAME.equals(sourceSet.getName()) || TestFixturesSupport.TEST_FIXTURE_SOURCESET_NAME.equals(sourceSet.getName())) {
                     // The user has chosen to use the java-library plugin;
                     // add a classes variant for groovy's main sourceSet compilation,
                     // so default-configuration project dependencies will see groovy's output.

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java
@@ -17,18 +17,10 @@ package org.gradle.api.plugins;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.api.tasks.compile.JavaCompile;
 
-import javax.inject.Inject;
-
-import static org.gradle.api.plugins.JavaPlugin.COMPILE_JAVA_TASK_NAME;
-import static org.gradle.api.plugins.internal.JavaPluginsHelper.registerClassesDirVariant;
+import static org.gradle.api.plugins.internal.JavaPluginsHelper.addApiToSourceSet;
 
 /**
  * <p>A {@link Plugin} which extends the capabilities of the {@link JavaPlugin Java plugin} by cleanly separating
@@ -37,12 +29,6 @@ import static org.gradle.api.plugins.internal.JavaPluginsHelper.registerClassesD
  * @since 3.4
  */
 public class JavaLibraryPlugin implements Plugin<Project> {
-    private final ObjectFactory objectFactory;
-
-    @Inject
-    public JavaLibraryPlugin(ObjectFactory objectFactory) {
-        this.objectFactory = objectFactory;
-    }
 
     @Override
     public void apply(Project project) {
@@ -50,29 +36,7 @@ public class JavaLibraryPlugin implements Plugin<Project> {
 
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         ConfigurationContainer configurations = project.getConfigurations();
-        addApiToMainSourceSet(project, sourceSets, configurations);
-    }
-
-    private void addApiToMainSourceSet(Project project, SourceSetContainer sourceSets, ConfigurationContainer configurations) {
-        SourceSet sourceSet = sourceSets.getByName("main");
-
-        Configuration apiConfiguration = configurations.maybeCreate(sourceSet.getApiConfigurationName());
-        apiConfiguration.setVisible(false);
-        apiConfiguration.setDescription("API dependencies for " + sourceSet + ".");
-        apiConfiguration.setCanBeResolved(false);
-        apiConfiguration.setCanBeConsumed(false);
-
-        Configuration apiElementsConfiguration = configurations.getByName(sourceSet.getApiElementsConfigurationName());
-        apiElementsConfiguration.extendsFrom(apiConfiguration);
-
-        final Provider<JavaCompile> javaCompile = project.getTasks().named(COMPILE_JAVA_TASK_NAME, JavaCompile.class);
-        registerClassesDirVariant(javaCompile, objectFactory, apiElementsConfiguration);
-
-        Configuration implementationConfiguration = configurations.getByName(sourceSet.getImplementationConfigurationName());
-        implementationConfiguration.extendsFrom(apiConfiguration);
-
-        Configuration compileConfiguration = configurations.getByName(sourceSet.getCompileConfigurationName());
-        apiConfiguration.extendsFrom(compileConfiguration);
+        addApiToSourceSet(project, sourceSets.getByName("main"), configurations);
     }
 
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -72,4 +72,26 @@ public interface JavaPluginExtension {
      */
     @Incubating
     void disableAutoTargetJvm();
+
+    /**
+     * If this method is called, a new source set will be created for test fixtures.
+     * This source set will automatically depend on the main component, and the tests
+     * will also automatically depend on test fixtures.
+     *
+     * Consumers of this project may use this test fixtures by calling the {@link #usesTestFixturesOf(Object)} method
+     *
+     * @since 5.6
+     */
+    @Incubating
+    void enableTestFixtures();
+
+    /**
+     * Indicates that this project uses the test fixtures of another project or external module.
+     * It is assumed that those test fixtures were enabled using the {@link #enableTestFixtures()} method
+     * of the producer.
+     *
+     * @since 5.6
+     */
+    @Incubating
+    void usesTestFixturesOf(Object notation);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -73,25 +73,4 @@ public interface JavaPluginExtension {
     @Incubating
     void disableAutoTargetJvm();
 
-    /**
-     * If this method is called, a new source set will be created for test fixtures.
-     * This source set will automatically depend on the main component, and the tests
-     * will also automatically depend on test fixtures.
-     *
-     * Consumers of this project may use this test fixtures by calling the {@link #usesTestFixturesOf(Object)} method
-     *
-     * @since 5.6
-     */
-    @Incubating
-    void enableTestFixtures();
-
-    /**
-     * Indicates that this project uses the test fixtures of another project or external module.
-     * It is assumed that those test fixtures were enabled using the {@link #enableTestFixtures()} method
-     * of the producer.
-     *
-     * @since 5.6
-     */
-    @Incubating
-    void usesTestFixturesOf(Object notation);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.internal.component.external.model.ProjectTestFixtures;
+import org.gradle.api.tasks.SourceSet;
+
+import static org.gradle.api.plugins.internal.JavaPluginsHelper.addApiToSourceSet;
+import static org.gradle.internal.component.external.model.TestFixturesSupport.*;
+
+public class JavaTestFixturesPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().withPlugin("java", plugin -> {
+            JavaPluginConvention convention = findJavaConvention(project);
+            JavaPluginExtension extension = findJavaPluginExtension(project);
+            SourceSet testFixtures = convention.getSourceSets().create(TEST_FIXTURE_SOURCESET_NAME);
+            extension.registerFeature(TEST_FIXTURES_FEATURE_NAME, featureSpec -> featureSpec.usingSourceSet(testFixtures));
+            addApiToSourceSet(project, testFixtures, project.getConfigurations());
+            createImplicitTestFixturesDependencies(project, convention);
+        });
+    }
+
+    private void createImplicitTestFixturesDependencies(Project project, JavaPluginConvention convention) {
+        DependencyHandler dependencies = project.getDependencies();
+        dependencies.add(TEST_FIXTURES_API, dependencies.create(project));
+        ProjectDependency testDependency = (ProjectDependency) dependencies.add(findTestSourceSet(convention).getImplementationConfigurationName(), dependencies.create(project));
+        testDependency.capabilities(new ProjectTestFixtures(project));
+    }
+
+    private SourceSet findTestSourceSet(JavaPluginConvention convention) {
+        return convention.getSourceSets().getByName("test");
+    }
+
+    private JavaPluginExtension findJavaPluginExtension(Project project) {
+        return project.getExtensions().getByType(JavaPluginExtension.class);
+    }
+
+    private JavaPluginConvention findJavaConvention(Project project) {
+        return (JavaPluginConvention) project.getConvention().getPlugins().get("java");
+    }
+
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
@@ -15,16 +15,31 @@
  */
 package org.gradle.api.plugins;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
-import org.gradle.internal.component.external.model.ProjectTestFixtures;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.internal.component.external.model.ProjectTestFixtures;
 
 import static org.gradle.api.plugins.internal.JavaPluginsHelper.addApiToSourceSet;
-import static org.gradle.internal.component.external.model.TestFixturesSupport.*;
+import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURES_API;
+import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURES_FEATURE_NAME;
+import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURE_SOURCESET_NAME;
 
+/**
+ * Adds support for producing test fixtures. This plugin will automatically
+ * create a `testFixtures` source set, and wires the tests to use those
+ * test fixtures automatically.
+ *
+ * Other projects may consume the test fixtures of the current project by
+ * declaring a dependency using the {@link DependencyHandler#testFixtures(Object)}
+ * method.
+ *
+ * @since 5.6
+ */
+@Incubating
 public class JavaTestFixturesPlugin implements Plugin<Project> {
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -21,6 +21,11 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.model.ObjectFactory;
@@ -28,13 +33,22 @@ import org.gradle.api.plugins.FeatureSpec;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.util.TextUtil;
 
 import java.util.regex.Pattern;
 
+import static org.gradle.api.plugins.internal.JavaPluginsHelper.addApiToSourceSet;
+
 public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private final static Pattern VALID_FEATURE_NAME = Pattern.compile("[a-zA-Z0-9]+");
+    private final static String TEST_FIXTURE_SOURCESET_NAME = "testFixtures";
+    private final static String TEST_FIXTURES_FEATURE_NAME = "testFixtures";
+    private final static String TEST_FIXTURES_API = "testFixturesApi";
+    private final static String TEST_FIXTURES_CAPABILITY_APPENDIX = "-test-fixtures";
+
     private final JavaPluginConvention convention;
     private final ConfigurationContainer configurations;
     private final ObjectFactory objectFactory;
@@ -94,6 +108,43 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         convention.disableAutoTargetJvm();
     }
 
+    @Override
+    public void enableTestFixtures() {
+        SourceSet testFixtures = convention.getSourceSets().create(TEST_FIXTURE_SOURCESET_NAME);
+        registerFeature(TEST_FIXTURES_FEATURE_NAME, featureSpec -> featureSpec.usingSourceSet(testFixtures));
+        addApiToSourceSet(project, testFixtures, configurations);
+        createImplicitTestFixturesDependencies();
+    }
+
+    private void createImplicitTestFixturesDependencies() {
+        DependencyHandler dependencies = project.getDependencies();
+        dependencies.add(TEST_FIXTURES_API, dependencies.create(project));
+        ProjectDependency testDependency = (ProjectDependency) dependencies.add(findTestSourceSet().getImplementationConfigurationName(), dependencies.create(project));
+        testDependency.capabilities(new ProjectTestFixtures(project));
+    }
+
+    private SourceSet findTestSourceSet() {
+        return convention.getSourceSets().getByName("test");
+    }
+
+    @Override
+    public void usesTestFixturesOf(Object notation) {
+        DependencyHandler dependencies = project.getDependencies();
+        Dependency testFixturesDependency = dependencies.add(findTestSourceSet().getImplementationConfigurationName(), dependencies.create(notation));
+        if (testFixturesDependency instanceof ProjectDependency) {
+            ProjectDependency projectDependency = (ProjectDependency) testFixturesDependency;
+            projectDependency.capabilities(new ProjectTestFixtures(projectDependency.getDependencyProject()));
+        } else if (testFixturesDependency instanceof ModuleDependency) {
+            ModuleDependency moduleDependency = (ModuleDependency) testFixturesDependency;
+            moduleDependency.capabilities(capabilities -> {
+                    capabilities.requireCapability(new ImmutableCapability(
+                        moduleDependency.getGroup(),
+                        moduleDependency.getName() + TEST_FIXTURES_CAPABILITY_APPENDIX,
+                        null));
+                });
+        }
+    }
+
     private static String validateFeatureName(String name) {
         if (!VALID_FEATURE_NAME.matcher(name).matches()) {
             throw new InvalidUserDataException("Invalid feature name '" + name + "'. Must match " + VALID_FEATURE_NAME.pattern());
@@ -130,6 +181,19 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         @Override
         public String getVersion() {
             return notNull("version", project.getVersion());
+        }
+    }
+
+    private static class ProjectTestFixtures implements Action<ModuleDependencyCapabilitiesHandler> {
+        private final Project project;
+
+        private ProjectTestFixtures(Project project) {
+            this.project = project;
+        }
+
+        @Override
+        public void execute(ModuleDependencyCapabilitiesHandler capabilities) {
+            capabilities.requireCapability(new LazyDefaultFeatureCapability(project, TEST_FIXTURES_FEATURE_NAME));
         }
     }
 }

--- a/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.java-test-fixtures.properties
+++ b/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.java-test-fixtures.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.gradle.api.plugins.JavaTestFixturesPlugin


### PR DESCRIPTION
This commit introduces conventional support for _test fixtures_
in the Java ecosystem.

The newly introduced `java-test-fixtures` plugin will create an additional source
set for test fixtures.

In addition the `dependencies` container now supports a new `testFixtures`
method, which, similarly to the `platform` method, allows targeting test
fixtures of a project or external module.

This feature builds on top of the existing feature variant
infrastructure, which means that:

- test fixtures are published (as optional dependencies in Maven,
as variants with Gradle metadata)
- test fixtures have a conventional capability

The capability for test fixtures is `test-fixtures`, so it means
that if the project has a name `foo`, then its test fixtures
would be published with a capability name of `foo-test-fixtures`.

Test fixtures expose an API and an implementation, available
through the `testFixturesApi` and `testFixturesImplementation`
configurations.

When test fixtures are enabled, the test fixtures API automatically
gets a dependency onto the main component (aka `src/main/java`).

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
