### PR TITLE
Fix invalid resolution graph state when deferring selection

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -572,4 +572,74 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
             }
         }
     }
+
+    void 'dependency constraint can be not pending, then pending, then not pending and still participate in resolution'() {
+        def constrainedBase = mavenRepo.module('org', 'constrained', '1.0').publish()
+        def constrained = mavenRepo.module('org', 'constrained', '1.1').publish()
+        def bom = mavenRepo.module('org', 'bom', '1.0').hasType('pom').dependencyConstraint(constrained).publish()
+        def user = mavenRepo.module('org', 'user', '1.0').dependsOn(constrainedBase).publish()
+        def higherUser = mavenRepo.module('org', 'user', '1.1').dependsOn(constrainedBase).publish()
+        def otherUser = mavenRepo.module('org', 'otherUser', '1.0').dependsOn(higherUser).publish()
+        mavenRepo.module('org', 'indirect', '1.0').dependsOn(user).dependsOn(otherUser).dependsOn(bom).publish()
+
+        buildFile << """
+            class PickPlatformRule implements ComponentMetadataRule {
+                ObjectFactory objects
+                
+                @javax.inject.Inject
+                PickPlatformRule(ObjectFactory objects) {
+                    this.objects = objects
+                }
+                
+                @Override
+                void execute(ComponentMetadataContext context) {
+                    def details = context.details
+                    if (details.id.name == 'indirect') {
+                        details.allVariants {
+                            withDependencies {
+                                it.each {
+                                    if (it.name == 'bom') {
+                                        it.attributes {
+                                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, 'platform'))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            dependencies {
+                conf(platform('org:bom:1.0'))
+                
+                conf 'org:indirect:1.0'
+                
+                components {
+                    withModule('org:indirect', PickPlatformRule)
+                }
+            }
+"""
+
+        when:
+        run 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module("org:bom:1.0:platform-runtime") {
+                    constraint("org:constrained:1.1", "org:constrained:1.1")
+                    noArtifacts()
+                }
+                module("org:indirect:1.0") {
+                    edge("org:user:1.0", "org:user:1.1") {
+                        edge("org:constrained:1.0", "org:constrained:1.1")
+                    }
+                    module("org:otherUser:1.0") {
+                        module( "org:user:1.1")
+                    }
+                    module("org:bom:1.0:platform-runtime")
+                }
+            }
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -154,7 +154,9 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     public void removeFromTargetConfigurations() {
-        if (!targetNodes.isEmpty()) {
+        if (targetNodes.isEmpty()) {
+            selector.getTargetModule().removeUnattachedDependency(this);
+        } else {
             for (NodeState targetConfiguration : targetNodes) {
                 targetConfiguration.removeIncomingEdge(this);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -842,6 +842,7 @@ public class NodeState implements DependencyGraphNode {
 
     void makePending(EdgeState edgeState) {
         outgoingEdges.remove(edgeState);
+        edgeState.getSelector().release();
         registerActivatingConstraint(edgeState.getDependencyState());
     }
 


### PR DESCRIPTION
The deferred selection still had a couple corner cases where the graph
was not in the right state. It was possible to leak selectors and/or
unattached dependencies.