### PR TITLE
Apply unique name of copied configurations using a counter

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -308,4 +308,24 @@ task check {
         expect:
         succeeds ":check"
     }
+
+    def "copied configuration have unique names"() {
+        buildFile << """
+            configurations {
+              conf
+            }
+
+            task check {
+                doLast {
+                    assert configurations.conf.copyRecursive().name == 'confCopy'
+                    assert configurations.conf.copyRecursive().name == 'confCopy2'
+                    assert configurations.conf.copyRecursive().name == 'confCopy3'
+                    assert configurations.conf.copy().name == 'confCopy4'
+                    assert configurations.conf.copy().name == 'confCopy5'
+                }
+            }
+            """
+        expect:
+        succeeds ":check"
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -221,7 +221,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private UserCodeApplicationContext userCodeApplicationContext;
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
-    private AtomicInteger copyCount = new AtomicInteger(-1);
+    private AtomicInteger copyCount = new AtomicInteger(0);
 
     private Action<? super ConfigurationInternal> beforeLocking;
 
@@ -968,7 +968,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         DetachedConfigurationsProvider configurationsProvider = new DetachedConfigurationsProvider();
         RootComponentMetadataBuilder rootComponentMetadataBuilder = this.rootComponentMetadataBuilder.withConfigurationsProvider(configurationsProvider);
 
-        String newName = name + getNameWithCopySuffix();
+        String newName = getNameWithCopySuffix();
 
         Factory<ResolutionStrategyInternal> childResolutionStrategy = resolutionStrategy != null ? Factories.constant(resolutionStrategy.copy()) : resolutionStrategyFactory;
         DefaultConfiguration copiedConfiguration = instantiator.newInstance(DefaultConfiguration.class, domainObjectContext, newName,
@@ -1018,9 +1018,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     private String getNameWithCopySuffix() {
         int count = copyCount.incrementAndGet();
-        return count == 0
-            ? name
-            : name + "Copy" + count;
+        String copyName = name + "Copy";
+        return count == 1
+            ? copyName
+            : copyName + count;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -220,6 +220,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private UserCodeApplicationContext userCodeApplicationContext;
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
+    private int copyCount;
     private Action<? super ConfigurationInternal> beforeLocking;
 
     public DefaultConfiguration(DomainObjectContext domainObjectContext,
@@ -964,7 +965,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private DefaultConfiguration createCopy(Set<Dependency> dependencies, Set<DependencyConstraint> dependencyConstraints, boolean recursive) {
         DetachedConfigurationsProvider configurationsProvider = new DetachedConfigurationsProvider();
         RootComponentMetadataBuilder rootComponentMetadataBuilder = this.rootComponentMetadataBuilder.withConfigurationsProvider(configurationsProvider);
-        String newName = name + "Copy";
+        copyCount++;
+        String newName = name + "Copy" + (copyCount > 1 ? copyCount : "");
+
         Factory<ResolutionStrategyInternal> childResolutionStrategy = resolutionStrategy != null ? Factories.constant(resolutionStrategy.copy()) : resolutionStrategyFactory;
         DefaultConfiguration copiedConfiguration = instantiator.newInstance(DefaultConfiguration.class, domainObjectContext, newName,
             configurationsProvider, resolver, listenerManager, metaDataProvider, childResolutionStrategy, projectAccessListener, projectFinder, fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser, attributesFactory,

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -58,6 +58,10 @@ The repository and publication names are used to construct task names when publi
 
 Contributed by link:https://github.com/wreulicke[wreulicke]
 
+==== Configuration copies have unique names
+
+Previously, all copies of a configuration always had the name `<OriginConfigurationName>Copy`. Now when creating multiple copies will have a unique name by adding an index starting from the second copy. (e.g. `CompileOnlyCopy2`)
+
 [[changes_5.5]]
 == Upgrading from 5.4 and earlier
 


### PR DESCRIPTION
### Context

This is a PR for fixing https://github.com/gradle/gradle-private/issues/2328
