### PR TITLE
Attach node selection failures to constraint edges

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -642,4 +642,27 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
             }
         }
     }
+
+    void 'dependency constraint on failed variant resolution needs to be in the right state'() {
+        mavenRepo.module('org', 'bar', '1.0').publish()
+
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf 'org:bar:1.0'
+                }
+                conf('org:bar') {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'wrong'))
+                    }
+                }
+            }
+"""
+
+        when:
+        succeeds 'dependencyInsight', '--configuration', 'conf', '--dependency', 'org:bar'
+
+        then:
+        outputContains("org:bar: FAILED")
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -216,6 +216,11 @@ class EdgeState implements DependencyGraphEdge {
                     for (EdgeState otherEdge : unattachedDependencies) {
                         if (otherEdge != this && !otherEdge.isConstraint()) {
                             otherEdge.attachToTargetConfigurations();
+                            if (otherEdge.targetNodeSelectionFailure != null) {
+                                // Copy selection failure
+                                this.targetNodeSelectionFailure = otherEdge.targetNodeSelectionFailure;
+                                return;
+                            }
                             break;
                         }
                     }


### PR DESCRIPTION
When a constraint edge cannot find target nodes, we check if a selection
failure needs to be attached.