### PR TITLE
Let InstantExecution support Callable runtime input properties

### DIFF
--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -28,7 +28,7 @@ configurations {
 }
 
 tasks.classpathManifest {
-    optionalProjects = listOf("gradle-kotlin-dsl")
+    optionalProjects.add(":kotlinDsl")
 }
 
 dependencies {

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -104,5 +104,5 @@ testFilesCleanup {
 }
 
 tasks.classpathManifest {
-    additionalProjects = listOf(project(":runtimeApiInfo"))
+    additionalProjects.add(":runtimeApiInfo")
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -34,6 +34,7 @@ import sun.reflect.ReflectionFactory
 import java.io.File
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
+import java.util.concurrent.Callable
 import java.util.function.Supplier
 
 
@@ -125,6 +126,9 @@ class BeanPropertyReader(
                     null -> Providers.notDefined()
                     else -> Providers.of(value)
                 })
+            }
+            Callable::class.java -> { bean, value ->
+                field.set(bean, Callable { value })
             }
             Supplier::class.java -> { bean, value ->
                 field.set(bean, Supplier { value })

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -28,6 +28,7 @@ import org.gradle.instantexecution.serialization.PropertyKind
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.logProperty
 import org.gradle.instantexecution.serialization.logPropertyWarning
+import java.util.concurrent.Callable
 import java.util.function.Supplier
 
 
@@ -91,6 +92,7 @@ class BeanPropertyWriter(
         is RegularFileProperty -> fieldValue.asFile.orNull
         is Property<*> -> fieldValue.orNull
         is Provider<*> -> fieldValue.orNull
+        is Callable<*> -> fieldValue.call()
         is Supplier<*> -> fieldValue.get()
         is Function0<*> -> (fieldValue as (() -> Any?)).invoke()
         is Lazy<*> -> unpack(fieldValue.value)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -86,7 +86,6 @@ class BeanPropertyWriter(
         conventionMapping.getConventionValue<Any?>(null, fieldName, false)
     }
 
-    private
     fun unpack(fieldValue: Any?): Any? = when (fieldValue) {
         is DirectoryProperty -> fieldValue.asFile.orNull
         is RegularFileProperty -> fieldValue.asFile.orNull

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
@@ -33,8 +33,11 @@ internal
 fun relevantStateOf(taskType: Class<*>): Sequence<Field> =
     relevantTypeHierarchyOf(taskType).flatMap { type ->
         type.declaredFields.asSequence().filterNot { field ->
-            // Ignore the `metaClass` field that Groovy generates
-            Modifier.isStatic(field.modifiers) || (field.isSynthetic && field.name == "metaClass" && MetaClass::class.java.isAssignableFrom(field.type))
+            Modifier.isStatic(field.modifiers)
+                // Ignore the `metaClass` field that Groovy generates
+                || (field.isSynthetic && field.name == "metaClass" && MetaClass::class.java.isAssignableFrom(field.type))
+                // Ignore the `__meta_class__` field that Gradle generates
+                || (field.name == "__meta_class__" && MetaClass::class.java.isAssignableFrom(field.type))
         }
     }.onEach {
         it.isAccessible = true

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -124,7 +124,7 @@ fun WriteContext.writeRegisteredPropertiesOf(
 ) = propertyWriter.run {
 
     fun writeProperty(propertyName: String, propertyValue: PropertyValue, kind: PropertyKind): Boolean {
-        val value = propertyValue.call() ?: return false
+        val value = unpack(propertyValue.call()) ?: return false
         return writeNextProperty(propertyName, value, kind)
     }
 


### PR DESCRIPTION
This PR includes a set of fixes to let `:baseServices:compileJava` on the `gradle/gradle` build run with instant execution. The `ClasspathManifest` task was also fixed to not hold references to `Project` instances.