### PR TITLE
Log complete path of values written to the instant execution cache

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -491,7 +491,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         instantRun "broken"
 
         then:
-        outputContains("instant-execution > Cannot serialize object of type ${type} as these are not supported with instant execution.")
+        outputContains("instant-execution > cannot serialize object of type ${type} as these are not supported with instant execution.")
 
         when:
         instantRun "broken"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -72,6 +72,50 @@ interface IsolateContext {
     val logger: Logger
 
     val isolate: Isolate
+
+    var trace: PropertyTrace
+}
+
+
+sealed class PropertyTrace {
+
+    object Unknown : PropertyTrace()
+
+    class Task(
+        val type: Class<*>,
+        val path: String
+    ) : PropertyTrace()
+
+    class Bean(
+        val type: Class<*>,
+        val trace: PropertyTrace
+    ) : PropertyTrace()
+
+    class Property(
+        val kind: PropertyKind,
+        val name: String,
+        val trace: PropertyTrace
+    ) : PropertyTrace()
+
+    override fun toString(): String = when (this) {
+        is Property -> "$kind `$name` of $trace"
+        is Bean -> "`${type.name}` bean found in $trace"
+        is Task -> "task `$path` of type `${type.name}`"
+        is Unknown -> "unknown property"
+    }
+}
+
+
+enum class PropertyKind {
+    Field {
+        override fun toString() = "field"
+    },
+    InputProperty {
+        override fun toString() = "input property"
+    },
+    OutputProperty {
+        override fun toString() = "output property"
+    }
 }
 
 
@@ -109,6 +153,18 @@ inline fun <T : MutableIsolateContext> T.withIsolate(owner: Task, block: T.() ->
         block()
     } finally {
         leaveIsolate()
+    }
+}
+
+
+internal
+inline fun <T : IsolateContext, R> T.withPropertyTrace(trace: PropertyTrace, block: T.() -> R): R {
+    val previousTrace = this.trace
+    this.trace = trace
+    try {
+        return block()
+    } finally {
+        this.trace = previousTrace
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -130,6 +130,8 @@ abstract class AbstractIsolateContext<T> : MutableIsolateContext {
     private
     var currentIsolate: T? = null
 
+    var trace: PropertyTrace = PropertyTrace.Unknown
+
     protected
     abstract fun newIsolate(owner: Task): T
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
@@ -19,35 +19,19 @@ package org.gradle.instantexecution.serialization
 import kotlin.reflect.KClass
 
 
-enum class PropertyKind {
-    Field {
-        override fun toString() = "field"
-    },
-    InputProperty {
-        override fun toString() = "input property"
-    },
-    OutputProperty {
-        override fun toString() = "output property"
-    }
+fun IsolateContext.logPropertyWarning(action: String, message: String) {
+    logger.warn("instant-execution > failed to {} {} because {}", action, trace, message)
 }
 
 
-fun IsolateContext.logPropertyWarning(action: String, kind: PropertyKind, type: Class<*>, fieldName: String, message: String) {
-    logger.warn(
-        "instant-execution > task '{}' {} '{}.{}' cannot be {}d because {}.",
-        isolate.owner.path, kind, type.name, fieldName, action, message
-    )
-}
-
-
-fun IsolateContext.logProperty(action: String, kind: PropertyKind, type: Class<*>, name: String, value: Any?) {
-    logger.info(
-        "instant-execution > task '{}' {} '{}.{}' {}d value {}",
-        isolate.owner.path, kind, type.name, name, action, value
-    )
+fun IsolateContext.logProperty(action: String, value: Any?) {
+    logger.info("instant-execution > {}d {} with value {}", action, trace, value)
 }
 
 
 fun IsolateContext.logUnsupported(type: KClass<*>) {
-    logger.warn("instant-execution > Cannot serialize object of type ${type.java.name} as these are not supported with instant execution.")
+    logger.warn(
+        "instant-execution > cannot serialize object of type {} as these are not supported with instant execution.",
+        type.qualifiedName
+    )
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -28,9 +28,11 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.instantexecution.serialization.PropertyKind
+import org.gradle.instantexecution.serialization.PropertyTrace
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.logProperty
 import org.gradle.instantexecution.serialization.logPropertyWarning
+import org.gradle.instantexecution.serialization.withPropertyTrace
 import org.gradle.internal.reflect.JavaReflectionUtil
 import sun.reflect.ReflectionFactory
 import java.io.File
@@ -74,33 +76,10 @@ class BeanPropertyReader(
         constructorForSerialization.newInstance()
 
     fun ReadContext.readFieldsOf(bean: Any) {
-        while (true) {
-            val (fieldName, fieldValue) = readNextProperty(PropertyKind.Field) ?: break
+        readEachProperty(PropertyKind.Field) { fieldName, fieldValue ->
             val setter = setterByFieldName.getValue(fieldName)
             setter(bean, fieldValue)
         }
-    }
-
-    /**
-     * Returns `null` when there are no more properties to be read.
-     */
-    fun ReadContext.readNextProperty(kind: PropertyKind): Pair<String, Any?>? {
-
-        val name = readString()
-        if (name.isEmpty()) {
-            return null
-        }
-
-        val value =
-            try {
-                read().also {
-                    logProperty("deserialize", kind, beanType, name, it)
-                }
-            } catch (e: Throwable) {
-                throw GradleException("Could not load the value of $kind '${beanType.name}.$name'.", e)
-            }
-
-        return name to value
     }
 
     @Suppress("unchecked_cast")
@@ -150,7 +129,7 @@ class BeanPropertyReader(
                 if (isAssignableTo(type, value)) {
                     field.set(bean, value)
                 } else if (value != null) {
-                    logPropertyWarning("deserialize", PropertyKind.Field, beanType, field.name, "value $value is not assignable to $type")
+                    logPropertyWarning("deserialize", "value $value is not assignable to $type")
                 } // else null value -> ignore
             }
         }
@@ -164,4 +143,30 @@ class BeanPropertyReader(
     private
     fun newConstructorForSerialization(beanType: Class<*>, constructor: Constructor<*>): Constructor<out Any> =
         ReflectionFactory.getReflectionFactory().newConstructorForSerialization(beanType, constructor)
+}
+
+
+/**
+ * Reads a sequence of properties written with [writingProperties].
+ */
+fun ReadContext.readEachProperty(kind: PropertyKind, action: (String, Any?) -> Unit) {
+    while (true) {
+
+        val name = readString()
+        if (name.isEmpty()) {
+            break
+        }
+
+        withPropertyTrace(PropertyTrace.Property(kind, name, trace)) {
+            val value =
+                try {
+                    read().also {
+                        logProperty("deserialize", it)
+                    }
+                } catch (e: Throwable) {
+                    throw GradleException("Could not load the value of $trace.", e)
+                }
+            action(name, value)
+        }
+    }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -27,6 +27,7 @@ import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.instantexecution.serialization.IsolateContext
 import org.gradle.instantexecution.serialization.PropertyKind
 import org.gradle.instantexecution.serialization.PropertyTrace
 import org.gradle.instantexecution.serialization.ReadContext
@@ -157,7 +158,7 @@ fun ReadContext.readEachProperty(kind: PropertyKind, action: (String, Any?) -> U
             break
         }
 
-        withPropertyTrace(PropertyTrace.Property(kind, name, trace)) {
+        withPropertyTrace(kind, name) {
             val value =
                 try {
                     read().also {
@@ -170,3 +171,10 @@ fun ReadContext.readEachProperty(kind: PropertyKind, action: (String, Any?) -> U
         }
     }
 }
+
+
+internal
+inline fun <T : IsolateContext, R> T.withPropertyTrace(kind: PropertyKind, name: String, action: () -> R): R =
+    withPropertyTrace(PropertyTrace.Property(kind, name, trace)) {
+        action()
+    }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -25,11 +25,9 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.PropertyKind
-import org.gradle.instantexecution.serialization.PropertyTrace
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.logProperty
 import org.gradle.instantexecution.serialization.logPropertyWarning
-import org.gradle.instantexecution.serialization.withPropertyTrace
 import java.util.concurrent.Callable
 import java.util.function.Supplier
 
@@ -78,7 +76,7 @@ class BeanPropertyWriter(
  * a suitable [Codec] for its [value].
  */
 fun WriteContext.writeNextProperty(name: String, value: Any?, kind: PropertyKind): Boolean {
-    withPropertyTrace(PropertyTrace.Property(kind, name, trace)) {
+    withPropertyTrace(kind, name) {
         val writeValue = writeActionFor(value)
         if (writeValue == null) {
             logPropertyWarning("serialize", "there's no serializer for type '${GeneratedSubclasses.unpackType(value!!).name}'")

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/PropertyTraceTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/PropertyTraceTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.Task
+
+import org.gradle.instantexecution.serialization.PropertyKind
+import org.gradle.instantexecution.serialization.PropertyTrace
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+
+class PropertyTraceTest {
+
+    @Test
+    fun `field of bean found in input property of task`() {
+
+        val beanType = PropertyTraceTest::class.java
+        val taskType = Task::class.java
+
+        assertThat(
+            PropertyTrace.Property(
+                PropertyKind.Field,
+                "f",
+                PropertyTrace.Bean(
+                    beanType,
+                    PropertyTrace.Property(
+                        PropertyKind.InputProperty,
+                        "i",
+                        PropertyTrace.Task(
+                            taskType,
+                            ":t"
+                        )
+                    )
+                )
+            ).toString(),
+            equalTo(
+                "field `f` of " +
+                    "`${beanType.name}` bean found in " +
+                    "input property `i` of " +
+                    "task `:t` of type `${taskType.name}`"
+            )
+        )
+    }
+}


### PR DESCRIPTION
In order to make it easier to understand where values are coming from when things go wrong.
