### PR TITLE
Add option to package classes directory to a jar on the compile classpath

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/TaskPropertyValidationPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/TaskPropertyValidationPlugin.kt
@@ -21,6 +21,7 @@ import accessors.reporting
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Usage
 import org.gradle.api.tasks.testing.Test
 
@@ -46,6 +47,8 @@ open class TaskPropertyValidationPlugin : Plugin<Project> {
                 val validationRuntime by configurations.creating {
                     isCanBeConsumed = false
                     attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+                    // Required to select the right :distributions variant
+                    attributes.attribute(Attribute.of("org.gradle.runtime", String::class.java), "minimal")
                 }
                 dependencies.add(
                     validationRuntime.name,

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeCompatibilityRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeCompatibilityRule.java
@@ -26,7 +26,7 @@ import org.gradle.api.Incubating;
  * mark the producer value as compatible or not.
  * <p>
  * Note that the rule will never receive a {@code CompatibilityCheckDetails} that has {@code equal} consumer and producer
- * values as this check is performed before invoking the rule and assumes compatiblity in that case.
+ * values as this check is performed before invoking the rule and assumes compatibility in that case.
  *
  * @since 4.0
  * @param <T> The attribute value type.

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
@@ -23,10 +23,11 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 /**
  * This attribute describes the categories of variants for a given module.
  * <p>
- * Two values are found in published components:
+ * Three values are found in published components:
  * <ul>
  *     <li>{@code library}: Indicates that the variant is a library, that usually means a binary and a set of dependencies</li>
- *     <li>{@code platform}: indicates that the variant is a platform, that usually means a definition of dependency constraints</li>
+ *     <li>{@code platform}: Indicates that the variant is a platform, that usually means a definition of dependency constraints</li>
+ *     <li>{@code documentation}: Indicates that the variant is documentation of the software module</li>
  * </ul>
  * One value is used for derivation. A {@code platform} variant can be consumed as a {@code enforced-platform} which means all the dependency
  * information it provides is applied as {@code forced}.
@@ -53,4 +54,12 @@ public interface Category extends Named {
      * The enforced platform, usually a synthetic variant derived from the {@code platform}
      */
     String ENFORCED_PLATFORM = "enforced-platform";
+
+    /**
+     * The documentation category
+     *
+     * @since 5.6
+     */
+    String DOCUMENTATION = "documentation";
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/DocsType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/DocsType.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.attributes;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Named;
+
+/**
+ * Attributes to qualify the type of documentation.
+ * <p>
+ * This attribute is usually found on variants that have the {@link Category} attribute valued at {@link Category#DOCUMENTATION documentation}.
+ *
+ * @since 5.6
+ */
+@Incubating
+public interface DocsType extends Named {
+    Attribute<DocsType> DOCS_TYPE_ATTRIBUTE = Attribute.of("org.gradle.docstype", DocsType.class);
+
+    /**
+     * The typical documentation for Java APIs
+     */
+    String JAVADOC = "javadoc";
+
+    /**
+     * The source files of the module
+     */
+    String SOURCES = "sources";
+
+    /**
+     * A user manual
+     */
+    String USER_MANUAL = "user-manual";
+
+    /**
+     * Samples illustrating how to use the software module
+     */
+    String SAMPLES = "samples";
+
+    /**
+     * The typical documentation for native APIs
+     */
+    String DOXYGEN = "doxygen";
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Format.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Format.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.attributes;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Named;
+
+/**
+ * Attribute representing the technical format of a variant.
+ * <p>
+ * This attribute is not about the packaging of the variant, which is represented by the {@link org.gradle.api.artifacts.type.ArtifactTypeDefinition} attribute.
+ *
+ * @since 5.6
+ */
+@Incubating
+public interface Format extends Named {
+    Attribute<Format> FORMAT_ATTRIBUTE = Attribute.of("org.gradle.format", Format.class);
+
+    /**
+     * The JVM classes format
+     */
+    String CLASSES = "classes";
+
+    /**
+     * The JVM archive format
+     */
+    String JAR = "jar";
+
+    /**
+     * JVM resources
+     */
+    String RESOURCES = "resources";
+
+    /**
+     * Dependency metadata
+     */
+    String METADATA = "metadata";
+
+    /**
+     * Header files for C++
+     */
+    String HEADERS_CPLUSPLUS = "headers-cplusplus";
+
+    /**
+     * Link archives for native modules
+     */
+    String LINK_ARCHIVE = "link-archive";
+
+    /**
+     * Objects for native modules
+     */
+    String OBJECTS = "objects";
+
+    /**
+     * Dynamic libraries for native modules
+     */
+    String DYNAMIC_LIB = "dynamic-lib";
+
+    /**
+     * HTML format
+     */
+    String HTML = "html";
+
+
+    /**
+     * PDF format
+     */
+    String PDF = "pdf";
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/LibraryElements.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/LibraryElements.java
@@ -20,15 +20,13 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
- * Attribute representing the technical format of a variant.
- * <p>
- * This attribute is not about the packaging of the variant, which is represented by the {@link org.gradle.api.artifacts.type.ArtifactTypeDefinition} attribute.
+ * Attribute representing the technical elements of a library variant.
  *
  * @since 5.6
  */
 @Incubating
-public interface Format extends Named {
-    Attribute<Format> FORMAT_ATTRIBUTE = Attribute.of("org.gradle.format", Format.class);
+public interface LibraryElements extends Named {
+    Attribute<LibraryElements> LIBRARY_ELEMENTS_ATTRIBUTE = Attribute.of("org.gradle.libraryElements", LibraryElements.class);
 
     /**
      * The JVM classes format
@@ -44,11 +42,6 @@ public interface Format extends Named {
      * JVM resources
      */
     String RESOURCES = "resources";
-
-    /**
-     * Dependency metadata
-     */
-    String METADATA = "metadata";
 
     /**
      * Header files for C++
@@ -69,15 +62,4 @@ public interface Format extends Named {
      * Dynamic libraries for native modules
      */
     String DYNAMIC_LIB = "dynamic-lib";
-
-    /**
-     * HTML format
-     */
-    String HTML = "html";
-
-
-    /**
-     * PDF format
-     */
-    String PDF = "pdf";
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
@@ -41,7 +41,7 @@ public interface Usage extends Named {
      *
      * @since 4.0
      */
-    @Incubating
+    @Deprecated
     String JAVA_API_CLASSES = "java-api-classes";
 
     /**
@@ -49,7 +49,7 @@ public interface Usage extends Named {
      *
      * @since 5.3
      */
-    @Incubating
+    @Deprecated
     String JAVA_API_JARS = "java-api-jars";
 
     /**
@@ -65,7 +65,7 @@ public interface Usage extends Named {
      *
      * @since 4.0
      */
-    @Incubating
+    @Deprecated
     String JAVA_RUNTIME_JARS = "java-runtime-jars";
 
     /**
@@ -73,7 +73,7 @@ public interface Usage extends Named {
      *
      * @since 4.0
      */
-    @Incubating
+    @Deprecated
     String JAVA_RUNTIME_CLASSES = "java-runtime-classes";
 
     /**
@@ -81,7 +81,7 @@ public interface Usage extends Named {
      *
      * @since 4.0
      */
-    @Incubating
+    @Deprecated
     String JAVA_RUNTIME_RESOURCES = "java-runtime-resources";
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.initialization.dsl.ScriptHandler;
@@ -119,6 +120,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
             classpathConfiguration = configContainer.create(CLASSPATH_CONFIGURATION);
             AttributeContainer attributes = classpathConfiguration.getAttributes();
             attributes.attribute(Usage.USAGE_ATTRIBUTE, instantiator.named(Usage.class, Usage.JAVA_RUNTIME));
+            attributes.attribute(Format.FORMAT_ATTRIBUTE, instantiator.named(Format.class, Format.JAR));
             attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, instantiator.named(Bundling.class, Bundling.EXTERNAL));
             attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Bundling;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.initialization.dsl.ScriptHandler;
@@ -120,7 +120,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
             classpathConfiguration = configContainer.create(CLASSPATH_CONFIGURATION);
             AttributeContainer attributes = classpathConfiguration.getAttributes();
             attributes.attribute(Usage.USAGE_ATTRIBUTE, instantiator.named(Usage.class, Usage.JAVA_RUNTIME));
-            attributes.attribute(Format.FORMAT_ATTRIBUTE, instantiator.named(Format.class, Format.JAR));
+            attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, instantiator.named(LibraryElements.class, LibraryElements.JAR));
             attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, instantiator.named(Bundling.class, Bundling.EXTERNAL));
             attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -185,7 +185,7 @@ project(":b") {
                     variant('runtime')
                     module('org.other:externalA:1.2') {
                         byReason('also check dependency reasons')
-                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.category':'library', 'org.gradle.usage':'java-runtime', 'org.gradle.format': 'jar'])
+                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.category':'library', 'org.gradle.usage':'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -185,7 +185,7 @@ project(":b") {
                     variant('runtime')
                     module('org.other:externalA:1.2') {
                         byReason('also check dependency reasons')
-                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.category':'library', 'org.gradle.usage':'java-runtime'])
+                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.category':'library', 'org.gradle.usage':'java-runtime', 'org.gradle.format': 'jar'])
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -47,7 +47,8 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeResolved = false
                     canBeConsumed = true
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
+                        attribute(Format.FORMAT_ATTRIBUTE, project.objects.named(Format, 'jar'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
                         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
@@ -65,7 +66,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                 implementation project(':lib')
                 implementation (project(':lib')) {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
                     }
                     capabilities {
                         requireCapability('org:lib-fixtures')
@@ -81,11 +82,11 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api', 'org.gradle.format': 'jar', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
-                    variant "testFixtures", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "testFixtures", ['org.gradle.usage':'java-api', 'org.gradle.format': 'jar', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
                 }
             }
@@ -102,7 +103,8 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeResolved = false
                     canBeConsumed = true
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
+                        attribute(Format.FORMAT_ATTRIBUTE, project.objects.named(Format, 'jar'))
                         attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
                         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
@@ -130,7 +132,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api', 'org.gradle.format': 'jar', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -48,7 +48,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeConsumed = true
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
-                        attribute(Format.FORMAT_ATTRIBUTE, project.objects.named(Format, 'jar'))
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'jar'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
                         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
@@ -82,11 +82,11 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api', 'org.gradle.format': 'jar', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api', 'org.gradle.libraryElements': 'jar', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
-                    variant "testFixtures", ['org.gradle.usage':'java-api', 'org.gradle.format': 'jar', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "testFixtures", ['org.gradle.usage':'java-api', 'org.gradle.libraryElements': 'jar', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
                 }
             }
@@ -104,7 +104,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeConsumed = true
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
-                        attribute(Format.FORMAT_ATTRIBUTE, project.objects.named(Format, 'jar'))
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'jar'))
                         attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
                         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
@@ -132,7 +132,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api', 'org.gradle.format': 'jar', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api', 'org.gradle.libraryElements': 'jar', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -153,8 +153,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -258,8 +258,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', lifecycle: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', lifecycle: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', lifecycle: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', lifecycle: 'c2']
     }
 
     @RequiredFeatures(
@@ -355,7 +355,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:test:1.0') {
                     configuration = 'api'
-                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1'])
+                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1'])
                 }
             }
         }
@@ -401,16 +401,18 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
   - Variant 'api' capability org:test:1.0:
       - Incompatible attribute:
-          - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api-jars'.
+          - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api'.
       - Other attributes:
           - Required custom 'c1' and found compatible value 'c1'.
+          - Found org.gradle.format 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
   - Variant 'runtime' capability org:test:1.0:
       - Incompatible attribute:
           - Required custom 'c1' and found incompatible value 'c2'.
       - Other attributes:
+          - Found org.gradle.format 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
-          - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime-jars'""")
+          - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.""")
     }
 
     @RequiredFeatures(
@@ -462,8 +464,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
-        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
+        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -522,8 +524,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
-        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
+        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -569,16 +571,18 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
   - Variant 'api' capability org:test:1.0:
       - Incompatible attribute:
-          - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api-jars'.
+          - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api'.
       - Other attributes:
           - Required custom 'c1' and found compatible value 'c1'.
+          - Found org.gradle.format 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
   - Variant 'runtime' capability org:test:1.0:
       - Incompatible attribute:
           - Required custom 'c1' and found incompatible value 'c2'.
       - Other attributes:
+          - Found org.gradle.format 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
-          - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime-jars'""")
+          - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.""")
     }
 
     @RequiredFeatures(
@@ -708,8 +712,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
     }
 
 
@@ -858,8 +862,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -948,25 +952,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}-jars", custom: transitiveAttributeValueA])
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}-jars", custom: transitiveAttributeValueB])
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }
@@ -1045,25 +1049,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}-jars", custom: transitiveAttributeValueA])
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}-jars", custom: transitiveAttributeValueB])
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -153,8 +153,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -258,8 +258,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', lifecycle: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', lifecycle: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', lifecycle: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', lifecycle: 'c2']
     }
 
     @RequiredFeatures(
@@ -355,7 +355,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:test:1.0') {
                     configuration = 'api'
-                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1'])
+                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', custom: 'c1'])
                 }
             }
         }
@@ -404,13 +404,13 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
           - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api'.
       - Other attributes:
           - Required custom 'c1' and found compatible value 'c1'.
-          - Found org.gradle.format 'jar' but wasn't required.
+          - Found org.gradle.libraryElements 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
   - Variant 'runtime' capability org:test:1.0:
       - Incompatible attribute:
           - Required custom 'c1' and found incompatible value 'c2'.
       - Other attributes:
-          - Found org.gradle.format 'jar' but wasn't required.
+          - Found org.gradle.libraryElements 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
           - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.""")
     }
@@ -464,8 +464,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
-        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', custom: 'c1']
+        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -524,8 +524,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
-        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', custom: 'c1']
+        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -574,13 +574,13 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
           - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api'.
       - Other attributes:
           - Required custom 'c1' and found compatible value 'c1'.
-          - Found org.gradle.format 'jar' but wasn't required.
+          - Found org.gradle.libraryElements 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
   - Variant 'runtime' capability org:test:1.0:
       - Incompatible attribute:
           - Required custom 'c1' and found incompatible value 'c2'.
       - Other attributes:
-          - Found org.gradle.format 'jar' but wasn't required.
+          - Found org.gradle.libraryElements 'jar' but wasn't required.
           - Found org.gradle.status '${defaultStatus()}' but wasn't required.
           - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.""")
     }
@@ -712,8 +712,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', custom: 'c2']
     }
 
 
@@ -862,8 +862,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -952,25 +952,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueA])
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.libraryElements': 'jar', custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueB])
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.libraryElements': 'jar', custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }
@@ -1049,25 +1049,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueA])
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.libraryElements': 'jar', custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.format': 'jar', custom: transitiveAttributeValueB])
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.libraryElements': 'jar', custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.format': 'jar', custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryElements': 'jar', custom: configurationAttributeValue])
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -262,10 +262,10 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             resolve.expectGraph {
                 root(":", ":test:") {
                     edge('org:test:1.0', 'org:test:1.0') {
-                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2'])
+                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2'])
                     }
                     module('org:test:1.0') {
-                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2'])
+                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2'])
                     }
                 }
             }
@@ -358,7 +358,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                     byConflictResolution('between versions 1.1 and 1.0')
                     // the following assertion is true but limitations to the test fixtures make it hard to check
                     //variant('altruntime', [custom: 'c3', 'org.gradle.status': defaultStatus()])
-                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c2'
                     artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c3'
                 }
@@ -447,7 +447,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         then:
         failure.assertHasCause("""Multiple incompatible variants of org:foo:1.1 were selected:
    - Variant org:foo:1.1 variant altruntime has attributes {custom=c3, org.gradle.status=${defaultStatus()}}
-   - Variant org:foo:1.1 variant runtime has attributes {custom=c2, org.gradle.status=${defaultStatus()}, org.gradle.usage=java-runtime-jars}""")
+   - Variant org:foo:1.1 variant runtime has attributes {custom=c2, org.gradle.format=jar, org.gradle.status=${defaultStatus()}, org.gradle.usage=java-runtime}""")
 
     }
 
@@ -587,7 +587,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             root(":", ":test:") {
                 edge('org:foo:1.0', 'org:foo:1.1') {
                     byConflictResolution('between versions 1.1 and 1.0')
-                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c2'
                 }
                 module('org:bar:1.0') {
@@ -634,7 +634,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -262,10 +262,10 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             resolve.expectGraph {
                 root(":", ":test:") {
                     edge('org:test:1.0', 'org:test:1.0') {
-                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2'])
+                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', custom: 'c2'])
                     }
                     module('org:test:1.0') {
-                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', custom: 'c2'])
+                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', custom: 'c2'])
                     }
                 }
             }
@@ -358,7 +358,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                     byConflictResolution('between versions 1.1 and 1.0')
                     // the following assertion is true but limitations to the test fixtures make it hard to check
                     //variant('altruntime', [custom: 'c3', 'org.gradle.status': defaultStatus()])
-                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c2'
                     artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c3'
                 }
@@ -447,7 +447,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         then:
         failure.assertHasCause("""Multiple incompatible variants of org:foo:1.1 were selected:
    - Variant org:foo:1.1 variant altruntime has attributes {custom=c3, org.gradle.status=${defaultStatus()}}
-   - Variant org:foo:1.1 variant runtime has attributes {custom=c2, org.gradle.format=jar, org.gradle.status=${defaultStatus()}, org.gradle.usage=java-runtime}""")
+   - Variant org:foo:1.1 variant runtime has attributes {custom=c2, org.gradle.libraryElements=jar, org.gradle.status=${defaultStatus()}, org.gradle.usage=java-runtime}""")
 
     }
 
@@ -587,7 +587,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             root(":", ":test:") {
                 edge('org:foo:1.0', 'org:foo:1.1') {
                     byConflictResolution('between versions 1.1 and 1.0')
-                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c2'
                 }
                 module('org:bar:1.0') {
@@ -634,7 +634,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resolve.bundling
 
+import org.gradle.api.attributes.Format
 import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.Bundling
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
@@ -62,11 +63,13 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, 'external'
                 }
                 variant('fatApi') {
-                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-api-jars'
+                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-api'
+                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
                 variant('fatRuntime') {
-                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-runtime-jars'
+                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-runtime'
+                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
             }
@@ -96,7 +99,8 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                     variant('api', [
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.status': defaultStatus(),
-                            'org.gradle.usage': 'java-api-jars'
+                            'org.gradle.usage': 'java-api',
+                            'org.gradle.format': 'jar'
                     ])
                     module('org:transitive:1.0')
                 }
@@ -122,11 +126,13 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, 'external'
                 }
                 variant('fatApi') {
-                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-api-jars'
+                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-api'
+                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
                 variant('fatRuntime') {
-                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-runtime-jars'
+                    attribute Usage.USAGE_ATTRIBUTE.name, 'java-runtime'
+                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
             }
@@ -169,7 +175,8 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                         variant('fatApi', [
                                 'org.gradle.dependency.bundling': selected,
                                 'org.gradle.status': defaultStatus(),
-                                'org.gradle.usage': 'java-api-jars'
+                                'org.gradle.usage': 'java-api',
+                                'org.gradle.format': 'jar'
                         ])
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
@@ -16,7 +16,8 @@
 
 package org.gradle.integtests.resolve.bundling
 
-import org.gradle.api.attributes.Format
+
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.attributes.Bundling
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
@@ -64,12 +65,12 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                 }
                 variant('fatApi') {
                     attribute Usage.USAGE_ATTRIBUTE.name, 'java-api'
-                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
+                    attribute LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
                 variant('fatRuntime') {
                     attribute Usage.USAGE_ATTRIBUTE.name, 'java-runtime'
-                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
+                    attribute LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
             }
@@ -100,7 +101,7 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.status': defaultStatus(),
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.format': 'jar'
+                            'org.gradle.libraryElements': 'jar'
                     ])
                     module('org:transitive:1.0')
                 }
@@ -127,12 +128,12 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                 }
                 variant('fatApi') {
                     attribute Usage.USAGE_ATTRIBUTE.name, 'java-api'
-                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
+                    attribute LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
                 variant('fatRuntime') {
                     attribute Usage.USAGE_ATTRIBUTE.name, 'java-runtime'
-                    attribute Format.FORMAT_ATTRIBUTE.name, 'jar'
+                    attribute LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name, 'jar'
                     attribute Bundling.BUNDLING_ATTRIBUTE.name, bundling
                 }
             }
@@ -176,7 +177,7 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                                 'org.gradle.dependency.bundling': selected,
                                 'org.gradle.status': defaultStatus(),
                                 'org.gradle.usage': 'java-api',
-                                'org.gradle.format': 'jar'
+                                'org.gradle.libraryElements': 'jar'
                         ])
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -34,12 +34,14 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                 variant('runtime') {}
                 variant('feature1') {
                     capability('org', 'feature-1', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime-jars')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.format', 'jar')
                     artifact('feat1')
                 }
                 variant('feature2') {
                     capability('org', 'feature-2', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime-jars')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.format', 'jar')
                     artifact('feat2')
                 }
             }
@@ -69,11 +71,11 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {
-                    variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
+                    variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                 }
             }
@@ -88,12 +90,12 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                 variant('runtime') {}
                 variant('feature1') {
                     capability('org', 'feature-1', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime-jars')
+                    attribute('org.gradle.usage', 'java-runtime')
                     artifact('feat1')
                 }
                 variant('feature2') {
                     capability('org', 'feature-2', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime-jars')
+                    attribute('org.gradle.usage', 'java-runtime')
                     artifact('feat2')
                 }
             }
@@ -135,14 +137,16 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                 variant('v1') {
                     capability('org', 'feature-1', '1.0')
                     capability('org', 'feature-2', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime-jars')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.format', 'jar')
                     artifact('feat1')
                     artifact('feat2')
                 }
                 variant('v2') {
                     capability('org', 'feature-1', '1.0')
                     capability('org', 'feature-3', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime-jars')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.format', 'jar')
                     artifact('feat1')
                     artifact('feat3')
                 }
@@ -173,11 +177,11 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {
-                    variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
+                    variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat3'
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -35,13 +35,13 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                 variant('feature1') {
                     capability('org', 'feature-1', '1.0')
                     attribute('org.gradle.usage', 'java-runtime')
-                    attribute('org.gradle.format', 'jar')
+                    attribute('org.gradle.libraryElements', 'jar')
                     artifact('feat1')
                 }
                 variant('feature2') {
                     capability('org', 'feature-2', '1.0')
                     attribute('org.gradle.usage', 'java-runtime')
-                    attribute('org.gradle.format', 'jar')
+                    attribute('org.gradle.libraryElements', 'jar')
                     artifact('feat2')
                 }
             }
@@ -71,11 +71,11 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {
-                    variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                    variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                 }
             }
@@ -138,7 +138,7 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                     capability('org', 'feature-1', '1.0')
                     capability('org', 'feature-2', '1.0')
                     attribute('org.gradle.usage', 'java-runtime')
-                    attribute('org.gradle.format', 'jar')
+                    attribute('org.gradle.libraryElements', 'jar')
                     artifact('feat1')
                     artifact('feat2')
                 }
@@ -146,7 +146,7 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                     capability('org', 'feature-1', '1.0')
                     capability('org', 'feature-3', '1.0')
                     attribute('org.gradle.usage', 'java-runtime')
-                    attribute('org.gradle.format', 'jar')
+                    attribute('org.gradle.libraryElements', 'jar')
                     artifact('feat1')
                     artifact('feat3')
                 }
@@ -177,11 +177,11 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {
-                    variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                    variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat3'
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
@@ -86,7 +86,7 @@ class IvyGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependency
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api-jars'])
+                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
@@ -86,7 +86,7 @@ class IvyGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependency
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'])
+                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/ClassifierToVariantResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/ClassifierToVariantResolveIntegrationTest.groovy
@@ -49,15 +49,15 @@ class ClassifierToVariantResolveIntegrationTest extends AbstractHttpDependencyRe
     def "reasonable behavior when a Maven library uses a classifier to select a Gradle variant"() {
         def gradleLibrary = mavenHttpRepo.module("org", "lib", "1.0")
                 .adhocVariants()
-                .variant("apiElements", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'classic'])
-                .variant("runtimeElements", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'classic'])
-                .variant("apiElementsIndy", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'indy']) {
-            artifact("lib-1.0-indy.jar")
-        }
-        .variant("runtimeElementsIndy", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'indy']) {
-            artifact("lib-1.0-indy.jar")
-        }
-        .withGradleMetadataRedirection()
+                .variant("apiElements", ['org.gradle.usage': Usage.JAVA_API, 'groovy.runtime': 'classic'])
+                .variant("runtimeElements", ['org.gradle.usage': Usage.JAVA_RUNTIME, 'groovy.runtime': 'classic'])
+                .variant("apiElementsIndy", ['org.gradle.usage': Usage.JAVA_API, 'groovy.runtime': 'indy']) {
+                    artifact("lib-1.0-indy.jar")
+                }
+                .variant("runtimeElementsIndy", ['org.gradle.usage': Usage.JAVA_RUNTIME, 'groovy.runtime': 'indy']) {
+                    artifact("lib-1.0-indy.jar")
+                }
+                .withGradleMetadataRedirection()
                 .withModuleMetadata()
                 .publish()
         def mavenConsumer = mavenHttpRepo.module("org", "maven-consumer", "1.0")
@@ -84,7 +84,7 @@ class ClassifierToVariantResolveIntegrationTest extends AbstractHttpDependencyRe
                 module('org:maven-consumer:1.0') {
                     module('org:lib:1.0') {
                         variant('apiElementsIndy', [
-                                'org.gradle.usage': Usage.JAVA_API_JARS,
+                                'org.gradle.usage': Usage.JAVA_API,
                                 'org.gradle.status': 'release',
                                 'groovy.runtime': 'indy'])
                         artifact(name: 'lib', version: '1.0', classifier: 'indy')
@@ -105,15 +105,15 @@ class ClassifierToVariantResolveIntegrationTest extends AbstractHttpDependencyRe
     def "reasonable behavior when a Gradle consumer uses a classifier to select a Gradle variant"() {
         def gradleLibrary = mavenHttpRepo.module("org", "lib", "1.0")
                 .adhocVariants()
-                .variant("apiElements", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'classic'])
-                .variant("runtimeElements", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'classic'])
-                .variant("apiElementsIndy", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'indy']) {
-            artifact("lib-1.0-indy.jar")
-        }
-        .variant("runtimeElementsIndy", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'indy']) {
-            artifact("lib-1.0-indy.jar")
-        }
-        .withGradleMetadataRedirection()
+                .variant("apiElements", ['org.gradle.usage': Usage.JAVA_API, 'groovy.runtime': 'classic'])
+                .variant("runtimeElements", ['org.gradle.usage': Usage.JAVA_RUNTIME, 'groovy.runtime': 'classic'])
+                .variant("apiElementsIndy", ['org.gradle.usage': Usage.JAVA_API, 'groovy.runtime': 'indy']) {
+                    artifact("lib-1.0-indy.jar")
+                }
+                .variant("runtimeElementsIndy", ['org.gradle.usage': Usage.JAVA_RUNTIME, 'groovy.runtime': 'indy']) {
+                    artifact("lib-1.0-indy.jar")
+                }
+                .withGradleMetadataRedirection()
                 .withModuleMetadata()
                 .publish()
 
@@ -134,7 +134,7 @@ class ClassifierToVariantResolveIntegrationTest extends AbstractHttpDependencyRe
             root(":", ":test:") {
                 module('org:lib:1.0') {
                     variant('apiElementsIndy', [
-                            'org.gradle.usage': Usage.JAVA_API_JARS,
+                            'org.gradle.usage': Usage.JAVA_API,
                             'org.gradle.status': 'release',
                             'groovy.runtime': 'indy'])
                     artifact(name: 'lib', version: '1.0', classifier: 'indy')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -169,12 +169,12 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0") {
-                    variant("platform-runtime", ['org.gradle.category':'platform', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
+                    variant("platform-runtime", ['org.gradle.category':'platform', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime', 'org.gradle.format': 'metadata'])
                     constraint("group:moduleA:2.0")
                     noArtifacts()
                 }
                 module("group:bom:1.0") {
-                    variant("runtime", ['org.gradle.category':'library', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
+                    variant("runtime", ['org.gradle.category':'library', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime', 'org.gradle.format': 'jar'])
                     module("group:moduleC:1.0")
                     noArtifacts()
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -169,12 +169,12 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0") {
-                    variant("platform-runtime", ['org.gradle.category':'platform', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime', 'org.gradle.format': 'metadata'])
+                    variant("platform-runtime", ['org.gradle.category':'platform', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
                     constraint("group:moduleA:2.0")
                     noArtifacts()
                 }
                 module("group:bom:1.0") {
-                    variant("runtime", ['org.gradle.category':'library', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime', 'org.gradle.format': 'jar'])
+                    variant("runtime", ['org.gradle.category':'library', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime', 'org.gradle.libraryElements': 'jar'])
                     module("group:moduleC:1.0")
                     noArtifacts()
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
@@ -87,7 +87,7 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api-jars'])
+                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
@@ -87,7 +87,7 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'])
+                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve.platforms
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.Format
 import org.gradle.api.attributes.Usage
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
@@ -71,7 +72,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform'])
+                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform', 'org.gradle.format': 'metadata'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -115,7 +116,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("runtimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.category': 'platform'])
+                    variant("runtimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.category': 'platform', 'org.gradle.format': 'metadata'])
                     constraint("org:foo:1.1")
                     constraint("org:bar:1.2")
                     noArtifacts()
@@ -160,7 +161,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform'])
+                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform', 'org.gradle.format': 'metadata'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -201,7 +202,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("enforcedApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'enforced-platform'])
+                    variant("enforcedApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'enforced-platform', 'org.gradle.format': 'metadata'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -220,9 +221,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         def platform = mavenHttpRepo.module("org", "platform", "1.0")
                 .withModuleMetadata()
                 .adhocVariants()
-                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
+                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Format.FORMAT_ATTRIBUTE.name): Format.METADATA, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
                 .dependsOn("org", "foo", "1.0")
-                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
+                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Format.FORMAT_ATTRIBUTE.name): Format.METADATA, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
                     useDefaultArtifacts = false
                 }
                 .dependsOn("org", "foo", "1.0")
@@ -257,6 +258,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'enforced-platform',
                             'org.gradle.status': 'release',
+                            'org.gradle.format': 'metadata',
                     ])
                     module("org:foo:1.0")
                     noArtifacts()
@@ -297,6 +299,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
+                            'org.gradle.format': 'metadata',
                     ])
                     byConstraint()
                     noArtifacts()
@@ -306,6 +309,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
+                            'org.gradle.format': 'metadata',
                     ])
                 }
             }
@@ -351,6 +355,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                         'org.gradle.usage': 'java-api',
                         'org.gradle.category': 'platform',
                         'org.gradle.status': 'release',
+                        'org.gradle.format': 'metadata',
                     ])
                     byConstraint()
                     noArtifacts()
@@ -359,12 +364,14 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     variant("apiElements", ['org.gradle.category':'library',
                                             'org.gradle.dependency.bundling':'external',
                                             'org.gradle.jvm.version': JavaVersion.current().majorVersion,
-                                            'org.gradle.usage':'java-api-jars'])
+                                            'org.gradle.usage':'java-api',
+                                            'org.gradle.format': 'jar'])
                     constraint("org:platform:1.0", "org:platform:1.0") {
                         variant("platform-compile", [
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
+                            'org.gradle.format': 'metadata',
                         ])
                     }
                     artifact(name: 'main', noType: true)
@@ -399,7 +406,8 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     variant("enforced-platform-compile", [
                             'org.gradle.category': 'enforced-platform',
                             'org.gradle.status': 'release',
-                            'org.gradle.usage': 'java-api'])
+                            'org.gradle.usage': 'java-api',
+                            'org.gradle.format': 'metadata'])
                     noArtifacts()
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.platforms
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.Format
 import org.gradle.api.attributes.Usage
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
@@ -72,7 +71,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform', 'org.gradle.format': 'metadata'])
+                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -116,7 +115,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("runtimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.category': 'platform', 'org.gradle.format': 'metadata'])
+                    variant("runtimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.category': 'platform'])
                     constraint("org:foo:1.1")
                     constraint("org:bar:1.2")
                     noArtifacts()
@@ -161,7 +160,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform', 'org.gradle.format': 'metadata'])
+                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -202,7 +201,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("enforcedApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'enforced-platform', 'org.gradle.format': 'metadata'])
+                    variant("enforcedApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'enforced-platform'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -221,9 +220,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         def platform = mavenHttpRepo.module("org", "platform", "1.0")
                 .withModuleMetadata()
                 .adhocVariants()
-                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Format.FORMAT_ATTRIBUTE.name): Format.METADATA, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
+                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
                 .dependsOn("org", "foo", "1.0")
-                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Format.FORMAT_ATTRIBUTE.name): Format.METADATA, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
+                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
                     useDefaultArtifacts = false
                 }
                 .dependsOn("org", "foo", "1.0")
@@ -258,7 +257,6 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'enforced-platform',
                             'org.gradle.status': 'release',
-                            'org.gradle.format': 'metadata',
                     ])
                     module("org:foo:1.0")
                     noArtifacts()
@@ -299,7 +297,6 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
-                            'org.gradle.format': 'metadata',
                     ])
                     byConstraint()
                     noArtifacts()
@@ -309,7 +306,6 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
-                            'org.gradle.format': 'metadata',
                     ])
                 }
             }
@@ -355,7 +351,6 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                         'org.gradle.usage': 'java-api',
                         'org.gradle.category': 'platform',
                         'org.gradle.status': 'release',
-                        'org.gradle.format': 'metadata',
                     ])
                     byConstraint()
                     noArtifacts()
@@ -365,13 +360,12 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                                             'org.gradle.dependency.bundling':'external',
                                             'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                                             'org.gradle.usage':'java-api',
-                                            'org.gradle.format': 'jar'])
+                                            'org.gradle.libraryElements': 'jar'])
                     constraint("org:platform:1.0", "org:platform:1.0") {
                         variant("platform-compile", [
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
-                            'org.gradle.format': 'metadata',
                         ])
                     }
                     artifact(name: 'main', noType: true)
@@ -406,8 +400,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     variant("enforced-platform-compile", [
                             'org.gradle.category': 'enforced-platform',
                             'org.gradle.status': 'release',
-                            'org.gradle.usage': 'java-api',
-                            'org.gradle.format': 'metadata'])
+                            'org.gradle.usage': 'java-api'])
                     noArtifacts()
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
@@ -207,12 +207,14 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                         'org.gradle.dependency.bundling':'external',
                         'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                         'org.gradle.status':'release',
-                        'org.gradle.usage': 'java-api-jars']
+                        'org.gradle.usage': 'java-api',
+                        'org.gradle.format': 'jar']
                     module('com.acme.foo:platform:1.1') {
                         variant "apiElements", [
                             'org.gradle.category':'platform',
                             'org.gradle.status':'release',
-                            'org.gradle.usage': 'java-api']
+                            'org.gradle.usage': 'java-api',
+                            'org.gradle.format': 'metadata']
                         constraint('com.acme.foo:core:1.1')
                         constraint('com.acme.foo:lib:1.1')
                         noArtifacts()
@@ -223,7 +225,8 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                             'org.gradle.dependency.bundling':'external',
                             'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                             'org.gradle.status':'release',
-                            'org.gradle.usage': 'java-api-jars']
+                            'org.gradle.usage': 'java-api',
+                            'org.gradle.format': 'jar']
                         byConstraint("platform alignment")
                     }
                 }
@@ -233,12 +236,14 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                         'org.gradle.dependency.bundling':'external',
                         'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                         'org.gradle.status':'release',
-                        'org.gradle.usage': 'java-api-jars']
+                        'org.gradle.usage': 'java-api',
+                        'org.gradle.format': 'jar']
                     module('com.acme.foo:platform:1.1') {
                         variant "apiElements", [
                             'org.gradle.category':'platform',
                             'org.gradle.status':'release',
-                            'org.gradle.usage': 'java-api']
+                            'org.gradle.usage': 'java-api',
+                            'org.gradle.format': 'metadata']
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
@@ -208,13 +208,12 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                         'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                         'org.gradle.status':'release',
                         'org.gradle.usage': 'java-api',
-                        'org.gradle.format': 'jar']
+                        'org.gradle.libraryElements': 'jar']
                     module('com.acme.foo:platform:1.1') {
                         variant "apiElements", [
                             'org.gradle.category':'platform',
                             'org.gradle.status':'release',
-                            'org.gradle.usage': 'java-api',
-                            'org.gradle.format': 'metadata']
+                            'org.gradle.usage': 'java-api']
                         constraint('com.acme.foo:core:1.1')
                         constraint('com.acme.foo:lib:1.1')
                         noArtifacts()
@@ -226,7 +225,7 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                             'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                             'org.gradle.status':'release',
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.format': 'jar']
+                            'org.gradle.libraryElements': 'jar']
                         byConstraint("platform alignment")
                     }
                 }
@@ -237,13 +236,12 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                         'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                         'org.gradle.status':'release',
                         'org.gradle.usage': 'java-api',
-                        'org.gradle.format': 'jar']
+                        'org.gradle.libraryElements': 'jar']
                     module('com.acme.foo:platform:1.1') {
                         variant "apiElements", [
                             'org.gradle.category':'platform',
                             'org.gradle.status':'release',
-                            'org.gradle.usage': 'java-api',
-                            'org.gradle.format': 'metadata']
+                            'org.gradle.usage': 'java-api']
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -343,7 +343,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.test:projectA:1.0') {
-                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime-jars', 'thing': 'Bar'])
+                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', 'thing': 'Bar'])
                 }
             }
         }
@@ -355,7 +355,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.test:projectA:1.0') {
-                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime-jars', 'thing': 'Bar'])
+                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', 'thing': 'Bar'])
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -343,7 +343,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.test:projectA:1.0') {
-                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', 'thing': 'Bar'])
+                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', 'thing': 'Bar'])
                 }
             }
         }
@@ -355,7 +355,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.test:projectA:1.0') {
-                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar', 'thing': 'Bar'])
+                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar', 'thing': 'Bar'])
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
@@ -431,6 +431,7 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
@@ -429,10 +429,10 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.groupedOutput.task(':dependencyInsight').output.contains("""org:b:1
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : $expected

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -206,6 +206,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                                 expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                                 expectedAttributes['org.gradle.usage'] = 'java-api'
                                 expectedAttributes['org.gradle.category'] = 'library'
+                                expectedAttributes['org.gradle.format'] = 'jar'
                             }
                         }
                         variant(expectedTargetVariant, expectedAttributes)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -206,7 +206,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                                 expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                                 expectedAttributes['org.gradle.usage'] = 'java-api'
                                 expectedAttributes['org.gradle.category'] = 'library'
-                                expectedAttributes['org.gradle.format'] = 'jar'
+                                expectedAttributes['org.gradle.libraryElements'] = 'jar'
                             }
                         }
                         variant(expectedTargetVariant, expectedAttributes)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -66,15 +66,18 @@ project(':app') {
     dependencies {
         registerTransform {
             from.attribute(artifactType, 'java-classes-directory')
-            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API_CLASSES))
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+            from.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
             to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, 'size'))
             artifactTransform(FileSizer)
         }
         registerTransform {
             from.attribute(artifactType, 'jar')
-            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API_CLASSES))
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+            from.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
             to.attribute(artifactType, 'java-classes-directory')
-            to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API_CLASSES))
+            to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+            to.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
             artifactTransform(FileSizer)
         }
     }
@@ -169,7 +172,7 @@ project(':app') {
 
     dependencies {
         registerTransform {
-            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API_CLASSES))
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
             from.attribute(artifactType, 'java-classes-directory')
             to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
             to.attribute(artifactType, 'final')
@@ -182,9 +185,11 @@ project(':app') {
             artifactTransform(TestTransform)
         }
         registerTransform {
-            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API_JARS))
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+            from.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
             from.attribute(artifactType, 'jar')
             to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+            to.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
             to.attribute(artifactType, 'magic-jar')
 
             if (project.hasProperty('extraAttribute')) {
@@ -605,7 +610,7 @@ task resolve(type: Copy) {
         succeeds "resolve"
 
         then:
-        output.contains('variants: [{artifactType=size, org.gradle.dependency.bundling=external, org.gradle.usage=java-api}]')
+        output.contains('variants: [{artifactType=size, org.gradle.dependency.bundling=external, org.gradle.format=jar, org.gradle.usage=java-api}]')
 
         where:
         apiFirst << [true, false]

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -67,17 +67,17 @@ project(':app') {
         registerTransform {
             from.attribute(artifactType, 'java-classes-directory')
             from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
-            from.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+            from.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
             to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, 'size'))
             artifactTransform(FileSizer)
         }
         registerTransform {
             from.attribute(artifactType, 'jar')
             from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
-            from.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+            from.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
             to.attribute(artifactType, 'java-classes-directory')
             to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
-            to.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+            to.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
             artifactTransform(FileSizer)
         }
     }
@@ -186,10 +186,10 @@ project(':app') {
         }
         registerTransform {
             from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-            from.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+            from.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
             from.attribute(artifactType, 'jar')
             to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-            to.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+            to.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
             to.attribute(artifactType, 'magic-jar')
 
             if (project.hasProperty('extraAttribute')) {
@@ -610,7 +610,7 @@ task resolve(type: Copy) {
         succeeds "resolve"
 
         then:
-        output.contains('variants: [{artifactType=size, org.gradle.dependency.bundling=external, org.gradle.format=jar, org.gradle.usage=java-api}]')
+        output.contains('variants: [{artifactType=size, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, org.gradle.usage=java-api}]')
 
         where:
         apiFirst << [true, false]

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -74,6 +74,14 @@ public class GradleModuleMetadataParser {
         this.excludeRuleConverter = new DefaultExcludeRuleConverter(moduleIdentifierFactory);
     }
 
+    public ImmutableAttributesFactory getAttributesFactory() {
+        return attributesFactory;
+    }
+
+    public NamedObjectInstantiator getInstantiator() {
+        return instantiator;
+    }
+
     public void parse(final LocallyAvailableExternalResource resource, final MutableModuleComponentResolveMetadata metadata) {
         resource.withContent(new Transformer<Void, InputStream>() {
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -406,7 +406,7 @@ public class DependencyGraphBuilder {
             Object v1 = firstAttributes.getAttribute(attribute);
             Object v2 = secondAttributes.getAttribute(attribute);
             // for all commons attributes, make sure they are compatible with each other
-            if (!compatible(rule, v1, v2) || !compatible(rule, v2, v1)) {
+            if (!compatible(rule, v1, v2) && !compatible(rule, v2, v1)) {
                 incompatibleNodes.add(first);
                 incompatibleNodes.add(second);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
@@ -41,12 +41,14 @@ import java.util.List;
  */
 public class DefaultGradleModuleMetadataSource extends AbstractMetadataSource<MutableModuleComponentResolveMetadata> {
     private final GradleModuleMetadataParser metadataParser;
+    private final GradleModuleMetadataCompatibilityConverter metadataCompatibilityConverter;
     private final MutableModuleMetadataFactory<? extends MutableModuleComponentResolveMetadata> mutableModuleMetadataFactory;
     private final boolean listVersions;
 
     @Inject
     public DefaultGradleModuleMetadataSource(GradleModuleMetadataParser metadataParser, MutableModuleMetadataFactory<? extends MutableModuleComponentResolveMetadata> mutableModuleMetadataFactory, boolean listVersions) {
         this.metadataParser = metadataParser;
+        this.metadataCompatibilityConverter = new GradleModuleMetadataCompatibilityConverter(metadataParser.getAttributesFactory(), metadataParser.getInstantiator());
         this.mutableModuleMetadataFactory = mutableModuleMetadataFactory;
         this.listVersions = listVersions;
     }
@@ -58,6 +60,7 @@ public class DefaultGradleModuleMetadataSource extends AbstractMetadataSource<Mu
         if (gradleMetadataArtifact != null) {
             MutableModuleComponentResolveMetadata metaDataFromResource = mutableModuleMetadataFactory.create(moduleComponentIdentifier);
             metadataParser.parse(gradleMetadataArtifact, metaDataFromResource);
+            metadataCompatibilityConverter.process(metaDataFromResource);
             return metaDataFromResource;
         }
         return null;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -19,6 +19,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -80,6 +81,7 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
+            result = concat(result, FORMAT_ATTRIBUTE, new CoercingStringValueSnapshot(Format.JAR, objectInstantiator));
             result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.LIBRARY, objectInstantiator));
             concatCache.put(entry, result);
         }
@@ -93,6 +95,7 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
+            result = concat(result, FORMAT_ATTRIBUTE, new CoercingStringValueSnapshot(Format.METADATA, objectInstantiator));
             result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(componentType, objectInstantiator));
             concatCache.put(entry, result);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -19,7 +19,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -81,7 +81,7 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
-            result = concat(result, FORMAT_ATTRIBUTE, new CoercingStringValueSnapshot(Format.JAR, objectInstantiator));
+            result = concat(result, FORMAT_ATTRIBUTE, new CoercingStringValueSnapshot(LibraryElements.JAR, objectInstantiator));
             result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.LIBRARY, objectInstantiator));
             concatCache.put(entry, result);
         }
@@ -95,7 +95,6 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
-            result = concat(result, FORMAT_ATTRIBUTE, new CoercingStringValueSnapshot(Format.METADATA, objectInstantiator));
             result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(componentType, objectInstantiator));
             concatCache.put(entry, result);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.metadata;
+
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.component.external.model.MutableComponentVariant;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
+
+public class GradleModuleMetadataCompatibilityConverter {
+
+    public static final Attribute<String> USAGE_STING_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
+    public static final Attribute<String> FORMAT_STRING_ATTRIBUTE = Attribute.of(Format.FORMAT_ATTRIBUTE.getName(), String.class);
+
+    private ImmutableAttributesFactory attributesFactory;
+    private NamedObjectInstantiator instantiator;
+
+    public GradleModuleMetadataCompatibilityConverter(ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator instantiator) {
+        this.attributesFactory = attributesFactory;
+        this.instantiator = instantiator;
+    }
+
+    public void process(MutableModuleComponentResolveMetadata metaDataFromResource) {
+        for (MutableComponentVariant variant : metaDataFromResource.getMutableVariants()) {
+            ImmutableAttributes attributes = variant.getAttributes();
+            ImmutableAttributes updatedAttributes = ImmutableAttributes.EMPTY;
+            if (attributes.contains(USAGE_STING_ATTRIBUTE)) {
+                String attributeValue = attributes.getAttribute(USAGE_STING_ATTRIBUTE);
+                if (attributeValue.endsWith("-jars")) {
+                    updatedAttributes = attributesFactory.concat(updatedAttributes, USAGE_STING_ATTRIBUTE, new CoercingStringValueSnapshot(attributeValue.replace("-jars", ""), instantiator));
+                }
+            }
+            if (!updatedAttributes.isEmpty() && !attributes.contains(FORMAT_STRING_ATTRIBUTE)) {
+                updatedAttributes = attributesFactory.concat(updatedAttributes, FORMAT_STRING_ATTRIBUTE, new CoercingStringValueSnapshot(Format.JAR, instantiator));
+            }
+            if (!updatedAttributes.isEmpty()) {
+                updatedAttributes = attributesFactory.concat(attributes, updatedAttributes);
+                variant.setAttributes(updatedAttributes);
+            }
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -29,7 +29,7 @@ import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 public class GradleModuleMetadataCompatibilityConverter {
 
     public static final Attribute<String> USAGE_STING_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
-    public static final Attribute<String> FORMAT_STRING_ATTRIBUTE = Attribute.of(Format.FORMAT_ATTRIBUTE.getName(), String.class);
+    public static final Attribute<String> FORMAT_STRING_ATTRIBUTE = Attribute.of(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.getName(), String.class);
 
     private ImmutableAttributesFactory attributesFactory;
     private NamedObjectInstantiator instantiator;
@@ -50,7 +50,7 @@ public class GradleModuleMetadataCompatibilityConverter {
                 }
             }
             if (!updatedAttributes.isEmpty() && !attributes.contains(FORMAT_STRING_ATTRIBUTE)) {
-                updatedAttributes = attributesFactory.concat(updatedAttributes, FORMAT_STRING_ATTRIBUTE, new CoercingStringValueSnapshot(Format.JAR, instantiator));
+                updatedAttributes = attributesFactory.concat(updatedAttributes, FORMAT_STRING_ATTRIBUTE, new CoercingStringValueSnapshot(LibraryElements.JAR, instantiator));
             }
             if (!updatedAttributes.isEmpty()) {
                 updatedAttributes = attributesFactory.concat(attributes, updatedAttributes);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -30,6 +31,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 public interface MavenImmutableAttributesFactory extends ImmutableAttributesFactory {
     // We need to work with the 'String' version of the usage attribute, since this is expected for all providers by the `PreferJavaRuntimeVariant` schema
     Attribute<String> USAGE_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
+    Attribute<String> FORMAT_ATTRIBUTE = Attribute.of(Format.FORMAT_ATTRIBUTE.getName(), String.class);
     Attribute<String> CATEGORY_ATTRIBUTE = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class);
 
     ImmutableAttributes libraryWithUsage(ImmutableAttributes original, String usage);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -31,7 +31,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 public interface MavenImmutableAttributesFactory extends ImmutableAttributesFactory {
     // We need to work with the 'String' version of the usage attribute, since this is expected for all providers by the `PreferJavaRuntimeVariant` schema
     Attribute<String> USAGE_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
-    Attribute<String> FORMAT_ATTRIBUTE = Attribute.of(Format.FORMAT_ATTRIBUTE.getName(), String.class);
+    Attribute<String> FORMAT_ATTRIBUTE = Attribute.of(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.getName(), String.class);
     Attribute<String> CATEGORY_ATTRIBUTE = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class);
 
     ImmutableAttributes libraryWithUsage(ImmutableAttributes original, String usage);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -238,6 +238,11 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     }
 
     @Override
+    public List<? extends MutableComponentVariant> getMutableVariants() {
+        return newVariants;
+    }
+
+    @Override
     public ImmutableAttributesFactory getAttributesFactory() {
         return attributesFactory;
     }
@@ -261,11 +266,12 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
 
     protected static class MutableVariantImpl implements MutableComponentVariant {
         private final String name;
-        private final ImmutableAttributes attributes;
         private final List<DependencyImpl> dependencies = Lists.newArrayList();
         private final List<DependencyConstraintImpl> dependencyConstraints = Lists.newArrayList();
         private final List<FileImpl> files = Lists.newArrayList();
         private final List<ImmutableCapability> capabilities = Lists.newArrayList();
+
+        private ImmutableAttributes attributes;
 
         MutableVariantImpl(String name, ImmutableAttributes attributes) {
             this.name = name;
@@ -294,6 +300,16 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
 
         public String getName() {
             return name;
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            return attributes;
+        }
+
+        @Override
+        public void setAttributes(ImmutableAttributes updatedAttributes) {
+            this.attributes = updatedAttributes;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -31,4 +31,8 @@ public interface MutableComponentVariant {
     void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes);
 
     void addCapability(String group, String name, String version);
+
+    ImmutableAttributes getAttributes();
+
+    void setAttributes(ImmutableAttributes updatedAttributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -99,4 +99,6 @@ public interface MutableModuleComponentResolveMetadata {
 
     @Nullable
     Set<? extends ComponentIdentifier> getPlatformOwners();
+
+    List<? extends MutableComponentVariant> getMutableVariants();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -17,7 +17,7 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.Sets;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.DisambiguationRule;
 import org.gradle.api.internal.attributes.EmptySchema;
@@ -38,15 +38,15 @@ import java.util.Set;
  * declaring no preference for a particular variant.
  */
 public class PreferJavaRuntimeVariant extends EmptySchema {
-    private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Sets.newHashSet(Usage.USAGE_ATTRIBUTE, Format.FORMAT_ATTRIBUTE);
+    private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Sets.newHashSet(Usage.USAGE_ATTRIBUTE, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
     private final PreferRuntimeVariantUsageDisambiguationRule usageDisambiguationRule;
     private final PreferJarVariantUsageDisambiguationRule formatDisambiguationRule;
 
     public PreferJavaRuntimeVariant(NamedObjectInstantiator instantiator) {
         Usage runtimeUsage = instantiator.named(Usage.class, Usage.JAVA_RUNTIME);
-        Format jarFormat = instantiator.named(Format.class, Format.JAR);
+        LibraryElements jarLibraryElements = instantiator.named(LibraryElements.class, LibraryElements.JAR);
         usageDisambiguationRule = new PreferRuntimeVariantUsageDisambiguationRule(runtimeUsage);
-        formatDisambiguationRule = new PreferJarVariantUsageDisambiguationRule(jarFormat);
+        formatDisambiguationRule = new PreferJarVariantUsageDisambiguationRule(jarLibraryElements);
     }
 
     @Override
@@ -59,7 +59,7 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
         if (Usage.USAGE_ATTRIBUTE.equals(attribute)) {
             return Cast.uncheckedCast(usageDisambiguationRule);
         }
-        if (Format.FORMAT_ATTRIBUTE.equals(attribute)) {
+        if (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.equals(attribute)) {
             return Cast.uncheckedCast(formatDisambiguationRule);
         }
         return super.disambiguationRules(attribute);
@@ -88,11 +88,11 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
         }
     }
 
-    private static class PreferJarVariantUsageDisambiguationRule implements DisambiguationRule<Format> {
-        private final Format jarFormat;
+    private static class PreferJarVariantUsageDisambiguationRule implements DisambiguationRule<LibraryElements> {
+        private final LibraryElements jarLibraryElements;
 
-        public PreferJarVariantUsageDisambiguationRule(Format jarFormat) {
-            this.jarFormat = jarFormat;
+        public PreferJarVariantUsageDisambiguationRule(LibraryElements jarLibraryElements) {
+            this.jarLibraryElements = jarLibraryElements;
         }
 
         @Override
@@ -101,11 +101,11 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
         }
 
         @Override
-        public void execute(MultipleCandidatesResult<Format> details) {
+        public void execute(MultipleCandidatesResult<LibraryElements> details) {
             if (details.getConsumerValue() == null) {
-                Set<Format> candidates = details.getCandidateValues();
-                if (candidates.contains(jarFormat)) {
-                    details.closestMatch(jarFormat);
+                Set<LibraryElements> candidates = details.getCandidateValues();
+                if (candidates.contains(jarLibraryElements)) {
+                    details.closestMatch(jarLibraryElements);
                 }
             }
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/PreferJavaRuntimeVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/PreferJavaRuntimeVariantTest.groovy
@@ -47,7 +47,7 @@ class PreferJavaRuntimeVariantTest extends Specification {
         null               | [Usage.JAVA_RUNTIME, Usage.JAVA_API]            | true
         null               | [Usage.JAVA_API, Usage.JAVA_RUNTIME]            | true
         null               | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | true
-        null               | [Usage.JAVA_API, Usage.JAVA_API_CLASSES]        | false
+        null               | [Usage.JAVA_API, "unknown"]                     | false
         Usage.JAVA_API     | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | false
         Usage.JAVA_RUNTIME | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | false
         "unknown"          | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | false

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
@@ -459,16 +459,16 @@ class ComponentAttributeMatcherTest extends Specification {
             attribute(usage)
             attribute(bundling)
             attribute(status)
-            accept(usage, 'java-api', 'java-api-jars')
-            accept(usage, 'java-api', 'java-runtime-jars')
-            prefer(usage, 'java-api-jars')
+            accept(usage, 'java-api', 'java-api-extra')
+            accept(usage, 'java-api', 'java-runtime-extra')
+            prefer(usage, 'java-api-extra')
         }
 
         def requested = attributes(usage: 'java-api')
-        def candidate1 = attributes(usage: 'java-api-jars', status: 'integration')
-        def candidate2 = attributes(usage: 'java-runtime-jars', status: 'integration')
-        def candidate3 = attributes(usage: 'java-api-jars', status: 'integration', bundling: 'embedded')
-        def candidate4 = attributes(usage: 'java-runtime-jars', status: 'integration', bundling: 'embedded')
+        def candidate1 = attributes(usage: 'java-api-extra', status: 'integration')
+        def candidate2 = attributes(usage: 'java-runtime-extra', status: 'integration')
+        def candidate3 = attributes(usage: 'java-api-extra', status: 'integration', bundling: 'embedded')
+        def candidate4 = attributes(usage: 'java-runtime-extra', status: 'integration', bundling: 'embedded')
 
         when:
         def result = matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null)
@@ -477,10 +477,10 @@ class ComponentAttributeMatcherTest extends Specification {
         result == [candidate1]
 
         when: // check with a different attribute order
-        candidate1 = attributes(usage: 'java-api-jars', status: 'integration')
-        candidate2 = attributes(usage: 'java-runtime-jars', status: 'integration')
-        candidate3 = attributes(usage: 'java-api-jars', bundling: 'embedded', status: 'integration')
-        candidate4 = attributes(usage: 'java-runtime-jars', bundling: 'embedded', status: 'integration')
+        candidate1 = attributes(usage: 'java-api-extra', status: 'integration')
+        candidate2 = attributes(usage: 'java-runtime-extra', status: 'integration')
+        candidate3 = attributes(usage: 'java-api-extra', bundling: 'embedded', status: 'integration')
+        candidate4 = attributes(usage: 'java-runtime-extra', bundling: 'embedded', status: 'integration')
 
         result = matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null)
 
@@ -488,10 +488,10 @@ class ComponentAttributeMatcherTest extends Specification {
         result == [candidate1]
 
         when: // yet another attribute order
-        candidate1 = attributes(status: 'integration', usage: 'java-api-jars')
-        candidate2 = attributes(usage: 'java-runtime-jars', status: 'integration')
-        candidate3 = attributes(bundling: 'embedded', status: 'integration', usage: 'java-api-jars')
-        candidate4 = attributes(status: 'integration', usage: 'java-runtime-jars', bundling: 'embedded')
+        candidate1 = attributes(status: 'integration', usage: 'java-api-extra')
+        candidate2 = attributes(usage: 'java-runtime-extra', status: 'integration')
+        candidate3 = attributes(bundling: 'embedded', status: 'integration', usage: 'java-api-extra')
+        candidate4 = attributes(status: 'integration', usage: 'java-runtime-extra', bundling: 'embedded')
 
         result = matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null)
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -151,6 +151,7 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -205,6 +206,7 @@ org:leaf2:2.5
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -261,6 +263,7 @@ org:leaf:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -283,6 +286,7 @@ org:leaf:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -339,6 +343,7 @@ org:leaf2:2.5
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -412,6 +417,7 @@ org:leaf2:2.5
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -584,6 +590,7 @@ org:leaf:1.0 (forced)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -605,6 +612,7 @@ org:leaf:1.0 (selected by rule)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -648,6 +656,7 @@ org:leaf:2
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -760,6 +769,7 @@ org:bar:2.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -823,6 +833,7 @@ org.test:bar:2.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -835,6 +846,7 @@ org:baz:1.0 (selected by rule)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -845,6 +857,7 @@ org:foo:2.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -893,6 +906,7 @@ org:baz:2.0 (selected by rule)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -903,6 +917,7 @@ org:bar:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -950,6 +965,7 @@ org:new-leaf:77 (selected by rule)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -999,6 +1015,7 @@ org:leaf:2.0 -> org:new-leaf:77
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -1011,6 +1028,7 @@ org:foo:2.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -1104,6 +1122,7 @@ org:leaf:2.0 (forced)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -1152,6 +1171,7 @@ org:leaf:1.5 (forced)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -1201,6 +1221,7 @@ org:leaf:1.0 (forced)
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -1249,6 +1270,7 @@ org:leaf:2.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
    Selection reasons:
@@ -1662,6 +1684,7 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -1705,11 +1728,13 @@ org:leaf2:1.0
 project :
    variant "runtimeClasspath" [
       org.gradle.usage               = java-runtime
+      org.gradle.format              = jar
       org.gradle.dependency.bundling = external
       org.gradle.jvm.version         = $jvmVersion
    ]
    variant "runtimeElements" [
-      org.gradle.usage               = java-runtime-jars (compatible with: java-runtime)
+      org.gradle.usage               = java-runtime
+      org.gradle.format              = jar
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = $jvmVersion
@@ -1761,6 +1786,7 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
+      org.gradle.format              = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -1813,7 +1839,8 @@ org:leaf2:1.0
         outputContains """
 project :impl
    variant "apiElements" [
-      org.gradle.usage               = java-api-jars (compatible with: java-api)
+      org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = $jvmVersion
@@ -1867,6 +1894,7 @@ org:leaf4:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -1905,6 +1933,7 @@ org:leaf1:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -1925,6 +1954,7 @@ org:leaf2:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -1984,7 +2014,8 @@ org:leaf2:1.0
         outputContains """
 project :api
    variant "apiElements" [
-      org.gradle.usage               = java-api-jars (compatible with: java-api)
+      org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
@@ -2002,7 +2033,8 @@ project :api
         outputContains """
 project :some:deeply:nested
    variant "apiElements" [
-      org.gradle.usage               = java-api-jars (compatible with: java-api)
+      org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
@@ -2019,7 +2051,8 @@ project :some:deeply:nested
         outputContains """
 project :some:deeply:nested
    variant "apiElements" [
-      org.gradle.usage               = java-api-jars (compatible with: java-api)
+      org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
@@ -2072,6 +2105,7 @@ org:leaf3:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2122,6 +2156,7 @@ org:leaf3:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -2132,6 +2167,7 @@ foo:foo:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -2176,6 +2212,7 @@ foo:foo:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2232,6 +2269,7 @@ org:foo -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2285,6 +2323,7 @@ org:foo -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2335,6 +2374,7 @@ org:foo:${displayVersion} -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2391,6 +2431,7 @@ org:foo:[1.1,1.3] -> 1.3
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2407,6 +2448,7 @@ org:foo:1.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2467,6 +2509,7 @@ org:bar:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2484,6 +2527,7 @@ org:foo:1.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2529,6 +2573,7 @@ org:leaf:1.0 (by constraint)
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2582,6 +2627,7 @@ org.test:leaf:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2631,6 +2677,7 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -2764,6 +2811,7 @@ org:foo:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2821,6 +2869,7 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2887,6 +2936,7 @@ org:foo:1.0
       color                          = blue
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2897,11 +2947,13 @@ org:foo:1.0
       - Rejection : version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
+          - Attribute 'org.gradle.format' didn't match. Requested 'classes', was: not found
           - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
+          - Attribute 'org.gradle.format' didn't match. Requested 'classes', was: not found
           - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
 
@@ -2962,6 +3014,7 @@ planet:mercury:1.0.2
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2993,6 +3046,7 @@ planet:venus:2.0.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -3024,6 +3078,7 @@ planet:pluto:1.0.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -149,10 +149,10 @@ No dependencies matching given input were found in configuration ':conf'
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -204,10 +204,10 @@ org:leaf2:1.0
 Task :dependencyInsight
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 2.5, 1.5 and 1.0
@@ -261,10 +261,10 @@ org:leaf2:1.5 -> 2.5
         outputContains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0
@@ -284,10 +284,10 @@ org:leaf:1.0
         outputContains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0
@@ -341,10 +341,10 @@ org:leaf:1.0
 
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 2.5, 1.5 and 1.0
@@ -415,10 +415,10 @@ org:leaf2:1.5 -> 2.5
 
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 2.5, 1.5 and 1.0
@@ -588,10 +588,10 @@ org:foo:1.+ FAILED
         outputContains """
 org:leaf:1.0 (forced)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0
@@ -610,10 +610,10 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:1.0 (selected by rule)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0
@@ -654,10 +654,10 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:2
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Was requested : didn't match version 3 because testing stuff
@@ -767,10 +767,10 @@ org:leaf:latest.integration -> 1.0
         outputContains """
 org:bar:2.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Forced
@@ -831,10 +831,10 @@ org:foo:1.0 -> org:bar:2.0
         outputContains """
 org.test:bar:2.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : why not?
@@ -844,10 +844,10 @@ org:bar:1.0 -> org.test:bar:2.0
 
 org:baz:1.0 (selected by rule)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:baz:1.0
@@ -855,10 +855,10 @@ org:baz:1.0
 
 org:foo:2.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : because I am in control
@@ -904,10 +904,10 @@ org:foo:1.0 -> 2.0
         outputContains """
 org:baz:2.0 (selected by rule)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:baz:1.1 -> 2.0
@@ -915,10 +915,10 @@ org:baz:1.1 -> 2.0
 
 org:bar:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : foo superseded by bar
@@ -963,10 +963,10 @@ org:foo:1.0 -> org:bar:1.0
         outputContains """
 org:new-leaf:77 (selected by rule)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0 -> org:new-leaf:77
@@ -1013,10 +1013,10 @@ org:leaf:2.0 -> org:new-leaf:77
         then:
         outputContains """org:bar:2.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : I am not sure I want to explain
@@ -1026,10 +1026,10 @@ org:bar:1.0 -> 2.0
 
 org:foo:2.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : I want to
@@ -1120,10 +1120,10 @@ org:leaf:latest.integration -> 1.6
         outputContains """
 org:leaf:2.0 (forced)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:2.0
@@ -1169,10 +1169,10 @@ org:leaf:1.0 -> 2.0
         outputContains """
 org:leaf:1.5 (forced)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0 -> 1.5
@@ -1219,10 +1219,10 @@ org:leaf:2.0 -> 1.5
         outputContains """
 org:leaf:1.0 (forced)
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0
@@ -1268,10 +1268,10 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:2.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
    Selection reasons:
       - Forced
@@ -1682,10 +1682,10 @@ project :C FAILED
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -1728,13 +1728,13 @@ org:leaf2:1.0
 project :
    variant "runtimeClasspath" [
       org.gradle.usage               = java-runtime
-      org.gradle.format              = jar
+      org.gradle.libraryElements     = jar
       org.gradle.dependency.bundling = external
       org.gradle.jvm.version         = $jvmVersion
    ]
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime
-      org.gradle.format              = jar
+      org.gradle.libraryElements     = jar
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = $jvmVersion
@@ -1786,7 +1786,7 @@ org:leaf2:1.0
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.format              = jar
+      org.gradle.libraryElements     = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -1840,7 +1840,7 @@ org:leaf2:1.0
 project :impl
    variant "apiElements" [
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = $jvmVersion
@@ -1894,7 +1894,7 @@ org:leaf4:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -1933,7 +1933,7 @@ org:leaf1:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -1954,7 +1954,7 @@ org:leaf2:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2015,7 +2015,7 @@ org:leaf2:1.0
 project :api
    variant "apiElements" [
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
@@ -2034,7 +2034,7 @@ project :api
 project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
@@ -2052,7 +2052,7 @@ project :some:deeply:nested
 project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
       org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
@@ -2105,7 +2105,7 @@ org:leaf3:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2154,10 +2154,10 @@ org:leaf3:1.0
         then:
         result.groupedOutput.task(":dependencyInsight").output.contains("""foo:bar:2.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 foo:bar:2.0
@@ -2165,10 +2165,10 @@ foo:bar:2.0
 
 foo:foo:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 foo:foo:1.0
@@ -2212,7 +2212,7 @@ foo:foo:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2269,7 +2269,7 @@ org:foo -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2323,7 +2323,7 @@ org:foo -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2374,7 +2374,7 @@ org:foo:${displayVersion} -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2431,7 +2431,7 @@ org:foo:[1.1,1.3] -> 1.3
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2448,7 +2448,7 @@ org:foo:1.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2509,7 +2509,7 @@ org:bar:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2527,7 +2527,7 @@ org:foo:1.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2573,7 +2573,7 @@ org:leaf:1.0 (by constraint)
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2627,7 +2627,7 @@ org.test:leaf:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2675,10 +2675,10 @@ org.test:leaf:1.0
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -2811,7 +2811,7 @@ org:foo:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2869,7 +2869,7 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2936,7 +2936,7 @@ org:foo:1.0
       color                          = blue
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -2947,14 +2947,14 @@ org:foo:1.0
       - Rejection : version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
-          - Attribute 'org.gradle.format' didn't match. Requested 'classes', was: not found
           - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
+          - Attribute 'org.gradle.libraryElements' didn't match. Requested 'classes', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
-          - Attribute 'org.gradle.format' didn't match. Requested 'classes', was: not found
           - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
+          - Attribute 'org.gradle.libraryElements' didn't match. Requested 'classes', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
 
 org:foo:[1.0,) -> 1.0
@@ -3014,7 +3014,7 @@ planet:mercury:1.0.2
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -3046,7 +3046,7 @@ planet:venus:2.0.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -3078,7 +3078,7 @@ planet:pluto:1.0.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -66,8 +66,8 @@ project :$expectedProject
 
         where:
         configuration      | expectedProject | expectedVariant   | expectedAttributes
-        'compileClasspath' | 'b'             | 'apiElements'     | 'org.gradle.usage               = java-api-jars (compatible with: java-api)'
-        'runtimeClasspath' | 'c'             | 'runtimeElements' | 'org.gradle.usage               = java-runtime-jars (compatible with: java-runtime)'
+        'compileClasspath' | 'b'             | 'apiElements'     | 'org.gradle.usage               = java-api\n      org.gradle.format              = jar (compatible with: classes)'
+        'runtimeClasspath' | 'c'             | 'runtimeElements' | 'org.gradle.usage               = java-runtime\n      org.gradle.format              = jar'
     }
 
     def "shows published variant details"() {
@@ -75,7 +75,7 @@ project :$expectedProject
         mavenRepo.with {
             def leaf = module('org.test', 'leaf', '1.0')
                 .withModuleMetadata()
-                .variant('api', ['org.gradle.usage': 'java-api', 'org.gradle.test': 'published attribute'])
+                .variant('api', ['org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', 'org.gradle.test': 'published attribute'])
                 .publish()
             module('org.test', 'a', '1.0')
                 .dependsOn(leaf)
@@ -105,6 +105,7 @@ project :$expectedProject
         outputContains """org.test:leaf:1.0
    variant "api" [
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.test                = published attribute (not requested)
       org.gradle.status              = release (not requested)
 
@@ -181,6 +182,7 @@ org:leaf:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -221,6 +223,7 @@ org:leaf:1.0
    variant "runtime" [
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
       Requested attributes not found in the selected variant:
          usage               = dummy
@@ -284,6 +287,7 @@ org:testA:1.0
       custom              = dep_value
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 
@@ -295,6 +299,7 @@ org:testB:1.0
       custom              = dep_value
       org.gradle.status   = release (not requested)
       org.gradle.usage    = java-runtime (not requested)
+      org.gradle.format   = jar (not requested)
       org.gradle.category = library (not requested)
    ]
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -66,8 +66,8 @@ project :$expectedProject
 
         where:
         configuration      | expectedProject | expectedVariant   | expectedAttributes
-        'compileClasspath' | 'b'             | 'apiElements'     | 'org.gradle.usage               = java-api\n      org.gradle.format              = jar (compatible with: classes)'
-        'runtimeClasspath' | 'c'             | 'runtimeElements' | 'org.gradle.usage               = java-runtime\n      org.gradle.format              = jar'
+        'compileClasspath' | 'b'             | 'apiElements'     | 'org.gradle.usage               = java-api\n      org.gradle.libraryElements     = jar (compatible with: classes)'
+        'runtimeClasspath' | 'c'             | 'runtimeElements' | 'org.gradle.usage               = java-runtime\n      org.gradle.libraryElements     = jar'
     }
 
     def "shows published variant details"() {
@@ -75,7 +75,7 @@ project :$expectedProject
         mavenRepo.with {
             def leaf = module('org.test', 'leaf', '1.0')
                 .withModuleMetadata()
-                .variant('api', ['org.gradle.usage': 'java-api', 'org.gradle.format': 'jar', 'org.gradle.test': 'published attribute'])
+                .variant('api', ['org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar', 'org.gradle.test': 'published attribute'])
                 .publish()
             module('org.test', 'a', '1.0')
                 .dependsOn(leaf)
@@ -105,7 +105,7 @@ project :$expectedProject
         outputContains """org.test:leaf:1.0
    variant "api" [
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.test                = published attribute (not requested)
       org.gradle.status              = release (not requested)
 
@@ -180,10 +180,10 @@ org:middle:1.0 FAILED
         output.contains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:leaf:1.0
@@ -221,12 +221,12 @@ org:leaf:1.0
         then:
         output.contains """org:leaf:1.0
    variant "runtime" [
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
       Requested attributes not found in the selected variant:
-         usage               = dummy
+         usage                      = dummy
    ]
 
 org:leaf:1.0
@@ -284,11 +284,11 @@ org:leaf:1.0
         outputContains """
 org:testA:1.0
    variant "runtime" [
-      custom              = dep_value
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      custom                     = dep_value
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:testA:1.0
@@ -296,11 +296,11 @@ org:testA:1.0
 
 org:testB:1.0
    variant "runtime" [
-      custom              = dep_value
-      org.gradle.status   = release (not requested)
-      org.gradle.usage    = java-runtime (not requested)
-      org.gradle.format   = jar (not requested)
-      org.gradle.category = library (not requested)
+      custom                     = dep_value
+      org.gradle.status          = release (not requested)
+      org.gradle.usage           = java-runtime (not requested)
+      org.gradle.libraryElements = jar (not requested)
+      org.gradle.category        = library (not requested)
    ]
 
 org:testB:+ -> 1.0

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -69,6 +69,12 @@ One benefit of managing plugin versions in this way is that the `pluginManagemen
 
 See [plugin version management](userguide/plugins.html#sec:plugin_version_management) for more details.
 
+## Performance fix for using the Java library plugin in very large projects on Windows
+
+Very large multi-projects can suffer from a significant performance decrease in Java compilation when switching from the `java` to the `java-library` plugin.
+This is caused by the large amount of class files on the classpath, which is only an issue on Windows systems.
+You can now tell the `java-library` plugin to [prefer jars over class folders on the compile classpath](userguide/java_library_plugin.html#sec:java_library_known_issues_windows_performance) by setting the `org.gradle.java.compile-classpath-packaging` system property to `true`.
+
 ## Improvements for plugin authors
 
 ### Task dependencies are honored for `@Input` properties of type `Provider`

--- a/subprojects/docs/src/docs/userguide/java_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_library_plugin.adoc
@@ -249,3 +249,11 @@ include::sample[dir="java-library/with-groovy/kotlin",files="a/build.gradle.kts[
 === Increased memory usage for consumers
 
 When a project uses the Java Library plugin, consumers will use the output classes directory of this project directly on their compile classpath, instead of the jar file if the project uses the Java plugin. An indirect consequence is that up-to-date checking will require more memory, because Gradle will snapshot individual class files instead of a single jar. This may lead to increased memory consumption for large projects.
+
+[[sec:java_library_known_issues_windows_performance]]
+=== Significant build performance drop on Windows for huge multi-projects
+
+Another side effect of the snapshotting of individual class files, only affecting Windows systems, is that the performance can significantly drop when processing a very large amount of class files on the compile classpath.
+This only concerns very large multi-projects where a lot of classes are present on the classpath by using many `api` or (deprecated) `compile` dependencies.
+To mitigate this, you can set the `org.gradle.java.compile-classpath-packaging` system property to `true` to change the behavior of the Java Library plugin to use jars instead of class folders for everything on the compile classpath.
+Note, since this has other performance impacts and potentially side effects, by triggering all jar tasks at compile time, it is only recommended to activate this if you suffer from the described performance issue on Windows.

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
@@ -4,6 +4,7 @@ org.mongodb:bson:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
+      org.gradle.format              = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -22,6 +23,7 @@ org.mongodb:mongodb-driver-core:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
+      org.gradle.format              = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -38,6 +40,7 @@ org.mongodb:mongodb-driver-sync:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
+      org.gradle.format              = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
@@ -4,7 +4,7 @@ org.mongodb:bson:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.format              = jar
+      org.gradle.libraryElements     = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -23,7 +23,7 @@ org.mongodb:mongodb-driver-core:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.format              = jar
+      org.gradle.libraryElements     = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
@@ -40,7 +40,7 @@ org.mongodb:mongodb-driver-sync:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.format              = jar
+      org.gradle.libraryElements     = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
@@ -4,6 +4,7 @@ mysql:mysql-connector-java:8.0.14
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
+      org.gradle.format              = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
@@ -4,7 +4,7 @@ mysql:mysql-connector-java:8.0.14
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.format              = jar
+      org.gradle.libraryElements     = jar
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
@@ -2,6 +2,7 @@ org.ow2.asm:asm:7.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
@@ -2,7 +2,7 @@ org.ow2.asm:asm:7.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
@@ -21,6 +21,7 @@ org.slf4j:slf4j-log4j12:1.6.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
+      org.gradle.format              = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
@@ -21,7 +21,7 @@ org.slf4j:slf4j-log4j12:1.6.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.format              = jar (compatible with: classes)
+      org.gradle.libraryElements     = jar (compatible with: classes)
       org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -104,7 +105,11 @@ public class EclipseDependenciesCreator {
                 return;
             }
             Usage usage = artifact.getVariant().getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
-            if (usage == null || !usage.getName().equals(Usage.JAVA_RUNTIME_JARS)) {
+            if (usage == null || !usage.getName().equals(Usage.JAVA_RUNTIME)) {
+                return;
+            }
+            Format format = artifact.getVariant().getAttributes().getAttribute(Format.FORMAT_ATTRIBUTE);
+            if (format == null || !format.getName().equals(Format.JAR)) {
                 return;
             }
             ComponentArtifactMetadata artifactId = (ComponentArtifactMetadata) artifact.getId();

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -108,8 +108,8 @@ public class EclipseDependenciesCreator {
             if (usage == null || !usage.getName().equals(Usage.JAVA_RUNTIME)) {
                 return;
             }
-            Format format = artifact.getVariant().getAttributes().getAttribute(Format.FORMAT_ATTRIBUTE);
-            if (format == null || !format.getName().equals(Format.JAR)) {
+            LibraryElements libraryElements = artifact.getVariant().getAttributes().getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
+            if (libraryElements == null || !libraryElements.getName().equals(LibraryElements.JAR)) {
                 return;
             }
             ComponentArtifactMetadata artifactId = (ComponentArtifactMetadata) artifact.getId();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -17,6 +17,7 @@ package org.gradle.test.fixtures.ivy
 
 import groovy.xml.MarkupBuilder
 import org.gradle.api.Action
+import org.gradle.api.attributes.Format
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.internal.xml.XmlTransformer
@@ -46,7 +47,8 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     final Map extendsFrom = [:]
     final Map extraAttributes = [:]
     final Map extraInfo = [:]
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API_JARS]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME_JARS])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Format.FORMAT_ATTRIBUTE.name): Format.JAR]),
+                                                        new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Format.FORMAT_ATTRIBUTE.name): Format.JAR])]
     String branch = null
     String status = "integration"
     MetadataPublish metadataPublish = MetadataPublish.ALL

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -17,7 +17,7 @@ package org.gradle.test.fixtures.ivy
 
 import groovy.xml.MarkupBuilder
 import org.gradle.api.Action
-import org.gradle.api.attributes.Format
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.internal.xml.XmlTransformer
@@ -47,8 +47,8 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     final Map extendsFrom = [:]
     final Map extraAttributes = [:]
     final Map extraInfo = [:]
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Format.FORMAT_ATTRIBUTE.name): Format.JAR]),
-                                                        new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Format.FORMAT_ATTRIBUTE.name): Format.JAR])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR]),
+                                                        new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR])]
     String branch = null
     String status = "integration"
     MetadataPublish metadataPublish = MetadataPublish.ALL

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -17,6 +17,7 @@
 package org.gradle.test.fixtures.maven
 
 import groovy.xml.MarkupBuilder
+import org.gradle.api.attributes.Format
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.internal.hash.HashUtil
@@ -45,7 +46,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     int publishCount = 1
     private boolean hasPom = true
     private boolean gradleMetadataRedirect = false
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API_JARS]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME_JARS])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Format.FORMAT_ATTRIBUTE.name): Format.JAR]),
+                                                        new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Format.FORMAT_ATTRIBUTE.name): Format.JAR])]
     private final List dependencies = []
     private final List artifacts = []
     final updateFormat = new SimpleDateFormat("yyyyMMddHHmmss")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -17,7 +17,7 @@
 package org.gradle.test.fixtures.maven
 
 import groovy.xml.MarkupBuilder
-import org.gradle.api.attributes.Format
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.internal.hash.HashUtil
@@ -46,8 +46,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     int publishCount = 1
     private boolean hasPom = true
     private boolean gradleMetadataRedirect = false
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Format.FORMAT_ATTRIBUTE.name): Format.JAR]),
-                                                        new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Format.FORMAT_ATTRIBUTE.name): Format.JAR])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR]),
+                                                        new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR])]
     private final List dependencies = []
     private final List artifacts = []
     final updateFormat = new SimpleDateFormat("yyyyMMddHHmmss")

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -97,8 +97,8 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
 
         where:
         [apiMapping, runtimeMapping] << ([
-            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)"), apiJarsUsingUsage(), apiJarsUsingUsage("fromResolutionOf('compileClasspath')"), apiJarsUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
-            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)"), runtimeJarsUsingUsage(), runtimeJarsUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeJarsUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
         ].combinations() + [[allVariants(), noop()]])
     }
 
@@ -177,8 +177,8 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
 
         where:
         [apiMapping, runtimeMapping] << ([
-            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)"), apiJarsUsingUsage(), apiJarsUsingUsage("fromResolutionOf('compileClasspath')"), apiJarsUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
-            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)"), runtimeJarsUsingUsage(), runtimeJarsUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeJarsUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
         ].combinations() + [[allVariants(), noop()]])
     }
 
@@ -393,14 +393,6 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
 
     private static String apiUsingUsage(String config = "fromResolutionResult()") {
         """ usage("java-api") { $config } """
-    }
-
-    private static String apiJarsUsingUsage(String config = "fromResolutionResult()") {
-        """ usage("java-api-jars") { $config } """
-    }
-
-    private static String runtimeJarsUsingUsage(String config = "fromResolutionResult()") {
-        """ usage("java-runtime-jars") { $config } """
     }
 
     private static String runtimeUsingUsage(String config = "fromResolutionResult()") {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -407,7 +407,8 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
             
             task processDependency {
                 def lazyInputs = configurations.runtimeClasspath.incoming.artifactView { 
-                    attributes{ attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.${token})) }
+                    attributes{ attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME)) }
+                    attributes{ attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.${token})) }
                 }.files
                 inputs.files(lazyInputs)
                 doLast {
@@ -429,9 +430,9 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         notExecuted ":b:$notExec"
 
         where:
-        scenario              | token                    | expectedDirName     | executed           | notExec
-        'class directory'     | 'JAVA_RUNTIME_CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
-        'resources directory' | 'JAVA_RUNTIME_RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
+        scenario              | token       | expectedDirName     | executed           | notExec
+        'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
+        'resources directory' | 'RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
     }
 
     @Issue("gradle/gradle#1347")

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -408,7 +408,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
             task processDependency {
                 def lazyInputs = configurations.runtimeClasspath.incoming.artifactView { 
                     attributes{ attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME)) }
-                    attributes{ attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.${token})) }
+                    attributes{ attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.${token})) }
                 }.files
                 inputs.files(lazyInputs)
                 doLast {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
@@ -366,7 +366,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                     canBeResolved = false
                     canBeConsumed = true
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME_JARS))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                     }
                     outgoing.capability("org:optional-feature:\${version}")
                 }
@@ -388,7 +388,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             
             def alt = configurations.optionalFeatureRuntimeElements.outgoing.variants.create("alternate")
             alt.attributes {
-                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-runtime-jars'))
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-runtime'))
             }
             def altFile = file("\${buildDir}/\${name}-\${version}-alt.jar")
             task createFile { doFirst { altFile.parentFile.mkdirs(); altFile.text = "test file" } }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -105,8 +105,8 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         where:
         [apiMapping, runtimeMapping] << ([
-                [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)"), apiJarsUsingUsage(), apiJarsUsingUsage("fromResolutionOf('compileClasspath')"), apiJarsUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
-                [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)"), runtimeJarsUsingUsage(), runtimeJarsUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeJarsUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+                [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+                [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
         ].combinations() + [[allVariants(), noop()]])
     }
 
@@ -192,8 +192,8 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         where:
         [apiMapping, runtimeMapping] << ([
-                [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)"), apiJarsUsingUsage(), apiJarsUsingUsage("fromResolutionOf('compileClasspath')"), apiJarsUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
-                [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)"), runtimeJarsUsingUsage(), runtimeJarsUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeJarsUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+                [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+                [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
         ].combinations() + [[allVariants(), noop()]])
     }
 
@@ -522,14 +522,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
     private static String apiUsingUsage(String config = "fromResolutionResult()") {
         """ usage("java-api") { $config } """
-    }
-
-    private static String apiJarsUsingUsage(String config = "fromResolutionResult()") {
-        """ usage("java-api-jars") { $config } """
-    }
-
-    private static String runtimeJarsUsingUsage(String config = "fromResolutionResult()") {
-        """ usage("java-runtime-jars") { $config } """
     }
 
     private static String runtimeUsingUsage(String config = "fromResolutionResult()") {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -178,8 +178,8 @@ public class MavenPublishPlugin implements Plugin<Project> {
                 // If the Java plugin is applied, we want to express that the "compile" and "runtime" variants
                 // are mapped to some attributes, which can be used in the version mapping strategy.
                 // This is only required for POM publication, because the variants have _implicit_ attributes that we want explicit for matching
-                generatePomTask.withCompileScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS)))
-                        .withRuntimeScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
+                generatePomTask.withCompileScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API)))
+                        .withRuntimeScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME)));
             });
         });
         publication.setPomGenerator(generatorTask);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractIsolatableScalarValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractIsolatableScalarValue.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.snapshot.impl;
 
-import org.gradle.internal.isolation.Isolatable;
+import org.gradle.internal.isolation .Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
 import javax.annotation.Nullable;

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.experiment.java
 
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.results.BaselineVersion
@@ -32,6 +33,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
     def "java-library vs java on #testProject"() {
         def javaLibraryRuns = "java-library-plugin"
         def javaRuns = "java-plugin"
+        def compileClasspathPackaging = OperatingSystem.current().windows
 
         given:
         runner.testGroup = "java plugins"
@@ -39,7 +41,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject.projectName).displayName(javaLibraryRuns).invocation {
-                tasksToRun("clean", "classes").args("-PcompileConfiguration").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                tasksToRun("clean", "classes").args("-PcompileConfiguration", "-Dorg.gradle.java.compile-classpath-packaging=$compileClasspathPackaging").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
             }
         }
         runner.baseline {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
@@ -79,7 +79,8 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
                             'org.gradle.category': 'library',
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': JavaVersion.current().majorVersion,
-                            'org.gradle.usage': "java-api-jars"]) // this is a bit curious, it's an artifact of how selection is done
+                            'org.gradle.usage': 'java-api',
+                            'org.gradle.format': 'jar'])
                     switch (expected) {
                         case "jar":
                             artifact(name: "groovyLib")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
@@ -80,7 +80,7 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': JavaVersion.current().majorVersion,
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.format': 'jar'])
+                            'org.gradle.libraryElements': 'jar'])
                     switch (expected) {
                         case "jar":
                             artifact(name: "groovyLib")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
@@ -35,9 +35,14 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
 
     @Issue("https://github.com/gradle/gradle/issues/7398")
     @Unroll
-    def "selects #expected output when #consumerPlugin plugin adds a project dependency to #consumerConf and producer has java-library=#groovyWithJavaLib"(
-            String consumerPlugin, String consumerConf, boolean groovyWithJavaLib, String expected) {
+    def "selects #expected output when #consumerPlugin plugin adds a project dependency to #consumerConf and producer has java-library=#groovyWithJavaLib with compile-classpath-packaging=#compileClasspathPackaging"(
+            String consumerPlugin, String consumerConf, boolean groovyWithJavaLib, boolean compileClasspathPackaging, String expected) {
         given:
+        if (compileClasspathPackaging) {
+            propertiesFile << """
+                systemProp.org.gradle.java.compile-classpath-packaging=true
+            """.trim()
+        }
         multiProjectBuild('issue7398', ['groovyLib', 'javaLib']) {
             file('groovyLib').with {
                 file('src/main/groovy/GroovyClass.groovy') << "public class GroovyClass {}"
@@ -97,17 +102,29 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
         }
 
         where:
-        consumerPlugin | consumerConf     | groovyWithJavaLib | expected
-        'java-library' | 'api'            | true              | "classes"
-        'java-library' | 'api'            | false             | "jar"
-        'java-library' | 'compile'        | true              | "classes"
-        'java-library' | 'compile'        | false             | "jar"
-        'java-library' | 'implementation' | true              | "classes"
-        'java-library' | 'implementation' | false             | "jar"
+        consumerPlugin | consumerConf     | groovyWithJavaLib | compileClasspathPackaging | expected
+        'java-library' | 'api'            | true              | false                     | "classes"
+        'java-library' | 'api'            | false             | false                     | "jar"
+        'java-library' | 'compile'        | true              | false                     | "classes"
+        'java-library' | 'compile'        | false             | false                     | "jar"
+        'java-library' | 'implementation' | true              | false                     | "classes"
+        'java-library' | 'implementation' | false             | false                     | "jar"
 
-        'java'         | 'compile'        | true              | "classes"
-        'java'         | 'compile'        | false             | "jar"
-        'java'         | 'implementation' | true              | "classes"
-        'java'         | 'implementation' | false             | "jar"
+        'java'         | 'compile'        | true              | false                     | "classes"
+        'java'         | 'compile'        | false             | false                     | "jar"
+        'java'         | 'implementation' | true              | false                     | "classes"
+        'java'         | 'implementation' | false             | false                     | "jar"
+
+        'java-library' | 'api'            | true              | true                      | "jar"
+        'java-library' | 'api'            | false             | true                      | "jar"
+        'java-library' | 'compile'        | true              | true                      | "jar"
+        'java-library' | 'compile'        | false             | true                      | "jar"
+        'java-library' | 'implementation' | true              | true                      | "jar"
+        'java-library' | 'implementation' | false             | true                      | "jar"
+
+        'java'         | 'compile'        | true              | true                      | "jar"
+        'java'         | 'compile'        | false             | true                      | "jar"
+        'java'         | 'implementation' | true              | true                      | "jar"
+        'java'         | 'implementation' | false             | true                      | "jar"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -79,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -95,18 +95,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
-    @Unroll
-    def "provides API variant - #usage"() {
+    def "provides API variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
 
@@ -118,8 +119,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -134,23 +135,22 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
-
-        where:
-        usage                                          | _
-        "objects.named(Usage, Usage.JAVA_API)"         | _
-        "objects.named(Usage, Usage.JAVA_API_CLASSES)" | _
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
     }
 
     @Unroll
-    def "provides runtime variant - #usage"() {
+    def "provides runtime variant - format: #format"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                if ($format) {
+                    configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+                }
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
         when:
@@ -161,8 +161,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -177,15 +177,15 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         where:
-        usage                                           | _
-        "objects.named(Usage, Usage.JAVA_RUNTIME)"      | _
-        "objects.named(Usage, Usage.JAVA_RUNTIME_JARS)" | _
+        format | _
+        true   | _
+        false  | _
     }
 
     def "provides runtime JAR variant using artifactType attribute"() {
@@ -202,15 +202,17 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
 
@@ -222,8 +224,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -238,17 +240,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime resources variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.RESOURCES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+               dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
 
@@ -260,8 +264,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -276,10 +280,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
     
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -79,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -95,19 +95,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
     }
 
     def "provides API variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
 
@@ -119,8 +119,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -135,10 +135,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-api}")
     }
 
     @Unroll
@@ -147,10 +147,10 @@ project(':consumer') {
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                 if ($format) {
-                    configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+                    configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
                 }
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
         when:
@@ -161,8 +161,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -177,10 +177,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
 
         where:
         format | _
@@ -202,17 +202,17 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
 
@@ -224,8 +224,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -240,19 +240,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime resources variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.RESOURCES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.RESOURCES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-               dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+               dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
 
@@ -264,8 +264,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -280,10 +280,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
     }
     
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -376,7 +376,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
             
             task processDependency {
                 def lazyInputs = configurations.runtimeClasspath.incoming.artifactView {
-                    attributes{ attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.${token})) }
+                    attributes{ attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.${token})) }
                 }.files
                 inputs.files(lazyInputs)
                 doLast {
@@ -398,9 +398,9 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         notExecuted ":b:$notExec"
 
         where:
-        scenario              | token                    | expectedDirName     | executed           | notExec
-        'class directory'     | 'JAVA_RUNTIME_CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
-        'resources directory' | 'JAVA_RUNTIME_RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
+        scenario              | token       | expectedDirName     | executed           | notExec
+        'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
+        'resources directory' | 'RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
     }
 
     private void subproject(String name, @DelegatesTo(value=FileTreeBuilder, strategy = Closure.DELEGATE_FIRST) Closure<Void> config) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -376,7 +376,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
             
             task processDependency {
                 def lazyInputs = configurations.runtimeClasspath.incoming.artifactView {
-                    attributes{ attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.${token})) }
+                    attributes{ attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.${token})) }
                 }.files
                 inputs.files(lazyInputs)
                 doLast {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -25,7 +25,18 @@ import java.util.jar.JarOutputStream
 
 class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
-    def "project can declare an API dependency"() {
+    private toggleCompileClasspathPackaging(boolean activate) {
+        if (activate) {
+            propertiesFile << """
+                systemProp.org.gradle.java.compile-classpath-packaging=true
+            """.trim()
+        }
+    }
+
+    @Unroll
+    def "project can declare an API dependency [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         given:
         subproject('a') {
             'build.gradle'('''
@@ -61,7 +72,12 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
     def "uses the default configuration when producer is not a library"() {
@@ -147,7 +163,9 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    def "uses the API of a library when compiling a custom source set against it"() {
+    def "uses the API of a library when compiling a custom source set against it [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         given:
         subproject('a') {
             'build.gradle'("""
@@ -188,7 +206,12 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
     @Unroll
@@ -234,7 +257,10 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         configuration << ['testCompile', 'testImplementation']
     }
 
-    def "recompiles consumer if API dependency of producer changed"() {
+    @Unroll
+    def "recompiles consumer if API dependency of producer changed [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         publishSharedV1()
         publishSharedV11()
 
@@ -286,7 +312,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':a:compileJava', ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
 
         when:
         file('b/build.gradle').text = file('b/build.gradle').text.replace(/api 'org.gradle.test:shared:1.0'/, '''
@@ -297,10 +323,18 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         then:
         succeeds ':a:compileJava', 'a:compileJava'
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
-    def "doesn't recompile consumer if implementation dependency of producer changed"() {
+    @Unroll
+    def "doesn't recompile consumer if implementation dependency of producer changed [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         publishSharedV1()
         publishSharedV11()
 
@@ -348,7 +382,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':a:compileJava', ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
 
         when:
         file('b/build.gradle').text = file('b/build.gradle').text.replace(/implementation 'org.gradle.test:shared:1.0'/, '''
@@ -359,8 +393,13 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         then:
         succeeds 'a:compileJava'
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
         skipped ':a:compileJava'
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
     @Unroll
@@ -401,6 +440,15 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         scenario              | token       | expectedDirName     | executed           | notExec
         'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
         'resources directory' | 'RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
+    }
+
+    private void packagingTasks(boolean expectExecuted) {
+        def tasks = [':b:processResources', ':b:classes', ':b:jar']
+        if (expectExecuted) {
+            executed(*tasks)
+        } else {
+            notExecuted(*tasks)
+        }
     }
 
     private void subproject(String name, @DelegatesTo(value=FileTreeBuilder, strategy = Closure.DELEGATE_FIRST) Closure<Void> config) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -63,14 +63,16 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
       - Incompatible attribute:
           - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.''')
     }
 
     @Unroll
@@ -86,7 +88,8 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
                         canBeConsumed = true
                         canBeResolved = false
                         attributes {
-                            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-api-jars'))
+                            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-api'))
+                            attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, 'jar'))
                             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, 'external'))
                             attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, v)
                         }
@@ -111,7 +114,8 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
                     variant(expected, [
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': selected,
-                            'org.gradle.usage':'java-api-jars'
+                            'org.gradle.usage':'java-api',
+                            'org.gradle.format': 'jar'
                     ])
                     artifact(classifier: "jdk${selected}")
                 }
@@ -152,14 +156,16 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
       - Incompatible attribute:
           - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.""")
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.""")
 
         when:
         buildFile << """
@@ -177,7 +183,8 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
                             'org.gradle.category': 'library',
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': 7,
-                            'org.gradle.usage':'java-api-jars'
+                            'org.gradle.usage':'java-api',
+                            'org.gradle.format': 'jar'
                     ])
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -63,7 +63,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
       - Incompatible attribute:
@@ -71,7 +71,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.''')
     }
 
@@ -89,7 +89,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
                         canBeResolved = false
                         attributes {
                             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-api'))
-                            attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, 'jar'))
+                            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, 'jar'))
                             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, 'external'))
                             attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, v)
                         }
@@ -115,7 +115,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': selected,
                             'org.gradle.usage':'java-api',
-                            'org.gradle.format': 'jar'
+                            'org.gradle.libraryElements': 'jar'
                     ])
                     artifact(classifier: "jdk${selected}")
                 }
@@ -156,7 +156,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
       - Incompatible attribute:
@@ -164,7 +164,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Other attributes:
           - Found org.gradle.category 'library' but wasn't required.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.""")
 
         when:
@@ -184,7 +184,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': 7,
                             'org.gradle.usage':'java-api',
-                            'org.gradle.format': 'jar'
+                            'org.gradle.libraryElements': 'jar'
                     ])
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -81,8 +81,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -97,18 +97,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
-    @Unroll
-    def "provides API variant - #usage"() {
+    def "provides API variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
         when:
@@ -119,8 +120,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -135,23 +136,22 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-
-        where:
-        usage                                          | _
-        "objects.named(Usage, Usage.JAVA_API)"         | _
-        "objects.named(Usage, Usage.JAVA_API_CLASSES)" | _
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
     }
 
     @Unroll
-    def "provides runtime variant - #usage"() {
+    def "provides runtime variant - format: #format"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                if ($format) {
+                    configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+                }
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
         when:
@@ -162,8 +162,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -178,15 +178,15 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         where:
-        usage                                           | _
-        "objects.named(Usage, Usage.JAVA_RUNTIME)"      | _
-        "objects.named(Usage, Usage.JAVA_RUNTIME_JARS)" | _
+        format | _
+        true   | _
+        false  | _
     }
 
     def "provides runtime JAR variant using artifactType"() {
@@ -203,15 +203,17 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
 
@@ -223,8 +225,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -239,17 +241,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime resources variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.RESOURCES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
 
@@ -261,8 +265,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -277,10 +281,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -81,8 +81,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -97,19 +97,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
     }
 
     def "provides API variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
         when:
@@ -120,8 +120,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-api}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -136,10 +136,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-api}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-api}")
     }
 
     @Unroll
@@ -148,10 +148,10 @@ project(':consumer') {
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                 if ($format) {
-                    configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+                    configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
                 }
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
         when:
@@ -162,8 +162,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -178,10 +178,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
 
         where:
         format | _
@@ -203,17 +203,17 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
 
@@ -225,8 +225,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -241,19 +241,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=classes, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime resources variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.RESOURCES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.RESOURCES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
 
@@ -265,8 +265,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -281,10 +281,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryElements=resources, org.gradle.usage=java-runtime}")
     }
 
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
@@ -51,27 +51,33 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
                 .variant("apiElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 6,
-                'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk6.jar') })
+                'org.gradle.format': 'jar',
+                'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("apiElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 7,
-                'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk7.jar') })
+                'org.gradle.format': 'jar',
+                'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("apiElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 9,
-                'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk9.jar') })
+                'org.gradle.format': 'jar',
+                'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk9.jar') })
                 .variant("runtimeElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 6,
-                'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk6.jar') })
+                'org.gradle.format': 'jar',
+                'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("runtimeElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 7,
-                'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk7.jar') })
+                'org.gradle.format': 'jar',
+                'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("runtimeElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 9,
-                'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk9.jar') })
+                'org.gradle.format': 'jar',
+                'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk9.jar') })
                 .publish()
 
     }
@@ -94,43 +100,49 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
           - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'apiElementsJdk7' capability org:producer:1.0:
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'apiElementsJdk9' capability org:producer:1.0:
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'runtimeElementsJdk6' capability org:producer:1.0:
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.
   - Variant 'runtimeElementsJdk7' capability org:producer:1.0:
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.
   - Variant 'runtimeElementsJdk9' capability org:producer:1.0:
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+          - Required org.gradle.format 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
-          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
+          - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.''')
     }
 
     @Unroll
@@ -153,7 +165,8 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
                     variant(expected, [
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': selected,
-                            'org.gradle.usage': 'java-api-jars',
+                            'org.gradle.usage': 'java-api',
+                            'org.gradle.format': 'jar',
                             'org.gradle.status': 'release'
                     ])
                     artifact(classifier: "jdk${selected}")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
@@ -51,32 +51,32 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
                 .variant("apiElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 6,
-                'org.gradle.format': 'jar',
+                'org.gradle.libraryElements': 'jar',
                 'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("apiElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 7,
-                'org.gradle.format': 'jar',
+                'org.gradle.libraryElements': 'jar',
                 'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("apiElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 9,
-                'org.gradle.format': 'jar',
+                'org.gradle.libraryElements': 'jar',
                 'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk9.jar') })
                 .variant("runtimeElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 6,
-                'org.gradle.format': 'jar',
+                'org.gradle.libraryElements': 'jar',
                 'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("runtimeElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 7,
-                'org.gradle.format': 'jar',
+                'org.gradle.libraryElements': 'jar',
                 'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("runtimeElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 9,
-                'org.gradle.format': 'jar',
+                'org.gradle.libraryElements': 'jar',
                 'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk9.jar') })
                 .publish()
 
@@ -100,7 +100,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
           - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'apiElementsJdk7' capability org:producer:1.0:
@@ -108,7 +108,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
           - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'apiElementsJdk9' capability org:producer:1.0:
@@ -116,7 +116,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
           - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'runtimeElementsJdk6' capability org:producer:1.0:
@@ -124,7 +124,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
           - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.
   - Variant 'runtimeElementsJdk7' capability org:producer:1.0:
@@ -132,7 +132,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
           - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.
   - Variant 'runtimeElementsJdk9' capability org:producer:1.0:
@@ -140,7 +140,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
           - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Other attributes:
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
-          - Required org.gradle.format 'classes' and found compatible value 'jar'.
+          - Required org.gradle.libraryElements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.''')
     }
@@ -166,7 +166,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': selected,
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.format': 'jar',
+                            'org.gradle.libraryElements': 'jar',
                             'org.gradle.status': 'release'
                     ])
                     artifact(classifier: "jdk${selected}")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -79,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -95,18 +95,20 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     @Unroll
-    def "provides API variant - #usage"() {
+    def "provides API variant - #format"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, $format))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
         when:
@@ -117,8 +119,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -133,24 +135,28 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
 
         where:
-        usage                                          | _
-        "objects.named(Usage, Usage.JAVA_API)"         | _
-        "objects.named(Usage, Usage.JAVA_API_CLASSES)" | _
-        "objects.named(Usage, Usage.JAVA_API_JARS)"    | _
+        format             | _
+        "Format.JAR"       | _
+        "Format.CLASSES"   | _
+        "Format.RESOURCES" | _
     }
 
     @Unroll
-    def "provides runtime variant - #usage"() {
+    def "provides runtime variant - format: #format"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                if ($format) {
+                    configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+                }
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
         when:
@@ -161,8 +167,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -177,15 +183,15 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         where:
-        usage                                           | _
-        "objects.named(Usage, Usage.JAVA_RUNTIME)"      | _
-        "objects.named(Usage, Usage.JAVA_RUNTIME_JARS)" | _
+        format | _
+        true   | _
+        false  | _
     }
 
     def "provides runtime JAR variant using artifactType"() {
@@ -202,15 +208,17 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
         when:
@@ -221,8 +229,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -237,17 +245,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime resources variant"() {
         buildFile << """
             project(':consumer') {
-                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
+                configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.RESOURCES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
             }
 """
 
@@ -259,8 +269,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -275,10 +285,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -79,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -95,10 +95,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     @Unroll
@@ -106,9 +106,9 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, $format))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, $format))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
         when:
@@ -119,8 +119,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
 
         when:
         buildFile << """
@@ -135,16 +135,16 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-api}")
 
         where:
         format             | _
-        "Format.JAR"       | _
-        "Format.CLASSES"   | _
-        "Format.RESOURCES" | _
+        "LibraryElements.JAR"       | _
+        "LibraryElements.CLASSES"   | _
+        "LibraryElements.RESOURCES" | _
     }
 
     @Unroll
@@ -153,10 +153,10 @@ project(':consumer') {
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                 if ($format) {
-                    configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.JAR))
+                    configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
                 }
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
         when:
@@ -167,8 +167,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -183,10 +183,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         where:
         format | _
@@ -208,17 +208,17 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=jar, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.CLASSES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
         when:
@@ -229,8 +229,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -245,19 +245,19 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=classes, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     def "provides runtime resources variant"() {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                configurations.consume.attributes.attribute(Format.FORMAT_ATTRIBUTE, objects.named(Format, Format.RESOURCES))
+                configurations.consume.attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.RESOURCES))
                 dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
-                dependencies.attributesSchema.attribute(Format.FORMAT_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.FormatCompatibilityRules)
+                dependencies.attributesSchema.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.LibraryElementsCompatibilityRules)
             }
 """
 
@@ -269,8 +269,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
 
         when:
         buildFile << """
@@ -285,10 +285,10 @@ project(':consumer') {
         then:
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
-        outputContains("file-dep.jar {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.format=jar, org.gradle.usage=java-runtime}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.format=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.libraryElements=jar, org.gradle.usage=java-runtime}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryElements=resources, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime}")
     }
 
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -106,7 +106,7 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
         executedAndNotSkipped(*expectedJars)
     }
 
-    def "test fixtures implementation dependencies to not leak into the test compile classpath"() {
+    def "test fixtures implementation dependencies do not leak into the test compile classpath"() {
         buildFile << """
             apply plugin: 'java-test-fixtures'
         
@@ -272,12 +272,12 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
 
     def "can consume test fixtures of an external module"() {
         mavenRepo.module("com.acme", "external-module", "1.3")
-            .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api-jars']) {
+            .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.format': 'jar']) {
                 capability('com.acme', 'external-module-test-fixtures', '1.3')
                 dependsOn("com.acme:external-module:1.3")
                 artifact("external-module-1.3-test-fixtures.jar")
             }
-            .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime-jars']) {
+            .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar']) {
                 capability('com.acme', 'external-module-test-fixtures', '1.3')
                 dependsOn("com.acme:external-module:1.3")
                 dependsOn("org.apache.commons:commons-lang3:3.9")
@@ -310,11 +310,11 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
                 }
                 module('com.acme:external-module:1.3') {
                     variant("testFixturesApiElements", [
-                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-api-jars'
+                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'
                     ])
                     firstLevelConfigurations = ['testFixturesApiElements']
                     module('com.acme:external-module:1.3') {
-                        variant("api", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api-jars'])
+                        variant("api", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'])
                         artifact(name: 'external-module', version:'1.3')
                     }
                     artifact(name: 'external-module', version:'1.3', classifier:'test-fixtures')
@@ -336,11 +336,11 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
                 }
                 module('com.acme:external-module:1.3') {
                     variant("testFixturesRuntimeElements", [
-                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime-jars'
+                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'
                     ])
                     firstLevelConfigurations = ['testFixturesRuntimeElements']
                     module('com.acme:external-module:1.3') {
-                        variant("runtime", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime-jars'])
+                        variant("runtime", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
                         artifact(name: 'external-module', version:'1.3')
                     }
                     module("org.apache.commons:commons-lang3:3.9") {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -272,12 +272,12 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
 
     def "can consume test fixtures of an external module"() {
         mavenRepo.module("com.acme", "external-module", "1.3")
-            .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.format': 'jar']) {
+            .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar']) {
                 capability('com.acme', 'external-module-test-fixtures', '1.3')
                 dependsOn("com.acme:external-module:1.3")
                 artifact("external-module-1.3-test-fixtures.jar")
             }
-            .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar']) {
+            .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar']) {
                 capability('com.acme', 'external-module-test-fixtures', '1.3')
                 dependsOn("com.acme:external-module:1.3")
                 dependsOn("org.apache.commons:commons-lang3:3.9")
@@ -310,11 +310,11 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
                 }
                 module('com.acme:external-module:1.3') {
                     variant("testFixturesApiElements", [
-                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'
+                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar'
                     ])
                     firstLevelConfigurations = ['testFixturesApiElements']
                     module('com.acme:external-module:1.3') {
-                        variant("api", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.format': 'jar'])
+                        variant("api", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryElements': 'jar'])
                         artifact(name: 'external-module', version:'1.3')
                     }
                     artifact(name: 'external-module', version:'1.3', classifier:'test-fixtures')
@@ -336,11 +336,11 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
                 }
                 module('com.acme:external-module:1.3') {
                     variant("testFixturesRuntimeElements", [
-                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'
+                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'
                     ])
                     firstLevelConfigurations = ['testFixturesRuntimeElements']
                     module('com.acme:external-module:1.3') {
-                        variant("runtime", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.format': 'jar'])
+                        variant("runtime", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryElements': 'jar'])
                         artifact(name: 'external-module', version:'1.3')
                     }
                     module("org.apache.commons:commons-lang3:3.9") {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
@@ -22,6 +22,11 @@ class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaTestFixturesInt
         'java-library'
     }
 
+    @Override
+    List getSkippedJars(boolean compileClasspathPackaging) {
+        compileClasspathPackaging ? [] : [':jar', ':testFixturesJar']
+    }
+
     def "can consume test fixtures of subproject written in Groovy"() {
         settingsFile << """
             include 'sub'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
@@ -21,4 +21,10 @@ class JavaTestFixturesIntegrationTest extends AbstractJavaTestFixturesIntegratio
     String getPluginName() {
         'java'
     }
+
+    @Override
+    List getSkippedJars(boolean compileClasspathPackaging) {
+        compileClasspathPackaging ? [] : [':testFixturesJar']
+    }
+
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
@@ -139,7 +140,9 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     private void configureSchema(ProjectInternal project) {
         AttributesSchema attributesSchema = project.getDependencies().getAttributesSchema();
         JavaEcosystemSupport.configureSchema(attributesSchema, objectFactory);
-        project.getDependencies().getArtifactTypes().create(ArtifactTypeDefinition.JAR_TYPE).getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS));
+        project.getDependencies().getArtifactTypes().create(ArtifactTypeDefinition.JAR_TYPE).getAttributes()
+                .attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME))
+                .attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
     }
 
 
@@ -276,6 +279,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSetName + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
         compileClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
+        compileClasspathConfiguration.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.CLASSES));
         compileClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         ((ConfigurationInternal)compileClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 
@@ -298,6 +302,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSetName + ".");
         runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration, implementationConfiguration);
         runtimeClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        runtimeClasspathConfiguration.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
         runtimeClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         ((ConfigurationInternal)runtimeClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -28,7 +28,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.Bundling;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
@@ -142,7 +142,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         JavaEcosystemSupport.configureSchema(attributesSchema, objectFactory);
         project.getDependencies().getArtifactTypes().create(ArtifactTypeDefinition.JAR_TYPE).getAttributes()
                 .attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME))
-                .attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
+                .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
     }
 
 
@@ -279,7 +279,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSetName + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
         compileClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
-        compileClasspathConfiguration.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.CLASSES));
+        compileClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
         compileClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         ((ConfigurationInternal)compileClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 
@@ -302,7 +302,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSetName + ".");
         runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration, implementationConfiguration);
         runtimeClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
-        runtimeClasspathConfiguration.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
+        runtimeClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
         runtimeClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         ((ConfigurationInternal)runtimeClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -77,6 +77,16 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     public static final String DOCUMENTATION_GROUP = "documentation";
 
     /**
+     * Set this property to use JARs build from subprojects, instead of the classes folder from these project, on the compile classpath.
+     * The main use case for this is to mitigate performance issues on very large multi-projects building on Windows.
+     * Setting this property will cause the 'jar' task of all subprojects in the dependency tree to always run during compilation.
+     *
+     * @since 5.6
+     */
+    @Incubating
+    public static final String COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY = "org.gradle.java.compile-classpath-packaging";
+
+    /**
      * A list of known artifact types which are known to prevent from
      * publication.
      *
@@ -90,10 +100,12 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     );
 
     private final ObjectFactory objectFactory;
+    private final boolean javaClasspathPackaging;
 
     @Inject
     public JavaBasePlugin(ObjectFactory objectFactory) {
         this.objectFactory = objectFactory;
+        this.javaClasspathPackaging = Boolean.getBoolean(COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY);
     }
 
     @Override
@@ -279,7 +291,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSetName + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
         compileClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
-        compileClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
+        compileClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, javaClasspathPackaging? LibraryElements.JAR : LibraryElements.CLASSES));
         compileClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         ((ConfigurationInternal)compileClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
@@ -134,7 +135,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
 
         Configuration classpath = configurations.create(CLASSPATH_CONFIGURATION_NAME, AS_RESOLVABLE_CONFIGURATION);
         classpath.extendsFrom(runtimeElements);
-        declareConfigurationUsage(project.getObjects(), classpath, Usage.JAVA_RUNTIME);
+        declareConfigurationUsage(project.getObjects(), classpath, Usage.JAVA_RUNTIME, Format.JAR);
 
         createSoftwareComponent(project, apiElements, runtimeElements);
     }
@@ -142,7 +143,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     private Configuration createConsumableRuntime(Project project, Configuration apiElements, String name, String platformKind) {
         Configuration runtimeElements = project.getConfigurations().create(name, AS_CONSUMABLE_CONFIGURATION);
         runtimeElements.extendsFrom(apiElements);
-        declareConfigurationUsage(project.getObjects(), runtimeElements, Usage.JAVA_RUNTIME);
+        declareConfigurationUsage(project.getObjects(), runtimeElements, Usage.JAVA_RUNTIME, Format.METADATA);
         declareConfigurationCategory(project.getObjects(), runtimeElements, platformKind);
         return runtimeElements;
     }
@@ -150,7 +151,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     private Configuration createConsumableApi(Project project, ConfigurationContainer configurations, Configuration api, String name, String platformKind) {
         Configuration apiElements = configurations.create(name, AS_CONSUMABLE_CONFIGURATION);
         apiElements.extendsFrom(api);
-        declareConfigurationUsage(project.getObjects(), apiElements, Usage.JAVA_API);
+        declareConfigurationUsage(project.getObjects(), apiElements, Usage.JAVA_API, Format.METADATA);
         declareConfigurationCategory(project.getObjects(), apiElements, platformKind);
         return apiElements;
     }
@@ -159,8 +160,9 @@ public class JavaPlatformPlugin implements Plugin<Project> {
         configuration.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, value));
     }
 
-    private void declareConfigurationUsage(ObjectFactory objectFactory, Configuration configuration, String usage) {
+    private void declareConfigurationUsage(ObjectFactory objectFactory, Configuration configuration, String usage, String format) {
         configuration.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage));
+        configuration.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, format));
     }
 
     private void configureExtension(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -24,7 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Category;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
@@ -135,7 +135,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
 
         Configuration classpath = configurations.create(CLASSPATH_CONFIGURATION_NAME, AS_RESOLVABLE_CONFIGURATION);
         classpath.extendsFrom(runtimeElements);
-        declareConfigurationUsage(project.getObjects(), classpath, Usage.JAVA_RUNTIME, Format.JAR);
+        declareConfigurationUsage(project.getObjects(), classpath, Usage.JAVA_RUNTIME, LibraryElements.JAR);
 
         createSoftwareComponent(project, apiElements, runtimeElements);
     }
@@ -143,7 +143,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     private Configuration createConsumableRuntime(Project project, Configuration apiElements, String name, String platformKind) {
         Configuration runtimeElements = project.getConfigurations().create(name, AS_CONSUMABLE_CONFIGURATION);
         runtimeElements.extendsFrom(apiElements);
-        declareConfigurationUsage(project.getObjects(), runtimeElements, Usage.JAVA_RUNTIME, Format.METADATA);
+        declareConfigurationUsage(project.getObjects(), runtimeElements, Usage.JAVA_RUNTIME);
         declareConfigurationCategory(project.getObjects(), runtimeElements, platformKind);
         return runtimeElements;
     }
@@ -151,7 +151,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     private Configuration createConsumableApi(Project project, ConfigurationContainer configurations, Configuration api, String name, String platformKind) {
         Configuration apiElements = configurations.create(name, AS_CONSUMABLE_CONFIGURATION);
         apiElements.extendsFrom(api);
-        declareConfigurationUsage(project.getObjects(), apiElements, Usage.JAVA_API, Format.METADATA);
+        declareConfigurationUsage(project.getObjects(), apiElements, Usage.JAVA_API);
         declareConfigurationCategory(project.getObjects(), apiElements, platformKind);
         return apiElements;
     }
@@ -160,9 +160,13 @@ public class JavaPlatformPlugin implements Plugin<Project> {
         configuration.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, value));
     }
 
-    private void declareConfigurationUsage(ObjectFactory objectFactory, Configuration configuration, String usage, String format) {
+    private void declareConfigurationUsage(ObjectFactory objectFactory, Configuration configuration, String usage, String libraryContents) {
+        declareConfigurationUsage(objectFactory, configuration, usage);
+        configuration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, libraryContents));
+    }
+
+    private void declareConfigurationUsage(ObjectFactory objectFactory, Configuration configuration, String usage) {
         configuration.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage));
-        configuration.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, format));
     }
 
     private void configureExtension(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.component.AdhocComponentWithVariants;
@@ -64,6 +65,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Callable;
 
+import static org.gradle.api.attributes.Format.FORMAT_ATTRIBUTE;
 import static org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE;
 import static org.gradle.api.attributes.Bundling.EXTERNAL;
 import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE;
@@ -372,7 +374,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         // Define some additional variants
         NamedDomainObjectContainer<ConfigurationVariant> runtimeVariants = publications.getVariants();
         ConfigurationVariant classesVariant = runtimeVariants.create("classes");
-        classesVariant.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_CLASSES));
+        classesVariant.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        classesVariant.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.CLASSES));
         classesVariant.artifact(new JavaPluginsHelper.IntermediateJavaArtifact(ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, javaCompile) {
             @Override
             public File getFile() {
@@ -380,7 +383,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
             }
         });
         ConfigurationVariant resourcesVariant = runtimeVariants.create("resources");
-        resourcesVariant.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_RESOURCES));
+        resourcesVariant.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        resourcesVariant.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.RESOURCES));
         resourcesVariant.artifact(new JavaPluginsHelper.IntermediateJavaArtifact(ArtifactTypeDefinition.JVM_RESOURCES_DIRECTORY, processResources) {
             @Override
             public File getFile() {
@@ -463,7 +467,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         apiElementsConfiguration.setDescription("API elements for main.");
         apiElementsConfiguration.setCanBeResolved(false);
         apiElementsConfiguration.setCanBeConsumed(true);
-        apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS));
+        apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
+        apiElementsConfiguration.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
         apiElementsConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, EXTERNAL));
         apiElementsConfiguration.getAttributes().attribute(CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         apiElementsConfiguration.extendsFrom(runtimeConfiguration);
@@ -473,7 +478,8 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         runtimeElementsConfiguration.setCanBeConsumed(true);
         runtimeElementsConfiguration.setCanBeResolved(false);
         runtimeElementsConfiguration.setDescription("Elements of runtime for main.");
-        runtimeElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS));
+        runtimeElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        runtimeElementsConfiguration.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
         runtimeElementsConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, EXTERNAL));
         runtimeElementsConfiguration.getAttributes().attribute(CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         runtimeElementsConfiguration.extendsFrom(implementationConfiguration, runtimeOnlyConfiguration, runtimeConfiguration);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -30,7 +30,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Category;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.component.AdhocComponentWithVariants;
@@ -65,7 +65,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Callable;
 
-import static org.gradle.api.attributes.Format.FORMAT_ATTRIBUTE;
+import static org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE;
 import static org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE;
 import static org.gradle.api.attributes.Bundling.EXTERNAL;
 import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE;
@@ -375,7 +375,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         NamedDomainObjectContainer<ConfigurationVariant> runtimeVariants = publications.getVariants();
         ConfigurationVariant classesVariant = runtimeVariants.create("classes");
         classesVariant.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
-        classesVariant.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.CLASSES));
+        classesVariant.getAttributes().attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
         classesVariant.artifact(new JavaPluginsHelper.IntermediateJavaArtifact(ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, javaCompile) {
             @Override
             public File getFile() {
@@ -384,7 +384,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         });
         ConfigurationVariant resourcesVariant = runtimeVariants.create("resources");
         resourcesVariant.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
-        resourcesVariant.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.RESOURCES));
+        resourcesVariant.getAttributes().attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.RESOURCES));
         resourcesVariant.artifact(new JavaPluginsHelper.IntermediateJavaArtifact(ArtifactTypeDefinition.JVM_RESOURCES_DIRECTORY, processResources) {
             @Override
             public File getFile() {
@@ -468,7 +468,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         apiElementsConfiguration.setCanBeResolved(false);
         apiElementsConfiguration.setCanBeConsumed(true);
         apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
-        apiElementsConfiguration.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
+        apiElementsConfiguration.getAttributes().attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
         apiElementsConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, EXTERNAL));
         apiElementsConfiguration.getAttributes().attribute(CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         apiElementsConfiguration.extendsFrom(runtimeConfiguration);
@@ -479,7 +479,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         runtimeElementsConfiguration.setCanBeResolved(false);
         runtimeElementsConfiguration.setDescription("Elements of runtime for main.");
         runtimeElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
-        runtimeElementsConfiguration.getAttributes().attribute(FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
+        runtimeElementsConfiguration.getAttributes().attribute(LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
         runtimeElementsConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, EXTERNAL));
         runtimeElementsConfiguration.getAttributes().attribute(CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         runtimeElementsConfiguration.extendsFrom(implementationConfiguration, runtimeOnlyConfiguration, runtimeConfiguration);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.java.TargetJvmVersion;
@@ -133,8 +134,8 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
         apiElements.extendsFrom(api);
         final Configuration runtimeElements = export(runtimeElementsConfigurationName);
         runtimeElements.extendsFrom(impl);
-        configureUsage(apiElements, Usage.JAVA_API_JARS);
-        configureUsage(runtimeElements, Usage.JAVA_RUNTIME_JARS);
+        configureUsage(apiElements, Usage.JAVA_API);
+        configureUsage(runtimeElements, Usage.JAVA_RUNTIME);
         configurePacking(apiElements);
         configurePacking(runtimeElements);
         configureTargetPlatform(apiElements);
@@ -241,6 +242,7 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
             @Override
             public void execute(AttributeContainer attrs) {
                 attrs.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage));
+                attrs.attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
             }
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Category;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.java.TargetJvmVersion;
@@ -242,7 +242,7 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
             @Override
             public void execute(AttributeContainer attrs) {
                 attrs.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage));
-                attrs.attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.JAR));
+                attrs.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
             }
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaPluginsHelper.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ConfigurationPublications;
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.attributes.Format;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
 import org.gradle.api.model.ObjectFactory;
@@ -42,7 +43,8 @@ public class JavaPluginsHelper {
         // Define a classes variant to use for compilation
         ConfigurationPublications publications = configuration.getOutgoing();
         ConfigurationVariant variant = publications.getVariants().maybeCreate("classes");
-        variant.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_CLASSES));
+        variant.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
+        variant.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.CLASSES));
         variant.artifact(new IntermediateJavaArtifact(ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, compileTask) {
             @Override
             public File getFile() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaPluginsHelper.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ConfigurationPublications;
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
-import org.gradle.api.attributes.Format;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
 import org.gradle.api.model.ObjectFactory;
@@ -44,7 +44,7 @@ public class JavaPluginsHelper {
         ConfigurationPublications publications = configuration.getOutgoing();
         ConfigurationVariant variant = publications.getVariants().maybeCreate("classes");
         variant.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
-        variant.getAttributes().attribute(Format.FORMAT_ATTRIBUTE, objectFactory.named(Format.class, Format.CLASSES));
+        variant.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
         variant.artifact(new IntermediateJavaArtifact(ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, compileTask) {
             @Override
             public File getFile() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -448,60 +448,60 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         where:
         consumer                     | producer                     | compatible
         Usage.JAVA_API               | Usage.JAVA_API               | true
-        Usage.JAVA_API               | Usage.JAVA_API_CLASSES       | true
-        Usage.JAVA_API               | Usage.JAVA_API_JARS          | true
+//        Usage.JAVA_API               | Usage.JAVA_API_CLASSES       | true
+//        Usage.JAVA_API               | Usage.JAVA_API_JARS          | true
         Usage.JAVA_API               | Usage.JAVA_RUNTIME           | true
-        Usage.JAVA_API               | Usage.JAVA_RUNTIME_CLASSES   | true
-        Usage.JAVA_API               | Usage.JAVA_RUNTIME_RESOURCES | false
-        Usage.JAVA_API               | Usage.JAVA_RUNTIME_JARS      | true
+//        Usage.JAVA_API               | Usage.JAVA_RUNTIME_CLASSES   | true
+//        Usage.JAVA_API               | Usage.JAVA_RUNTIME_RESOURCES | false
+//        Usage.JAVA_API               | Usage.JAVA_RUNTIME_JARS      | true
 
-        Usage.JAVA_API_CLASSES       | Usage.JAVA_API               | true
-        Usage.JAVA_API_CLASSES       | Usage.JAVA_API_CLASSES       | true
-        Usage.JAVA_API_CLASSES       | Usage.JAVA_API_JARS          | true
-        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME           | true
-        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_CLASSES   | true
-        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_RESOURCES | false
-        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_JARS      | true
+//        Usage.JAVA_API_CLASSES       | Usage.JAVA_API               | true
+//        Usage.JAVA_API_CLASSES       | Usage.JAVA_API_CLASSES       | true
+//        Usage.JAVA_API_CLASSES       | Usage.JAVA_API_JARS          | true
+//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME           | true
+//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_CLASSES   | true
+//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_RESOURCES | false
+//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_JARS      | true
 
-        Usage.JAVA_API_JARS          | Usage.JAVA_API               | true
-        Usage.JAVA_API_JARS          | Usage.JAVA_API_CLASSES       | false
-        Usage.JAVA_API_JARS          | Usage.JAVA_API_JARS          | true
-        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME           | true
-        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_CLASSES   | false
-        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_RESOURCES | false
-        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_JARS      | true
+//        Usage.JAVA_API_JARS          | Usage.JAVA_API               | true
+//        Usage.JAVA_API_JARS          | Usage.JAVA_API_CLASSES       | false
+//        Usage.JAVA_API_JARS          | Usage.JAVA_API_JARS          | true
+//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME           | true
+//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_CLASSES   | false
+//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_RESOURCES | false
+//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_JARS      | true
 
         Usage.JAVA_RUNTIME           | Usage.JAVA_API               | false
-        Usage.JAVA_RUNTIME           | Usage.JAVA_API_CLASSES       | false
-        Usage.JAVA_RUNTIME           | Usage.JAVA_API_JARS          | false
+//        Usage.JAVA_RUNTIME           | Usage.JAVA_API_CLASSES       | false
+//        Usage.JAVA_RUNTIME           | Usage.JAVA_API_JARS          | false
         Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME           | true
-        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_CLASSES   | false
-        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_RESOURCES | false
-        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_JARS      | true
+//        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_CLASSES   | false
+//        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_RESOURCES | false
+//        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_JARS      | true
 
-        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API               | false
-        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_CLASSES       | false
-        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_JARS          | false
-        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME           | true
-        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_CLASSES   | true
-        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_RESOURCES | false
-        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_JARS      | true
+//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API               | false
+//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_CLASSES       | false
+//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_JARS          | false
+//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME           | true
+//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_CLASSES   | true
+//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_RESOURCES | false
+//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_JARS      | true
 
-        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API               | false
-        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_CLASSES       | false
-        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_JARS          | false
-        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME           | true
-        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_CLASSES   | false
-        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_RESOURCES | true
-        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_JARS      | true
+//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API               | false
+//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_CLASSES       | false
+//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_JARS          | false
+//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME           | true
+//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_CLASSES   | false
+//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_RESOURCES | true
+//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_JARS      | true
 
-        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API               | false
-        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_CLASSES       | false
-        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_JARS          | false
-        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME           | true
-        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_CLASSES   | false
-        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_RESOURCES | false
-        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_JARS      | true
+//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API               | false
+//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_CLASSES       | false
+//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_JARS          | false
+//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME           | true
+//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_CLASSES   | false
+//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_RESOURCES | false
+//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_JARS      | true
     }
 
     @Issue("gradle/gradle#8700")
@@ -510,12 +510,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         given:
         JavaEcosystemSupport.UsageDisambiguationRules rules = new JavaEcosystemSupport.UsageDisambiguationRules(
                 usage(Usage.JAVA_API),
-                usage(Usage.JAVA_API_JARS),
-                usage(Usage.JAVA_API_CLASSES),
-                usage(Usage.JAVA_RUNTIME),
-                usage(Usage.JAVA_RUNTIME_JARS),
-                usage(Usage.JAVA_RUNTIME_CLASSES),
-                usage(Usage.JAVA_RUNTIME_RESOURCES)
+                usage(Usage.JAVA_RUNTIME)
         )
         MultipleCandidatesDetails details = Mock()
 
@@ -529,13 +524,13 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         where: // not exhaustive, tests pathological cases
         consumer                | candidates                                            | preferred
-        Usage.JAVA_API          | [Usage.JAVA_API_JARS, Usage.JAVA_API_CLASSES]         | Usage.JAVA_API_CLASSES
-        Usage.JAVA_API          | [Usage.JAVA_RUNTIME_CLASSES, Usage.JAVA_API_CLASSES]  | Usage.JAVA_API_CLASSES
-        Usage.JAVA_API          | [Usage.JAVA_RUNTIME_CLASSES, Usage.JAVA_RUNTIME_JARS] | Usage.JAVA_RUNTIME_CLASSES
-        Usage.JAVA_API          | [Usage.JAVA_API_JARS, Usage.JAVA_RUNTIME_JARS]        | Usage.JAVA_API_JARS
+        Usage.JAVA_API          | [Usage.JAVA_API, Usage.JAVA_RUNTIME]         | Usage.JAVA_API
+//        Usage.JAVA_API          | [Usage.JAVA_RUNTIME_CLASSES, Usage.JAVA_API_CLASSES]  | Usage.JAVA_API_CLASSES
+//        Usage.JAVA_API          | [Usage.JAVA_RUNTIME_CLASSES, Usage.JAVA_RUNTIME_JARS] | Usage.JAVA_RUNTIME_CLASSES
+//        Usage.JAVA_API          | [Usage.JAVA_API_JARS, Usage.JAVA_RUNTIME_JARS]        | Usage.JAVA_API_JARS
 
-        Usage.JAVA_RUNTIME      | [Usage.JAVA_RUNTIME, Usage.JAVA_RUNTIME_JARS]         | Usage.JAVA_RUNTIME
-        Usage.JAVA_RUNTIME_JARS | [Usage.JAVA_RUNTIME, Usage.JAVA_RUNTIME_JARS]         | Usage.JAVA_RUNTIME_JARS
+        Usage.JAVA_RUNTIME      | [Usage.JAVA_RUNTIME, Usage.JAVA_API]         | Usage.JAVA_RUNTIME
+//        Usage.JAVA_RUNTIME_JARS | [Usage.JAVA_RUNTIME, Usage.JAVA_RUNTIME_JARS]         | Usage.JAVA_RUNTIME_JARS
 
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -452,6 +452,11 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         Usage.JAVA_RUNTIME           | Usage.JAVA_API               | false
         Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME           | true
+
+        // Temporary compatibility
+        Usage.JAVA_API               | Usage.JAVA_RUNTIME_JARS      | true
+        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_JARS      | true
+
     }
 
     @Issue("gradle/gradle#8700")
@@ -460,7 +465,9 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         given:
         JavaEcosystemSupport.UsageDisambiguationRules rules = new JavaEcosystemSupport.UsageDisambiguationRules(
                 usage(Usage.JAVA_API),
-                usage(Usage.JAVA_RUNTIME)
+                usage(Usage.JAVA_API_JARS),
+                usage(Usage.JAVA_RUNTIME),
+                usage(Usage.JAVA_RUNTIME_JARS)
         )
         MultipleCandidatesDetails details = Mock()
 
@@ -472,11 +479,14 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         1 * details.getCandidateValues() >> candidates.collect { usage(it) }
         1 * details.closestMatch(usage(preferred))
 
-        where:
-        consumer                | candidates                                            | preferred
-        Usage.JAVA_API          | [Usage.JAVA_API, Usage.JAVA_RUNTIME]         | Usage.JAVA_API
+        where: // not exhaustive, tests pathological cases
+        consumer                | candidates                                     | preferred
+        Usage.JAVA_API          | [Usage.JAVA_API, Usage.JAVA_RUNTIME]           | Usage.JAVA_API
+        Usage.JAVA_RUNTIME      | [Usage.JAVA_RUNTIME, Usage.JAVA_API]           | Usage.JAVA_RUNTIME
 
-        Usage.JAVA_RUNTIME      | [Usage.JAVA_RUNTIME, Usage.JAVA_API]         | Usage.JAVA_RUNTIME
+        //Temporary compatibility
+        Usage.JAVA_API          | [Usage.JAVA_API_JARS, Usage.JAVA_RUNTIME_JARS] | Usage.JAVA_API_JARS
+        Usage.JAVA_RUNTIME      | [Usage.JAVA_API, Usage.JAVA_RUNTIME_JARS]      | Usage.JAVA_RUNTIME_JARS
 
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -448,60 +448,10 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         where:
         consumer                     | producer                     | compatible
         Usage.JAVA_API               | Usage.JAVA_API               | true
-//        Usage.JAVA_API               | Usage.JAVA_API_CLASSES       | true
-//        Usage.JAVA_API               | Usage.JAVA_API_JARS          | true
         Usage.JAVA_API               | Usage.JAVA_RUNTIME           | true
-//        Usage.JAVA_API               | Usage.JAVA_RUNTIME_CLASSES   | true
-//        Usage.JAVA_API               | Usage.JAVA_RUNTIME_RESOURCES | false
-//        Usage.JAVA_API               | Usage.JAVA_RUNTIME_JARS      | true
-
-//        Usage.JAVA_API_CLASSES       | Usage.JAVA_API               | true
-//        Usage.JAVA_API_CLASSES       | Usage.JAVA_API_CLASSES       | true
-//        Usage.JAVA_API_CLASSES       | Usage.JAVA_API_JARS          | true
-//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME           | true
-//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_CLASSES   | true
-//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_RESOURCES | false
-//        Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_JARS      | true
-
-//        Usage.JAVA_API_JARS          | Usage.JAVA_API               | true
-//        Usage.JAVA_API_JARS          | Usage.JAVA_API_CLASSES       | false
-//        Usage.JAVA_API_JARS          | Usage.JAVA_API_JARS          | true
-//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME           | true
-//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_CLASSES   | false
-//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_RESOURCES | false
-//        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_JARS      | true
 
         Usage.JAVA_RUNTIME           | Usage.JAVA_API               | false
-//        Usage.JAVA_RUNTIME           | Usage.JAVA_API_CLASSES       | false
-//        Usage.JAVA_RUNTIME           | Usage.JAVA_API_JARS          | false
         Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME           | true
-//        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_CLASSES   | false
-//        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_RESOURCES | false
-//        Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_JARS      | true
-
-//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API               | false
-//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_CLASSES       | false
-//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_JARS          | false
-//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME           | true
-//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_CLASSES   | true
-//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_RESOURCES | false
-//        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_JARS      | true
-
-//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API               | false
-//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_CLASSES       | false
-//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_JARS          | false
-//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME           | true
-//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_CLASSES   | false
-//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_RESOURCES | true
-//        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_JARS      | true
-
-//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API               | false
-//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_CLASSES       | false
-//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_JARS          | false
-//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME           | true
-//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_CLASSES   | false
-//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_RESOURCES | false
-//        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_JARS      | true
     }
 
     @Issue("gradle/gradle#8700")
@@ -522,15 +472,11 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         1 * details.getCandidateValues() >> candidates.collect { usage(it) }
         1 * details.closestMatch(usage(preferred))
 
-        where: // not exhaustive, tests pathological cases
+        where:
         consumer                | candidates                                            | preferred
         Usage.JAVA_API          | [Usage.JAVA_API, Usage.JAVA_RUNTIME]         | Usage.JAVA_API
-//        Usage.JAVA_API          | [Usage.JAVA_RUNTIME_CLASSES, Usage.JAVA_API_CLASSES]  | Usage.JAVA_API_CLASSES
-//        Usage.JAVA_API          | [Usage.JAVA_RUNTIME_CLASSES, Usage.JAVA_RUNTIME_JARS] | Usage.JAVA_RUNTIME_CLASSES
-//        Usage.JAVA_API          | [Usage.JAVA_API_JARS, Usage.JAVA_RUNTIME_JARS]        | Usage.JAVA_API_JARS
 
         Usage.JAVA_RUNTIME      | [Usage.JAVA_RUNTIME, Usage.JAVA_API]         | Usage.JAVA_RUNTIME
-//        Usage.JAVA_RUNTIME_JARS | [Usage.JAVA_RUNTIME, Usage.JAVA_RUNTIME_JARS]         | Usage.JAVA_RUNTIME_JARS
 
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.plugins
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.Format
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -94,9 +95,11 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         classpath.canBeResolved
         classpath.extendsFrom == [runtimeElements] as Set
         def attributes = classpath.attributes.keySet()
-        attributes.size() == 1
-        def usage = classpath.attributes.getAttribute(attributes[0])
+        attributes.size() == 2
+        def usage = classpath.attributes.getAttribute(Usage.USAGE_ATTRIBUTE)
         usage.name == Usage.JAVA_RUNTIME
+        def format = classpath.attributes.getAttribute(Format.FORMAT_ATTRIBUTE)
+        format.name == Format.JAR
 
     }
 
@@ -120,7 +123,7 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         runtimeUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         runtimeUsage.dependencyConstraints.size() == 2
         runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
-        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Format.FORMAT_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
         runtimeUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
         runtimeUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
 
@@ -128,7 +131,7 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         apiUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         apiUsage.dependencyConstraints.size() == 1
         apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
-        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Format.FORMAT_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
         apiUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
         apiUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.plugins
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.Format
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -98,8 +98,8 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         attributes.size() == 2
         def usage = classpath.attributes.getAttribute(Usage.USAGE_ATTRIBUTE)
         usage.name == Usage.JAVA_RUNTIME
-        def format = classpath.attributes.getAttribute(Format.FORMAT_ATTRIBUTE)
-        format.name == Format.JAR
+        def format = classpath.attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)
+        format.name == LibraryElements.JAR
 
     }
 
@@ -123,7 +123,7 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         runtimeUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         runtimeUsage.dependencyConstraints.size() == 2
         runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
-        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Format.FORMAT_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
         runtimeUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
         runtimeUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
 
@@ -131,7 +131,7 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         apiUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         apiUsage.dependencyConstraints.size() == 1
         apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
-        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Format.FORMAT_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
         apiUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
         apiUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -110,7 +110,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
             public void execute(ActionConfiguration actionConfiguration) {
                 actionConfiguration.params(incrementalAnalysisUsage);
                 actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_API));
-                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS));
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
             }
         });
     }
@@ -252,19 +252,19 @@ public class ScalaBasePlugin implements Plugin<Project> {
 
     static class UsageDisambiguationRules implements AttributeDisambiguationRule<Usage> {
         private final ImmutableSet<Usage> expectedUsages;
-        private final Usage javaRuntimeJars;
+        private final Usage javaRuntime;
 
         @Inject
-        UsageDisambiguationRules(Usage incrementalAnalysis, Usage javaApi, Usage javaRuntimeJars) {
-            this.javaRuntimeJars = javaRuntimeJars;
-            this.expectedUsages = ImmutableSet.of(incrementalAnalysis, javaApi, javaRuntimeJars);
+        UsageDisambiguationRules(Usage incrementalAnalysis, Usage javaApi, Usage javaRuntime) {
+            this.javaRuntime = javaRuntime;
+            this.expectedUsages = ImmutableSet.of(incrementalAnalysis, javaApi, javaRuntime);
         }
 
         @Override
         public void execute(MultipleCandidatesDetails<Usage> details) {
             if (details.getConsumerValue() == null) {
                 if (details.getCandidateValues().equals(expectedUsages)) {
-                    details.closestMatch(javaRuntimeJars);
+                    details.closestMatch(javaRuntime);
                 }
             }
         }


### PR DESCRIPTION
A solution for #6784.

This PR requires #9670 to be merged first.

### How it works

Turn on using the `jar`, built by the _jar task_, instead of the class folder on the compile classpath by setting the following system property:

`org.gradle.java.compile-classpath-packaging=true`

### Measurements 
Results for measuring the [huge project](https://github.com/gradle/gradle/blob/5b7a84089e44e9eee446ee7401ff7f6fb4a44fda/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProject.groovy#L38-L41) on Windows:

**Without compile-classpath-packaging** 

```
    Measuring Gradle tasks: clean classes
    Speed java-library-plugin: Results were inconclusive with 95% confidence.
    Difference: 22.622 s slower (22622 ms), 9.79%
      java-library-plugin median: 4.23 m min: 4.164 m, max: 4.266 m, se: 2.516 s}
      > [4.266 m, 4.23 m, 4.164 m]
      java-plugin median: 3.853 m min: 3.837 m, max: 3.866 m, se: 710.32 ms}
      > [3.837 m, 3.866 m, 3.853 m]
```

**With compile-classpath-packaging** 
```
    Measuring Gradle tasks: clean classes
    Speed java-library-plugin: Results were inconclusive with 95% confidence.
    Difference: 10.114 s faster (10114 ms), -4.37%
      java-library-plugin median: 3.688 m min: 3.671 m, max: 3.72 m, se: 1.22 s}
      > [3.688 m, 3.671 m, 3.72 m]
      java-plugin median: 3.856 m min: 3.839 m, max: 3.86 m, se: 544.53 ms}
      > [3.839 m, 3.86 m, 3.856 m]
```