### PR TITLE
Minor build init plugin tidy ups

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
@@ -59,17 +59,11 @@ public class KotlinApplicationProjectInitDescriptor extends JvmProjectInitDescri
     public void generate(InitSettings settings, BuildScriptBuilder buildScriptBuilder, TemplateFactory templateFactory) {
         super.generate(settings, buildScriptBuilder, templateFactory);
 
-        String kotlinVersion = libraryVersionProvider.getVersion("kotlin");
-        buildScriptBuilder.dependencies().platformDependency(
-            "implementation", "Align versions of all Kotlin components", "org.jetbrains.kotlin:kotlin-bom"
-        );
+        new KotlinProjectInitDescriptor(libraryVersionProvider).generate(buildScriptBuilder);
+
         buildScriptBuilder
             .fileComment("This generated file contains a sample Kotlin application project to get you started.")
-            .plugin("Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.", "org.jetbrains.kotlin.jvm", kotlinVersion)
             .plugin("Apply the application plugin to add support for building a CLI application.", "application")
-            .implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-            .testImplementationDependency("Use the Kotlin test library.", "org.jetbrains.kotlin:kotlin-test")
-            .testImplementationDependency("Use the Kotlin JUnit integration.", "org.jetbrains.kotlin:kotlin-test-junit")
             .block(null, "application", b -> {
                 b.propertyAssignment("Define the main class for the application", "mainClassName", withPackage(settings, "AppKt"));
             });

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinGradlePluginProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinGradlePluginProjectInitDescriptor.java
@@ -55,17 +55,7 @@ public class KotlinGradlePluginProjectInitDescriptor extends JvmGradlePluginProj
     public void generate(InitSettings settings, BuildScriptBuilder buildScriptBuilder, TemplateFactory templateFactory) {
         super.generate(settings, buildScriptBuilder, templateFactory);
 
-        String kotlinVersion = libraryVersionProvider.getVersion("kotlin");
-        buildScriptBuilder.plugin("Apply the Kotlin JVM plugin to add support for Kotlin.", "org.jetbrains.kotlin.jvm", kotlinVersion);
-        buildScriptBuilder.dependencies().platformDependency(
-            "implementation", "Align versions of all Kotlin components", "org.jetbrains.kotlin:kotlin-bom"
-        );
-        buildScriptBuilder.
-            implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8");
-
-        buildScriptBuilder
-            .testImplementationDependency("Use the Kotlin test library.", "org.jetbrains.kotlin:kotlin-test")
-            .testImplementationDependency("Use the Kotlin JUnit integration.", "org.jetbrains.kotlin:kotlin-test-junit");
+        new KotlinProjectInitDescriptor(libraryVersionProvider).generate(buildScriptBuilder);
     }
 
     @Override

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinLibraryProjectInitDescriptor.java
@@ -59,16 +59,9 @@ public class KotlinLibraryProjectInitDescriptor extends JvmProjectInitDescriptor
     public void generate(InitSettings settings, BuildScriptBuilder buildScriptBuilder, TemplateFactory templateFactory) {
         super.generate(settings, buildScriptBuilder, templateFactory);
 
-        String kotlinVersion = libraryVersionProvider.getVersion("kotlin");
-        buildScriptBuilder.dependencies().platformDependency(
-            "implementation", "Align versions of all Kotlin components", "org.jetbrains.kotlin:kotlin-bom"
-        );
-        buildScriptBuilder
-            .fileComment("This generated file contains a sample Kotlin library project to get you started.")
-            .plugin("Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.", "org.jetbrains.kotlin.jvm", kotlinVersion)
-            .implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-            .testImplementationDependency("Use the Kotlin test library.", "org.jetbrains.kotlin:kotlin-test")
-            .testImplementationDependency("Use the Kotlin JUnit integration.", "org.jetbrains.kotlin:kotlin-test-junit");
+        new KotlinProjectInitDescriptor(libraryVersionProvider).generate(buildScriptBuilder);
+
+        buildScriptBuilder.fileComment("This generated file contains a sample Kotlin library project to get you started.");
 
         TemplateOperation kotlinSourceTemplate = templateFactory.fromSourceTemplate("kotlinlibrary/Library.kt.template", "main");
         TemplateOperation kotlinTestTemplate = templateFactory.fromSourceTemplate("kotlinlibrary/LibraryTest.kt.template", "test");

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinProjectInitDescriptor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.buildinit.plugins.internal;
+
+public class KotlinProjectInitDescriptor {
+    private final TemplateLibraryVersionProvider libraryVersionProvider;
+
+    public KotlinProjectInitDescriptor(TemplateLibraryVersionProvider libraryVersionProvider) {
+        this.libraryVersionProvider = libraryVersionProvider;
+    }
+
+    public void generate(BuildScriptBuilder buildScriptBuilder) {
+        String kotlinVersion = libraryVersionProvider.getVersion("kotlin");
+        buildScriptBuilder.plugin("Apply the Kotlin JVM plugin to add support for Kotlin.", "org.jetbrains.kotlin.jvm", kotlinVersion);
+        buildScriptBuilder.dependencies().platformDependency(
+            "implementation", "Align versions of all Kotlin components", "org.jetbrains.kotlin:kotlin-bom"
+        );
+        buildScriptBuilder.
+            implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8");
+
+        buildScriptBuilder
+            .testImplementationDependency("Use the Kotlin test library.", "org.jetbrains.kotlin:kotlin-test")
+            .testImplementationDependency("Use the Kotlin JUnit integration.", "org.jetbrains.kotlin:kotlin-test-junit");
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -11,6 +11,7 @@ Include only their name, impactful features should be called out separately belo
 [Semyon Levin](https://github.com/remal),
 [wreulicke](https://github.com/wreulicke),
 [John Rodriguez](https://github.com/jrodbx),
+[mig4](https://github.com/mig4),
 and [Ivo Anjo](https://github.com/ivoanjo).
 
 <!-- 


### PR DESCRIPTION
### Context

Some build init tidy ups as a follow up for #9186.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
