### PR TITLE
Instant execution collects FileCollection resolution exception messages

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionIntegrationTest.groovy
@@ -26,6 +26,10 @@ class AbstractInstantExecutionIntegrationTest extends AbstractIntegrationSpec {
         run(INSTANT_EXECUTION_PROPERTY, *args)
     }
 
+    void instantFails(String... args) {
+        fails(INSTANT_EXECUTION_PROPERTY, *args)
+    }
+
     static final String INSTANT_EXECUTION_PROPERTY = "-Dorg.gradle.unsafe.instant-execution"
 
     protected InstantExecutionBuildOperationsFixture newInstantExecutionFixture() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -98,4 +98,43 @@ class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionInte
         and:
         assertTestsExecuted("ThingTest", "ok")
     }
+
+    def "compileGroovy without sources nor groovy dependency is executed but skipped"() {
+        given:
+        buildFile << """
+            plugins { id 'groovy' }
+        """
+
+        when:
+        instantRun "assemble"
+        instantRun "assemble"
+
+        then:
+        result.assertTaskExecuted(":compileGroovy")
+        result.assertTaskSkipped(":compileGroovy")
+    }
+
+    def "compileGroovy with sources but no groovy dependency is executed and fails with a reasonable error message"() {
+        given:
+        buildFile << """
+            plugins { id 'groovy' }
+        """
+        file("src/main/groovy/Thing.groovy") << """
+            class Thing {}
+        """
+
+        when:
+        instantFails "assemble"
+
+        then:
+        result.assertTaskExecuted(":compileGroovy")
+        failureCauseContains("Cannot infer Groovy class path because no Groovy Jar was found on class path")
+
+        when:
+        instantFails "assemble"
+
+        then:
+        result.assertTaskExecuted(":compileGroovy")
+        failureCauseContains("Cannot infer Groovy class path because no Groovy Jar was found on class path")
+    }
 }


### PR DESCRIPTION
This lets the groovy plugin validation of groovy dependency work with instant execution. Capturing other lazy constructs errors and stack traces is left as a later enhancement.