### PR TITLE
Use isolation framework for IsolationMode.NONE

### DIFF
--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -139,7 +139,39 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         assertRunnableExecuted("runAgainInWorker")
 
         where:
-        isolationMode << ISOLATION_MODES
+        isolationMode << (ISOLATION_MODES - "IsolationMode.NONE")
+    }
+
+    def "produces a sensible error when a parameter can't be serialized to the worker in IsolationMode.NONE"() {
+        fixture.withRunnableClassInBuildSrc()
+        withParameterMemberThatFailsSerialization()
+
+        buildFile << """
+            ${fixture.alternateRunnable}
+
+            task runAgainInWorker(type: WorkerTask) {
+                isolationMode = IsolationMode.NONE
+                runnableClass = AlternateRunnable.class
+            }
+            
+            task runInWorker(type: WorkerTask) {
+                isolationMode = IsolationMode.NONE
+                foo = new FooWithUnserializableBar()
+                finalizedBy runAgainInWorker
+            }
+        """.stripIndent()
+
+        when:
+        fails("runInWorker")
+
+        then:
+        failureHasCause("A failure occurred while executing org.gradle.test.TestRunnable")
+        failureHasCause("Could not isolate value")
+        failureHasCause("java.io.IOException: Broken")
+
+        and:
+        executedAndNotSkipped(":runAgainInWorker")
+        assertRunnableExecuted("runAgainInWorker")
     }
 
     @Unroll

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Unroll
+import spock.lang.Ignore
 
 import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 
@@ -472,6 +473,24 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
         and:
         outputContains("Guava version: 23.1.0.jre")
+    }
+
+    @Ignore
+    def "null parameters can be provided"() {
+        fixture.withRunnableClassInBuildScript()
+
+        buildFile << """
+            task runInWorkerWithNullParameter(type: WorkerTask) {
+                foo = null
+                isolationMode = IsolationMode.NONE
+            } 
+        """
+
+        when:
+        succeeds "runInWorkerWithNullParameter"
+
+        then:
+        assertRunnableExecuted("runInWorkerWithNullParameter")
     }
 
     void withParameterClassReferencingClassInAnotherPackage() {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.internal.isolation.Isolatable;
+
+public class IsolatedParametersActionExecutionSpec implements ActionExecutionSpec {
+    private final String displayName;
+    private final Class<?> implementationClass;
+    private final Isolatable<?>[] isolatedParams;
+
+    public IsolatedParametersActionExecutionSpec(Class<?> implementationClass, String displayName, Isolatable<?>[] isolatedParams) {
+        this.implementationClass = implementationClass;
+        this.displayName = displayName;
+        this.isolatedParams = isolatedParams;
+    }
+
+    @Override
+    public Class<?> getImplementationClass() {
+        return implementationClass;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public Object[] getParams() {
+        Object[] params = new Object[isolatedParams.length];
+        for (int i=0; i<isolatedParams.length; i++) {
+            params[i] = isolatedParams[i].isolate();
+        }
+        return params;
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -53,9 +53,7 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
                     public DefaultWorkResult execute(ActionExecutionSpec spec) {
                         DefaultWorkResult result;
                         try {
-                            // TODO This should use the isolation framework to isolate the parameters instead of wrapping/unwrapping the parameters
-                            ActionExecutionSpec effectiveSpec = ((SerializedParametersActionExecutionSpec)spec).deserialize(spec.getImplementationClass().getClassLoader());
-                            result = workerServer.execute(effectiveSpec);
+                            result = workerServer.execute(spec);
                         } finally {
                             //TODO the async work tracker should wait for children of an operation to finish first.
                             //It should not be necessary to call it here.

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -23,6 +23,7 @@ import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
@@ -106,9 +107,10 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
                                             WorkerDirectoryProvider workerDirectoryProvider,
                                             ClassLoaderStructureProvider classLoaderStructureProvider,
                                             WorkerExecutionQueueFactory workerExecutionQueueFactory,
-                                            ServiceRegistry serviceRegistry) {
+                                            ServiceRegistry serviceRegistry,
+                                            IsolatableFactory isolatableFactory) {
             NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, serviceRegistry);
-            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider);
+            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider, isolatableFactory);
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;
         }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.ListenableFutureTask
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.Factory
 import org.gradle.internal.exceptions.DefaultMultiCauseException
+import org.gradle.internal.isolation.IsolatableFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
 import org.gradle.internal.work.ConditionalExecutionQueue
@@ -50,12 +51,13 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def executionQueueFactory = Mock(WorkerExecutionQueueFactory)
     def executionQueue = Mock(ConditionalExecutionQueue)
     def classLoaderStructureProvider = Mock(ClassLoaderStructureProvider)
+    def isolatableFactory = Mock(IsolatableFactory)
     ListenableFutureTask task
     DefaultWorkerExecutor workerExecutor
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, isolatableFactory)
     }
 
     @Unroll

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.classloader.VisitableURLClassLoader
+import org.gradle.internal.isolation.IsolatableFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.work.AsyncWorkTracker
 import org.gradle.internal.work.ConditionalExecution
@@ -52,13 +53,14 @@ class DefaultWorkerExecutorTest extends Specification {
     def executionQueueFactory = Mock(WorkerExecutionQueueFactory)
     def executionQueue = Mock(ConditionalExecutionQueue)
     def classLoaderStructureProvider = Mock(ClassLoaderStructureProvider)
+    def isolatableFactory = Mock(IsolatableFactory)
     def worker = Mock(BuildOperationAwareWorker)
     ConditionalExecution task
     DefaultWorkerExecutor workerExecutor
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, isolatableFactory)
     }
 
     def "worker configuration fork property defaults to AUTO"() {

--- a/subprojects/workers/workers.gradle.kts
+++ b/subprojects/workers/workers.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(project(":coreApi"))
     implementation(project(":modelCore"))
     implementation(project(":core"))
+    implementation(project(":snapshots"))
 
     implementation(library("slf4j_api"))
     implementation(library("guava"))


### PR DESCRIPTION
This changes IsolationMode.NONE to use the isolation framework instead of serialization.  We'll change the other modes to use the isolation framework under a separate PR.