### PR TITLE
Upgrade Guava from 27.1 to 28.0 (android/jre)

### DIFF
--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api("com.google.guava:guava:27.1-jre")
+    api("com.google.guava:guava:28.0-jre")
     api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")
 
     implementation(project(":buildPlatform"))

--- a/buildSrc/subprojects/packaging/packaging.gradle.kts
+++ b/buildSrc/subprojects/packaging/packaging.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":configuration"))
     implementation(project(":build"))
     implementation(project(":kotlinDsl"))
-    implementation("com.google.guava:guava:27.1-jre")
+    implementation("com.google.guava:guava:28.0-android")
     implementation("org.ow2.asm:asm:7.1")
     implementation("org.ow2.asm:asm-commons:7.1")
     implementation("com.google.code.gson:gson:2.7")

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,7 @@ libraries.fastutil =            [coordinates: 'it.unimi.dsi:fastutil', version: 
 libraries.gcs =                 [coordinates: 'com.google.apis:google-api-services-storage', version: 'v1-rev136-1.25.0']
 libraries.groovy =              [coordinates: 'org.gradle.groovy:groovy-all', version: gradleGroovyVersion, because: 'emulating the Groovy 2.4-style groovy-all.jar, see https://github.com/gradle/gradle-groovy-all']
 libraries.gson =                [coordinates: 'com.google.code.gson:gson', version: '2.8.5']
-libraries.guava =               [coordinates: 'com.google.guava:guava', version: '27.1-android', because: 'JRE variant introduces regression - https://github.com/google/guava/issues/3223']
+libraries.guava =               [coordinates: 'com.google.guava:guava', version: '28.0-android', because: 'JRE variant introduces regression - https://github.com/google/guava/issues/3223']
 libraries.inject =              [coordinates: 'javax.inject:javax.inject', version: '1']
 libraries.ivy =                 [coordinates: 'org.apache.ivy:ivy', version: '2.3.0',
                                  because: '2.4.0 contains a breaking change in DefaultModuleDescriptor.getExtraInfo(), cf. https://issues.apache.org/jira/browse/IVY-1457']

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -48,7 +48,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
             'commons-lang-2.6.jar' : '50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c',
             'failureaccess-1.0.1.jar' : 'a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26',
             'groovy-all-1.0-2.5.4.jar' : '704d3307616c57234871c4db3a355c3e81ea975db8dac8ee6c9264b91c74d2b7',
-            'guava-27.1-android.jar' : '686404f2d1d4d221911f96bd627ff60dac2226a5dfa6fb8ba517073eb97ec0ef',
+            'guava-28.0-android.jar' : 'aa12035fa0ce8bdab6a4ddc218c2749df9306126f6fc9171bc0d73a5af2e0549',
             'jansi-1.17.1.jar' : 'b2234bfb0d8f245562d64ed9325df6b907093f4daa702c9082d4796db2a2d894',
             'javax.inject-1.jar' : '91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',
             'jcl-over-slf4j-1.7.25.jar' : '5e938457e79efcbfb3ab64bc29c43ec6c3b95fffcda3c155f4a86cc320c11e14',

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
@@ -30,7 +30,7 @@ class ToolingApiClasspathIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.classpath.size() == 2
         resolve.classpath.any {it.name ==~ /slf4j-api-.*\.jar/}
-        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 1.86 * 1024 * 1024
+        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 2.05 * 1024 * 1024
 
         cleanup:
         resolver.stop()


### PR DESCRIPTION
Separate Guava upgrade from Guava android-to-jre change.
Requirement for https://github.com/gradle/gradle/pull/9503