### PR TITLE
Move FingerprintMapSerializer to execution

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializer.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializer.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMultimap;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
-import org.gradle.internal.fingerprint.impl.FingerprintMapSerializer;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FingerprintMapSerializer.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FingerprintMapSerializer.java
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.fingerprint.impl;
+package org.gradle.internal.execution.history.impl;
 
 import com.google.common.base.Objects;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
+import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint;
+import org.gradle.internal.fingerprint.impl.IgnoredPathFileSystemLocationFingerprint;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;


### PR DESCRIPTION
It seems like it was an oversight to leave it in `:snapshots`, and it
now lives next to `FileCollectionFingerprintSerializer`.