### PR TITLE
Extend Java test projects to measure java-library performance 

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/ForkingGradleSession.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/ForkingGradleSession.groovy
@@ -78,7 +78,7 @@ class ForkingGradleSession implements GradleSession {
     }
 
     private void run(BuildExperimentInvocationInfo invocationInfo, GradleInvocationSpec invocation, List<String> tasks) {
-        String jvmArgs = invocation.jvmOpts.collect { '\'' + it + '\'' }.join(' ')
+        String jvmArgs = invocation.jvmOpts.join(' ')
         Map<String, String> env = [:]
         List<String> args = []
         if (OperatingSystem.current().isWindows()) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -51,6 +51,7 @@ abstract class FileContentGenerator {
         import org.gradle.util.GradleVersion
 
         ${missingJavaLibrarySupportFlag()}
+        ${noJavaLibraryPluginFlag()}
 
         ${config.plugins.collect { decideOnJavaPlugin(it, dependencyTree.hasParentProject(subProjectNumber)) }.join("\n        ")}
         
@@ -379,7 +380,7 @@ abstract class FileContentGenerator {
         if (plugin.contains('java')) {
             if (projectHasParents) {
                 return """
-                    if(missingJavaLibrarySupport) {
+                    if (missingJavaLibrarySupport || noJavaLibraryPlugin) {
                         ${imperativelyApplyPlugin("java")}
                     } else {
                         ${imperativelyApplyPlugin("java-library")}
@@ -430,6 +431,8 @@ abstract class FileContentGenerator {
     }
 
     protected abstract String missingJavaLibrarySupportFlag()
+
+    protected abstract String noJavaLibraryPluginFlag()
 
     protected abstract String tasksConfiguration()
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -403,15 +403,23 @@ abstract class FileContentGenerator {
                 it == abiProjectNumber ? projectDependencyDeclaration(hasParent ? api : implementation, abiProjectNumber) : projectDependencyDeclaration(implementation, it)
             }.join("\n            ")
         }
+        def block = """
+                    ${config.externalApiDependencies.collect { directDependencyDeclaration(hasParent ? api : implementation, it) }.join("\n            ")}
+                    ${config.externalImplementationDependencies.collect { directDependencyDeclaration(implementation, it) }.join("\n            ")}
+                    ${directDependencyDeclaration(testImplementation, config.useTestNG ? 'org.testng:testng:6.4' : 'junit:junit:4.12')}
+    
+                    $subProjectDependencies
+        """
         return """
             ${configurationsIfMissingJavaLibrarySupport(hasParent)}
-
-            dependencies {
-                ${config.externalApiDependencies.collect { directDependencyDeclaration(hasParent ? api : implementation, it) }.join("\n            ")}
-                ${config.externalImplementationDependencies.collect { directDependencyDeclaration(implementation, it) }.join("\n            ")}
-                ${directDependencyDeclaration(testImplementation, config.useTestNG ? 'org.testng:testng:6.4' : 'junit:junit:4.12')}
-
-                $subProjectDependencies
+            if (hasProperty("compileConfiguration")) {
+                dependencies {
+                    ${block.replace(api, 'compile').replace(implementation, 'compile').replace(testImplementation, 'testCompile')}
+                }
+            } else {
+                dependencies {
+                    $block
+                }
             }
         """
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
@@ -27,6 +27,11 @@ class GroovyDslFileContentGenerator extends FileContentGenerator {
     }
 
     @Override
+    protected String noJavaLibraryPluginFlag() {
+        "def noJavaLibraryPlugin = hasProperty('noJavaLibraryPlugin')"
+    }
+
+    @Override
     protected String tasksConfiguration() {
         """
         String compilerMemory = getProperty('compilerMemory')
@@ -87,6 +92,11 @@ class GroovyDslFileContentGenerator extends FileContentGenerator {
                 ${hasParent ? 'compile.extendsFrom api' : ''}
                 compile.extendsFrom implementation
                 testCompile.extendsFrom testImplementation
+            }
+        } else if (noJavaLibraryPlugin) {
+            configurations {
+                ${hasParent ? 'api' : ''}
+                ${hasParent ? 'compile.extendsFrom api' : ''}
             }
         }
         """

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProject.groovy
@@ -35,6 +35,10 @@ enum JavaTestProject {
         "largeJavaMultiProject", GROOVY, 100, 500, '1536m', '256m',
         [assemble: productionFile('largeJavaMultiProject'), test: productionFile('largeJavaMultiProject', 450, 2250, 45000)]
     ),
+    HUGE_JAVA_MULTI_PROJECT(
+        "hugeJavaMultiProject", GROOVY, 500, 500, '1536m', '1g',
+        [assemble: productionFile('hugeJavaMultiProject'), test: productionFile('hugeJavaMultiProject', 450, 2250, 45000)]
+    ),
     LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL(
         "largeJavaMultiProjectKotlinDsl", KOTLIN, 100, 500, '1536m', '256m',
         [assemble: productionFile('largeJavaMultiProject'), test: productionFile('largeJavaMultiProject', 450, 2250, 45000)]

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
@@ -27,6 +27,11 @@ class KotlinDslFileContentGenerator extends FileContentGenerator {
     }
 
     @Override
+    protected String noJavaLibraryPluginFlag() {
+        'val noJavaLibraryPlugin = hasProperty("noJavaLibraryPlugin")'
+    }
+
+    @Override
     protected String tasksConfiguration() {
         """
         val compilerMemory: String by project
@@ -85,6 +90,11 @@ class KotlinDslFileContentGenerator extends FileContentGenerator {
                 ${hasParent ? '"compile" { extendsFrom(configurations["api"]) }' : ''}
                 "compile" { extendsFrom(configurations["implementation"]) }
                 "testCompile" { extendsFrom(configurations["testImplementation"]) }
+            }
+        } else if (noJavaLibraryPlugin) {
+            configurations {
+                ${hasParent ? '"api"()' : ''}
+                ${hasParent ? '"compile" { extendsFrom(configurations["api"]) }' : ''}
             }
         }
         """

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaselineVersion.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaselineVersion.groovy
@@ -69,20 +69,20 @@ class BaselineVersion implements VersionResults {
         }
     }
 
-    boolean significantlyFasterThan(MeasuredOperationList other) {
+    boolean significantlyFasterThan(MeasuredOperationList other, double minConfidence = MINIMUM_CONFIDENCE) {
         def myTime = results.totalTime
         def otherTime = other.totalTime
-        myTime && myTime.median < otherTime.median && differenceIsSignificant(myTime, otherTime)
+        myTime && myTime.median < otherTime.median && differenceIsSignificant(myTime, otherTime, minConfidence)
     }
 
-    boolean significantlySlowerThan(MeasuredOperationList other) {
+    boolean significantlySlowerThan(MeasuredOperationList other, double minConfidence = MINIMUM_CONFIDENCE) {
         def myTime = results.totalTime
         def otherTime = other.totalTime
-        myTime && myTime.median > otherTime.median && differenceIsSignificant(myTime, otherTime)
+        myTime && myTime.median > otherTime.median && differenceIsSignificant(myTime, otherTime, minConfidence)
     }
 
-    private static boolean differenceIsSignificant(DataSeries<Duration> myTime, DataSeries<Duration> otherTime) {
-        DataSeries.confidenceInDifference(myTime, otherTime) > MINIMUM_CONFIDENCE
+    private static boolean differenceIsSignificant(DataSeries<Duration> myTime, DataSeries<Duration> otherTime, double minConfidence) {
+        DataSeries.confidenceInDifference(myTime, otherTime) > minConfidence
     }
 
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -64,7 +64,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
 
         where:
         testProject                   | warmUpRuns | runs
-        LARGE_JAVA_MULTI_PROJECT      | 2          | 6
+        LARGE_JAVA_MULTI_PROJECT      | 2          | 3
     }
 
     private static BaselineVersion buildBaselineResults(CrossBuildPerformanceResults results, String name) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -59,7 +59,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
         def javaLibraryResults = results.buildResult(javaLibraryRuns)
         def speedStats = javaResults.getSpeedStatsAgainst(javaLibraryResults.name, javaLibraryResults)
         println(speedStats)
-        if (javaResults.significantlySlowerThan(javaLibraryResults)) {
+        if (javaResults.significantlyFasterThan(javaLibraryResults, 0.95)) {
             throw new AssertionError(speedStats)
         }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -24,7 +24,6 @@ import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
-import static org.gradle.performance.generator.JavaTestProject.HUGE_JAVA_MULTI_PROJECT
 
 @Category(PerformanceExperiment)
 class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest {
@@ -66,7 +65,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
         where:
         testProject                   | warmUpRuns | runs
         LARGE_JAVA_MULTI_PROJECT      | 2          | 3
-        HUGE_JAVA_MULTI_PROJECT       | 2          | 3
+        // HUGE_JAVA_MULTI_PROJECT    | 2          | 3
     }
 
     private static BaselineVersion buildBaselineResults(CrossBuildPerformanceResults results, String name) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.experiment.java
+
+import org.gradle.performance.AbstractCrossBuildPerformanceTest
+import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.results.BaselineVersion
+import org.gradle.performance.results.CrossBuildPerformanceResults
+import org.junit.experimental.categories.Category
+import spock.lang.Unroll
+
+import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
+
+@Category(PerformanceExperiment)
+class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest {
+
+    @Unroll
+    def "java-library vs java on #testProject"() {
+        def javaLibraryRuns = "java-library-plugin"
+        def javaRuns = "java-plugin"
+
+        given:
+        runner.testGroup = "java plugins"
+        runner.buildSpec {
+            warmUpCount = warmUpRuns
+            invocationCount = runs
+            projectName(testProject.projectName).displayName(javaLibraryRuns).invocation {
+                tasksToRun("clean", "assemble").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+            }
+        }
+        runner.baseline {
+            warmUpCount = warmUpRuns
+            invocationCount = runs
+            projectName(testProject.projectName).displayName(javaRuns).invocation {
+                tasksToRun("clean", "assemble").args("-PnoJavaLibraryPlugin").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+            }
+        }
+
+        when:
+        def results = runner.run()
+
+        then:
+        def javaResults = buildBaselineResults(results, javaRuns)
+        def javaLibraryResults = results.buildResult(javaLibraryRuns)
+        def speedStats = javaResults.getSpeedStatsAgainst(javaLibraryResults.name, javaLibraryResults)
+        println(speedStats)
+        if (javaResults.significantlySlowerThan(javaLibraryResults)) {
+            throw new AssertionError(speedStats)
+        }
+
+        where:
+        testProject                   | warmUpRuns | runs
+        LARGE_JAVA_MULTI_PROJECT      | 2          | 6
+    }
+
+    private static BaselineVersion buildBaselineResults(CrossBuildPerformanceResults results, String name) {
+        def baselineResults = new BaselineVersion(name)
+        baselineResults.results.name = name
+        baselineResults.results.addAll(results.buildResult(name))
+        return baselineResults
+    }
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -39,14 +39,14 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject.projectName).displayName(javaLibraryRuns).invocation {
-                tasksToRun("clean", "assemble").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                tasksToRun("clean", "assemble").args("-PcompileConfiguration").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
             }
         }
         runner.baseline {
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject.projectName).displayName(javaRuns).invocation {
-                tasksToRun("clean", "assemble").args("-PnoJavaLibraryPlugin").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                tasksToRun("clean", "assemble").args("-PcompileConfiguration", "-PnoJavaLibraryPlugin").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
             }
         }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -39,14 +39,14 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject.projectName).displayName(javaLibraryRuns).invocation {
-                tasksToRun("clean", "assemble").args("-PcompileConfiguration").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                tasksToRun("clean", "classes").args("-PcompileConfiguration").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
             }
         }
         runner.baseline {
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject.projectName).displayName(javaRuns).invocation {
-                tasksToRun("clean", "assemble").args("-PcompileConfiguration", "-PnoJavaLibraryPlugin").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                tasksToRun("clean", "classes").args("-PcompileConfiguration", "-PnoJavaLibraryPlugin").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
             }
         }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -24,6 +24,7 @@ import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
+import static org.gradle.performance.generator.JavaTestProject.HUGE_JAVA_MULTI_PROJECT
 
 @Category(PerformanceExperiment)
 class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest {
@@ -65,6 +66,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
         where:
         testProject                   | warmUpRuns | runs
         LARGE_JAVA_MULTI_PROJECT      | 2          | 3
+        HUGE_JAVA_MULTI_PROJECT       | 2          | 3
     }
 
     private static BaselineVersion buildBaselineResults(CrossBuildPerformanceResults results, String name) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/ParallelBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/ParallelBuildPerformanceTest.groovy
@@ -54,8 +54,8 @@ class ParallelBuildPerformanceTest extends AbstractCrossBuildPerformanceTest {
 
         where:
         testProject                   | warmUpRuns | runs
-        LARGE_MONOLITHIC_JAVA_PROJECT | 2          | 6
-        LARGE_JAVA_MULTI_PROJECT      | 2          | 6
+        LARGE_MONOLITHIC_JAVA_PROJECT | 2          | 3
+        LARGE_JAVA_MULTI_PROJECT      | 2          | 3
     }
 
 }

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -41,7 +41,7 @@ tasks.register("gradleBuildBaseline", RemoteProject) {
         inputs.property('args') { // Arguments are covered by the testProjectName and the outputs. We don't want them to contain the absolute path
             return []
         }
-        classpath = sourceSets.performanceTest.runtimeClasspath
+        classpath = sourceSets.performanceTest.runtimeClasspath.filter { it.name.contains('groovy') || it.name.contains('guava')  || it.name.contains('gradle-') }
         main = 'org.gradle.performance.generator.TestProjectGenerator'
         args name, buildDir.absolutePath
     }

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -31,7 +31,7 @@ tasks.register("gradleBuildBaseline", RemoteProject) {
 }
 
 // === Java ===
-['largeMonolithicJavaProject', 'largeJavaMultiProject', 'largeJavaMultiProjectKotlinDsl', 'largeJavaMultiProjectNoBuildSrc',
+['largeMonolithicJavaProject', 'largeJavaMultiProject', 'hugeJavaMultiProject', 'largeJavaMultiProjectKotlinDsl', 'largeJavaMultiProjectNoBuildSrc',
  'mediumMonolithicJavaProject', 'mediumJavaMultiProject', 'mediumJavaMultiProjectWithTestNG', 'mediumJavaCompositeBuild', 'mediumJavaPredefinedCompositeBuild',
  'smallJavaMultiProject', 'smallJavaMultiProjectNoBuildSrc'].each { template ->
     tasks.register(template, JavaExecProjectGeneratorTask) {


### PR DESCRIPTION
This PR contains performance test enhancements to investigate #6784 on Windows.

This PR does add a performance test in the "experiments"-bucket (`JavaLibraryPluginPerformanceTest`). The test passes on Linux currently, but fails for very large projects on Windows. A follow up PR will provide a solution for that.

The Windows execution is not part of the pipeline at the moment, because we don't have Windows agent for performance configured there. Also running the test on the HUGE project, added with this PR, takes over an hour. So this is used for manual testing atm.

In a follow up, we can think about setting this up to run this sporadically on CI (e.g. on the weekends). With the changes in this PR, the tests should technically run on Windows.