### PR TITLE
Remove :configureBuildReceipt configuration task in the gradle/gradle build

### DIFF
--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
@@ -69,14 +69,18 @@ open class DetermineCommitId @Inject constructor(
         // Builds of Gradle happening on the CI server
         { System.getenv("BUILD_VCS_NUMBER") },
         // For the discovery builds, this points to the Gradle revision
-        { System.getenv().filterKeys { it.startsWith("BUILD_VCS_NUMBER_Gradle_Master") }.values.firstOrNull() },
+        { firstSystemEnvStartsWithOrNull("BUILD_VCS_NUMBER_Gradle_Master") },
         // For the discovery release builds, this points to the Gradle revision
-        { System.getenv().filterKeys { it.startsWith("BUILD_VCS_NUMBER_Gradle_release_branch") }.values.firstOrNull() },
+        { firstSystemEnvStartsWithOrNull("BUILD_VCS_NUMBER_Gradle_release_branch") },
         // If it's a checkout, ask Git for it
         { gitCommitId() },
         // It's a source distribution, we don't know.
         { "<unknown>" }
     )
+
+    private
+    fun firstSystemEnvStartsWithOrNull(prefix: String) =
+        System.getenv().asSequence().firstOrNull { it.key.startsWith(prefix) }?.value
 
     private
     fun gitCommitId(): String? {

--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.versioning
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.process.internal.ExecActionFactory
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+
+
+@Suppress("unused")
+open class DetermineCommitId @Inject constructor(
+    objects: ObjectFactory,
+    layout: ProjectLayout,
+    private val execActionFactory: ExecActionFactory
+) : DefaultTask() {
+
+    @get:OutputFile
+    val commitIdFile = objects.fileProperty()
+        .convention(layout.buildDirectory.file("determined-commit-id.txt"))
+
+    @get:Internal
+    val commitId: Provider<String>
+        get() = commitIdFile.map { it.asFile.readText() }
+
+    init {
+        outputs.upToDateWhen { false }
+    }
+
+    private
+    val promotionCommitId: String? =
+        project.findProperty("promotionCommitId")?.toString()
+
+    private
+    val rootDir =
+        project.rootDir
+
+    @TaskAction
+    fun determineCommitId() {
+        val commitId = buildStrategies().mapNotNull { it() }.first()
+        commitIdFile.get().asFile.writeText(commitId)
+    }
+
+    private
+    fun buildStrategies(): Sequence<() -> String?> = sequenceOf(
+        // For promotion builds use the commitId passed in as a project property
+        { promotionCommitId },
+        // Builds of Gradle happening on the CI server
+        { System.getenv("BUILD_VCS_NUMBER") },
+        // For the discovery builds, this points to the Gradle revision
+        { System.getenv().filterKeys { it.startsWith("BUILD_VCS_NUMBER_Gradle_Master") }.values.firstOrNull() },
+        // For the discovery release builds, this points to the Gradle revision
+        { System.getenv().filterKeys { it.startsWith("BUILD_VCS_NUMBER_Gradle_release_branch") }.values.firstOrNull() },
+        // If it's a checkout, ask Git for it
+        { gitCommitId() },
+        // It's a source distribution, we don't know.
+        { "<unknown>" }
+    )
+
+    private
+    fun gitCommitId(): String? {
+        val gitDir = rootDir.resolve(".git")
+        if (!gitDir.isDirectory) {
+            return null
+        }
+        val execOutput = ByteArrayOutputStream()
+        val execResult = execActionFactory.newExecAction().apply {
+            workingDir = rootDir
+            isIgnoreExitValue = true
+            commandLine = listOf("git", "log", "-1", "--format=%H")
+            if (OperatingSystem.current().isWindows) {
+                commandLine = listOf("cmd", "/c") + commandLine
+            }
+            standardOutput = execOutput
+        }.execute()
+        return when {
+            execResult.exitValue == 0 -> String(execOutput.toByteArray()).trim()
+            gitDir.resolve("HEAD").exists() -> {
+                // Read commit id directly from filesystem
+                val headRef = gitDir.resolve("HEAD").readText()
+                    .replace("ref: ", "").trim()
+                gitDir.resolve(headRef).readText().trim()
+            }
+            else -> null
+        }
+    }
+}

--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
@@ -41,7 +41,7 @@ open class DetermineCommitId @Inject constructor(
         .convention(layout.buildDirectory.file("determined-commit-id.txt"))
 
     @get:Internal
-    val commitId: Provider<String>
+    val determinedCommitId: Provider<String>
         get() = commitIdFile.map { it.asFile.readText() }
 
     init {

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -48,7 +48,7 @@ tasks.register("createBuildReceipt", BuildReceipt) {
     baseVersion.set(provider { rootProject.baseVersion })
     snapshot.set(provider { rootProject.isSnapshot })
     buildTimestampFrom(provider { rootProject.buildTimestamp })
-    commitId.set(determineCommitId.flatMap { it.commitId })
+    commitId.set(determineCommitId.flatMap { it.determinedCommitId })
     destinationDir = file("${rootProject.buildDir}")
 }
 

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -1,6 +1,6 @@
 import org.gradle.build.BuildReceipt
 import org.gradle.gradlebuild.BuildEnvironment
-import org.gradle.internal.os.OperatingSystem
+import org.gradle.gradlebuild.versioning.DetermineCommitId
 
 if (buildTypes.promotionBuild.active) {
     logger.lifecycle "Invocation tasks: $gradle.startParameter.taskNames\nInvocation properties: $gradle.startParameter.projectProperties"
@@ -9,7 +9,7 @@ if (buildTypes.promotionBuild.active) {
 ext.milestoneNumber = project.hasProperty("milestoneNumber") ? project.milestoneNumber.toInteger() : null
 ext.rcNumber = project.hasProperty("rcNumber") ? project.rcNumber.toInteger() : null
 ext.finalRelease = project.hasProperty("finalRelease")
-ext.versionQualifier = project.hasProperty("versionQualifier") ? project.versionQualifier: null
+ext.versionQualifier = project.hasProperty("versionQualifier") ? project.versionQualifier : null
 if ((milestoneNumber != null && rcNumber != null) ||
     (rcNumber != null && finalRelease) ||
     (milestoneNumber != null && finalRelease)) {
@@ -30,7 +30,7 @@ if (!project.hasProperty("ignoreIncomingBuildReceipt") && new File(incomingBuild
     if (project.hasProperty("buildTimestamp")) {
         buildTime = timestampFormat.parse(buildTimestamp)
     } else {
-        if (BuildEnvironment.isCiServer || ['install', 'installAll'].collectMany { [':' + it, it]}.any { gradle.startParameter.taskNames.contains(it) }) {
+        if (BuildEnvironment.isCiServer || ['install', 'installAll'].collectMany { [':' + it, it] }.any { gradle.startParameter.taskNames.contains(it) }) {
             buildTime = new Date()
         } else {
             def sdf = new java.text.SimpleDateFormat("yyyy-MM-dd");
@@ -41,89 +41,14 @@ if (!project.hasProperty("ignoreIncomingBuildReceipt") && new File(incomingBuild
     ext.buildTimestamp = timestampFormat.format(buildTime)
 }
 
-def determineCommitId = tasks.register("determineCommitId") {
-    ext.commitId = null
+def determineCommitId = tasks.register("determineCommitId", DetermineCommitId)
 
-    doLast {
-        def strategies = []
-
-        def env = System.getenv()
-
-        // For promotion builds use the commitId passed in as a project property
-        strategies << {
-            project.hasProperty('promotionCommitId') ? project.property('promotionCommitId') : null
-        }
-
-        // Builds of Gradle happening on the CI server
-        strategies << {
-            env["BUILD_VCS_NUMBER"]
-        }
-
-        // For the discovery builds, this points to the Gradle revision
-        strategies << {
-            env.find { it.key.startsWith("BUILD_VCS_NUMBER_Gradle_Master") }?.value
-        }
-
-        // For the discovery release builds, this points to the Gradle revision
-        strategies << {
-            env.find { it.key.startsWith("BUILD_VCS_NUMBER_Gradle_release_branch") }?.value
-        }
-
-        // If it's a checkout, ask Git for it
-        strategies << {
-            def gitDir = file("${rootDir}/.git")
-            if (gitDir.exists()) {
-                def baos = new ByteArrayOutputStream()
-                def execResult = exec {
-                    workingDir = rootDir
-                    ignoreExitValue = true
-                    commandLine = ["git", "log", "-1", "--format=%H"]
-                    if (OperatingSystem.current().windows) {
-                        commandLine = ["cmd", "/c"] + commandLine
-                    }
-
-                    standardOutput = baos
-                }
-                if (execResult.exitValue == 0) {
-                    new String(baos.toByteArray(), "utf8").trim()
-                } else if (file("${gitDir}/HEAD").exists()) {
-                    // Read commit id directly from filesystem
-                    def headRef = file("${gitDir}/HEAD").text
-                    headRef = headRef.replaceAll('ref: ', '').trim()
-                    file("${gitDir}/$headRef").text.trim()
-                }
-            } else {
-                null
-            }
-        }
-
-        // It's a source distribution, we don't know.
-        strategies << {
-            "<unknown>"
-        }
-
-        for (strategy in strategies) {
-            commitId = strategy()
-            if (commitId) {
-                break
-            }
-        }
-    }
-}
-
-def configureBuildReceipt = tasks.register("configureBuildReceipt") {
-    dependsOn determineCommitId
-    doLast {
-        createBuildReceipt.versionNumber = rootProject.version
-        createBuildReceipt.baseVersion = rootProject.baseVersion
-        createBuildReceipt.snapshot = rootProject.isSnapshot
-        createBuildReceipt.buildTimestamp = rootProject.buildTimestamp
-        createBuildReceipt.commitId = determineCommitId.get().commitId
-    }
-}
-
-tasks.register("createBuildReceipt", org.gradle.build.BuildReceipt) {
-    dependsOn configureBuildReceipt
+tasks.register("createBuildReceipt", BuildReceipt) {
+    versionNumber.set(provider { rootProject.version })
+    baseVersion.set(provider { rootProject.baseVersion })
+    snapshot.set(provider { rootProject.isSnapshot })
+    buildTimestampFrom(provider { rootProject.buildTimestamp })
+    commitId.set(determineCommitId.flatMap { it.commitId })
     destinationDir = file("${rootProject.buildDir}")
 }
 
@@ -138,7 +63,7 @@ if (finalRelease) {
     version += "-rc-$rcNumber"
 } else if (milestoneNumber != null) {
     version += "-milestone-$milestoneNumber"
-} else if (versionQualifier != null ) {
+} else if (versionQualifier != null) {
     isSnapshot = true
     version += "-$versionQualifier-$buildTimestamp"
 } else {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -51,6 +51,7 @@ import org.gradle.internal.serialize.BaseSerializerFactory.SHORT_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALIZER
 import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.serialize.SetSerializer
+import org.gradle.process.internal.ExecActionFactory
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import kotlin.reflect.KClass
 
@@ -116,6 +117,7 @@ class Codecs(
         bind(ownerProjectService<FileOperations>())
         bind(ownerProjectService<BuildOperationExecutor>())
         bind(ownerProjectService<ToolingModelBuilderRegistry>())
+        bind(ownerProjectService<ExecActionFactory>())
 
         bind(BeanCodec())
     }

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -19,7 +19,7 @@ import org.gradle.testing.performance.generator.tasks.*
 // === Gradle Build ===
 tasks.register("gradleBuildCurrent", RemoteProject) {
     remoteUri = rootDir.absolutePath
-    ref = rootProject.tasks.named("determineCommitId").flatMap { it.commitId }
+    ref = rootProject.tasks.named("determineCommitId").flatMap { it.determinedCommitId }
 }
 
 tasks.register("gradleBuildBaseline", RemoteProject) {

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -18,9 +18,8 @@ import org.gradle.testing.performance.generator.tasks.*
 
 // === Gradle Build ===
 tasks.register("gradleBuildCurrent", RemoteProject) {
-    dependsOn rootProject.determineCommitId
     remoteUri = rootDir.absolutePath
-    ref = provider { rootProject.determineCommitId.commitId }
+    ref = rootProject.tasks.named("determineCommitId").flatMap { it.commitId }
 }
 
 tasks.register("gradleBuildBaseline", RemoteProject) {

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -29,7 +29,7 @@ plugins {
 
 val testPublishRuntime by configurations.creating
 
-val buildReceipt: Provider<RegularFile> = rootProject.tasks.withType<BuildReceipt>().named("createBuildReceipt").map { layout.file(provider { it.receiptFile }).get() }
+val buildReceipt: Provider<RegularFile> = rootProject.tasks.named<BuildReceipt>("createBuildReceipt").map { layout.file(provider { it.receiptFile }).get() }
 
 shadedJar {
     shadedConfiguration.exclude(mapOf("group" to "org.slf4j", "module" to "slf4j-api"))


### PR DESCRIPTION
Preferring idiomatic task outputs wiring.

This PR extracts `:determineCommitId` into `buildSrc` and changes it so it writes the determined commit id to an output file. It removes the `:configureBuildReceipt` configuration task. It then changes `:createBuildReceipt` to consume the commit id from the outputs of `:determineCommitId`.

This lets those tasks that execute very early in the build run with instant execution.