### PR TITLE
Serialize a few more types to the instant execution cache

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -21,9 +21,11 @@ import org.gradle.api.Task
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.TaskContainer
 import org.gradle.initialization.LoadProjectsBuildOperationType
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.junit.Rule
 import org.slf4j.Logger
 import spock.lang.Unroll
@@ -291,6 +293,8 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         String.name                      | "null"                                                        | "null"
         Boolean.name                     | "true"                                                        | "true"
         boolean.name                     | "true"                                                        | "true"
+        Character.name                   | "'a'"                                                         | "a"
+        char.name                        | "'a'"                                                         | "a"
         Byte.name                        | "12"                                                          | "12"
         byte.name                        | "12"                                                          | "12"
         Short.name                       | "12"                                                          | "12"
@@ -351,9 +355,10 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         noExceptionThrown()
 
         where:
-        type               | reference | invocation
-        Logger.name        | "logger"  | "info('hi')"
-        ObjectFactory.name | "objects" | "newInstance(SomeBean)"
+        type                             | reference                                                   | invocation
+        Logger.name                      | "logger"                                                    | "info('hi')"
+        ObjectFactory.name               | "objects"                                                   | "newInstance(SomeBean)"
+        ToolingModelBuilderRegistry.name | "project.services.get(${ToolingModelBuilderRegistry.name})" | "toString()"
     }
 
     @Unroll
@@ -494,11 +499,12 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         outputContains("bean.reference = null")
 
         where:
-        type          | reference
-        Project.name  | "project"
-        Gradle.name   | "project.gradle"
-        Settings.name | "project.gradle.settings"
-        Task.name     | "project.tasks.other"
+        type               | reference
+        Project.name       | "project"
+        Gradle.name        | "project.gradle"
+        Settings.name      | "project.gradle.settings"
+        Task.name          | "project.tasks.other"
+        TaskContainer.name | "project.tasks"
     }
 
     def "task can reference itself"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -86,14 +86,14 @@ class BeanPropertyWriter(
     }
 
     private
-    fun unpack(fieldValue: Any?) = when (fieldValue) {
+    fun unpack(fieldValue: Any?): Any? = when (fieldValue) {
         is DirectoryProperty -> fieldValue.asFile.orNull
         is RegularFileProperty -> fieldValue.asFile.orNull
         is Property<*> -> fieldValue.orNull
         is Provider<*> -> fieldValue.orNull
         is Supplier<*> -> fieldValue.get()
         is Function0<*> -> (fieldValue as (() -> Any?)).invoke()
-        is Lazy<*> -> fieldValue.value
+        is Lazy<*> -> unpack(fieldValue.value)
         else -> fieldValue
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.util.internal.PatternSpecFactory
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.DecodingProvider
@@ -40,6 +41,7 @@ import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.serialize.BaseSerializerFactory.BOOLEAN_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.BYTE_SERIALIZER
+import org.gradle.internal.serialize.BaseSerializerFactory.CHAR_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.DOUBLE_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.FILE_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.FLOAT_SERIALIZER
@@ -49,6 +51,7 @@ import org.gradle.internal.serialize.BaseSerializerFactory.SHORT_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALIZER
 import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.serialize.SetSerializer
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import kotlin.reflect.KClass
 
 
@@ -69,6 +72,7 @@ class Codecs(
         bind(STRING_SERIALIZER)
         bind(BOOLEAN_SERIALIZER)
         bind(INTEGER_SERIALIZER)
+        bind(CHAR_SERIALIZER)
         bind(SHORT_SERIALIZER)
         bind(LONG_SERIALIZER)
         bind(BYTE_SERIALIZER)
@@ -111,6 +115,7 @@ class Codecs(
         bind(ownerProjectService<FileCollectionFactory>())
         bind(ownerProjectService<FileOperations>())
         bind(ownerProjectService<BuildOperationExecutor>())
+        bind(ownerProjectService<ToolingModelBuilderRegistry>())
 
         bind(BeanCodec())
     }
@@ -128,6 +133,7 @@ class Codecs(
         is Project -> unsupportedState(Project::class)
         is Gradle -> unsupportedState(Gradle::class)
         is Settings -> unsupportedState(Settings::class)
+        is TaskContainer -> unsupportedState(TaskContainer::class)
         else -> encodings.computeIfAbsent(candidate.javaClass, ::computeEncoding)
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -28,6 +28,7 @@ public class BaseSerializerFactory {
     public static final Serializer<String> STRING_SERIALIZER = new StringSerializer();
     public static final Serializer<Boolean> BOOLEAN_SERIALIZER = new BooleanSerializer();
     public static final Serializer<Byte> BYTE_SERIALIZER = new ByteSerializer();
+    public static final Serializer<Character> CHAR_SERIALIZER = new CharSerializer();
     public static final Serializer<Short> SHORT_SERIALIZER = new ShortSerializer();
     public static final Serializer<Integer> INTEGER_SERIALIZER = new IntegerSerializer();
     public static final Serializer<Long> LONG_SERIALIZER = new LongSerializer();
@@ -201,6 +202,18 @@ public class BaseSerializerFactory {
 
         @Override
         public void write(Encoder encoder, Short value) throws Exception {
+            encoder.writeInt(value);
+        }
+    }
+
+    private static class CharSerializer extends AbstractSerializer<Character> {
+        @Override
+        public Character read(Decoder decoder) throws Exception {
+            return (char) decoder.readInt();
+        }
+
+        @Override
+        public void write(Encoder encoder, Character value) throws Exception {
             encoder.writeInt(value);
         }
     }


### PR DESCRIPTION
### Context

Handle a few types used by the 3.6.0-alpha01 Android plugin:

- Kotlin lazy properties with a value that should be unpacked (eg `Provider<T>`).
- `Character` and `char` types.
- `ToolingModelBuilder` service.
- Disallow `TaskContainer` values. These are currently replaced with `null`, same as the other disallowed types.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
