### PR TITLE
Fix exclude rule merging performance

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.factories;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeAnyOf;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.GroupExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.GroupSetExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleIdExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleIdSetExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleSetExclude;
+
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+class Intersections {
+    private final ExcludeFactory factory;
+
+    public Intersections(ExcludeFactory factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * Tries to compute an intersection of 2 specs.
+     * The result MUST be a simplification, otherwise this method returns null.
+     */
+    ExcludeSpec tryIntersect(ExcludeSpec left, ExcludeSpec right) {
+        if (left.equals(right)) {
+            return left;
+        }
+        if (left instanceof GroupExclude) {
+            return intersectGroup((GroupExclude) left, right);
+        } else if (right instanceof GroupExclude) {
+            return intersectGroup((GroupExclude) right, left);
+        } else if (left instanceof ModuleExclude) {
+            return intersectModule((ModuleExclude) left, right);
+        } else if (right instanceof ModuleExclude) {
+            return intersectModule((ModuleExclude) right, left);
+        } else if (left instanceof GroupSetExclude) {
+            return intersectGroupSet((GroupSetExclude) left, right);
+        } else if (right instanceof GroupSetExclude) {
+            return intersectGroupSet((GroupSetExclude) right, left);
+        } else if (left instanceof ModuleIdSetExclude) {
+            return intersectModuleIdSet((ModuleIdSetExclude) left, right);
+        } else if (right instanceof ModuleIdSetExclude) {
+            return intersectModuleIdSet((ModuleIdSetExclude) right, left);
+        } else if (left instanceof ExcludeAnyOf) {
+            return intersectAnyOf((ExcludeAnyOf) left, right);
+        }
+        return null;
+    }
+
+    private ExcludeSpec intersectAnyOf(ExcludeAnyOf left, ExcludeSpec right) {
+        if (right instanceof ExcludeAnyOf) {
+            Set<ExcludeSpec> common = Sets.newHashSet(left.getComponents());
+            Set<ExcludeSpec> rightComponents = ((ExcludeAnyOf) right).getComponents();
+            common.retainAll(rightComponents);
+            if (common.size() >= 1) {
+                Set<ExcludeSpec> toIntersect = Sets.newHashSet();
+                for (ExcludeSpec component : left.getComponents()) {
+                    if (!common.contains(component)) {
+                        toIntersect.add(component);
+                    }
+                }
+                for (ExcludeSpec component : rightComponents) {
+                    if (!common.contains(component)) {
+                        toIntersect.add(component);
+                    }
+                }
+                ExcludeSpec alpha = common.size() == 1 ? common.iterator().next() : factory.anyOf(common);
+                ExcludeSpec beta = toIntersect.size() == 1 ? toIntersect.iterator().next() : factory.allOf(toIntersect);
+                return factory.anyOf(alpha, beta);
+            }
+        }
+        return null;
+    }
+
+    private ExcludeSpec intersectModuleIdSet(ModuleIdSetExclude left, ExcludeSpec right) {
+        Set<ModuleIdentifier> moduleIds = left.getModuleIds();
+        if (right instanceof ModuleIdSetExclude) {
+            Set<ModuleIdentifier> common = Sets.newHashSet(((ModuleIdSetExclude) right).getModuleIds());
+            common.retainAll(moduleIds);
+            return moduleIds(common);
+        }
+        return null;
+    }
+
+    private ExcludeSpec moduleIds(Set<ModuleIdentifier> common) {
+        if (common.isEmpty()) {
+            return factory.nothing();
+        }
+        if (common.size() == 1) {
+            return factory.moduleId(common.iterator().next());
+        }
+        return factory.moduleIdSet(common);
+    }
+
+    private ExcludeSpec intersectGroup(GroupExclude left, ExcludeSpec right) {
+        String group = left.getGroup();
+        if (right instanceof GroupExclude) {
+            // equality has been tested before so we know groups are different
+            return factory.nothing();
+        } else if (right instanceof ModuleIdExclude) {
+            if (((ModuleIdExclude) right).getModuleId().getGroup().equals(group)) {
+                return right;
+            } else {
+                return factory.nothing();
+            }
+        } else if (right instanceof GroupSetExclude) {
+            if (((GroupSetExclude) right).getGroups().stream().anyMatch(g -> g.equals(group))) {
+                return left;
+            }
+            return factory.nothing();
+        } else if (right instanceof ModuleIdSetExclude) {
+            Set<ModuleIdentifier> moduleIds = ((ModuleIdSetExclude) right).getModuleIds().stream().filter(id -> id.getGroup().equals(group)).collect(toSet());
+            return moduleIdSet(moduleIds);
+        }
+        return null;
+    }
+
+    private ExcludeSpec moduleIdSet(Set<ModuleIdentifier> moduleIds) {
+        if (moduleIds.isEmpty()) {
+            return factory.nothing();
+        }
+        if (moduleIds.size() == 1) {
+            return factory.moduleId(moduleIds.iterator().next());
+        }
+        return factory.moduleIdSet(moduleIds);
+    }
+
+    private ExcludeSpec intersectGroupSet(GroupSetExclude left, ExcludeSpec right) {
+        Set<String> groups = left.getGroups();
+        if (right instanceof GroupSetExclude) {
+            Set<String> common = Sets.newHashSet(((GroupSetExclude) right).getGroups());
+            common.retainAll(groups);
+            return groupSet(common);
+        } else if (right instanceof ModuleIdExclude) {
+            if (groups.contains(((ModuleIdExclude) right).getModuleId().getGroup())) {
+                return right;
+            }
+            return factory.nothing();
+        } else if (right instanceof ModuleIdSetExclude) {
+            Set<ModuleIdentifier> filtered = ((ModuleIdSetExclude) right).getModuleIds()
+                .stream()
+                .filter(id -> groups.contains(id.getGroup()))
+                .collect(toSet());
+            return moduleIdSet(filtered);
+        }
+        return null;
+    }
+
+    private ExcludeSpec groupSet(Set<String> common) {
+        if (common.isEmpty()) {
+            return factory.nothing();
+        }
+        if (common.size() == 1) {
+            return factory.group(common.iterator().next());
+        }
+        return factory.groupSet(common);
+    }
+
+
+    private ExcludeSpec intersectModule(ModuleExclude left, ExcludeSpec right) {
+        String module = left.getModule();
+        if (right instanceof ModuleExclude) {
+            if (((ModuleExclude) right).getModule().equals(module)) {
+                return left;
+            } else {
+                return factory.nothing();
+            }
+        } else if (right instanceof ModuleIdExclude) {
+            if (((ModuleIdExclude) right).getModuleId().getName().equals(module)) {
+                return right;
+            } else {
+                return factory.nothing();
+            }
+        } else if (right instanceof ModuleSetExclude) {
+            if (((ModuleSetExclude) right).getModules().stream().anyMatch(g -> g.equals(module))) {
+                return left;
+            }
+            return factory.nothing();
+        } else if (right instanceof ModuleIdSetExclude) {
+            Set<ModuleIdentifier> common = ((ModuleIdSetExclude) right).getModuleIds().stream().filter(id -> id.getName().equals(module)).collect(toSet());
+            return moduleIdSet(common);
+        }
+        return null;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactory.java
@@ -51,8 +51,11 @@ import static java.util.stream.Collectors.toSet;
  * It shouldn't be too slow, or the whole chain will pay the price.
  */
 public class NormalizingExcludeFactory extends DelegatingExcludeFactory {
+    private final Intersections intersections;
+
     public NormalizingExcludeFactory(ExcludeFactory delegate) {
         super(delegate);
+        this.intersections = new Intersections(this);
     }
 
     @Override
@@ -264,6 +267,33 @@ public class NormalizingExcludeFactory extends DelegatingExcludeFactory {
         Set<ExcludeSpec> result = flattened.result;
         if (result.isEmpty()) {
             return everything();
+        }
+        if (result.size() > 1) {
+            // try simplify
+            ExcludeSpec[] asArray = result.toArray(new ExcludeSpec[result.size()]);
+            boolean simplified = false;
+            for (int i = 0; i < asArray.length; i++) {
+                ExcludeSpec left = asArray[i];
+                if (left != null) {
+                    for (int j = 0; j < asArray.length; j++) {
+                        ExcludeSpec right = asArray[j];
+                        if (right != null && i != j) {
+                            ExcludeSpec merged = intersections.tryIntersect(left, right);
+                            if (merged != null) {
+                                if (merged instanceof ExcludeNothing) {
+                                    return merged;
+                                }
+                                asArray[i] = merged;
+                                asArray[j] = null;
+                                simplified = true;
+                            }
+                        }
+                    }
+                }
+            }
+            if (simplified) {
+                result = Arrays.stream(asArray).filter(Objects::nonNull).collect(toSet());
+            }
         }
         return Optimizations.optimizeCollection(this, result, delegate::allOf);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultCompositeExclude.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultCompositeExclude.java
@@ -49,14 +49,17 @@ abstract class DefaultCompositeExclude implements CompositeExclude {
 
     @Override
     public boolean equalsIgnoreArtifact(ExcludeSpec o) {
-        if (this == o) {
-            return true;
+        if (mayExcludeArtifacts()) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DefaultCompositeExclude that = (DefaultCompositeExclude) o;
+            return equalsIgnoreArtifact(components, that.components);
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DefaultCompositeExclude that = (DefaultCompositeExclude) o;
-        return equalsIgnoreArtifact(components, that.components);
+        return equals(o);
     }
 
     private boolean equalsIgnoreArtifact(ImmutableSet<ExcludeSpec> components, ImmutableSet<ExcludeSpec> other) {
@@ -73,17 +76,38 @@ abstract class DefaultCompositeExclude implements CompositeExclude {
         // The fast check iterator is there assuming that we have 2 collections with identical contents
         // in which case we can perform a faster check for sets, as if they were lists
         Iterator<ExcludeSpec> fastCheckIterator = other.iterator();
+        boolean[] alreadyFound = new boolean[other.size()];
+        int outerCount = 0;
         for (ExcludeSpec component : components) {
             boolean found = false;
             if (fastCheckIterator != null && fastCheckIterator.next().equalsIgnoreArtifact(component)) {
+                alreadyFound[outerCount++] = true;
                 continue;
             }
+            outerCount++;
             // we're unlucky, sets are either different, or in a different order
             fastCheckIterator = null;
+            int innerCount = 0;
+            // perform a first, quick check based on identity, in case it's just
+            // a matter of ordering
             for (ExcludeSpec o : other) {
-                if (component.equalsIgnoreArtifact(o)) {
+                if (!alreadyFound[innerCount] && component == o) {
                     found = true;
+                    alreadyFound[innerCount] = true;
                     break;
+                }
+                innerCount++;
+            }
+            if (!found) {
+                // slowest path when we can't find something which is the same instance
+                innerCount = 0;
+                for (ExcludeSpec o : other) {
+                    if (!alreadyFound[innerCount] && component.equalsIgnoreArtifact(o)) {
+                        found = true;
+                        alreadyFound[innerCount] = true;
+                        break;
+                    }
+                    innerCount++;
                 }
             }
             if (!found) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultCompositeExclude.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultCompositeExclude.java
@@ -77,14 +77,18 @@ abstract class DefaultCompositeExclude implements CompositeExclude {
         // in which case we can perform a faster check for sets, as if they were lists
         Iterator<ExcludeSpec> fastCheckIterator = other.iterator();
         boolean[] alreadyFound = new boolean[other.size()];
-        int outerCount = 0;
+        int fastCheckCount = 0;
         for (ExcludeSpec component : components) {
             boolean found = false;
-            if (fastCheckIterator != null && fastCheckIterator.next().equalsIgnoreArtifact(component)) {
-                alreadyFound[outerCount++] = true;
-                continue;
+            if (fastCheckIterator != null) {
+                if (fastCheckIterator.next().equalsIgnoreArtifact(component)) {
+                    alreadyFound[fastCheckCount++] = true;
+                    continue;
+                } else if (!fastCheckIterator.hasNext()) {
+                    // this was the last element, so we already know there's no possible match
+                    return false;
+                }
             }
-            outerCount++;
             // we're unlucky, sets are either different, or in a different order
             fastCheckIterator = null;
             int innerCount = 0;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultExcludeAllOf.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultExcludeAllOf.java
@@ -30,6 +30,8 @@ final class DefaultExcludeAllOf extends DefaultCompositeExclude implements Exclu
         super(components);
     }
 
+    private Boolean mayExcludeArtifacts;
+
     @Override
     protected String getDisplayName() {
         return "all of";
@@ -47,7 +49,11 @@ final class DefaultExcludeAllOf extends DefaultCompositeExclude implements Exclu
 
     @Override
     public boolean mayExcludeArtifacts() {
-        return components().allMatch(ExcludeSpec::mayExcludeArtifacts);
+        if (mayExcludeArtifacts != null) {
+            return mayExcludeArtifacts;
+        }
+        mayExcludeArtifacts = components().allMatch(ExcludeSpec::mayExcludeArtifacts);
+        return mayExcludeArtifacts;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultExcludeAnyOf.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultExcludeAnyOf.java
@@ -30,6 +30,8 @@ final class DefaultExcludeAnyOf extends DefaultCompositeExclude implements Exclu
         super(components);
     }
 
+    private Boolean mayExcludeArtifacts;
+
     @Override
     protected String getDisplayName() {
         return "any of";
@@ -47,6 +49,10 @@ final class DefaultExcludeAnyOf extends DefaultCompositeExclude implements Exclu
 
     @Override
     public boolean mayExcludeArtifacts() {
-        return components().anyMatch(ExcludeSpec::mayExcludeArtifacts);
+        if (mayExcludeArtifacts != null) {
+            return mayExcludeArtifacts;
+        }
+        mayExcludeArtifacts = components().anyMatch(ExcludeSpec::mayExcludeArtifacts);
+        return mayExcludeArtifacts;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultModuleArtifactExclude.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultModuleArtifactExclude.java
@@ -82,4 +82,9 @@ final class DefaultModuleArtifactExclude implements ArtifactExclude {
     public int hashCode() {
         return hashCode;
     }
+
+    @Override
+    public String toString() {
+        return "{artifact " + artifactName + " of module=" + moduleId + "}";
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/IntersectionsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/IntersectionsTest.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.factories
+
+
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.simple.DefaultExcludeFactory
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import static org.gradle.api.internal.artifacts.DefaultModuleIdentifier.newId
+
+class IntersectionsTest extends Specification {
+    @Shared
+    private ExcludeFactory factory = new DefaultExcludeFactory()
+
+    @Subject
+    private Intersections ops = new Intersections(factory)
+
+    def "intersects identical specs"() {
+        expect:
+        ops.tryIntersect(spec, spec) == spec
+
+        where:
+        spec << [
+            group("foo"),
+            groupSet("foo", "bar"),
+            module("foo"),
+            moduleSet("foo", "bar"),
+            moduleId("foo", "bar"),
+            moduleIdSet(["foo", "bar"], ["foo", "baz"])
+        ]
+    }
+
+    @Unroll
+    def "intersection of #one with #other = #expected"() {
+        expect:
+        ops.tryIntersect(one, other) == expected
+        ops.tryIntersect(other, one) == expected
+
+        where:
+        one                                                     | other                                                         | expected
+        group("org")                                            | group("foo")                                                  | factory.nothing()
+        group("org")                                            | group("org")                                                  | group("org")
+        group("org")                                            | groupSet("foo", "org")                                        | group("org")
+        group("org")                                            | groupSet("foo", "org", "baz")                                 | group("org")
+        group("org")                                            | groupSet("foo", "baz")                                        | factory.nothing()
+        group("org")                                            | moduleId("org", "bar")                                        | moduleId("org", "bar")
+        group("org")                                            | moduleId("com", "bar")                                        | factory.nothing()
+        group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"])                   | moduleId("org", "bar")
+        group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"], ["org", "baz"])   | moduleIdSet(["org", "bar"], ["org", "baz"])
+        group("org")                                            | module("mod")                                                 | null
+        group("org")                                            | moduleSet("mod", "mod2")                                      | null
+        module("foo")                                           | module("bar")                                                 | factory.nothing()
+        module("foo")                                           | moduleSet("foo", "bar")                                       | module("foo")
+        module("foo")                                           | moduleId("org", "foo")                                        | moduleId("org", "foo")
+        module("foo")                                           | moduleId("org", "bar")                                        | factory.nothing()
+        module("foo")                                           | moduleIdSet(["org", "foo"], ["org", "bar"])                   | moduleId("org", "foo")
+        module("foo")                                           | moduleIdSet(["org", "foo"], ["org", "bar"], ["com", "foo"])   | moduleIdSet(["org", "foo"], ["com", "foo"])
+        groupSet("org", "org2")                                 | groupSet("org2", "org3")                                      | group("org2")
+        groupSet("org", "org2", "org3")                         | groupSet("org", "org3", "org4")                               | groupSet("org", "org3")
+        groupSet("org", "org2")                                 | moduleId("org", "foo")                                        | moduleId("org", "foo")
+        groupSet("org", "org2")                                 | moduleIdSet(["org", "foo"], ["org2", "bar"], ["org3", "baz"]) | moduleIdSet(["org", "foo"], ["org2", "bar"])
+        moduleIdSet(["org", "foo"], ["org", "bar"])             | moduleIdSet(["org", "bar"], ["org2", "baz"])                  | moduleId("org", "bar")
+        moduleIdSet(["org", "foo"], ["org", "bar"])             | moduleIdSet(["org", "bar"], ["org2", "baz"], ["org", "foo"])  | moduleIdSet(["org", "bar"], ["org", "foo"])
+
+        // for operations below the result can be further simplified, but it's not this class responsibility to do it
+        anyOf(group("foo"), group("bar"))                       | anyOf(group("foo"), group("baz"))                             | anyOf(group("foo"), allOf(group("bar"), group("baz")))
+        anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "c"])) | anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "d"]))       | anyOf(group("g1"), allOf(moduleIdSet(["a", "b"], ["a", "c"]), moduleIdSet(["a", "b"], ["a", "d"])))
+    }
+
+    @Unroll("intersection of #one with #other = #expected using normalizing factory")
+    def "further simplifications are performed by the normalizing factory"() {
+        given:
+        factory = new NormalizingExcludeFactory(factory)
+        ops = new Intersections(factory)
+
+        expect:
+        ops.tryIntersect(one, other) == expected
+        ops.tryIntersect(other, one) == expected
+
+        where:
+        one                                                     | other                                                   | expected
+        anyOf(group("foo"), group("bar"))                       | anyOf(group("foo"), group("baz"))                       | group("foo")
+        anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "c"])) | anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "d"])) | anyOf(group("g1"), moduleId("a", "b"))
+    }
+
+    private ExcludeSpec group(String group) {
+        factory.group(group)
+    }
+
+    private ExcludeSpec module(String name) {
+        factory.module(name)
+    }
+
+    private ExcludeSpec moduleSet(String... names) {
+        factory.moduleSet(names as Set<String>)
+    }
+
+    private ExcludeSpec groupSet(String... groups) {
+        factory.groupSet(groups as Set<String>)
+    }
+
+    private ExcludeSpec moduleId(String group, String name) {
+        factory.moduleId(newId(group, name))
+    }
+
+    private ExcludeSpec moduleIdSet(List<String>... ids) {
+        factory.moduleIdSet(ids.collect { newId(it[0], it[1]) } as Set)
+    }
+
+    private ExcludeSpec anyOf(ExcludeSpec... specs) {
+        switch (specs.length) {
+            case 0:
+                return factory.nothing()
+            case 1:
+                return specs[0]
+            case 2:
+                return factory.anyOf(specs[0], specs[1])
+            default:
+                return factory.anyOf(specs as Set)
+        }
+    }
+
+    private ExcludeSpec allOf(ExcludeSpec... specs) {
+        switch (specs.length) {
+            case 0:
+                return factory.nothing()
+            case 1:
+                return specs[0]
+            case 2:
+                return factory.allOf(specs[0], specs[1])
+            default:
+                return factory.allOf(specs as Set)
+        }
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactoryTest.groovy
@@ -47,16 +47,16 @@ class NormalizingExcludeFactoryTest extends Specification {
         factory.anyOf(right, left) == expected
 
         where:
-        left                               | right                | expected
-        everything()                       | nothing()            | everything()
-        everything()                       | everything()         | everything()
-        nothing()                          | nothing()            | nothing()
-        everything()                       | group("foo")         | everything()
-        nothing()                          | group("foo")         | group("foo")
+        left                               | right         | expected
+        everything()                       | nothing()     | everything()
+        everything()                       | everything()  | everything()
+        nothing()                          | nothing()     | nothing()
+        everything()                       | group("foo")  | everything()
+        nothing()                          | group("foo")  | group("foo")
         //group("foo")                       | group("bar")         | anyOf(group("foo"), group("bar"))
-        group("foo")                       | module("bar")        | anyOf(group("foo"), module("bar"))
+        group("foo")                       | module("bar") | anyOf(group("foo"), module("bar"))
         //anyOf(group("foo"), group("bar"))  | group("foo")         | anyOf(group("foo"), group("bar"))
-        anyOf(group("foo"), module("bar")) | module("bar")        | anyOf(module("bar"), group("foo"))
+        anyOf(group("foo"), module("bar")) | module("bar") | anyOf(module("bar"), group("foo"))
     }
 
     @Unroll("#one ∪ #two ∪ #three = #expected")
@@ -84,14 +84,15 @@ class NormalizingExcludeFactoryTest extends Specification {
         factory.allOf(right, left) == expected
 
         where:
-        left                                                 | right                                                                             | expected
-        everything()                                         | nothing()                                                                         | nothing()
-        everything()                                         | everything()                                                                      | everything()
-        nothing()                                            | nothing()                                                                         | nothing()
-        everything()                                         | group("foo")                                                                      | group("foo")
-        nothing()                                            | group("foo")                                                                      | nothing()
-        group("foo")                                         | group("foo")                                                                      | group("foo")
-        allOf(group("foo"), group("foo2"))                   | module("bar")                                                                     | allOf(group("foo2"), group("foo"), module("bar"))
+        left                               | right         | expected
+        everything()                       | nothing()     | nothing()
+        everything()                       | everything()  | everything()
+        nothing()                          | nothing()     | nothing()
+        everything()                       | group("foo")  | group("foo")
+        nothing()                          | group("foo")  | nothing()
+        group("foo")                       | group("foo")  | group("foo")
+        allOf(group("foo"), group("foo2")) | module("bar") | nothing()
+        allOf(group("foo"), module("bar")) | module("bar") | allOf(group("foo"), module("bar"))
     }
 
     private ExcludeSpec nothing() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultCompositeExcludeTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultCompositeExcludeTest.groovy
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.simple
+
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ArtifactExclude
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.CompositeExclude
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.GroupExclude
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.GroupSetExclude
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleExclude
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleIdExclude
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleIdSetExclude
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleSetExclude
+import org.gradle.internal.component.model.DefaultIvyArtifactName
+import org.gradle.internal.component.model.IvyArtifactName
+import spock.lang.Specification
+
+class DefaultCompositeExcludeTest extends Specification {
+    private static final DefaultExcludeFactory FACTORY = new DefaultExcludeFactory()
+    private static final String[] GROUPS = ["org.foo", "org.bar", "org.baz", "com.acme"]
+    private static final String[] MODULES = ["mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"]
+    private static final IvyArtifactName[] ARTIFACTS = [artifactName("foo"), artifactName('bar'), artifactName('baz'), artifactName('foo', 'jar', 'jar', 'classy')]
+    private static final Long SEED = Long.getLong("org.gradle.internal.test.excludes.seed", 58745094L)
+    private static final int MAX_DEPTH = 3
+    private static final int MAX_CACHED = 10_000
+
+    private final Random random = new Random(SEED)
+    private final Set<ExcludeSpec> cached = new HashSet<>()
+    private final List<ExcludeSpec> cachedLinear = new ArrayList<>(MAX_CACHED)
+    private int depth
+
+    /**
+     * This test has been baked to maximize code coverage of {@link DefaultCompositeExclude}
+     */
+    def "compares specs"() {
+        expect:
+        (500_000).times {
+            ExcludeSpec a = next()
+            ExcludeSpec b = next()
+
+            if (a == b) {
+                assert b == a
+                assert a.equalsIgnoreArtifact(b)
+                assert b.equalsIgnoreArtifact(a)
+            } else {
+                if (a.equalsIgnoreArtifact(b)) {
+                    if (a instanceof CompositeExclude || b instanceof CompositeExclude) {
+                        println("$a\n   equalsIgnoreArtifact\n$b\n")
+                    }
+                }
+                assert !(b == a)
+            }
+            if (a.equalsIgnoreArtifact(b)) {
+                assert b.equalsIgnoreArtifact(a)
+            } else {
+                assert !b.equalsIgnoreArtifact(a)
+            }
+        }
+        true
+    }
+
+    ExcludeSpec cache(ExcludeSpec spec) {
+        if (cached.add(spec)) {
+            cachedLinear << spec
+        }
+        spec
+    }
+
+    ExcludeSpec next() {
+        try {
+            int rnd = random.nextInt(9)
+            if (depth++ == MAX_DEPTH) {
+                // avoid too deep levels
+                rnd = rnd % 6
+            }
+            if (cached.size() >= MAX_CACHED) {
+                rnd = 0 // always use a cached value
+            }
+            switch (rnd) {
+                case 0:
+                    return cached ? cachedLinear[random.nextInt(cached.size())] : next()
+                case 1:
+                    return cache(nextModule())
+                case 2:
+                    return cache(nextGroup())
+                case 3:
+                    return cache(nextModuleId())
+                case 4:
+                    return cache(nextGroupSet())
+                case 5:
+                    return cache(nextModuleIdSet())
+                case 6:
+                    return cache(nextArtifact())
+                case 7:
+                    return cache(nextAny())
+                case 8:
+                    return cache(nextAll())
+            }
+            throw new IllegalStateException()
+        } finally {
+            depth--
+        }
+    }
+
+    ModuleExclude nextModule() {
+        FACTORY.module(randomModuleName())
+    }
+
+    GroupExclude nextGroup() {
+        FACTORY.group(randomGroupName())
+    }
+
+    ModuleIdExclude nextModuleId() {
+        FACTORY.moduleId(randomModuleId())
+    }
+
+    ModuleSetExclude nextModuleSet() {
+        FACTORY.moduleSet((0..(1 + random.nextInt(5))).collect { randomModuleName() } as Set<String>)
+    }
+
+    GroupSetExclude nextGroupSet() {
+        FACTORY.groupSet((0..(1 + random.nextInt(5))).collect { randomGroupName() } as Set<String>)
+    }
+
+    ModuleIdSetExclude nextModuleIdSet() {
+        FACTORY.moduleIdSet((0..(1 + random.nextInt(5))).collect { randomModuleId() } as Set<ModuleIdentifier>)
+    }
+
+    ExcludeSpec nextAny() {
+        FACTORY.anyOf((0..(1 + random.nextInt(3))).collect { next() } as Set<ExcludeSpec>)
+    }
+
+    ExcludeSpec nextAll() {
+        FACTORY.allOf((0..(1 + random.nextInt(3))).collect { next() } as Set<ExcludeSpec>)
+    }
+
+    ArtifactExclude nextArtifact() {
+        FACTORY.artifact(randomModuleId(), randomArtifactName())
+    }
+
+    private String randomGroupName() {
+        GROUPS[random.nextInt(GROUPS.length)]
+    }
+
+    private String randomModuleName() {
+        MODULES[random.nextInt(MODULES.length)]
+    }
+
+    private ModuleIdentifier randomModuleId() {
+        DefaultModuleIdentifier.newId(randomGroupName(), randomModuleName())
+    }
+
+    private IvyArtifactName randomArtifactName() {
+        ARTIFACTS[random.nextInt(ARTIFACTS.length)]
+    }
+
+    private static IvyArtifactName artifactName(String name, String type = 'jar', String extension = 'jar', String classifier = null) {
+        new DefaultIvyArtifactName(name, type, extension, classifier)
+    }
+}


### PR DESCRIPTION
### Context

In some cases, calling `equalsIgnoreArtifact` may be extremely
costly. This optimizes the algorithm for different cases:

1. the specs we compare actually do not exclude artifacts, in
which case we can compare by equality
2. the specs we compare are in a different order, in which
case we can avoid deep `equals` calls
3. the specs we compare are different, but some of them are
equal and we should avoid considering them candidates again
