### PR TITLE
Changes in case for input files causes Sync tasks to fail

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyAction.java
@@ -18,9 +18,11 @@ package org.gradle.api.internal.file.copy;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
+import org.gradle.internal.FileUtils;
 import org.gradle.internal.file.PathToFileResolver;
 
 import java.io.File;
+import java.util.Objects;
 
 public class FileCopyAction implements CopyAction {
 
@@ -43,9 +45,19 @@ public class FileCopyAction implements CopyAction {
         @Override
         public void processFile(FileCopyDetailsInternal details) {
             File target = fileResolver.resolve(details.getRelativePath().getPathString());
+            renameIfCaseChanged(target);
             boolean copied = details.copyTo(target);
             if (copied) {
                 didWork = true;
+            }
+        }
+
+        private void renameIfCaseChanged(File target) {
+            if (target.exists()) {
+                File canonicalizedTarget = FileUtils.canonicalize(target);
+                if (!Objects.equals(target.getName(), canonicalizedTarget.getName())) {
+                    canonicalizedTarget.renameTo(target);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #9586

This is the follow-up of https://github.com/gradle/gradle/pull/9625, based on the file permission related concerns expressed by @lptr in https://github.com/gradle/gradle/pull/9625#issuecomment-500203675

Unlike the original PR, we're not deleting everything and copying after, rather if we detect case change, we rename the file/folder explicitly, since the copy is done via streams, not OS specific copy.