### PR TITLE
Improve performance loading tasks from instant execution cache

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
@@ -24,8 +24,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class VisitableURLClassLoader extends URLClassLoader implements ClassLoaderHierarchy {
     static {
@@ -36,25 +37,21 @@ public class VisitableURLClassLoader extends URLClassLoader implements ClassLoad
         }
     }
 
-    private final EnumMap<UserData, Object> userData = new EnumMap<UserData, Object>(UserData.class);
-
-    public enum UserData {
-        NAMED_OBJECT_INSTANTIATOR
-    }
+    private final Map<Object, Object> userData = new HashMap<Object, Object>();
 
     /**
      * This method can be used to store user data that should live among with this classloader
-     * @param user the consumer
+     * @param consumerId the consumer
      * @param onMiss called to create the initial data, when not found
      * @param <T> the type of data
      * @return user data
      */
-    public synchronized <T> T getUserData(UserData user, Factory<T> onMiss) {
-        if (userData.containsKey(user)) {
-            return Cast.uncheckedCast(userData.get(user));
+    public synchronized <T> T getUserData(Object consumerId, Factory<T> onMiss) {
+        if (userData.containsKey(consumerId)) {
+            return Cast.uncheckedCast(userData.get(consumerId));
         }
         T value = onMiss.create();
-        userData.put(user, value);
+        userData.put(consumerId, value);
         return value;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -21,8 +21,8 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
-import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.initialization.dsl.ScriptHandler;
@@ -49,6 +49,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
     private final ClassLoaderScope classLoaderScope;
     private final ScriptClassPathResolver scriptClassPathResolver;
     private final DependencyResolutionServices dependencyResolutionServices;
+    private final NamedObjectInstantiator instantiator;
     // The following values are relatively expensive to create, so defer creation until required
     private RepositoryHandler repositoryHandler;
     private DependencyHandler dependencyHandler;
@@ -57,11 +58,12 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
     private DynamicObject dynamicObject;
 
     public DefaultScriptHandler(ScriptSource scriptSource, DependencyResolutionServices dependencyResolutionServices, ClassLoaderScope classLoaderScope,
-                                ScriptClassPathResolver scriptClassPathResolver) {
+                                ScriptClassPathResolver scriptClassPathResolver, NamedObjectInstantiator instantiator) {
         this.dependencyResolutionServices = dependencyResolutionServices;
         this.scriptResource = scriptSource.getResource().getLocation();
         this.classLoaderScope = classLoaderScope;
         this.scriptClassPathResolver = scriptClassPathResolver;
+        this.instantiator = instantiator;
         JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getObjectFactory());
     }
 
@@ -116,8 +118,8 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         if (classpathConfiguration == null) {
             classpathConfiguration = configContainer.create(CLASSPATH_CONFIGURATION);
             AttributeContainer attributes = classpathConfiguration.getAttributes();
-            attributes.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME));
-            attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Bundling.class, Bundling.EXTERNAL));
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, instantiator.named(Usage.class, Usage.JAVA_RUNTIME));
+            attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, instantiator.named(Bundling.class, Bundling.EXTERNAL));
             attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandlerFactory.java
@@ -23,23 +23,27 @@ import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvid
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.groovy.scripts.ScriptSource;
 
 public class DefaultScriptHandlerFactory implements ScriptHandlerFactory {
     private final DependencyManagementServices dependencyManagementServices;
     private final DependencyMetaDataProvider dependencyMetaDataProvider;
     private final ScriptClassPathResolver scriptClassPathResolver;
+    private final NamedObjectInstantiator instantiator;
     private final FileResolver fileResolver;
     private final ProjectFinder projectFinder = new UnknownProjectFinder("Cannot use project dependencies in a script classpath definition.");
 
     public DefaultScriptHandlerFactory(DependencyManagementServices dependencyManagementServices,
                                        FileResolver fileResolver,
                                        DependencyMetaDataProvider dependencyMetaDataProvider,
-                                       ScriptClassPathResolver scriptClassPathResolver) {
+                                       ScriptClassPathResolver scriptClassPathResolver,
+                                       NamedObjectInstantiator instantiator) {
         this.dependencyManagementServices = dependencyManagementServices;
         this.fileResolver = fileResolver;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.scriptClassPathResolver = scriptClassPathResolver;
+        this.instantiator = instantiator;
     }
 
     @Override
@@ -50,7 +54,7 @@ public class DefaultScriptHandlerFactory implements ScriptHandlerFactory {
     @Override
     public ScriptHandlerInternal create(ScriptSource scriptSource, ClassLoaderScope classLoaderScope, DomainObjectContext context) {
         DependencyResolutionServices services = dependencyManagementServices.create(fileResolver, dependencyMetaDataProvider, projectFinder, context);
-        return new DefaultScriptHandler(scriptSource, services, classLoaderScope, scriptClassPathResolver);
+        return new DefaultScriptHandler(scriptSource, services, classLoaderScope, scriptClassPathResolver, instantiator);
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactory.java
@@ -16,13 +16,16 @@
 
 package org.gradle.cache.internal;
 
-import javax.annotation.concurrent.ThreadSafe;
 import org.gradle.api.Transformer;
 import org.gradle.initialization.SessionLifecycleListener;
+import org.gradle.internal.Factory;
+import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.event.ListenerManager;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 import java.lang.ref.SoftReference;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -38,47 +41,39 @@ import java.util.WeakHashMap;
  * Uses a simple algorithm to collect unused values, by retaining strong references to all keys and values used during the current build session, and the previous build session. All other values are referenced only by soft references.
  */
 @ThreadSafe
-public class DefaultCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCacheFactory {
+public class DefaultCrossBuildInMemoryCacheFactory implements CrossBuildInMemoryCacheFactory {
     private final ListenerManager listenerManager;
 
     public DefaultCrossBuildInMemoryCacheFactory(ListenerManager listenerManager) {
         this.listenerManager = listenerManager;
     }
 
-    /**
-     * Creates a new cache instance. Keys are always referenced using strong references, values by strong or soft references depending on their usage.
-     *
-     * Note: this should be used to create _only_ global scoped instances.
-     */
     @Override
     public <K, V> CrossBuildInMemoryCache<K, V> newCache() {
-        DefaultCrossBuildInMemoryCache<K, V> cache = new DefaultCrossBuildInMemoryCache<K, V>(new HashMap<K, SoftReference<V>>());
+        DefaultCrossBuildInMemoryCache<K, V> cache = new DefaultCrossBuildInMemoryCache<>(new HashMap<>());
         listenerManager.addListener(cache);
         return cache;
     }
 
-    /**
-     * Creates a new cache instance whose keys are Class instances. Keys are referenced using strong or weak references, values by strong or soft references depending on their usage.
-     *
-     * Note: this should be used to create _only_ global scoped instances.
-     */
     @Override
     public <V> CrossBuildInMemoryCache<Class<?>, V> newClassCache() {
-        DefaultCrossBuildInMemoryCache<Class<?>, V> cache = new DefaultCrossBuildInMemoryCache<Class<?>, V>(new WeakHashMap<Class<?>, SoftReference<V>>());
+        // Should use some variation of DefaultClassMap below to associate values with classes, as currently we retain a strong reference to each value for one session after the ClassLoader
+        // for the entry's key is discarded, which is unnecessary because we won't attempt to locate the entry again once the ClassLoader has been discarded
+        DefaultCrossBuildInMemoryCache<Class<?>, V> cache = new DefaultCrossBuildInMemoryCache<>(new WeakHashMap<>());
         listenerManager.addListener(cache);
         return cache;
     }
 
-    private static class DefaultCrossBuildInMemoryCache<K, V> implements CrossBuildInMemoryCache<K, V>, SessionLifecycleListener {
+    @Override
+    public <V> CrossBuildInMemoryCache<Class<?>, V> newClassMap() {
+        DefaultClassMap<V> map = new DefaultClassMap<>();
+        listenerManager.addListener(map);
+        return map;
+    }
+
+    private abstract static class AbstractCrossBuildInMemoryCache<K, V> implements CrossBuildInMemoryCache<K, V>, SessionLifecycleListener {
         private final Object lock = new Object();
         private final Map<K, V> valuesForThisSession = new HashMap<K, V>();
-        // This is used only to retain strong references to the values
-        private final Set<V> valuesForPreviousSession = new HashSet<V>();
-        private final Map<K, SoftReference<V>> allValues;
-
-        public DefaultCrossBuildInMemoryCache(Map<K, SoftReference<V>> allValues) {
-            this.allValues = allValues;
-        }
 
         @Override
         public void afterStart() {
@@ -87,9 +82,7 @@ public class DefaultCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCac
         @Override
         public void beforeComplete() {
             synchronized (lock) {
-                // Retain strong references to the values created for this session
-                valuesForPreviousSession.clear();
-                valuesForPreviousSession.addAll(valuesForThisSession.values());
+                retainValuesFromCurrentSession(valuesForThisSession.values());
                 valuesForThisSession.clear();
             }
         }
@@ -98,10 +91,18 @@ public class DefaultCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCac
         public void clear() {
             synchronized (lock) {
                 valuesForThisSession.clear();
-                valuesForPreviousSession.clear();
-                allValues.clear();
+                discardRetainedValues();
             }
         }
+
+        protected abstract void retainValuesFromCurrentSession(Collection<V> values);
+
+        protected abstract void discardRetainedValues();
+
+        protected abstract void retainValue(K key, V v);
+
+        @Nullable
+        protected abstract V maybeGetRetainedValue(K key);
 
         @Nullable
         @Override
@@ -122,7 +123,8 @@ public class DefaultCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCac
                 // TODO - do not hold lock while computing value
                 v = factory.transform(key);
 
-                allValues.put(key, new SoftReference<V>(v));
+                retainValue(key, v);
+
                 // Retain strong reference
                 valuesForThisSession.put(key, v);
 
@@ -133,7 +135,7 @@ public class DefaultCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCac
         @Override
         public void put(K key, V value) {
             synchronized (lock) {
-                allValues.put(key, new SoftReference<V>(value));
+                retainValue(key, value);
                 valuesForThisSession.put(key, value);
             }
         }
@@ -145,17 +147,95 @@ public class DefaultCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCac
                 return v;
             }
 
-            SoftReference<V> reference = allValues.get(key);
-            if (reference != null) {
-                v = reference.get();
-                if (v != null) {
-                    // Retain strong reference
-                    valuesForThisSession.put(key, v);
-                    return v;
-                }
+            v = maybeGetRetainedValue(key);
+            if (v != null) {
+                // Retain strong reference
+                valuesForThisSession.put(key, v);
+                return v;
             }
 
             return null;
+        }
+    }
+
+    private static class DefaultCrossBuildInMemoryCache<K, V> extends AbstractCrossBuildInMemoryCache<K, V> {
+        // This is used only to retain strong references to the values
+        private final Set<V> valuesForPreviousSession = new HashSet<V>();
+        private final Map<K, SoftReference<V>> allValues;
+
+        public DefaultCrossBuildInMemoryCache(Map<K, SoftReference<V>> allValues) {
+            this.allValues = allValues;
+        }
+
+        @Override
+        protected void retainValuesFromCurrentSession(Collection<V> values) {
+            // Retain strong references to the values created for this session
+            valuesForPreviousSession.clear();
+            valuesForPreviousSession.addAll(values);
+        }
+
+        @Override
+        protected void discardRetainedValues() {
+            valuesForPreviousSession.clear();
+            allValues.clear();
+        }
+
+        @Override
+        protected void retainValue(K key, V v) {
+            allValues.put(key, new SoftReference<V>(v));
+        }
+
+        @Nullable
+        @Override
+        protected V maybeGetRetainedValue(K key) {
+            SoftReference<V> reference = allValues.get(key);
+            if (reference != null) {
+                return reference.get();
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Retains strong references to the keys and values via the key's ClassLoader. This allows the ClassLoader to be collected.
+     */
+    private static class DefaultClassMap<V> extends AbstractCrossBuildInMemoryCache<Class<?>, V> {
+        // Currently retains strong references to types that are not loaded using a VisitableURLClassLoader
+        // This is fine for JVM types, but a problem when a custom ClassLoader is used (which should probably be deprecated instead of supported)
+        private final Map<Class<?>, V> leakyValues = new HashMap<>();
+
+        @Override
+        protected void retainValuesFromCurrentSession(Collection<V> values) {
+            // Ignore
+        }
+
+        @Override
+        protected void discardRetainedValues() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected void retainValue(Class<?> key, V v) {
+            getCacheScope(key).put(key, v);
+        }
+
+        @Nullable
+        @Override
+        protected V maybeGetRetainedValue(Class<?> key) {
+            return getCacheScope(key).get(key);
+        }
+
+        private Map<Class<?>, V> getCacheScope(Class<?> type) {
+            ClassLoader classLoader = type.getClassLoader();
+            if (classLoader instanceof VisitableURLClassLoader) {
+                return ((VisitableURLClassLoader) classLoader).getUserData(this, new Factory<Map<Class<?>, V>>() {
+                    @Override
+                    public Map<Class<?>, V> create() {
+                        return new HashMap<>();
+                    }
+                });
+            }
+            return leakyValues;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -44,6 +44,7 @@ import org.gradle.api.internal.initialization.ScriptClassPathInitializer;
 import org.gradle.api.internal.initialization.ScriptClassPathResolver;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.plugins.DefaultPluginRegistry;
 import org.gradle.api.internal.plugins.PluginInspector;
 import org.gradle.api.internal.plugins.PluginRegistry;
@@ -76,12 +77,12 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.FileLockManager;
 import org.gradle.caching.internal.BuildCacheServices;
-import org.gradle.configuration.ProjectsPreparer;
-import org.gradle.configuration.DefaultProjectsPreparer;
+import org.gradle.configuration.BuildOperatingFiringProjectsPreparer;
 import org.gradle.configuration.DefaultInitScriptProcessor;
+import org.gradle.configuration.DefaultProjectsPreparer;
 import org.gradle.configuration.DefaultScriptPluginFactory;
 import org.gradle.configuration.ImportsReader;
-import org.gradle.configuration.BuildOperatingFiringProjectsPreparer;
+import org.gradle.configuration.ProjectsPreparer;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.configuration.ScriptPluginFactorySelector;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
@@ -104,6 +105,7 @@ import org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory;
 import org.gradle.groovy.scripts.internal.FileCacheBackedScriptClassCompiler;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildLoader;
+import org.gradle.initialization.BuildOperatingFiringSettingsPreparer;
 import org.gradle.initialization.BuildOperationSettingsProcessor;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.initialization.ClassLoaderRegistry;
@@ -118,7 +120,6 @@ import org.gradle.initialization.InitScriptHandler;
 import org.gradle.initialization.InstantiatingBuildLoader;
 import org.gradle.initialization.ModelConfigurationListener;
 import org.gradle.initialization.NotifyingBuildLoader;
-import org.gradle.initialization.BuildOperatingFiringSettingsPreparer;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.initialization.ProjectPropertySettingBuildLoader;
 import org.gradle.initialization.PropertiesLoadingSettingsProcessor;
@@ -390,13 +391,13 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new DefaultScriptClassPathResolver(initializers);
     }
 
-    protected ScriptHandlerFactory createScriptHandlerFactory() {
+    protected ScriptHandlerFactory createScriptHandlerFactory(DependencyManagementServices dependencyManagementServices, FileResolver fileResolver, DependencyMetaDataProvider dependencyMetaDataProvider, ScriptClassPathResolver classPathResolver, NamedObjectInstantiator instantiator) {
         return new DefaultScriptHandlerFactory(
-            get(DependencyManagementServices.class),
-            get(FileResolver.class),
-            get(DependencyMetaDataProvider.class),
-            get(ScriptClassPathResolver.class)
-        );
+            dependencyManagementServices,
+            fileResolver,
+            dependencyMetaDataProvider,
+            classPathResolver,
+            instantiator);
     }
 
     protected ProjectConfigurer createProjectConfigurer(BuildCancellationToken cancellationToken) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -211,8 +211,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new DefaultCompileClasspathFingerprinter(resourceSnapshotterCacheService, fileSystemSnapshotter, stringInterner);
     }
 
-    DefaultImmutableAttributesFactory createImmutableAttributesFactory(IsolatableFactory isolatableFactory) {
-        return new DefaultImmutableAttributesFactory(isolatableFactory, NamedObjectInstantiator.INSTANCE);
+    DefaultImmutableAttributesFactory createImmutableAttributesFactory(IsolatableFactory isolatableFactory, NamedObjectInstantiator instantiator) {
+        return new DefaultImmutableAttributesFactory(isolatableFactory, instantiator);
     }
 
     AsyncWorkTracker createAsyncWorkTracker(ProjectLeaseRegistry projectLeaseRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -266,10 +266,14 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         return new DefaultFilePropertyFactory(fileResolver);
     }
 
-    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory) {
+    NamedObjectInstantiator createNamedObjectInstantiator() {
+        return NamedObjectInstantiator.instance();
+    }
+
+    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory, NamedObjectInstantiator instantiator) {
         return new DefaultObjectFactory(
             instantiatorFactory.injectAndDecorate(services),
-            NamedObjectInstantiator.INSTANCE,
+            instantiator,
             fileResolver,
             directoryFileTreeFactory,
             new DefaultFilePropertyFactory(fileResolver),

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -267,7 +267,7 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
     }
 
     NamedObjectInstantiator createNamedObjectInstantiator() {
-        return NamedObjectInstantiator.instance();
+        return new NamedObjectInstantiator();
     }
 
     ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory, NamedObjectInstantiator instantiator) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -266,8 +266,8 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         return new DefaultFilePropertyFactory(fileResolver);
     }
 
-    NamedObjectInstantiator createNamedObjectInstantiator() {
-        return new NamedObjectInstantiator();
+    NamedObjectInstantiator createNamedObjectInstantiator(CrossBuildInMemoryCacheFactory cacheFactory) {
+        return new NamedObjectInstantiator(cacheFactory);
     }
 
     ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory, NamedObjectInstantiator instantiator) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -225,12 +225,13 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultModelRegistry(ruleExtractor, project.getPath());
     }
 
-    protected ScriptHandlerInternal createScriptHandler() {
+    protected ScriptHandlerInternal createScriptHandler(DependencyManagementServices dependencyManagementServices, FileResolver fileResolver, DependencyMetaDataProvider dependencyMetaDataProvider, ScriptClassPathResolver scriptClassPathResolver, NamedObjectInstantiator instantiator) {
         ScriptHandlerFactory factory = new DefaultScriptHandlerFactory(
-            get(DependencyManagementServices.class),
-            get(FileResolver.class),
-            get(DependencyMetaDataProvider.class),
-            get(ScriptClassPathResolver.class));
+            dependencyManagementServices,
+            fileResolver,
+            dependencyMetaDataProvider,
+            scriptClassPathResolver,
+            instantiator);
         return factory.create(project.getBuildScriptSource(), project.getClassLoaderScope(), new ScriptScopedContext(project));
     }
 
@@ -315,10 +316,10 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultFileCollectionFactory(fileResolver, taskResolver);
     }
 
-    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory) {
+    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory, NamedObjectInstantiator namedObjectInstantiator) {
         ServiceRegistry services = ProjectScopeServices.this;
         Instantiator instantiator = instantiatorFactory.injectAndDecorate(services);
-        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory, fileCollectionFactory, domainObjectCollectionFactory);
+        return new DefaultObjectFactory(instantiator, namedObjectInstantiator, fileResolver, directoryFileTreeFactory, filePropertyFactory, fileCollectionFactory, domainObjectCollectionFactory);
     }
 
     protected DomainObjectCollectionFactory createDomainObjectCollectionFactory(InstantiatorFactory instantiatorFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator, CrossProjectConfigurator projectConfigurator) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.attributes
 
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.util.SnapshotTestUtil
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultImmutableAttributesFactoryTest extends Specification {
@@ -28,7 +28,7 @@ class DefaultImmutableAttributesFactoryTest extends Specification {
     private static final Attribute<String> BAZ = Attribute.of("baz", String)
 
     def snapshotter = SnapshotTestUtil.valueSnapshotter()
-    def instantiator = NamedObjectInstantiator.INSTANCE
+    def instantiator = TestUtil.objectInstantiator()
 
     def factory = new DefaultImmutableAttributesFactory(snapshotter, instantiator)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.util.ConfigureUtil
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultScriptHandlerTest extends Specification {
@@ -44,7 +45,8 @@ class DefaultScriptHandlerTest extends Specification {
         getLocalClassLoader() >> baseClassLoader
     }
     def classpathResolver = Mock(ScriptClassPathResolver)
-    def handler = new DefaultScriptHandler(scriptSource, depMgmtServices, classLoaderScope, classpathResolver)
+    def instantiator = TestUtil.objectInstantiator()
+    def handler = new DefaultScriptHandler(scriptSource, depMgmtServices, classLoaderScope, classpathResolver, instantiator)
     def attributes = Mock(AttributeContainerInternal)
 
     def "adds classpath configuration when configuration container is queried"() {

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCrossBuildInMemoryCacheFactoryTest.groovy
@@ -157,7 +157,32 @@ class DefaultCrossBuildInMemoryCacheFactoryTest extends ConcurrentSpec {
         transformer.transform(String) >> a
         transformer.transform(Long) >> b
 
-        def cache = factory.newCache()
+        def cache = factory.newClassCache()
+
+        expect:
+        cache.get(String, transformer) == a
+        cache.get(Long, transformer) == b
+        cache.get(String) == a
+        cache.get(Long) == b
+
+        cache.put(String, c)
+        cache.get(String) == c
+
+        cache.clear()
+        cache.get(String) == null
+    }
+
+    def "creates a map whose keys are classes"() {
+        def a = new Object()
+        def b = new Object()
+        def c = new Object()
+        def transformer = Mock(Transformer)
+
+        given:
+        transformer.transform(String) >> a
+        transformer.transform(Long) >> b
+
+        def cache = factory.newClassMap()
 
         expect:
         cache.get(String, transformer) == a
@@ -168,5 +193,4 @@ class DefaultCrossBuildInMemoryCacheFactoryTest extends ConcurrentSpec {
         cache.put(String, c)
         cache.get(String) == c
     }
-
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCrossBuildInMemoryCacheFactory.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.Transformer
 
 import java.util.concurrent.ConcurrentHashMap
 
-class TestCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCacheFactory {
+class TestCrossBuildInMemoryCacheFactory implements CrossBuildInMemoryCacheFactory {
     @Override
     <K, V> CrossBuildInMemoryCache<K, V> newCache() {
         return new TestCache<K, V>()
@@ -28,6 +28,11 @@ class TestCrossBuildInMemoryCacheFactory extends CrossBuildInMemoryCacheFactory 
 
     @Override
     <V> CrossBuildInMemoryCache<Class<?>, V> newClassCache() {
+        return new TestCache<Class<?>, V>()
+    }
+
+    @Override
+    <V> CrossBuildInMemoryCache<Class<?>, V> newClassMap() {
         return new TestCache<Class<?>, V>()
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/AttributeTestUtil.groovy
@@ -20,11 +20,10 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
-import org.gradle.api.internal.model.NamedObjectInstantiator
 
 class AttributeTestUtil {
     static ImmutableAttributesFactory attributesFactory() {
-        return new DefaultImmutableAttributesFactory(SnapshotTestUtil.valueSnapshotter(), NamedObjectInstantiator.INSTANCE)
+        return new DefaultImmutableAttributesFactory(SnapshotTestUtil.valueSnapshotter(), TestUtil.objectInstantiator())
     }
 
     static ImmutableAttributes attributes(Map<String, ?> values) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -88,12 +88,13 @@ class TestUtil {
             services = new DefaultServiceRegistry()
             services.add(ProviderFactory, new DefaultProviderFactory())
             services.add(InstantiatorFactory, instantiatorFactory())
+            services.add(NamedObjectInstantiator, new NamedObjectInstantiator())
         }
         return services
     }
 
     static NamedObjectInstantiator objectInstantiator() {
-        return NamedObjectInstantiator.instance()
+        return services().get(NamedObjectInstantiator)
     }
 
     static FeaturePreviews featurePreviews(boolean gradleMetadataEnabled = false) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.util
 
-
 import org.gradle.api.Task
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
@@ -31,7 +30,6 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
 import org.gradle.api.internal.provider.DefaultProviderFactory
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.instantiation.DefaultInstantiatorFactory
 import org.gradle.internal.instantiation.InjectAnnotationHandler
@@ -86,9 +84,12 @@ class TestUtil {
     private static ServiceRegistry services() {
         if (services == null) {
             services = new DefaultServiceRegistry()
-            services.add(ProviderFactory, new DefaultProviderFactory())
-            services.add(InstantiatorFactory, instantiatorFactory())
-            services.add(NamedObjectInstantiator, new NamedObjectInstantiator())
+            services.register {
+                it.add(DefaultProviderFactory)
+                it.add(InstantiatorFactory, instantiatorFactory())
+                it.add(TestCrossBuildInMemoryCacheFactory)
+                it.add(NamedObjectInstantiator)
+            }
         }
         return services
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -80,7 +80,7 @@ class TestUtil {
     }
 
     private static ObjectFactory objFactory(FileResolver fileResolver) {
-        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services()), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver), TestFiles.fileCollectionFactory(), domainObjectCollectionFactory())
+        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services()), objectInstantiator(), fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver), TestFiles.fileCollectionFactory(), domainObjectCollectionFactory())
     }
 
     private static ServiceRegistry services() {
@@ -93,7 +93,7 @@ class TestUtil {
     }
 
     static NamedObjectInstantiator objectInstantiator() {
-        return NamedObjectInstantiator.INSTANCE
+        return NamedObjectInstantiator.instance()
     }
 
     static FeaturePreviews featurePreviews(boolean gradleMetadataEnabled = false) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
@@ -219,12 +219,11 @@ buildscript {
         mavenRepo.module('org', 'bar').dependsOn(['scope': 'runtime'], foo).publish()
 
         settingsFile << """
-import org.gradle.api.internal.model.NamedObjectInstantiator
 buildscript {
     $repositoryDeclaration
 
     configurations.classpath {
-        attributes.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage, Usage.JAVA_API))
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, services.get(ObjectFactory).named(Usage, Usage.JAVA_API))
     }
     
     dependencies {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -429,7 +429,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                           IvyMutableModuleMetadataFactory ivyMetadataFactory,
                                                           IsolatableFactory isolatableFactory,
                                                           ObjectFactory objectFactory,
-                                                          CollectionCallbackActionDecorator callbackDecorator) {
+                                                          CollectionCallbackActionDecorator callbackDecorator,
+                                                          NamedObjectInstantiator instantiator) {
             return new DefaultBaseRepositoryFactory(
                 localMavenRepositoryLocator,
                 fileResolver,
@@ -438,7 +439,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 artifactIdentifierFileStore,
                 externalResourceFileStore,
                 new GradlePomModuleDescriptorParser(versionSelectorScheme, moduleIdentifierFactory, fileResourceRepository, metadataFactory),
-                new GradleModuleMetadataParser(attributesFactory, moduleIdentifierFactory, NamedObjectInstantiator.INSTANCE),
+                new GradleModuleMetadataParser(attributesFactory, moduleIdentifierFactory, instantiator),
                 authenticationSchemeRegistry,
                 ivyContextManager,
                 moduleIdentifierFactory,
@@ -508,7 +509,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         DependencyHandler createDependencyHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory,
-                                                  ProjectFinder projectFinder, DependencyConstraintHandler dependencyConstraintHandler, ComponentMetadataHandler componentMetadataHandler, ComponentModuleMetadataHandler componentModuleMetadataHandler, ArtifactResolutionQueryFactory resolutionQueryFactory, AttributesSchema attributesSchema, VariantTransformRegistry artifactTransformRegistrations, ArtifactTypeRegistry artifactTypeRegistry) {
+                                                  ProjectFinder projectFinder, DependencyConstraintHandler dependencyConstraintHandler, ComponentMetadataHandler componentMetadataHandler,
+                                                  ComponentModuleMetadataHandler componentModuleMetadataHandler, ArtifactResolutionQueryFactory resolutionQueryFactory,
+                                                  AttributesSchema attributesSchema, VariantTransformRegistry artifactTransformRegistrations, ArtifactTypeRegistry artifactTypeRegistry,
+                                                  NamedObjectInstantiator namedObjectInstantiator) {
             return instantiator.newInstance(DefaultDependencyHandler.class,
                 configurationContainer,
                 dependencyFactory,
@@ -520,7 +524,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 attributesSchema,
                 artifactTransformRegistrations,
                 artifactTypeRegistry,
-                NamedObjectInstantiator.INSTANCE);
+                namedObjectInstantiator);
         }
 
         DependencyLockingHandler createDependencyLockingHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer) {
@@ -531,8 +535,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules());
         }
 
-        DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, ComponentMetadataHandler componentMetadataHandler) {
-            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, NamedObjectInstantiator.INSTANCE);
+        DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, NamedObjectInstantiator namedObjectInstantiator) {
+            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, namedObjectInstantiator);
         }
 
         DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -47,6 +47,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConst
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultConfigurationResolver;
 import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver;
@@ -348,8 +349,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             this.domainObjectContext = domainObjectContext;
         }
 
-        AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory) {
-            return instantiatorFactory.decorateLenient().newInstance(DefaultAttributesSchema.class, new ComponentAttributeMatcher(), instantiatorFactory, isolatableFactory);
+        AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {
+            DefaultAttributesSchema attributesSchema = instantiatorFactory.decorateLenient().newInstance(DefaultAttributesSchema.class, new ComponentAttributeMatcher(), instantiatorFactory, isolatableFactory);
+            platformSupport.configureSchema(attributesSchema);
+            return attributesSchema;
         }
 
         MutableTransformationWorkspaceProvider createTransformerWorkspaceProvider(ProjectLayout projectLayout, ExecutionHistoryStore executionHistoryStore) {
@@ -512,7 +515,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                   ProjectFinder projectFinder, DependencyConstraintHandler dependencyConstraintHandler, ComponentMetadataHandler componentMetadataHandler,
                                                   ComponentModuleMetadataHandler componentModuleMetadataHandler, ArtifactResolutionQueryFactory resolutionQueryFactory,
                                                   AttributesSchema attributesSchema, VariantTransformRegistry artifactTransformRegistrations, ArtifactTypeRegistry artifactTypeRegistry,
-                                                  NamedObjectInstantiator namedObjectInstantiator) {
+                                                  NamedObjectInstantiator namedObjectInstantiator, PlatformSupport platformSupport) {
             return instantiator.newInstance(DefaultDependencyHandler.class,
                 configurationContainer,
                 dependencyFactory,
@@ -524,7 +527,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 attributesSchema,
                 artifactTransformRegistrations,
                 artifactTypeRegistry,
-                namedObjectInstantiator);
+                namedObjectInstantiator,
+                platformSupport);
         }
 
         DependencyLockingHandler createDependencyLockingHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer) {
@@ -535,8 +539,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules());
         }
 
-        DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, NamedObjectInstantiator namedObjectInstantiator) {
-            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, namedObjectInstantiator);
+        DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, NamedObjectInstantiator namedObjectInstantiator, PlatformSupport platformSupport) {
+            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, namedObjectInstantiator, platformSupport);
         }
 
         DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -98,6 +98,7 @@ import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
@@ -175,13 +176,13 @@ class DependencyManagementBuildScopeServices {
 
     MavenMutableModuleMetadataFactory createMutableMavenMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                                         ImmutableAttributesFactory attributesFactory,
-                                                                        FeaturePreviews featurePreviews,
-                                                                        NamedObjectInstantiator instantiator) {
-        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, instantiator, featurePreviews);
+                                                                        NamedObjectInstantiator instantiator,
+                                                                        PreferJavaRuntimeVariant schema) {
+        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, instantiator, schema);
     }
 
-    IvyMutableModuleMetadataFactory createMutableIvyMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory) {
-        return new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory);
+    IvyMutableModuleMetadataFactory createMutableIvyMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory, PreferJavaRuntimeVariant schema) {
+        return new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, schema);
     }
 
     AttributeContainerSerializer createAttributeContainerSerializer(ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator instantiator) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -175,16 +175,17 @@ class DependencyManagementBuildScopeServices {
 
     MavenMutableModuleMetadataFactory createMutableMavenMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                                         ImmutableAttributesFactory attributesFactory,
-                                                                        FeaturePreviews featurePreviews) {
-        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, NamedObjectInstantiator.INSTANCE, featurePreviews);
+                                                                        FeaturePreviews featurePreviews,
+                                                                        NamedObjectInstantiator instantiator) {
+        return new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory, instantiator, featurePreviews);
     }
 
     IvyMutableModuleMetadataFactory createMutableIvyMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory) {
         return new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, attributesFactory);
     }
 
-    AttributeContainerSerializer createAttributeContainerSerializer(ImmutableAttributesFactory attributesFactory) {
-        return new DesugaredAttributeContainerSerializer(attributesFactory, NamedObjectInstantiator.INSTANCE);
+    AttributeContainerSerializer createAttributeContainerSerializer(ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator instantiator) {
+        return new DesugaredAttributeContainerSerializer(attributesFactory, instantiator);
     }
 
     ModuleRepositoryCacheProvider createModuleRepositoryCacheProvider(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ImmutableModuleIdentifierFactory moduleIdentifierFactory,
@@ -370,8 +371,8 @@ class DependencyManagementBuildScopeServices {
         return SimpleMapInterner.threadSafe();
     }
 
-    ModuleComponentResolveMetadataSerializer createModuleComponentResolveMetadataSerializer(ImmutableAttributesFactory attributesFactory, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory) {
-        DesugaringAttributeContainerSerializer attributeContainerSerializer = new DesugaringAttributeContainerSerializer(attributesFactory, NamedObjectInstantiator.INSTANCE);
+    ModuleComponentResolveMetadataSerializer createModuleComponentResolveMetadataSerializer(ImmutableAttributesFactory attributesFactory, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, NamedObjectInstantiator instantiator) {
+        DesugaringAttributeContainerSerializer attributeContainerSerializer = new DesugaringAttributeContainerSerializer(attributesFactory, instantiator);
         return new ModuleComponentResolveMetadataSerializer(new ModuleMetadataSerializer(attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory), attributeContainerSerializer, moduleIdentifierFactory);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
@@ -127,6 +128,10 @@ class DependencyManagementGlobalScopeServices {
 
     PreferJavaRuntimeVariant createPreferJavaRuntimeVariant(NamedObjectInstantiator instantiator) {
         return new PreferJavaRuntimeVariant(instantiator);
+    }
+
+    PlatformSupport createPlatformSupport() {
+        return new PlatformSupport();
     }
 
     ArtifactTransformParameterScheme createArtifactTransformParameterScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -130,8 +130,8 @@ class DependencyManagementGlobalScopeServices {
         return new PreferJavaRuntimeVariant(instantiator);
     }
 
-    PlatformSupport createPlatformSupport() {
-        return new PlatformSupport();
+    PlatformSupport createPlatformSupport(NamedObjectInstantiator instantiator) {
+        return new PlatformSupport(instantiator);
     }
 
     ArtifactTransformParameterScheme createArtifactTransformParameterScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -38,6 +38,7 @@ import org.gradle.api.internal.artifacts.transform.ArtifactTransformParameterSch
 import org.gradle.api.internal.artifacts.transform.CacheableTransformTypeAnnotationHandler;
 import org.gradle.api.internal.artifacts.transform.InputArtifactAnnotationHandler;
 import org.gradle.api.internal.artifacts.transform.InputArtifactDependenciesAnnotationHandler;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
 import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory;
 import org.gradle.api.internal.tasks.properties.annotations.TypeAnnotationHandler;
@@ -53,6 +54,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.cache.internal.ProducerGuard;
+import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
@@ -121,6 +123,10 @@ class DependencyManagementGlobalScopeServices {
 
     InputArtifactDependenciesAnnotationHandler createInputArtifactDependenciesAnnotationHandler() {
         return new InputArtifactDependenciesAnnotationHandler();
+    }
+
+    PreferJavaRuntimeVariant createPreferJavaRuntimeVariant(NamedObjectInstantiator instantiator) {
+        return new PreferJavaRuntimeVariant(instantiator);
     }
 
     ArtifactTransformParameterScheme createArtifactTransformParameterScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -36,16 +36,19 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     private final DependencyFactory dependencyFactory;
     private final DynamicAddDependencyMethods dynamicMethods;
     private final NamedObjectInstantiator namedObjectInstantiator;
+    private final PlatformSupport platformSupport;
     private final Category platform;
     private final Category enforcedPlatform;
 
     public DefaultDependencyConstraintHandler(ConfigurationContainer configurationContainer,
                                               DependencyFactory dependencyFactory,
-                                              NamedObjectInstantiator namedObjectInstantiator) {
+                                              NamedObjectInstantiator namedObjectInstantiator,
+                                              PlatformSupport platformSupport) {
         this.configurationContainer = configurationContainer;
         this.dependencyFactory = dependencyFactory;
         this.dynamicMethods = new DynamicAddDependencyMethods(configurationContainer, new DependencyConstraintAdder());
         this.namedObjectInstantiator = namedObjectInstantiator;
+        this.platformSupport = platformSupport;
         platform = toCategory(Category.REGULAR_PLATFORM);
         enforcedPlatform = toCategory(Category.ENFORCED_PLATFORM);
     }
@@ -73,7 +76,7 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     @Override
     public DependencyConstraint platform(Object notation) {
         DependencyConstraint dependencyConstraint = create(notation);
-        PlatformSupport.addPlatformAttribute(dependencyConstraint, platform);
+        platformSupport.addPlatformAttribute(dependencyConstraint, platform);
         return dependencyConstraint;
     }
 
@@ -88,7 +91,7 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     public DependencyConstraint enforcedPlatform(Object notation) {
         DependencyConstraintInternal platformDependency = (DependencyConstraintInternal) create(notation);
         platformDependency.setForce(true);
-        PlatformSupport.addPlatformAttribute(platformDependency, enforcedPlatform);
+        platformSupport.addPlatformAttribute(platformDependency, enforcedPlatform);
         return platformDependency;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -60,6 +60,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     private final VariantTransformRegistry transforms;
     private final Factory<ArtifactTypeContainer> artifactTypeContainer;
     private final NamedObjectInstantiator namedObjectInstantiator;
+    private final PlatformSupport platformSupport;
     private final DynamicAddDependencyMethods dynamicMethods;
 
     public DefaultDependencyHandler(ConfigurationContainer configurationContainer,
@@ -72,7 +73,8 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
                                     AttributesSchema attributesSchema,
                                     VariantTransformRegistry transforms,
                                     Factory<ArtifactTypeContainer> artifactTypeContainer,
-                                    NamedObjectInstantiator namedObjectInstantiator) {
+                                    NamedObjectInstantiator namedObjectInstantiator,
+                                    PlatformSupport platformSupport) {
         this.configurationContainer = configurationContainer;
         this.dependencyFactory = dependencyFactory;
         this.projectFinder = projectFinder;
@@ -84,6 +86,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         this.transforms = transforms;
         this.artifactTypeContainer = artifactTypeContainer;
         this.namedObjectInstantiator = namedObjectInstantiator;
+        this.platformSupport = platformSupport;
         configureSchema();
         dynamicMethods = new DynamicAddDependencyMethods(configurationContainer, new DirectDependencyAdder());
     }
@@ -233,7 +236,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     public Dependency platform(Object notation) {
         Dependency dependency = create(notation);
         if (dependency instanceof HasConfigurableAttributes) {
-            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<Object>) dependency, toCategory(Category.REGULAR_PLATFORM));
+            platformSupport.addPlatformAttribute((HasConfigurableAttributes<Object>) dependency, toCategory(Category.REGULAR_PLATFORM));
         }
         return dependency;
     }
@@ -251,9 +254,9 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         if (platformDependency instanceof ExternalModuleDependency) {
             ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) platformDependency;
             externalModuleDependency.setForce(true);
-            PlatformSupport.addPlatformAttribute(externalModuleDependency, toCategory(Category.ENFORCED_PLATFORM));
+            platformSupport.addPlatformAttribute(externalModuleDependency, toCategory(Category.ENFORCED_PLATFORM));
         } else if (platformDependency instanceof HasConfigurableAttributes) {
-            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<?>) platformDependency, toCategory(Category.ENFORCED_PLATFORM));
+            platformSupport.addPlatformAttribute((HasConfigurableAttributes<?>) platformDependency, toCategory(Category.ENFORCED_PLATFORM));
         }
         return platformDependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -34,8 +34,8 @@ import java.util.Set;
 
 public abstract class PlatformSupport {
 
-    public static final Category REGULAR_PLATFORM = NamedObjectInstantiator.INSTANCE.named(Category.class, Category.REGULAR_PLATFORM);
-    public static final Category ENFORCED_PLATFORM = NamedObjectInstantiator.INSTANCE.named(Category.class, Category.ENFORCED_PLATFORM);
+    public static final Category REGULAR_PLATFORM = NamedObjectInstantiator.instance().named(Category.class, Category.REGULAR_PLATFORM);
+    public static final Category ENFORCED_PLATFORM = NamedObjectInstantiator.instance().named(Category.class, Category.ENFORCED_PLATFORM);
 
     public static boolean isTargettingPlatform(HasConfigurableAttributes<?> target) {
         Category category = target.getAttributes().getAttribute(Category.CATEGORY_ATTRIBUTE);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -30,24 +30,37 @@ import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAtt
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.model.ComponentVariant;
 
+import javax.inject.Inject;
 import java.util.Set;
 
 public class PlatformSupport {
+    private final Category regularPlatform;
+    private final Category enforcedPlatform;
+    private final Set<Category> platformTypes;
 
-    public static final Category REGULAR_PLATFORM = NamedObjectInstantiator.instance().named(Category.class, Category.REGULAR_PLATFORM);
-    public static final Category ENFORCED_PLATFORM = NamedObjectInstantiator.instance().named(Category.class, Category.ENFORCED_PLATFORM);
+    public PlatformSupport(NamedObjectInstantiator instantiator) {
+        regularPlatform = instantiator.named(Category.class, Category.REGULAR_PLATFORM);
+        enforcedPlatform = instantiator.named(Category.class, Category.ENFORCED_PLATFORM);
+        platformTypes = ImmutableSet.of(regularPlatform, enforcedPlatform);
+    }
 
     public boolean isTargettingPlatform(HasConfigurableAttributes<?> target) {
         Category category = target.getAttributes().getAttribute(Category.CATEGORY_ATTRIBUTE);
-        return REGULAR_PLATFORM.equals(category) || ENFORCED_PLATFORM.equals(category);
+        return regularPlatform.equals(category) || enforcedPlatform.equals(category);
     }
 
-    public static void configureSchema(AttributesSchema attributesSchema) {
+    public void configureSchema(AttributesSchema attributesSchema) {
         AttributeMatchingStrategy<Category> componentTypeMatchingStrategy = attributesSchema.attribute(Category.CATEGORY_ATTRIBUTE);
         componentTypeMatchingStrategy.getDisambiguationRules().add(PlatformSupport.ComponentCategoryDisambiguationRule.class);
     }
 
-    static <T> void addPlatformAttribute(HasConfigurableAttributes<T> dependency, final Category category) {
+    public void addDisambiguationRule(AttributesSchema attributesSchema) {
+        attributesSchema.getMatchingStrategy(Category.CATEGORY_ATTRIBUTE)
+            .getDisambiguationRules()
+            .add(PlatformSupport.PreferRegularPlatform.class, c -> c.params(platformTypes, regularPlatform));
+    }
+
+    public <T> void addPlatformAttribute(HasConfigurableAttributes<T> dependency, final Category category) {
         dependency.attributes(new Action<AttributeContainer>() {
             @Override
             public void execute(AttributeContainer attributeContainer) {
@@ -85,12 +98,19 @@ public class PlatformSupport {
     }
 
     public static class PreferRegularPlatform implements AttributeDisambiguationRule<Category> {
-        private final static Set<Category> PLATFORM_TYPES = ImmutableSet.of(REGULAR_PLATFORM, ENFORCED_PLATFORM);
+        private final Set<Category> platformTypes;
+        private final Category regularPlatform;
+
+        @Inject
+        public PreferRegularPlatform(Set<Category> platformTypes, Category regularPlatform) {
+            this.platformTypes = platformTypes;
+            this.regularPlatform = regularPlatform;
+        }
 
         @Override
         public void execute(MultipleCandidatesDetails<Category> details) {
-            if (details.getCandidateValues().equals(PLATFORM_TYPES)) {
-                details.closestMatch(REGULAR_PLATFORM);
+            if (details.getCandidateValues().equals(platformTypes)) {
+                details.closestMatch(regularPlatform);
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -32,12 +32,12 @@ import org.gradle.internal.component.external.model.ComponentVariant;
 
 import java.util.Set;
 
-public abstract class PlatformSupport {
+public class PlatformSupport {
 
     public static final Category REGULAR_PLATFORM = NamedObjectInstantiator.instance().named(Category.class, Category.REGULAR_PLATFORM);
     public static final Category ENFORCED_PLATFORM = NamedObjectInstantiator.instance().named(Category.class, Category.ENFORCED_PLATFORM);
 
-    public static boolean isTargettingPlatform(HasConfigurableAttributes<?> target) {
+    public boolean isTargettingPlatform(HasConfigurableAttributes<?> target) {
         Category category = target.getAttributes().getAttribute(Category.CATEGORY_ATTRIBUTE);
         return REGULAR_PLATFORM.equals(category) || ENFORCED_PLATFORM.equals(category);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/IvyMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/IvyMutableModuleMetadataFactory.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
+import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
 import org.gradle.internal.component.external.model.ivy.DefaultMutableIvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor;
 import org.gradle.internal.component.external.model.ivy.MutableIvyModuleResolveMetadata;
@@ -40,10 +41,12 @@ public class IvyMutableModuleMetadataFactory implements MutableModuleMetadataFac
 
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final ImmutableAttributesFactory attributesFactory;
+    private final PreferJavaRuntimeVariant schema;
 
-    public IvyMutableModuleMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory) {
+    public IvyMutableModuleMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableAttributesFactory attributesFactory, PreferJavaRuntimeVariant schema) {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.attributesFactory = attributesFactory;
+        this.schema = schema;
     }
 
     @Override
@@ -73,7 +76,8 @@ public class IvyMutableModuleMetadataFactory implements MutableModuleMetadataFac
             dependencies,
             configurationDefinitions,
             artifactDefinitions,
-            excludes);
+            excludes,
+            schema);
     }
 
     private ImmutableList<? extends Artifact> createDefaultArtifact(ModuleComponentIdentifier from) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -17,11 +17,11 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
 import org.gradle.internal.component.external.model.maven.DefaultMutableMavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
@@ -33,21 +33,22 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final MavenImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator objectInstantiator;
-    private final FeaturePreviews featurePreviews;
+    private final PreferJavaRuntimeVariant schema;
 
     public MavenMutableModuleMetadataFactory(ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                             ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator,
-                                             FeaturePreviews featurePreviews) {
+                                             ImmutableAttributesFactory attributesFactory,
+                                             NamedObjectInstantiator objectInstantiator,
+                                             PreferJavaRuntimeVariant schema) {
         this.moduleIdentifierFactory = moduleIdentifierFactory;
+        this.schema = schema;
         this.attributesFactory = new DefaultMavenImmutableAttributesFactory(attributesFactory, objectInstantiator);
         this.objectInstantiator = objectInstantiator;
-        this.featurePreviews = featurePreviews;
     }
 
     @Override
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator);
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.emptyList(), attributesFactory, objectInstantiator, schema);
     }
 
     private ModuleVersionIdentifier asVersionIdentifier(ModuleComponentIdentifier from) {
@@ -63,6 +64,6 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
 
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from, List<MavenDependencyDescriptor> dependencies) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator);
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, schema);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -23,8 +23,6 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.HasAttributes;
-import org.gradle.internal.instantiation.InstantiatorFactory;
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.component.model.AttributeSelectionSchema;
@@ -32,6 +30,7 @@ import org.gradle.internal.component.model.AttributeSelectionUtils;
 import org.gradle.internal.component.model.ComponentAttributeMatcher;
 import org.gradle.internal.component.model.DefaultCompatibilityCheckResult;
 import org.gradle.internal.component.model.DefaultMultipleCandidateResult;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 
 import javax.annotation.Nullable;
@@ -57,7 +56,6 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
         this.instantiatorFactory = instantiatorFactory;
         matcher = new DefaultAttributeMatcher(componentAttributeMatcher, mergeWith(EmptySchema.INSTANCE));
         this.isolatableFactory = isolatableFactory;
-        PlatformSupport.configureSchema(this);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -37,12 +37,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 abstract class AbstractModuleComponentResolveMetadata implements ModuleComponentResolveMetadata {
-
-    private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = PreferJavaRuntimeVariant.schema();
-    private static ImmutableAttributes extractAttributes(AbstractMutableModuleComponentResolveMetadata metadata) {
-        return ((AttributeContainerInternal) metadata.getAttributes()).asImmutable();
-    }
-
     private final ImmutableAttributesFactory attributesFactory;
     private final ModuleVersionIdentifier moduleVersionIdentifier;
     private final ModuleComponentIdentifier componentIdentifier;
@@ -55,6 +49,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final HashValue originalContentHash;
     private final ImmutableAttributes attributes;
     private final ImmutableList<? extends ComponentIdentifier> platformOwners;
+    private final AttributesSchemaInternal schema;
 
     public AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
         this.componentIdentifier = metadata.getId();
@@ -64,6 +59,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         statusScheme = metadata.getStatusScheme();
         moduleSource = metadata.getSource();
         attributesFactory = metadata.getAttributesFactory();
+        schema = metadata.getAttributesSchema();
         originalContentHash = metadata.getContentHash();
         attributes = extractAttributes(metadata);
         variants = metadata.getVariants();
@@ -78,6 +74,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         statusScheme = metadata.getStatusScheme();
         moduleSource = metadata.getSource();
         attributesFactory = metadata.getAttributesFactory();
+        schema = metadata.getAttributesSchema();
         originalContentHash = metadata.getOriginalContentHash();
         attributes = metadata.getAttributes();
         this.variants = variants;
@@ -92,6 +89,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         statusScheme = metadata.statusScheme;
         moduleSource = metadata.moduleSource;
         attributesFactory = metadata.attributesFactory;
+        schema = metadata.schema;
         originalContentHash = metadata.originalContentHash;
         attributes = metadata.attributes;
         variants = metadata.variants;
@@ -105,11 +103,16 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         missing = metadata.missing;
         statusScheme = metadata.statusScheme;
         attributesFactory = metadata.attributesFactory;
+        schema = metadata.schema;
         originalContentHash = metadata.originalContentHash;
         attributes = metadata.attributes;
         variants = metadata.variants;
         platformOwners = metadata.platformOwners;
         moduleSource = source;
+    }
+
+    private static ImmutableAttributes extractAttributes(AbstractMutableModuleComponentResolveMetadata metadata) {
+        return ((AttributeContainerInternal) metadata.getAttributes()).asImmutable();
     }
 
     @Override
@@ -155,7 +158,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     @Nullable
     @Override
     public AttributesSchemaInternal getAttributesSchema() {
-        return SCHEMA_DEFAULT_JAVA_VARIANTS;
+        return schema;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -30,6 +30,7 @@ import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -67,6 +68,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     private ModuleSource moduleSource;
     private HashValue contentHash = EMPTY_CONTENT;
     private /*Mutable*/AttributeContainerInternal componentLevelAttributes;
+    private final AttributesSchemaInternal schema;
 
     private final VariantMetadataRules variantMetadataRules;
 
@@ -74,11 +76,12 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     private ImmutableList<? extends ComponentVariant> variants;
     private Set<ComponentIdentifier> owners;
 
-    protected AbstractMutableModuleComponentResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier moduleVersionId, ModuleComponentIdentifier componentIdentifier) {
+    protected AbstractMutableModuleComponentResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier moduleVersionId, ModuleComponentIdentifier componentIdentifier, AttributesSchemaInternal schema) {
         this.attributesFactory = attributesFactory;
         this.componentId = componentIdentifier;
         this.moduleVersionId = moduleVersionId;
         this.componentLevelAttributes = defaultAttributes(attributesFactory);
+        this.schema = schema;
         this.variantMetadataRules = new VariantMetadataRules(attributesFactory, moduleVersionId);
     }
 
@@ -92,6 +95,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         this.contentHash = metadata.getOriginalContentHash();
         this.variants = metadata.getVariants();
         this.attributesFactory = metadata.getAttributesFactory();
+        this.schema = metadata.getAttributesSchema();
         this.componentLevelAttributes = attributesFactory.mutable((AttributeContainerInternal) metadata.getAttributes());
         this.variantMetadataRules = new VariantMetadataRules(attributesFactory, moduleVersionId);
         this.variantMetadataRules.setVariantDerivationStrategy(metadata.getVariantMetadataRules().getVariantDerivationStrategy());
@@ -236,6 +240,10 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     @Override
     public ImmutableAttributesFactory getAttributesFactory() {
         return attributesFactory;
+    }
+
+    public AttributesSchemaInternal getAttributesSchema() {
+        return schema;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -37,16 +37,13 @@ import java.util.Set;
  * declaring no preference for a particular variant.
  */
 public class PreferJavaRuntimeVariant extends EmptySchema {
-    private static final Usage RUNTIME_USAGE = NamedObjectInstantiator.instance().named(Usage.class, Usage.JAVA_RUNTIME);
-    private static final Usage RUNTIME_JARS_USAGE = NamedObjectInstantiator.instance().named(Usage.class, Usage.JAVA_RUNTIME_JARS);
     private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Collections.<Attribute<?>>singleton(Usage.USAGE_ATTRIBUTE);
-    private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
+    private final PreferRuntimeVariantUsageDisambiguationRule disambiguationRule;
 
-    static PreferJavaRuntimeVariant schema() {
-        return SCHEMA_DEFAULT_JAVA_VARIANTS;
-    }
-
-    private PreferJavaRuntimeVariant() {
+    public PreferJavaRuntimeVariant(NamedObjectInstantiator instantiator) {
+        Usage runtimeUsage = instantiator.named(Usage.class, Usage.JAVA_RUNTIME);
+        Usage runtimeJarsUsage = instantiator.named(Usage.class, Usage.JAVA_RUNTIME_JARS);
+        disambiguationRule = new PreferRuntimeVariantUsageDisambiguationRule(runtimeUsage, runtimeJarsUsage);
     }
 
     @Override
@@ -57,13 +54,19 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
     @Override
     public DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute) {
         if (Usage.USAGE_ATTRIBUTE.equals(attribute)) {
-            return Cast.uncheckedCast(PreferRuntimeVariantUsageDisambiguationRule.INSTANCE);
+            return Cast.uncheckedCast(disambiguationRule);
         }
         return super.disambiguationRules(attribute);
     }
 
     private static class PreferRuntimeVariantUsageDisambiguationRule implements DisambiguationRule<Usage> {
-        private final static PreferRuntimeVariantUsageDisambiguationRule INSTANCE = new PreferRuntimeVariantUsageDisambiguationRule();
+        private final Usage runtimeUsage;
+        private final Usage runtimeJarsUsage;
+
+        public PreferRuntimeVariantUsageDisambiguationRule(Usage runtimeUsage, Usage runtimeJarsUsage) {
+            this.runtimeUsage = runtimeUsage;
+            this.runtimeJarsUsage = runtimeJarsUsage;
+        }
 
         @Override
         public boolean doesSomething() {
@@ -74,10 +77,10 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
         public void execute(MultipleCandidatesResult<Usage> details) {
             if (details.getConsumerValue() == null) {
                 Set<Usage> candidates = details.getCandidateValues();
-                if (candidates.contains(RUNTIME_JARS_USAGE)) {
-                    details.closestMatch(RUNTIME_JARS_USAGE);
-                } else if (candidates.contains(RUNTIME_USAGE)) {
-                    details.closestMatch(RUNTIME_USAGE);
+                if (candidates.contains(runtimeJarsUsage)) {
+                    details.closestMatch(runtimeJarsUsage);
+                } else if (candidates.contains(runtimeUsage)) {
+                    details.closestMatch(runtimeUsage);
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -37,8 +37,8 @@ import java.util.Set;
  * declaring no preference for a particular variant.
  */
 public class PreferJavaRuntimeVariant extends EmptySchema {
-    private static final Usage RUNTIME_USAGE = NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME);
-    private static final Usage RUNTIME_JARS_USAGE = NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME_JARS);
+    private static final Usage RUNTIME_USAGE = NamedObjectInstantiator.instance().named(Usage.class, Usage.JAVA_RUNTIME);
+    private static final Usage RUNTIME_JARS_USAGE = NamedObjectInstantiator.instance().named(Usage.class, Usage.JAVA_RUNTIME_JARS);
     private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Collections.<Attribute<?>>singleton(Usage.USAGE_ATTRIBUTE);
     private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultMutableIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultMutableIvyModuleResolveMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
@@ -47,8 +48,9 @@ public class DefaultMutableIvyModuleResolveMetadata extends AbstractMutableModul
                                                   List<IvyDependencyDescriptor> dependencies,
                                                   Collection<Configuration> configurationDefinitions,
                                                   Collection<? extends Artifact> artifactDefinitions,
-                                                  Collection<? extends Exclude> excludes) {
-        super(attributesFactory, id, componentIdentifier);
+                                                  Collection<? extends Exclude> excludes,
+                                                  AttributesSchemaInternal schema) {
+        super(attributesFactory, id, componentIdentifier, schema);
         this.configurationDefinitions = toMap(configurationDefinitions);
         this.artifactDefinitions = ImmutableList.copyOf(artifactDefinitions);
         this.dependencies = ImmutableList.copyOf(dependencies);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.descriptor.Configuration;
@@ -42,8 +43,8 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
     private ImmutableList<MavenDependencyDescriptor> dependencies;
 
     public DefaultMutableMavenModuleResolveMetadata(ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier, Collection<MavenDependencyDescriptor> dependencies,
-                                                    ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator) {
-        super(attributesFactory, id, componentIdentifier);
+                                                    ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator, AttributesSchemaInternal schema) {
+        super(attributesFactory, id, componentIdentifier, schema);
         this.dependencies = ImmutableList.copyOf(dependencies);
         this.objectInstantiator = objectInstantiator;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -73,6 +73,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         this.status = status;
         this.attributesSchema = attributesSchema;
     }
+
     @Override
     public ComponentIdentifier getId() {
         return componentId;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
@@ -21,9 +21,9 @@ import org.gradle.api.artifacts.MutableVersionConstraint
 import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DesugaredAttributeContainerSerializer
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.ImmutableCapability
 import org.gradle.internal.serialize.SerializerSpec
+import org.gradle.util.TestUtil
 import spock.lang.Unroll
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
@@ -33,7 +33,7 @@ import static org.gradle.util.AttributeTestUtil.attributesFactory
 class ModuleComponentSelectorSerializerTest extends SerializerSpec {
     private final static ModuleIdentifier UTIL = DefaultModuleIdentifier.newId("org", "util")
 
-    private serializer = new ModuleComponentSelectorSerializer(new DesugaredAttributeContainerSerializer(attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    private serializer = new ModuleComponentSelectorSerializer(new DesugaredAttributeContainerSerializer(attributesFactory(), TestUtil.objectInstantiator()))
 
     @Unroll
     def "serializes"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -24,12 +24,11 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.MetadataResolutionContext
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
-import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.specs.Specs
 import org.gradle.cache.CacheRepository
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
@@ -67,8 +66,8 @@ class DefaultComponentMetadataHandlerTest extends Specification {
     RuleActionAdapter adapter = Mock(RuleActionAdapter)
     def mockedHandler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), adapter, moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.valueSnapshotter(), executor)
     def ruleAction = Stub(RuleAction)
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
-    def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
+    def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
+    def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     MetadataResolutionContext context = Mock()
 
     def 'setup'() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -22,9 +22,8 @@ import org.gradle.api.artifacts.ComponentMetadataDetails
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.MetadataResolutionContext
-import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
@@ -78,8 +77,8 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     def executor = new ComponentMetadataRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
     def instantiator = TestUtil.instantiatorFactory().decorateLenient()
     def stringInterner = SimpleMapInterner.notThreadSafe()
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
-    def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
+    def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
+    def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     def dependencyMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DirectDependencyMetadataImpl, stringInterner)
     def dependencyConstraintMetadataNotationParser = DependencyMetadataNotationParser.parser(instantiator, DependencyConstraintMetadataImpl, stringInterner)
     def moduleIdentifierNotationParser = NotationParserBuilder.toType(ModuleIdentifier).converter(new ModuleIdentifierNotationConverter(new DefaultImmutableModuleIdentifierFactory())).toComposite();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.DependencyConstraintSet
 import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
@@ -35,7 +36,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
     private def configuration = Mock(Configuration)
     private def dependencyConstraintSet = Mock(DependencyConstraintSet)
 
-    private DefaultDependencyConstraintHandler dependencyConstraintHandler = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory, TestUtil.objectInstantiator())
+    private DefaultDependencyConstraintHandler dependencyConstraintHandler = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory, TestUtil.objectInstantiator(), DependencyManagementTestUtil.platformSupport())
 
     void setup() {
         _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.attributes.AttributesSchema
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.VariantTransformRegistry
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory
 import org.gradle.api.plugins.ExtensionContainer
@@ -53,7 +54,7 @@ class DefaultDependencyHandlerTest extends Specification {
 
     private DefaultDependencyHandler dependencyHandler = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultDependencyHandler,
         configurationContainer, dependencyFactory, projectFinder, Stub(DependencyConstraintHandler), Stub(ComponentMetadataHandler), Stub(ComponentModuleMetadataHandler), Stub(ArtifactResolutionQueryFactory),
-        Stub(AttributesSchema), Stub(VariantTransformRegistry), Stub(Factory), TestUtil.objectInstantiator())
+        Stub(AttributesSchema), Stub(VariantTransformRegistry), Stub(Factory), TestUtil.objectInstantiator(), DependencyManagementTestUtil.platformSupport())
 
     void setup() {
         _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
@@ -37,8 +38,6 @@ import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -46,7 +45,7 @@ abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification
     @Rule
     public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
     final FileResourceRepository fileRepository = TestFiles.fileRepository()
     final GradlePomModuleDescriptorParser parser = new GradlePomModuleDescriptorParser(new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser()), moduleIdentifierFactory, fileRepository, mavenMetadataFactory)
     final parseContext = Mock(DescriptorParseContext)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/DisconnectedIvyXmlModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/DisconnectedIvyXmlModuleDescriptorParserTest.groovy
@@ -18,17 +18,17 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser
 
 import org.apache.ivy.core.module.descriptor.ModuleDescriptor
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.resource.ExternalResource
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource
-import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
 class DisconnectedIvyXmlModuleDescriptorParserTest extends Specification {
     LocallyAvailableExternalResource localResource = Mock()
     ExternalResource externalResource = Mock()
-    IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory())
+    IvyMutableModuleMetadataFactory ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     IvyXmlModuleDescriptorParser parser = new DisconnectedIvyXmlModuleDescriptorParser(null, moduleIdentifierFactory, TestFiles.fileRepository(), ivyMetadataFactory)
     DescriptorParseContext parseContext = Mock()
     private DefaultImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.MutableComponentVariant
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
@@ -29,6 +28,7 @@ import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -117,7 +117,7 @@ class GradleModuleMetadataParserTest extends Specification {
     final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 
     def identifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    def parser = new GradleModuleMetadataParser(AttributeTestUtil.attributesFactory(), identifierFactory, NamedObjectInstantiator.INSTANCE)
+    def parser = new GradleModuleMetadataParser(AttributeTestUtil.attributesFactory(), identifierFactory, TestUtil.objectInstantiator())
 
     VersionConstraint emptyConstraint() {
         DefaultImmutableVersionConstraint.of()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleResolveMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleResolveMetadataBuilderTest.groovy
@@ -20,10 +20,9 @@ import org.apache.ivy.core.module.descriptor.Configuration
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.component.model.IvyArtifactName
-import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
 import static com.google.common.collect.Sets.newHashSet
@@ -32,7 +31,7 @@ class IvyModuleResolveMetadataBuilderTest extends Specification {
 
     def md = new DefaultModuleDescriptor(ModuleRevisionId.newInstance("org", "foo", "1.0"), "release", null)
     def moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
+    def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     def meta = new IvyModuleResolveMetaDataBuilder(md, new IvyModuleDescriptorConverter(new DefaultImmutableModuleIdentifierFactory()), ivyMetadataFactory)
 
     def "adds correct artifact to meta-data"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
@@ -21,6 +21,7 @@ import com.google.common.collect.SetMultimap
 import org.apache.ivy.plugins.matcher.PatternMatcher
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
@@ -33,7 +34,6 @@ import org.gradle.internal.hash.HashUtil
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Resources
 import org.junit.Rule
 import spock.lang.Issue
@@ -49,7 +49,7 @@ class IvyXmlModuleDescriptorParserTest extends Specification {
 
     DefaultImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
     FileResourceRepository fileRepository = TestFiles.fileRepository()
-    IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory())
+    IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
     IvyXmlModuleDescriptorParser parser = new IvyXmlModuleDescriptorParser(new IvyModuleDescriptorConverter(moduleIdentifierFactory), moduleIdentifierFactory, fileRepository, metadataFactory)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DescriptorParseContext
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
@@ -53,8 +54,8 @@ import spock.lang.Unroll
 class ModuleMetadataSerializerTest extends Specification {
 
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    private final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
-    private final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory())
+    private final MavenMutableModuleMetadataFactory mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
+    private final IvyMutableModuleMetadataFactory ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     private final ModuleMetadataSerializer serializer = moduleMetadataSerializer()
     private GradlePomModuleDescriptorParser pomModuleDescriptorParser = pomParser()
     private MetaDataParser<MutableIvyModuleResolveMetadata> ivyDescriptorParser = ivyParser()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -22,11 +22,11 @@ import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DescriptorParseContext
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleDescriptorConverter
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyXmlModuleDescriptorParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
@@ -35,7 +35,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Desugar
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
 import org.gradle.internal.component.external.model.ivy.MutableIvyModuleResolveMetadata
@@ -151,7 +150,7 @@ class ModuleMetadataSerializerTest extends Specification {
 
     private ModuleMetadataSerializer moduleMetadataSerializer() {
         new ModuleMetadataSerializer(
-            new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE),
+            new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()),
             mavenMetadataFactory,
             ivyMetadataFactory
         )
@@ -179,7 +178,7 @@ class ModuleMetadataSerializerTest extends Specification {
         new GradleModuleMetadataParser(
             AttributeTestUtil.attributesFactory(),
             moduleIdentifierFactory,
-            NamedObjectInstantiator.INSTANCE
+            TestUtil.objectInstantiator()
         )
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
@@ -17,14 +17,12 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.resource.local.LocallyAvailableResource
 import org.gradle.internal.resource.local.PathKeyFileStore
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
 import org.gradle.util.internal.SimpleMapInterner
 import org.junit.Rule
 import spock.lang.Specification
@@ -42,7 +40,7 @@ class ModuleMetadataStoreTest extends Specification {
     def moduleComponentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "testArtifact"), "1.0")
     def serializer = Mock(ModuleMetadataSerializer)
     @Subject ModuleMetadataStore store = new ModuleMetadataStore(pathKeyFileStore, serializer, moduleIdentifierFactory, SimpleMapInterner.notThreadSafe())
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
 
     def "getModuleDescriptorFile returns null for not cached descriptors"() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
@@ -22,17 +22,17 @@ import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.serialize.SerializerSpec
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
 
 import static org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier.newId
 
 class ComponentResultSerializerTest extends SerializerSpec {
 
-    def serializer = new ComponentResultSerializer(new DefaultImmutableModuleIdentifierFactory(), new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    def serializer = new ComponentResultSerializer(new DefaultImmutableModuleIdentifierFactory(), new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()))
 
     def "serializes"() {
         def componentIdentifier = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('group', 'module'), 'version')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.component.external.model.ImmutableCapability
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector
@@ -35,12 +34,13 @@ import org.gradle.internal.component.local.model.TestComponentIdentifiers
 import org.gradle.internal.serialize.SerializerSpec
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
+import org.gradle.util.TestUtil
 import spock.lang.Unroll
 
 import static org.gradle.util.Path.path
 
 class ComponentSelectorSerializerTest extends SerializerSpec {
-    private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()))
 
     private static ImmutableVersionConstraint constraint(String version, String preferredVersion = '', String strictVersion = '', List<String> rejectVersions = []) {
         return new DefaultImmutableVersionConstraint(

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -27,21 +27,24 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static java.util.Collections.emptySet
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.CONFLICT_RESOLUTION
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.of
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.requested
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.root
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolutionResultPrinter.printGraph
-import static ComponentSelectionReasons.*
 
 class StreamingResolutionResultBuilderTest extends Specification {
 
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    StreamingResolutionResultBuilder builder = new StreamingResolutionResultBuilder(new DummyBinaryStore(), new DummyStore(), moduleIdentifierFactory, new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
+    StreamingResolutionResultBuilder builder = new StreamingResolutionResultBuilder(new DummyBinaryStore(), new DummyStore(), moduleIdentifierFactory, new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()))
 
     def "result can be read multiple times"() {
         def rootNode = rootNode(1, "org", "root", "1.0")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -18,11 +18,12 @@ package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.internal.CollectionCallbackActionDecorator
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -32,11 +33,9 @@ import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.api.model.ObjectFactory
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry
 import org.gradle.internal.authentication.DefaultAuthenticationSchemeRegistry
-import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.resource.cached.ExternalResourceFileStore
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
-import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -46,7 +45,6 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final FileResolver fileResolver = Mock()
     final RepositoryTransportFactory transportFactory = Mock()
     final LocallyAvailableResourceFinder locallyAvailableResourceFinder = Mock()
-    final ProgressLoggerFactory progressLoggerFactory = Mock()
     final ArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
     final ExternalResourceFileStore externalResourceFileStore = Stub()
     final MetaDataParser pomParser = Mock()
@@ -54,8 +52,8 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final ivyContextManager = Mock(IvyContextManager)
     final AuthenticationSchemeRegistry authenticationSchemeRegistry = new DefaultAuthenticationSchemeRegistry()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
-    final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
+    final IvyMutableModuleMetadataFactory ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(
         localMavenRepoLocator, fileResolver, transportFactory, locallyAvailableResourceFinder,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.InvalidUserDataException
-import org.gradle.internal.instantiation.InstantiatorFactory
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
@@ -27,9 +27,9 @@ import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.api.internal.filestore.ivy.ArtifactIdentifierFileStore
 import org.gradle.api.model.ObjectFactory
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
-import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
 class DefaultFlatDirArtifactRepositoryTest extends Specification {
@@ -40,7 +40,7 @@ class DefaultFlatDirArtifactRepositoryTest extends Specification {
     final LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder = Mock()
     final ArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory())
+    final IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
     final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, moduleIdentifierFactory, metadataFactory, Mock(InstantiatorFactory), Mock(ObjectFactory))
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ComponentMetadataSupplier
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
 import org.gradle.api.artifacts.ComponentMetadataVersionLister
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
@@ -39,10 +39,9 @@ import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.cached.ExternalResourceFileStore
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
-import spock.lang.Specification
-import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
+import spock.lang.Specification
 
 import javax.inject.Inject
 
@@ -59,7 +58,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final ivyContextManager = Mock(IvyContextManager)
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final GradleModuleMetadataParser moduleMetadataParser = new GradleModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
-    final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
+    final IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
     final DefaultIvyArtifactRepository repository = instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.featurePreviews(), metadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory))
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -21,9 +21,10 @@ import org.gradle.api.artifacts.ComponentMetadataSupplier
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
 import org.gradle.api.artifacts.ComponentMetadataVersionLister
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
@@ -35,7 +36,6 @@ import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.cached.ExternalResourceFileStore
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
-import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -53,7 +53,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final GradleModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
         resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, moduleIdentifierFactory, externalResourceFileStore, Mock(FileResourceRepository), TestUtil.featurePreviews(), mavenMetadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -16,9 +16,10 @@
 package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
@@ -29,7 +30,6 @@ import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
-import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -44,7 +44,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
     final GradleModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final MavenMutableModuleMetadataFactory mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenLocalArtifactRepository(resolver,
         transportFactory,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -18,13 +18,11 @@ package org.gradle.api.internal.artifacts.repositories.resolver
 
 import org.gradle.api.Action
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorBuilder
-import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory
@@ -54,8 +52,8 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     def testAttribute = Attribute.of("someAttribute", String)
     def attributes = AttributeTestUtil.attributesFactory().of(testAttribute, "someValue")
     def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.valueSnapshotter())
-    def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
-    def mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
+    def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
 
     def gradleMetadata
     def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.attributes.AttributeCompatibilityRule
 import org.gradle.api.attributes.AttributeDisambiguationRule
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.MultipleCandidatesDetails
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
@@ -351,7 +350,7 @@ class DefaultAttributesSchemaTest extends Specification {
     }
 
     static Flavor flavor(String name) {
-        NamedObjectInstantiator.INSTANCE.named(Flavor, name)
+        TestUtil.objectInstantiator().named(Flavor, name)
     }
 
     static class ConcreteNamed implements Named {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -20,14 +20,12 @@ import com.google.common.collect.ImmutableListMultimap
 import org.gradle.api.Action
 import org.gradle.api.artifacts.DependenciesMetadata
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
-import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -42,12 +40,12 @@ import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.internal.component.model.VariantResolveMetadata
-import spock.lang.Specification
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.SimpleMapInterner
 import spock.lang.Shared
+import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
@@ -61,8 +59,8 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     @Shared attributes = AttributeTestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
     @Shared schema = createSchema()
-    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
-    @Shared ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
+    @Shared mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
+    @Shared ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     @Shared defaultVariant
 
     protected static <T> VariantMetadataRules.VariantAction<T> variantAction(String variantName, Action<? super T> action) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -71,7 +70,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     private DefaultAttributesSchema createSchema() {
         def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.valueSnapshotter())
         JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
-        PlatformSupport.configureSchema(schema)
+        DependencyManagementTestUtil.platformSupport().configureSchema(schema)
         schema
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableListMultimap
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.project.ProjectInternal
@@ -34,7 +35,7 @@ import org.gradle.util.AttributeTestUtil
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class DefaultIvyModuleResolveMetadataTest extends AbstractLazyModuleComponentResolveMetadataTest {
-    def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
+    def ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), DependencyManagementTestUtil.defaultSchema())
 
     @Override
     ModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMavenImmutableAttributesFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.descriptor.MavenScope
@@ -148,7 +147,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         given:
         def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
         def componentTypeAttribute = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class)
-        def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], new DefaultMavenImmutableAttributesFactory(AttributeTestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE), TestUtil.objectInstantiator())
+        def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], new DefaultMavenImmutableAttributesFactory(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()), TestUtil.objectInstantiator())
         metadata.packaging = packaging
         metadata.variantMetadataRules.variantDerivationStrategy = new JavaEcosystemVariantDerivationStrategy()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -17,7 +17,7 @@
 
 package org.gradle.internal.component.external.model
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier
+
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
@@ -25,13 +25,12 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMavenImmutableAttributesFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.descriptor.MavenScope
-import org.gradle.internal.component.external.model.maven.DefaultMutableMavenModuleResolveMetadata
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.ModuleSource
@@ -44,7 +43,7 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentResolveMetadataTest {
 
     private
-    final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), DependencyManagementTestUtil.defaultSchema())
 
     @Override
     ModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List dependencies) {
@@ -147,7 +146,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         given:
         def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
         def componentTypeAttribute = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class)
-        def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], new DefaultMavenImmutableAttributesFactory(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()), TestUtil.objectInstantiator())
+        def metadata = mavenMetadataFactory.create(id)
         metadata.packaging = packaging
         metadata.variantMetadataRules.variantDerivationStrategy = new JavaEcosystemVariantDerivationStrategy()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.internal.component.external.model
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.internal.component.external.descriptor.Artifact
 import org.gradle.internal.component.external.descriptor.Configuration
@@ -29,10 +29,9 @@ import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.internal.hash.HashValue
-import org.gradle.util.AttributeTestUtil
 
 class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleComponentResolveMetadataTest {
-    private final IvyMutableModuleMetadataFactory ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
+    private final IvyMutableModuleMetadataFactory ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
     @Override
     AbstractMutableModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List<DependencyMetadata> dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.model.ComponentResolveMetadata
@@ -31,7 +32,7 @@ import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 
 class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModuleComponentResolveMetadataTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), DependencyManagementTestUtil.defaultSchema())
 
     @Override
     AbstractMutableModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List<DependencyMetadata> dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -18,19 +18,16 @@ package org.gradle.internal.component.external.model
 
 import org.gradle.api.Action
 import org.gradle.api.artifacts.DependenciesMetadata
-import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
-import org.gradle.util.AttributeTestUtil
-import org.gradle.util.TestUtil
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRulesTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    private final mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
 
     @Override
     boolean addAllDependenciesAsConstraints() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/PreferJavaRuntimeVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/PreferJavaRuntimeVariantTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 
 class PreferJavaRuntimeVariantTest extends Specification {
 
-    final PreferJavaRuntimeVariant schema = PreferJavaRuntimeVariant.schema()
+    final PreferJavaRuntimeVariant schema = new PreferJavaRuntimeVariant(TestUtil.objectInstantiator())
 
     @Unroll
     def "should prefer the runtime variant if the consumer doesn't express any preference and that runtime is in the candidates"() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts
 
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant
@@ -33,5 +34,9 @@ class DependencyManagementTestUtil {
 
     static PreferJavaRuntimeVariant defaultSchema() {
         return new PreferJavaRuntimeVariant(TestUtil.objectInstantiator())
+    }
+
+    static PlatformSupport platformSupport() {
+        return new PlatformSupport()
     }
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts
+
+import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
+import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
+
+class DependencyManagementTestUtil {
+    static MavenMutableModuleMetadataFactory mavenMetadataFactory() {
+        return new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), defaultSchema())
+    }
+
+    static IvyMutableModuleMetadataFactory ivyMetadataFactory() {
+        return new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory(), defaultSchema())
+    }
+
+    static PreferJavaRuntimeVariant defaultSchema() {
+        return new PreferJavaRuntimeVariant(TestUtil.objectInstantiator())
+    }
+}

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/DependencyManagementTestUtil.groovy
@@ -37,6 +37,6 @@ class DependencyManagementTestUtil {
     }
 
     static PlatformSupport platformSupport() {
-        return new PlatformSupport()
+        return new PlatformSupport(TestUtil.objectInstantiator())
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -29,7 +29,6 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
-import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
@@ -53,9 +52,7 @@ import java.util.List;
 import java.util.Set;
 
 public class EclipseDependenciesCreator {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(EclipseDependenciesCreator.class);
-    public static final Usage RUNTIME_JARS_USAGE = NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME_JARS);
     private final EclipseClasspath classpath;
     private final ProjectDependencyBuilder projectDependencyBuilder;
     private final ProjectComponentIdentifier currentProjectId;
@@ -107,7 +104,7 @@ public class EclipseDependenciesCreator {
                 return;
             }
             Usage usage = artifact.getVariant().getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
-            if (!RUNTIME_JARS_USAGE.equals(usage)) {
+            if (usage == null || !usage.getName().equals(Usage.JAVA_RUNTIME_JARS)) {
                 return;
             }
             ComponentArtifactMetadata artifactId = (ComponentArtifactMetadata) artifact.getId();

--- a/subprojects/ivy/ivy.gradle.kts
+++ b/subprojects/ivy/ivy.gradle.kts
@@ -66,6 +66,7 @@ testFixtures {
     from(":core")
     from(":modelCore")
     from(":platformBase")
+    from(":dependencyManagement")
 }
 
 testFilesCleanup {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -84,6 +84,7 @@ import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.Comparator;
@@ -124,6 +125,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final PublicationArtifactSet<IvyArtifact> publishableArtifacts;
     private final DefaultIvyDependencySet ivyDependencies;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
+    private final PlatformSupport platformSupport;
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final FeaturePreviews featurePreviews;
@@ -137,14 +139,16 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private boolean artifactsOverridden;
     private boolean versionMappingInUse = false;
 
+    @Inject
     public DefaultIvyPublication(
         String name, Instantiator instantiator, ObjectFactory objectFactory, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
         ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
         ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews,
-        CollectionCallbackActionDecorator collectionCallbackActionDecorator, VersionMappingStrategyInternal versionMappingStrategy) {
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator, VersionMappingStrategyInternal versionMappingStrategy, PlatformSupport platformSupport) {
         this.name = name;
         this.publicationIdentity = publicationIdentity;
         this.projectDependencyResolver = projectDependencyResolver;
+        this.platformSupport = platformSupport;
         this.configurations = instantiator.newInstance(DefaultIvyConfigurationContainer.class, instantiator, collectionCallbackActionDecorator);
         this.immutableAttributesFactory = immutableAttributesFactory;
         this.versionMappingStrategy = versionMappingStrategy;
@@ -284,7 +288,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                         addProjectDependency((ProjectDependency) dependency, confMapping);
                     } else {
                         ExternalDependency externalDependency = (ExternalDependency) dependency;
-                        if (PlatformSupport.isTargettingPlatform(dependency)) {
+                        if (platformSupport.isTargettingPlatform(dependency)) {
                             publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared as platform", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                         }
                         if (!versionMappingInUse && externalDependency.getVersion() == null) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -33,6 +33,7 @@ import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrat
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.internal.component.model.AttributeMatcher;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     private final Map<ImmutableAttributes, String> defaultConfigurations = Maps.newHashMap();
     private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
 
+    @Inject
     public DefaultVersionMappingStrategy(ObjectFactory objectFactory,
                                          ConfigurationContainer configurations,
                                          AttributesSchemaInternal schema,

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -21,18 +21,11 @@ import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionContainer;
@@ -76,25 +69,13 @@ public class IvyPublishPlugin implements Plugin<Project> {
     private final ObjectFactory objectFactory;
     private final DependencyMetaDataProvider dependencyMetaDataProvider;
     private final FileResolver fileResolver;
-    private final ProjectDependencyPublicationResolver projectDependencyResolver;
-    private final FileCollectionFactory fileCollectionFactory;
-    private final ImmutableAttributesFactory immutableAttributesFactory;
-    private final FeaturePreviews featurePreviews;
-    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
-    public IvyPublishPlugin(Instantiator instantiator, ObjectFactory objectFactory, DependencyMetaDataProvider dependencyMetaDataProvider, FileResolver fileResolver,
-                            ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-                            ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    public IvyPublishPlugin(Instantiator instantiator, ObjectFactory objectFactory, DependencyMetaDataProvider dependencyMetaDataProvider, FileResolver fileResolver) {
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
         this.fileResolver = fileResolver;
-        this.projectDependencyResolver = projectDependencyResolver;
-        this.fileCollectionFactory = fileCollectionFactory;
-        this.immutableAttributesFactory = immutableAttributesFactory;
-        this.featurePreviews = featurePreviews;
-        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     @Override
@@ -106,11 +87,8 @@ public class IvyPublishPlugin implements Plugin<Project> {
                 instantiator,
                 objectFactory,
                 fileResolver,
-                collectionCallbackActionDecorator,
-                project.getConfigurations(),
                 project.getPluginManager(),
-                project.getExtensions(),
-                (AttributesSchemaInternal) project.getDependencies().getAttributesSchema()));
+                project.getExtensions()));
             createTasksLater(project, extension, project.getLayout().getBuildDirectory());
         });
     }
@@ -187,25 +165,17 @@ public class IvyPublishPlugin implements Plugin<Project> {
         private final DependencyMetaDataProvider dependencyMetaDataProvider;
         private final ObjectFactory objectFactory;
         private final FileResolver fileResolver;
-        private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
-        private final ConfigurationContainer configurations;
         private final PluginManager plugins;
         private final ExtensionContainer extensionContainer;
-        private final AttributesSchemaInternal attributesSchema;
 
         private IvyPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver,
-                                      CollectionCallbackActionDecorator collectionCallbackActionDecorator, ConfigurationContainer configurations,
-                                      PluginManager plugins, ExtensionContainer extensionContainer,
-                                      AttributesSchemaInternal attributesSchema) {
+                                      PluginManager plugins, ExtensionContainer extensionContainer) {
             this.dependencyMetaDataProvider = dependencyMetaDataProvider;
             this.instantiator = instantiator;
             this.objectFactory = objectFactory;
             this.fileResolver = fileResolver;
-            this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
-            this.configurations = configurations;
             this.plugins = plugins;
             this.extensionContainer = extensionContainer;
-            this.attributesSchema = attributesSchema;
         }
 
         @Override
@@ -213,18 +183,10 @@ public class IvyPublishPlugin implements Plugin<Project> {
             Module module = dependencyMetaDataProvider.getModule();
             IvyPublicationIdentity publicationIdentity = new DefaultIvyPublicationIdentity(module);
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
-            VersionMappingStrategyInternal versionMappingStrategy = instantiator.newInstance(DefaultVersionMappingStrategy.class,
-                objectFactory,
-                configurations,
-                attributesSchema,
-                immutableAttributesFactory);
+            VersionMappingStrategyInternal versionMappingStrategy = objectFactory.newInstance(DefaultVersionMappingStrategy.class);
             configureDefaultConfigurationsUsedWhenMappingToResolvedVersions(versionMappingStrategy);
 
-            return instantiator.newInstance(
-                DefaultIvyPublication.class,
-                name, instantiator, objectFactory, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory, featurePreviews,
-                collectionCallbackActionDecorator, versionMappingStrategy
-            );
+            return objectFactory.newInstance(DefaultIvyPublication.class, name, publicationIdentity, notationParser, versionMappingStrategy);
         }
 
         private void configureDefaultConfigurationsUsedWhenMappingToResolvedVersions(VersionMappingStrategyInternal versionMappingStrategy) {

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
@@ -291,7 +292,8 @@ class DefaultIvyPublicationTest extends Specification {
             attributesFactory,
             featurePreviews,
             CollectionCallbackActionDecorator.NOOP,
-            Mock(VersionMappingStrategyInternal)
+            Mock(VersionMappingStrategyInternal),
+            Mock(PlatformSupport)
         )
         publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
 
@@ -377,7 +379,8 @@ class DefaultIvyPublicationTest extends Specification {
             attributesFactory,
             featurePreviews,
             CollectionCallbackActionDecorator.NOOP,
-            Mock(VersionMappingStrategyInternal)
+            Mock(VersionMappingStrategyInternal),
+            Mock(PlatformSupport)
         )
         publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(moduleDescriptorFile))

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Action
 import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.ivy.InvalidIvyPublicationException
@@ -28,7 +29,6 @@ import org.gradle.api.publish.ivy.internal.artifact.FileBasedIvyArtifact
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublicationIdentity
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.AttributeTestUtil
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -44,7 +44,7 @@ class ValidatingIvyPublisherTest extends Specification {
 
     def delegate = Mock(IvyPublisher)
     DefaultImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory())
+    IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
     def publisher = new ValidatingIvyPublisher(delegate, moduleIdentifierFactory, TestFiles.fileRepository(), metadataFactory)
     def repository = Mock(IvyArtifactRepository)

--- a/subprojects/maven/maven.gradle.kts
+++ b/subprojects/maven/maven.gradle.kts
@@ -73,6 +73,7 @@ gradlebuildJava {
 testFixtures {
     from(":core")
     from(":modelCore")
+    from(":dependencyManagement")
 }
 
 testFilesCleanup {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -33,6 +33,7 @@ import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrat
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.internal.component.model.AttributeMatcher;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ public class DefaultVersionMappingStrategy implements VersionMappingStrategyInte
     private final Map<ImmutableAttributes, String> defaultConfigurations = Maps.newHashMap();
     private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
 
+    @Inject
     public DefaultVersionMappingStrategy(ObjectFactory objectFactory,
                                          ConfigurationContainer configurations,
                                          AttributesSchemaInternal schema,

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
@@ -485,7 +486,7 @@ class DefaultMavenPublicationTest extends Specification {
         def instantiator = TestUtil.instantiatorFactory().decorateLenient()
         def objectFactory = TestUtil.objectFactory()
         def publication = new DefaultMavenPublication("pub-name", module, notationParser, instantiator, objectFactory, projectDependencyResolver, TestFiles.fileCollectionFactory(),
-            featurePreviews, AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP, Mock(VersionMappingStrategyInternal))
+            featurePreviews, AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP, Mock(VersionMappingStrategyInternal), DependencyManagementTestUtil.platformSupport())
         publication.setPomGenerator(createArtifactGenerator(pomFile))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(gradleMetadataFile))
         return publication

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.fixtures.publish.maven
 
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
@@ -112,7 +113,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
         def optional = params.optionalFeatureCapabilities.collect {
             "resolve($dependencyNotation) { capabilities { requireCapability('$it') } }"
         }.join('\n')
-        buildFile.text = """import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
+        buildFile.text = """import ${PlatformSupport.name}
 
             apply plugin: 'java-base' // to get the standard Java library derivation strategy
             configurations {
@@ -131,11 +132,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
             }
 
             dependencies {
-               attributesSchema { 
-                getMatchingStrategy(Category.CATEGORY_ATTRIBUTE)
-                   .disambiguationRules
-                   .add(PlatformSupport.PreferRegularPlatform)
-               }
+               services.get(PlatformSupport).addDisambiguationRule(attributesSchema)
                resolve($dependencyNotation) $extraArtifacts
                $optional
             }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -91,7 +91,7 @@ public class NamedObjectInstantiator implements Managed.Factory {
     private LoadingCache<Class<?>, LoadingCache<String, Object>> getCacheScope(Class<?> type) {
         ClassLoader classLoader = type.getClassLoader();
         if (classLoader instanceof VisitableURLClassLoader) {
-            return ((VisitableURLClassLoader) classLoader).getUserData(VisitableURLClassLoader.UserData.NAMED_OBJECT_INSTANTIATOR, cacheFactory);
+            return ((VisitableURLClassLoader) classLoader).getUserData(this, cacheFactory);
         }
         return leakyValues;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -40,16 +40,18 @@ import org.objectweb.asm.Type;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
 import static org.objectweb.asm.Opcodes.ARETURN;
 import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.V1_5;
 
 public class NamedObjectInstantiator implements Managed.Factory {
-    public static final NamedObjectInstantiator INSTANCE = new NamedObjectInstantiator();
     private static final Type OBJECT = Type.getType(Object.class);
     private static final Type STRING = Type.getType(String.class);
     private static final Type NAMED_OBJECT_INSTANTIATOR = Type.getType(NamedObjectInstantiator.class);
@@ -67,6 +69,38 @@ public class NamedObjectInstantiator implements Managed.Factory {
     private static final String NAME_FIELD = "_gr_name_";
     private static final String[] EMPTY_STRINGS = new String[0];
     private static final String CONSTRUCTOR_NAME = "<init>";
+    private static final String FACTORY_FIELD = "FACTORY";
+
+    private static final Set<String> SUFFIXES = new CopyOnWriteArraySet<>();
+    private static final NamedObjectInstantiator DEPRECATED_INSTANCE = new NamedObjectInstantiator();
+    private final String implSuffix;
+    private final String factorySuffix;
+
+    public NamedObjectInstantiator() {
+        implSuffix = unique("$Impl");
+        factorySuffix = unique("$Factory");
+    }
+
+    private static String unique(String suffix) {
+        if (SUFFIXES.add(suffix)) {
+            return suffix;
+        }
+        int i = 1;
+        while (true) {
+            String indexed = suffix + i;
+            if (SUFFIXES.add(indexed)) {
+                return indexed;
+            }
+            i++;
+        }
+    }
+
+    /**
+     * @deprecated This is available as an injected service. Use the injected service instead of this method.
+     */
+    public static NamedObjectInstantiator instance() {
+        return DEPRECATED_INSTANCE;
+    }
 
     private final Factory<LoadingCache<Class<?>, LoadingCache<String, Object>>> cacheFactory = new Factory<LoadingCache<Class<?>, LoadingCache<String, Object>>>() {
         @Override
@@ -123,7 +157,7 @@ public class NamedObjectInstantiator implements Managed.Factory {
             throw new GradleException(problemCollector.format());
         }
 
-        AsmClassGenerator generator = new AsmClassGenerator(publicClass, "$Impl");
+        AsmClassGenerator generator = new AsmClassGenerator(publicClass, implSuffix);
         Type implementationType = generator.getGeneratedType();
         ClassWriter visitor = generator.getVisitor();
         Type publicType = Type.getType(publicClass);
@@ -141,10 +175,16 @@ public class NamedObjectInstantiator implements Managed.Factory {
         visitor.visit(V1_5, ACC_PUBLIC | ACC_SYNTHETIC, implementationType.getInternalName(), null, superClass.getInternalName(), interfaces);
 
         //
-        // Add name field
+        // Add `name` field
         //
 
         visitor.visitField(ACC_PRIVATE, NAME_FIELD, STRING.getDescriptor(), null, null);
+
+        //
+        // Add static `factory` field to hold the owning factory for the type (this factory)
+        //
+
+        visitor.visitField(ACC_PRIVATE | ACC_STATIC, FACTORY_FIELD, NAMED_OBJECT_INSTANTIATOR.getDescriptor(), null, null);
 
         //
         // Add constructor
@@ -228,18 +268,19 @@ public class NamedObjectInstantiator implements Managed.Factory {
         //
 
         methodVisitor = visitor.visitMethod(ACC_PUBLIC, "managedFactory", RETURN_MANAGED_FACTORY, null, EMPTY_STRINGS);
-        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, NAMED_OBJECT_INSTANTIATOR.getInternalName(), "INSTANCE", NAMED_OBJECT_INSTANTIATOR.getDescriptor());
+        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, generator.getGeneratedType().getInternalName(), FACTORY_FIELD, NAMED_OBJECT_INSTANTIATOR.getDescriptor());
         methodVisitor.visitInsn(Opcodes.ARETURN);
         methodVisitor.visitMaxs(0, 0);
         methodVisitor.visitEnd();
 
-        generator.define();
+        Class<?> implClass = generator.define();
+        attachFactoryToImplType(implClass);
 
         //
         // Generate factory class
         //
 
-        generator = new AsmClassGenerator(publicClass, "$Factory");
+        generator = new AsmClassGenerator(publicClass, factorySuffix);
         visitor = generator.getVisitor();
         visitor.visit(V1_5, ACC_PUBLIC | ACC_SYNTHETIC, generator.getGeneratedType().getInternalName(), null, CLASS_GENERATING_LOADER.getInternalName(), EMPTY_STRINGS);
 
@@ -276,6 +317,16 @@ public class NamedObjectInstantiator implements Managed.Factory {
         Class<Object> factoryClass = generator.define();
         try {
             return (ClassGeneratingLoader) factoryClass.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    private void attachFactoryToImplType(Class<?> implClass) {
+        try {
+            Field factoryField = implClass.getDeclaredField(FACTORY_FIELD);
+            factoryField.setAccessible(true);
+            factoryField.set(null, this);
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -72,7 +72,7 @@ public class NamedObjectInstantiator implements Managed.Factory {
     private static final String FACTORY_FIELD = "FACTORY";
 
     private static final Set<String> SUFFIXES = new CopyOnWriteArraySet<>();
-    private static final NamedObjectInstantiator DEPRECATED_INSTANCE = new NamedObjectInstantiator();
+
     private final String implSuffix;
     private final String factorySuffix;
 
@@ -93,13 +93,6 @@ public class NamedObjectInstantiator implements Managed.Factory {
             }
             i++;
         }
-    }
-
-    /**
-     * @deprecated This is available as an injected service. Use the injected service instead of this method.
-     */
-    public static NamedObjectInstantiator instance() {
-        return DEPRECATED_INSTANCE;
     }
 
     private final Factory<LoadingCache<Class<?>, LoadingCache<String, Object>>> cacheFactory = new Factory<LoadingCache<Class<?>, LoadingCache<String, Object>>>() {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiationScheme.java
@@ -16,7 +16,11 @@
 
 package org.gradle.internal.instantiation;
 
+import org.gradle.api.Transformer;
 import org.gradle.api.reflect.ObjectInstantiationException;
+import org.gradle.cache.internal.CrossBuildInMemoryCache;
+import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceLookup;
 import sun.reflect.ReflectionFactory;
@@ -30,11 +34,17 @@ class DefaultInstantiationScheme implements InstantiationScheme {
     private final DependencyInjectingInstantiator instantiator;
     private final ConstructorSelector constructorSelector;
     private final Set<Class<? extends Annotation>> injectionAnnotations;
+    private final DeserializationInstantiator deserializationInstantiator;
 
-    public DefaultInstantiationScheme(ConstructorSelector constructorSelector, ServiceLookup defaultServices, Set<Class<? extends Annotation>> injectionAnnotations) {
+    public DefaultInstantiationScheme(ConstructorSelector constructorSelector, ServiceLookup defaultServices, Set<Class<? extends Annotation>> injectionAnnotations, CrossBuildInMemoryCacheFactory cacheFactory) {
+        this(constructorSelector, injectionAnnotations, new DependencyInjectingInstantiator(constructorSelector, defaultServices), new DefaultDeserializationInstantiator(constructorSelector, cacheFactory));
+    }
+
+    private DefaultInstantiationScheme(ConstructorSelector constructorSelector, Set<Class<? extends Annotation>> injectionAnnotations, DependencyInjectingInstantiator instantiator, DeserializationInstantiator deserializationInstantiator) {
+        this.instantiator = instantiator;
         this.constructorSelector = constructorSelector;
         this.injectionAnnotations = injectionAnnotations;
-        this.instantiator = new DependencyInjectingInstantiator(constructorSelector, defaultServices);
+        this.deserializationInstantiator = deserializationInstantiator;
     }
 
     @Override
@@ -49,7 +59,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
 
     @Override
     public InstantiationScheme withServices(ServiceLookup services) {
-        return new DefaultInstantiationScheme(constructorSelector, services, injectionAnnotations);
+        return new DefaultInstantiationScheme(constructorSelector, injectionAnnotations, new DependencyInjectingInstantiator(constructorSelector, services), deserializationInstantiator);
     }
 
     @Override
@@ -59,19 +69,38 @@ class DefaultInstantiationScheme implements InstantiationScheme {
 
     @Override
     public DeserializationInstantiator deserializationInstantiator() {
-        return new DeserializationInstantiator() {
-            @Override
-            public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
-                //TODO:instant-execution - use the class generator directly. Also will probably need some caching here
-                try {
-                    Constructor<?> constructor = ReflectionFactory.getReflectionFactory().newConstructorForSerialization(constructorSelector.forType(implType).getGeneratedClass(), baseClass.getDeclaredConstructor());
-                    return implType.cast(constructor.newInstance());
-                } catch (InvocationTargetException e) {
-                    throw new ObjectInstantiationException(implType, e.getCause());
-                } catch (Exception e) {
-                    throw new ObjectInstantiationException(implType, e);
-                }
+        return deserializationInstantiator;
+    }
+
+    private static class DefaultDeserializationInstantiator implements DeserializationInstantiator {
+        private final ConstructorSelector constructorSelector;
+        private final CrossBuildInMemoryCache<Class<?>, Constructor<?>> constructorCache;
+
+        public DefaultDeserializationInstantiator(ConstructorSelector constructorSelector, CrossBuildInMemoryCacheFactory cacheFactory) {
+            this.constructorSelector = constructorSelector;
+            this.constructorCache = cacheFactory.newClassCache();
+        }
+
+        @Override
+        public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
+            //TODO:instant-execution - use the class generator instead
+            try {
+                Constructor<?> constructor = constructorCache.get(implType, new Transformer<Constructor<?>, Class<?>>() {
+                    @Override
+                    public Constructor<?> transform(Class<?> aClass) {
+                        try {
+                            return ReflectionFactory.getReflectionFactory().newConstructorForSerialization(constructorSelector.forType(implType).getGeneratedClass(), baseClass.getDeclaredConstructor());
+                        } catch (NoSuchMethodException e) {
+                            throw UncheckedException.throwAsUncheckedException(e);
+                        }
+                    }
+                });
+                return implType.cast(constructor.newInstance());
+            } catch (InvocationTargetException e) {
+                throw new ObjectInstantiationException(implType, e.getCause());
+            } catch (Exception e) {
+                throw new ObjectInstantiationException(implType, e);
             }
-        };
+        }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiatorFactory.java
@@ -43,8 +43,8 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
         DefaultServiceRegistry services = new DefaultServiceRegistry();
         services.add(InstantiatorFactory.class, this);
         this.defaultServices = services;
-        ClassGenerator injectOnly = AsmBackedClassGenerator.injectOnly(annotationHandlers, ImmutableSet.of());
-        ClassGenerator decorated = AsmBackedClassGenerator.decorateAndInject(annotationHandlers, ImmutableSet.of());
+        ClassGenerator injectOnly = AsmBackedClassGenerator.injectOnly(annotationHandlers, ImmutableSet.of(), cacheFactory);
+        ClassGenerator decorated = AsmBackedClassGenerator.decorateAndInject(annotationHandlers, ImmutableSet.of(), cacheFactory);
         ConstructorSelector injectOnlyJsr330Selector = new Jsr330ConstructorSelector(injectOnly, cacheFactory.newClassCache());
         ConstructorSelector decoratedJsr330Selector = new Jsr330ConstructorSelector(decorated, cacheFactory.newClassCache());
         ConstructorSelector injectOnlyLenientSelector = new ParamsMatchingConstructorSelector(injectOnly, cacheFactory.newClassCache());
@@ -79,7 +79,7 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
         for (Class<? extends Annotation> annotation : injectAnnotations) {
             assertKnownAnnotation(annotation);
         }
-        ClassGenerator classGenerator = AsmBackedClassGenerator.injectOnly(annotationHandlers, ImmutableSet.copyOf(injectAnnotations));
+        ClassGenerator classGenerator = AsmBackedClassGenerator.injectOnly(annotationHandlers, ImmutableSet.copyOf(injectAnnotations), cacheFactory);
         Jsr330ConstructorSelector constructorSelector = new Jsr330ConstructorSelector(classGenerator, cacheFactory.newClassCache());
         ImmutableSet.Builder<Class<? extends Annotation>> builder = ImmutableSet.builderWithExpectedSize(injectAnnotations.size() + 1);
         builder.addAll(injectAnnotations);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/DefaultInstantiatorFactory.java
@@ -49,10 +49,10 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
         ConstructorSelector decoratedJsr330Selector = new Jsr330ConstructorSelector(decorated, cacheFactory.newClassCache());
         ConstructorSelector injectOnlyLenientSelector = new ParamsMatchingConstructorSelector(injectOnly, cacheFactory.newClassCache());
         ConstructorSelector decoratedLenientSelector = new ParamsMatchingConstructorSelector(decorated, cacheFactory.newClassCache());
-        injectOnlyScheme = new DefaultInstantiationScheme(injectOnlyJsr330Selector, defaultServices, ImmutableSet.of(Inject.class));
-        injectOnlyLenientScheme = new DefaultInstantiationScheme(injectOnlyLenientSelector, defaultServices, ImmutableSet.of(Inject.class));
-        decoratingScheme = new DefaultInstantiationScheme(decoratedJsr330Selector, defaultServices, ImmutableSet.of(Inject.class));
-        decoratingLenientScheme = new DefaultInstantiationScheme(decoratedLenientSelector, defaultServices, ImmutableSet.of(Inject.class));
+        injectOnlyScheme = new DefaultInstantiationScheme(injectOnlyJsr330Selector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
+        injectOnlyLenientScheme = new DefaultInstantiationScheme(injectOnlyLenientSelector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
+        decoratingScheme = new DefaultInstantiationScheme(decoratedJsr330Selector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
+        decoratingLenientScheme = new DefaultInstantiationScheme(decoratedLenientSelector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
         ImmutableSet.Builder<Class<? extends Annotation>> builder = ImmutableSet.builderWithExpectedSize(injectAnnotations.size() + 1);
         builder.addAll(injectAnnotations);
         builder.add(Inject.class);
-        return new DefaultInstantiationScheme(constructorSelector, defaultServices, builder.build());
+        return new DefaultInstantiationScheme(constructorSelector, defaultServices, builder.build(), cacheFactory);
     }
 
     @Override

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/model/NamedObjectInstantiatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/model/NamedObjectInstantiatorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.model
 
 import org.gradle.api.Named
 import org.gradle.api.reflect.ObjectInstantiationException
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.state.Managed
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.Matchers
@@ -27,7 +28,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CyclicBarrier
 
 class NamedObjectInstantiatorTest extends ConcurrentSpec {
-    static factory = new NamedObjectInstantiator()
+    static factory = new NamedObjectInstantiator(new TestCrossBuildInMemoryCacheFactory())
 
     def "creates instance of Named"() {
         expect:

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/model/NamedObjectInstantiatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/model/NamedObjectInstantiatorTest.groovy
@@ -27,7 +27,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CyclicBarrier
 
 class NamedObjectInstantiatorTest extends ConcurrentSpec {
-    static factory = NamedObjectInstantiator.INSTANCE
+    static factory = new NamedObjectInstantiator()
 
     def "creates instance of Named"() {
         expect:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.instantiation
 
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.state.Managed
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -23,7 +24,6 @@ import org.junit.ClassRule
 import spock.lang.Shared
 import spock.lang.Unroll
 
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.*
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.AbstractBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Bean
@@ -34,6 +34,7 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Inte
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceFilePropertyBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceListPropertyBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceMapPropertyBean
+import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfacePrimitiveBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfacePropertyBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceSetPropertyBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceWithDefaultMethods
@@ -42,7 +43,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
     @ClassRule
     @Shared
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [])
+    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory())
 
     def canConstructInstanceOfAbstractClassWithAbstractPropertyGetterAndSetter() {
         def bean = create(BeanWithAbstractProperty)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -22,15 +22,16 @@ import org.gradle.api.NonExtensible
 import org.gradle.api.internal.HasConvention
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.BiAction
 import org.gradle.internal.util.BiFunction
 import org.gradle.util.ConfigureUtil
 import spock.lang.Issue
 
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.*
+import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Bean
 
 class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [])
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory())
 
     def "can attach nested extensions to object"() {
         given:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.instantiation
 
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.util.TestUtil
@@ -37,7 +38,7 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.NonG
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.PrivateInjectBean
 
 class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [])
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory())
 
     def "can inject service using @Inject on a getter method with dummy method body"() {
         given:
@@ -228,7 +229,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         def services = defaultServices()
         _ * services.get(Number, CustomInject) >> 12
 
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject])
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
 
         when:
         def obj = create(generator, BeanWithCustomServices, services)
@@ -244,7 +245,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         def services = defaultServices()
         _ * services.get(Number, CustomInject) >> 12
 
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject])
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
 
         when:
         def obj = create(generator, AbstractBeanWithCustomServices, services)
@@ -256,7 +257,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot use multiple inject annotations on getter"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject])
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
 
         when:
         create(generator, MultipleInjectAnnotations)
@@ -325,7 +326,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom annotation that is known but not enabled to getter method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [])
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory())
 
         when:
         create(generator, BeanWithCustomServices)
@@ -336,7 +337,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom annotation that is known but not enabled to static method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [])
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory())
 
         when:
         create(generator, StaticCustomInjectBean)
@@ -347,7 +348,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom inject annotation to methods of ExtensionAware"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject])
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
 
         when:
         generator.generate(ExtensibleBeanWithCustomInject)
@@ -358,7 +359,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom inject annotation to static method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject])
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
 
         when:
         generator.generate(StaticCustomInjectBean)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.GeneratedSubclass
 import org.gradle.api.internal.HasConvention
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.ServiceLookup
 
 import javax.inject.Inject
@@ -29,7 +30,7 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Abst
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.BeanWithServiceGetters
 
 class AsmBackedClassGeneratorInjectUndecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [])
+    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory())
 
     def "returns original class when class is not abstract and no service getter methods present"() {
         expect:
@@ -82,8 +83,8 @@ class AsmBackedClassGeneratorInjectUndecoratedTest extends AbstractClassGenerato
         services.get(Number) >> 12
 
         expect:
-        def decorated = create(AsmBackedClassGenerator.decorateAndInject([], []), BeanWithServiceGetters)
-        def undecorated = create(AsmBackedClassGenerator.injectOnly([], []), BeanWithServiceGetters)
+        def decorated = create(AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory()), BeanWithServiceGetters)
+        def undecorated = create(AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory()), BeanWithServiceGetters)
         decorated.class != undecorated.class
         decorated instanceof ExtensionAware
         !(undecorated instanceof ExtensionAware)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
@@ -43,6 +43,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory;
 import org.gradle.internal.extensibility.ConventionAwareHelper;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.internal.extensibility.NoConventionMapping;
@@ -60,7 +61,6 @@ import spock.lang.Issue;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -101,7 +101,7 @@ import static org.junit.Assert.fail;
 public class AsmBackedClassGeneratorTest {
     @Rule
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
-    private final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject(Collections.<InjectAnnotationHandler>emptyList(), Collections.<Class<? extends Annotation>>emptyList());
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject(Collections.emptyList(), Collections.emptyList(), new TestCrossBuildInMemoryCacheFactory());
 
     private <T> T newInstance(Class<T> clazz, Object... args) throws Exception {
         DefaultServiceRegistry services = new DefaultServiceRegistry();

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiationSchemeTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiationSchemeTest.groovy
@@ -26,7 +26,7 @@ import java.lang.reflect.Type
 
 
 class DefaultInstantiationSchemeTest extends Specification {
-    def scheme = new DefaultInstantiationScheme(new Jsr330ConstructorSelector(new IdentityClassGenerator(), new TestCrossBuildInMemoryCacheFactory.TestCache<Class<?>, Jsr330ConstructorSelector.CachedConstructor>()), new DefaultServiceRegistry(), [] as Set)
+    def scheme = new DefaultInstantiationScheme(new Jsr330ConstructorSelector(new IdentityClassGenerator(), new TestCrossBuildInMemoryCacheFactory.TestCache<Class<?>, Jsr330ConstructorSelector.CachedConstructor>()), new DefaultServiceRegistry(), [] as Set, new TestCrossBuildInMemoryCacheFactory())
 
     def "can specify a set of services to inject"() {
         def services = Mock(ServiceLookup)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DependencyInjectionUsingClassGeneratorBackedInstantiatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DependencyInjectionUsingClassGeneratorBackedInstantiatorTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 import javax.inject.Inject
 
 class DependencyInjectionUsingClassGeneratorBackedInstantiatorTest extends Specification {
-    final ClassGenerator classGenerator = AsmBackedClassGenerator.decorateAndInject([], [])
+    final ClassGenerator classGenerator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory())
     final CrossBuildInMemoryCache cache = new TestCrossBuildInMemoryCacheFactory().newCache()
     final ServiceLookup services = new DefaultServiceRegistry()
     final DependencyInjectingInstantiator instantiator = new DependencyInjectingInstantiator(new Jsr330ConstructorSelector(classGenerator, cache), services)

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCache.java
@@ -29,7 +29,7 @@ public interface CrossBuildInMemoryCache<K, V> {
     /**
      * Locates the given entry, using the supplied factory when the entry is not present or has been discarded, to recreate the entry in the cache.
      *
-     * <p>Implementations should prevent more than one thread calculating the same key at the same time.
+     * <p>Implementations must prevent more than one thread calculating the same key at the same time.
      */
     V get(K key, Transformer<V, K> factory);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -87,10 +87,12 @@ public class JavaPlatformPlugin implements Plugin<Project> {
             "Found dependencies in the '%s' configuration.";
 
     private final SoftwareComponentFactory softwareComponentFactory;
+    private final PlatformSupport platformSupport;
 
     @Inject
-    public JavaPlatformPlugin(SoftwareComponentFactory softwareComponentFactory) {
+    public JavaPlatformPlugin(SoftwareComponentFactory softwareComponentFactory, PlatformSupport platformSupport) {
         this.softwareComponentFactory = softwareComponentFactory;
+        this.platformSupport = platformSupport;
     }
 
     @Override
@@ -105,16 +107,10 @@ public class JavaPlatformPlugin implements Plugin<Project> {
         configureExtension(project);
         addPlatformDisambiguationRule(project);
         JavaEcosystemSupport.configureSchema(project.getDependencies().getAttributesSchema(), project.getObjects());
-
-
     }
 
     private void addPlatformDisambiguationRule(Project project) {
-        project.getDependencies()
-                .getAttributesSchema()
-                .getMatchingStrategy(Category.CATEGORY_ATTRIBUTE)
-                .getDisambiguationRules()
-                .add(PlatformSupport.PreferRegularPlatform.class);
+        platformSupport.addDisambiguationRule(project.getDependencies().getAttributesSchema());
     }
 
     private void createSoftwareComponent(Project project, Configuration apiElements, Configuration runtimeElements) {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.snapshot.impl
 
 import org.gradle.api.Named
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.api.internal.provider.DefaultListProperty
 import org.gradle.api.internal.provider.DefaultMapProperty
 import org.gradle.api.internal.provider.DefaultPropertyState
@@ -580,7 +579,7 @@ class DefaultValueSnapshotterTest extends Specification {
     }
 
     def "creates snapshot for named managed type"() {
-        def instantiator = NamedObjectInstantiator.INSTANCE
+        def instantiator = TestUtil.objectInstantiator()
         def value = instantiator.named(Thing, "value1")
         def value1 = instantiator.named(Thing, "value1")
         def value2 = instantiator.named(Thing, "value2")
@@ -596,7 +595,7 @@ class DefaultValueSnapshotterTest extends Specification {
     }
 
     def "creates isolated named managed type"() {
-        def instantiator = NamedObjectInstantiator.INSTANCE
+        def instantiator = TestUtil.objectInstantiator()
         def value = instantiator.named(Thing, "value1")
 
         expect:
@@ -606,7 +605,7 @@ class DefaultValueSnapshotterTest extends Specification {
     }
 
     def "can coerce named managed type"() {
-        def instantiator = NamedObjectInstantiator.INSTANCE
+        def instantiator = TestUtil.objectInstantiator()
         def value = instantiator.named(Thing, "value1")
 
         def spec = new FilteringClassLoader.Spec()
@@ -633,7 +632,7 @@ class DefaultValueSnapshotterTest extends Specification {
     }
 
     def "creates snapshot for isolated named managed type"() {
-        def instantiator = NamedObjectInstantiator.INSTANCE
+        def instantiator = TestUtil.objectInstantiator()
         def value = instantiator.named(Thing, "value1")
         def other = instantiator.named(Thing, "other")
 
@@ -1015,7 +1014,7 @@ class DefaultValueSnapshotterTest extends Specification {
     }
 
     def "creates snapshot for named managed type from candidate"() {
-        def instantiator = NamedObjectInstantiator.INSTANCE
+        def instantiator = TestUtil.objectInstantiator()
         def value = instantiator.named(Thing, "value")
         def value1 = instantiator.named(Thing, "value")
         def value2 = instantiator.named(Thing, "value2")


### PR DESCRIPTION
### Context

This PR improves performance loading tasks from the instant execution cache by caching task constructors in memory rather than recreating the constructor for each task.

This PR also reworks the infrastructure for in-memory caching so that it can be used for caches that  hold entries with a class as a key and entries that reference generated subclasses. This is used for `AsmBackedClassGenerator` and `NamedObjectInstantiator`, replacing the custom caching these types used previously.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
