### PR TITLE
Extract managed factories from managed objects

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -78,6 +78,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
+        public int getFactoryId() {
+            return ManagedFactories.DirectoryManagedFactory.FACTORY_ID;
+        }
+
+        @Override
         public String toString() {
             return value.toString();
         }
@@ -151,6 +156,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         @Override
         public Object unpackState() {
             return file;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return ManagedFactories.RegularFileManagedFactory.FACTORY_ID;
         }
 
         @Override
@@ -247,6 +257,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
+        public int getFactoryId() {
+            return ManagedFactories.RegularFilePropertyManagedFactory.FACTORY_ID;
+        }
+
+        @Override
         public void set(File file) {
             if (file == null) {
                 value(null);
@@ -306,6 +321,11 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         @Override
         public Class<?> publicType() {
             return DirectoryProperty.class;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return ManagedFactories.DirectoryPropertyManagedFactory.FACTORY_ID;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.state.Managed;
+import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -73,8 +74,8 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        public Factory managedFactory() {
-            return new Factory() {
+        public ManagedFactory managedFactory() {
+            return new ManagedFactory() {
                 @Override
                 public <T> T fromState(Class<T> type, Object state) {
                     if (!type.isAssignableFrom(Directory.class)) {
@@ -162,8 +163,8 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        public Factory managedFactory() {
-            return new Factory() {
+        public ManagedFactory managedFactory() {
+            return new ManagedFactory() {
                 @Override
                 public <T> T fromState(Class<T> type, Object state) {
                     if (!type.isAssignableFrom(RegularFile.class)) {
@@ -268,8 +269,8 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        public Factory managedFactory() {
-            return new Factory() {
+        public ManagedFactory managedFactory() {
+            return new ManagedFactory() {
                 @Override
                 public <T> T fromState(Class<T> type, Object state) {
                     if (!type.isAssignableFrom(RegularFileProperty.class)) {
@@ -348,8 +349,8 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        public Factory managedFactory() {
-            return new Factory() {
+        public ManagedFactory managedFactory() {
+            return new ManagedFactory() {
                 @Override
                 public <T> T fromState(Class<T> type, Object state) {
                     if (!type.isAssignableFrom(DirectoryProperty.class)) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -32,7 +32,6 @@ import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.state.Managed;
-import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -74,19 +74,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        public ManagedFactory managedFactory() {
-            return new ManagedFactory() {
-                @Override
-                public <T> T fromState(Class<T> type, Object state) {
-                    if (!type.isAssignableFrom(Directory.class)) {
-                        return null;
-                    }
-                    return type.cast(new FixedDirectory((File) state, fileResolver));
-                }
-            };
-        }
-
-        @Override
         public Object unpackState() {
             return value;
         }
@@ -160,19 +147,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         @Override
         public Class<?> publicType() {
             return RegularFile.class;
-        }
-
-        @Override
-        public ManagedFactory managedFactory() {
-            return new ManagedFactory() {
-                @Override
-                public <T> T fromState(Class<T> type, Object state) {
-                    if (!type.isAssignableFrom(RegularFile.class)) {
-                        return null;
-                    }
-                    return type.cast(new FixedFile((File) state));
-                }
-            };
         }
 
         @Override
@@ -269,19 +243,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        public ManagedFactory managedFactory() {
-            return new ManagedFactory() {
-                @Override
-                public <T> T fromState(Class<T> type, Object state) {
-                    if (!type.isAssignableFrom(RegularFileProperty.class)) {
-                        return null;
-                    }
-                    return type.cast(new DefaultRegularFileVar(fileResolver).value((RegularFile) state));
-                }
-            };
-        }
-
-        @Override
         public Provider<File> getAsFile() {
             return new ToFileProvider(this);
         }
@@ -346,19 +307,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         @Override
         public Class<?> publicType() {
             return DirectoryProperty.class;
-        }
-
-        @Override
-        public ManagedFactory managedFactory() {
-            return new ManagedFactory() {
-                @Override
-                public <T> T fromState(Class<T> type, Object state) {
-                    if (!type.isAssignableFrom(DirectoryProperty.class)) {
-                        return null;
-                    }
-                    return type.cast(new DefaultDirectoryVar(resolver).value((Directory) state));
-                }
-            };
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.DefaultFilePropertyFactory.FixedDirectory;
+import org.gradle.internal.state.ManagedFactory;
+
+import java.io.File;
+
+public class ManagedFactories {
+
+    public static class RegularFileManagedFactory implements ManagedFactory {
+        @Override
+        public <T> T fromState(Class<T> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            return type.cast(new DefaultFilePropertyFactory.FixedFile((File) state));
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(RegularFile.class);
+        }
+    }
+
+    public static class RegularFilePropertyManagedFactory implements ManagedFactory {
+        private final FileResolver fileResolver;
+
+        public RegularFilePropertyManagedFactory(FileResolver fileResolver) {
+            this.fileResolver = fileResolver;
+        }
+
+        @Override
+        public <T> T fromState(Class<T> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            return type.cast(new DefaultFilePropertyFactory.DefaultRegularFileVar(fileResolver).value((RegularFile) state));
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(RegularFileProperty.class);
+        }
+    }
+
+    public static class DirectoryManagedFactory implements ManagedFactory {
+        private final FileResolver fileResolver;
+
+        public DirectoryManagedFactory(FileResolver fileResolver) {
+            this.fileResolver = fileResolver;
+        }
+
+        @Override
+        public <T> T fromState(Class<T> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            return type.cast(new FixedDirectory((File) state, fileResolver));
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(Directory.class);
+        }
+    }
+
+    public static class DirectoryPropertyManagedFactory implements ManagedFactory {
+        private final FileResolver fileResolver;
+
+        public DirectoryPropertyManagedFactory(FileResolver fileResolver) {
+            this.fileResolver = fileResolver;
+        }
+
+        @Override
+        public <T> T fromState(Class<T> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            return type.cast(new DefaultFilePropertyFactory.DefaultDirectoryVar(fileResolver).value((Directory) state));
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(DirectoryProperty.class);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.file;
 
+import com.google.common.base.Objects;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
@@ -27,68 +28,93 @@ import java.io.File;
 
 public class ManagedFactories {
 
-    public static class RegularFileManagedFactory extends ManagedFactory.TypedManagedFactory {
-        public RegularFileManagedFactory() {
-            super(RegularFile.class);
-        }
+    public static class RegularFileManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = RegularFile.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             return type.cast(new DefaultFilePropertyFactory.FixedFile((File) state));
         }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
+        }
     }
 
-    public static class RegularFilePropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
+    public static class RegularFilePropertyManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = RegularFileProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+
         private final FileResolver fileResolver;
 
         public RegularFilePropertyManagedFactory(FileResolver fileResolver) {
-            super(RegularFileProperty.class);
             this.fileResolver = fileResolver;
         }
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             return type.cast(new DefaultFilePropertyFactory.DefaultRegularFileVar(fileResolver).value((RegularFile) state));
         }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
+        }
     }
 
-    public static class DirectoryManagedFactory extends ManagedFactory.TypedManagedFactory {
+    public static class DirectoryManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = Directory.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+
         private final FileResolver fileResolver;
 
         public DirectoryManagedFactory(FileResolver fileResolver) {
-            super(Directory.class);
             this.fileResolver = fileResolver;
         }
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             return type.cast(new FixedDirectory((File) state, fileResolver));
         }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
+        }
     }
 
-    public static class DirectoryPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
+    public static class DirectoryPropertyManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = DirectoryProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+
         private final FileResolver fileResolver;
 
         public DirectoryPropertyManagedFactory(FileResolver fileResolver) {
-            super(DirectoryProperty.class);
             this.fileResolver = fileResolver;
         }
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             return type.cast(new DefaultFilePropertyFactory.DefaultDirectoryVar(fileResolver).value((Directory) state));
+        }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
@@ -27,81 +27,68 @@ import java.io.File;
 
 public class ManagedFactories {
 
-    public static class RegularFileManagedFactory implements ManagedFactory {
+    public static class RegularFileManagedFactory extends ManagedFactory.TypedManagedFactory {
+        public RegularFileManagedFactory() {
+            super(RegularFile.class);
+        }
+
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             return type.cast(new DefaultFilePropertyFactory.FixedFile((File) state));
         }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(RegularFile.class);
-        }
     }
 
-    public static class RegularFilePropertyManagedFactory implements ManagedFactory {
+    public static class RegularFilePropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
         private final FileResolver fileResolver;
 
         public RegularFilePropertyManagedFactory(FileResolver fileResolver) {
+            super(RegularFileProperty.class);
             this.fileResolver = fileResolver;
         }
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             return type.cast(new DefaultFilePropertyFactory.DefaultRegularFileVar(fileResolver).value((RegularFile) state));
         }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(RegularFileProperty.class);
-        }
     }
 
-    public static class DirectoryManagedFactory implements ManagedFactory {
+    public static class DirectoryManagedFactory extends ManagedFactory.TypedManagedFactory {
         private final FileResolver fileResolver;
 
         public DirectoryManagedFactory(FileResolver fileResolver) {
+            super(Directory.class);
             this.fileResolver = fileResolver;
         }
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             return type.cast(new FixedDirectory((File) state, fileResolver));
         }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(Directory.class);
-        }
     }
 
-    public static class DirectoryPropertyManagedFactory implements ManagedFactory {
+    public static class DirectoryPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
         private final FileResolver fileResolver;
 
         public DirectoryPropertyManagedFactory(FileResolver fileResolver) {
+            super(DirectoryProperty.class);
             this.fileResolver = fileResolver;
         }
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             return type.cast(new DefaultFilePropertyFactory.DefaultDirectoryVar(fileResolver).value((Directory) state));
-        }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(DirectoryProperty.class);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
@@ -30,7 +30,8 @@ public class ManagedFactories {
 
     public static class RegularFileManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = RegularFile.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = DefaultFilePropertyFactory.FixedFile.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
@@ -48,7 +49,8 @@ public class ManagedFactories {
 
     public static class RegularFilePropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = RegularFileProperty.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = DefaultFilePropertyFactory.DefaultRegularFileVar.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         private final FileResolver fileResolver;
 
@@ -72,7 +74,8 @@ public class ManagedFactories {
 
     public static class DirectoryManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = Directory.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = FixedDirectory.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         private final FileResolver fileResolver;
 
@@ -96,7 +99,8 @@ public class ManagedFactories {
 
     public static class DirectoryPropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = DirectoryProperty.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = DefaultFilePropertyFactory.DefaultDirectoryVar.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         private final FileResolver fileResolver;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
@@ -43,6 +43,7 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.PluginServiceRegistry;
+import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
@@ -84,6 +85,8 @@ public class PropertyValidationAccess {
             void configure(ServiceRegistration registration) {
                 registration.add(DefaultListenerManager.class, new DefaultListenerManager());
                 registration.add(DefaultCrossBuildInMemoryCacheFactory.class);
+                // TODO: do we need any factories here?
+                registration.add(DefaultManagedFactoryRegistry.class, new DefaultManagedFactoryRegistry());
                 registration.add(DefaultInstantiatorFactory.class);
                 List<PluginServiceRegistry> pluginServiceFactories = new DefaultServiceLocator(false, getClass().getClassLoader()).getAll(PluginServiceRegistry.class);
                 for (PluginServiceRegistry pluginServiceFactory : pluginServiceFactories) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -94,6 +94,7 @@ import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceLocator;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.model.internal.inspect.MethodModelRuleExtractor;
 import org.gradle.model.internal.inspect.MethodModelRuleExtractors;
 import org.gradle.model.internal.inspect.ModelRuleExtractor;
@@ -236,8 +237,8 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         return new StringInterner();
     }
 
-    InstantiatorFactory createInstantiatorFactory(CrossBuildInMemoryCacheFactory cacheFactory, List<InjectAnnotationHandler> annotationHandlers) {
-        return new DefaultInstantiatorFactory(cacheFactory, annotationHandlers);
+    InstantiatorFactory createInstantiatorFactory(CrossBuildInMemoryCacheFactory cacheFactory, List<InjectAnnotationHandler> annotationHandlers, ManagedFactoryRegistry managedFactoryRegistry) {
+        return new DefaultInstantiatorFactory(cacheFactory, annotationHandlers, managedFactoryRegistry);
     }
 
     GradleUserHomeScopeServiceRegistry createGradleUserHomeScopeServiceRegistry(ServiceRegistry globalServices) {
@@ -258,10 +259,6 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
 
     FilePropertyFactory createFilePropertyFactory(FileResolver fileResolver) {
         return new DefaultFilePropertyFactory(fileResolver);
-    }
-
-    NamedObjectInstantiator createNamedObjectInstantiator(CrossBuildInMemoryCacheFactory cacheFactory) {
-        return new NamedObjectInstantiator(cacheFactory);
     }
 
     ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory, NamedObjectInstantiator instantiator) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -93,6 +93,7 @@ import org.gradle.internal.snapshot.WellKnownFileLocations;
 import org.gradle.internal.snapshot.impl.DefaultFileSystemMirror;
 import org.gradle.internal.snapshot.impl.DefaultFileSystemSnapshotter;
 import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter;
+import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.process.internal.JavaExecHandleFactory;
 import org.gradle.process.internal.health.memory.MemoryManager;
 import org.gradle.process.internal.worker.DefaultWorkerProcessFactory;
@@ -150,8 +151,8 @@ public class GradleUserHomeScopeServices {
         return new CrossBuildInMemoryCachingScriptClassCache(cacheFactory);
     }
 
-    DefaultValueSnapshotter createValueSnapshotter(ClassLoaderHierarchyHasher classLoaderHierarchyHasher) {
-        return new DefaultValueSnapshotter(classLoaderHierarchyHasher);
+    DefaultValueSnapshotter createValueSnapshotter(ClassLoaderHierarchyHasher classLoaderHierarchyHasher, ManagedFactoryRegistry managedFactoryRegistry) {
+        return new DefaultValueSnapshotter(classLoaderHierarchyHasher, managedFactoryRegistry);
     }
 
     ClassLoaderHierarchyHasher createClassLoaderHierarchyHasher(ClassLoaderRegistry registry, ClassLoaderHasher classLoaderHasher) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -44,6 +44,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
+import org.gradle.api.internal.file.collections.ManagedFactories;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptClassPathResolver;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
@@ -89,6 +90,8 @@ import org.gradle.internal.resource.TextResourceLoader;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.state.DefaultManagedFactoryRegistry;
+import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.typeconversion.DefaultTypeConverter;
 import org.gradle.internal.typeconversion.TypeConverter;
@@ -325,6 +328,19 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     protected DomainObjectCollectionFactory createDomainObjectCollectionFactory(InstantiatorFactory instantiatorFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator, CrossProjectConfigurator projectConfigurator) {
         ServiceRegistry services = ProjectScopeServices.this;
         return new DefaultDomainObjectCollectionFactory(instantiatorFactory, services, collectionCallbackActionDecorator, MutationGuards.of(projectConfigurator));
+    }
+
+    protected ManagedFactoryRegistry createManagedFactoryRegistry(ManagedFactoryRegistry parent, FileResolver fileResolver) {
+        return new DefaultManagedFactoryRegistry(
+            parent,
+            // Note that order is important - the first factory in the list that can create
+            // a given type will be selected, so the order should be from most specific type to
+            // least specific type
+            new ManagedFactories.ConfigurableFileCollectionManagedFactory(fileResolver),
+            new org.gradle.api.internal.file.ManagedFactories.RegularFilePropertyManagedFactory(fileResolver),
+            new org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory(fileResolver),
+            new org.gradle.api.internal.file.ManagedFactories.DirectoryPropertyManagedFactory(fileResolver)
+        );
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -331,11 +331,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     }
 
     protected ManagedFactoryRegistry createManagedFactoryRegistry(ManagedFactoryRegistry parent, FileResolver fileResolver) {
-        return new DefaultManagedFactoryRegistry(
-            parent,
-            // Note that order is important - the first factory in the list that can create
-            // a given type will be selected, so the order should be from most specific type to
-            // least specific type
+        return new DefaultManagedFactoryRegistry(parent).withFactories(
             new ManagedFactories.ConfigurableFileCollectionManagedFactory(fileResolver),
             new org.gradle.api.internal.file.ManagedFactories.RegularFilePropertyManagedFactory(fileResolver),
             new org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory(fileResolver),

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -73,10 +73,7 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
     }
     
     ManagedFactoryRegistry createManagedFactoryRegistry(NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver) {
-        return new DefaultManagedFactoryRegistry(
-                // Note that order is important - the first factory in the list that can create
-                // a given type will be selected, so the order should be from most specific type to
-                // least specific type
+        return new DefaultManagedFactoryRegistry().withFactories(
                 new ConfigurableFileCollectionManagedFactory(fileResolver),
                 new RegularFileManagedFactory(),
                 new RegularFilePropertyManagedFactory(fileResolver),

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -101,7 +101,8 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider, Closea
             "commons-lang",
             "guava",
             "javax.inject",
-            "groovy-all"
+            "groovy-all",
+            "asm"
     };
 
     public WorkerProcessClassPathProvider(CacheRepository cacheRepository, ModuleRegistry moduleRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -28,6 +28,9 @@ import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.remote.internal.hub.StreamFailureHandler;
 import org.gradle.internal.service.DefaultServiceRegistry;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.state.DefaultManagedFactoryRegistry;
+import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 
 import java.io.Serializable;
@@ -53,10 +56,11 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
     public void execute(WorkerProcessContext workerProcessContext) {
         completed = new CountDownLatch(1);
         try {
+            ServiceRegistry parentServices = workerProcessContext.getServiceRegistry();
             if (instantiatorFactory == null) {
-                instantiatorFactory = new DefaultInstantiatorFactory(new DefaultCrossBuildInMemoryCacheFactory(new DefaultListenerManager()), Collections.emptyList());
+                instantiatorFactory = new DefaultInstantiatorFactory(new DefaultCrossBuildInMemoryCacheFactory(new DefaultListenerManager()), Collections.emptyList(), new DefaultManagedFactoryRegistry());
             }
-            DefaultServiceRegistry serviceRegistry = new DefaultServiceRegistry("worker-action-services", workerProcessContext.getServiceRegistry());
+            DefaultServiceRegistry serviceRegistry = new DefaultServiceRegistry("worker-action-services", parentServices);
             // Make the argument serializers available so work implementations can register their own serializers
             RequestArgumentSerializers argumentSerializers = new RequestArgumentSerializers();
             serviceRegistry.add(RequestArgumentSerializers.class, argumentSerializers);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -30,7 +30,6 @@ import org.gradle.internal.remote.internal.hub.StreamFailureHandler;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.state.DefaultManagedFactoryRegistry;
-import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 
 import java.io.Serializable;

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
@@ -29,6 +29,6 @@ class SnapshotTestUtil {
             HashCode getClassLoaderHash(ClassLoader classLoader) {
                 return HashCode.fromInt(classLoader.hashCode())
             }
-        })
+        }, null)
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -36,6 +36,7 @@ import org.gradle.internal.instantiation.InjectAnnotationHandler
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testfixtures.ProjectBuilder
@@ -60,7 +61,8 @@ class TestUtil {
         if (instantiatorFactory == null) {
             NativeServicesTestFixture.initialize()
             def annotationHandlers = ProjectBuilderImpl.getGlobalServices().getAll(InjectAnnotationHandler.class)
-            instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), annotationHandlers)
+            def managedFactoryRegistry = ProjectBuilderImpl.getGlobalServices().get(ManagedFactoryRegistry.class)
+            instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), annotationHandlers, managedFactoryRegistry)
         }
         return instantiatorFactory
     }

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -103,7 +103,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
     def outputFilesRepository = Stub(OutputFilesRepository) {
         isGeneratedByGradle() >> true
     }
-    def valueSnapshotter = new DefaultValueSnapshotter(classloaderHierarchyHasher)
+    def valueSnapshotter = new DefaultValueSnapshotter(classloaderHierarchyHasher, null)
 
     final outputFile = temporaryFolder.file("output-file")
     final outputDir = temporaryFolder.file("output-dir")

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -26,11 +26,10 @@ import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.state.Managed;
 import org.gradle.util.DeprecationLogger;
-import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.AbstractSet;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -93,20 +92,6 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     @Override
     public Object unpackState() {
         return getFiles();
-    }
-
-    @Override
-    public ManagedFactory managedFactory() {
-        return new ManagedFactory() {
-            @Nullable
-            @Override
-            public <T> T fromState(Class<T> type, Object state) {
-                if (!type.isAssignableFrom(ConfigurableFileCollection.class)) {
-                    return null;
-                }
-                return type.cast(new DefaultConfigurableFileCollection(resolver, null, (Set<File>) state));
-            }
-        };
     }
 
     @Override

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.state.Managed;
 import org.gradle.util.DeprecationLogger;
+import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -95,8 +96,8 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     }
 
     @Override
-    public Factory managedFactory() {
-        return new Factory() {
+    public ManagedFactory managedFactory() {
+        return new ManagedFactory() {
             @Nullable
             @Override
             public <T> T fromState(Class<T> type, Object state) {

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -109,6 +109,10 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
     }
 
+    public int getFactoryId() {
+        return ManagedFactories.ConfigurableFileCollectionManagedFactory.FACTORY_ID;
+    }
+
     @Override
     public String getDisplayName() {
         return displayName;

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.file.collections;
 
+import com.google.common.base.Objects;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.internal.state.ManagedFactory;
@@ -25,21 +26,28 @@ import java.io.File;
 import java.util.Set;
 
 public class ManagedFactories {
-    public static class ConfigurableFileCollectionManagedFactory extends ManagedFactory.TypedManagedFactory {
+    public static class ConfigurableFileCollectionManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = ConfigurableFileCollection.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+
         private final FileResolver resolver;
 
         public ConfigurableFileCollectionManagedFactory(FileResolver resolver) {
-            super(ConfigurableFileCollection.class);
             this.resolver = resolver;
         }
 
         @Nullable
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             return type.cast(new DefaultConfigurableFileCollection(resolver, null, (Set<File>) state));
+        }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
         }
     }
 }

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
@@ -25,25 +25,21 @@ import java.io.File;
 import java.util.Set;
 
 public class ManagedFactories {
-    public static class ConfigurableFileCollectionManagedFactory implements ManagedFactory {
+    public static class ConfigurableFileCollectionManagedFactory extends ManagedFactory.TypedManagedFactory {
         private final FileResolver resolver;
 
         public ConfigurableFileCollectionManagedFactory(FileResolver resolver) {
+            super(ConfigurableFileCollection.class);
             this.resolver = resolver;
         }
 
         @Nullable
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             return type.cast(new DefaultConfigurableFileCollection(resolver, null, (Set<File>) state));
-        }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(ConfigurableFileCollection.class);
         }
     }
 }

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.internal.state.ManagedFactory;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.Set;
+
+public class ManagedFactories {
+    public static class ConfigurableFileCollectionManagedFactory implements ManagedFactory {
+        private final FileResolver resolver;
+
+        public ConfigurableFileCollectionManagedFactory(FileResolver resolver) {
+            this.resolver = resolver;
+        }
+
+        @Nullable
+        @Override
+        public <T> T fromState(Class<T> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            return type.cast(new DefaultConfigurableFileCollection(resolver, null, (Set<File>) state));
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(ConfigurableFileCollection.class);
+        }
+    }
+}

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
@@ -28,7 +28,8 @@ import java.util.Set;
 public class ManagedFactories {
     public static class ConfigurableFileCollectionManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = ConfigurableFileCollection.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = DefaultConfigurableFileCollection.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         private final FileResolver resolver;
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -30,6 +30,7 @@ import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.state.Managed;
+import org.gradle.internal.state.ManagedFactory;
 import org.gradle.model.internal.asm.AsmClassGenerator;
 import org.gradle.model.internal.asm.ClassGeneratorSuffixRegistry;
 import org.gradle.model.internal.inspect.FormattingValidationProblemCollector;
@@ -51,7 +52,7 @@ import static org.objectweb.asm.Opcodes.ARETURN;
 import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.V1_5;
 
-public class NamedObjectInstantiator implements Managed.Factory {
+public class NamedObjectInstantiator implements ManagedFactory {
     private static final Type OBJECT = Type.getType(Object.class);
     private static final Type STRING = Type.getType(String.class);
     private static final Type NAMED_OBJECT_INSTANTIATOR = Type.getType(NamedObjectInstantiator.class);
@@ -63,7 +64,7 @@ public class NamedObjectInstantiator implements Managed.Factory {
     private static final String RETURN_CLASS = Type.getMethodDescriptor(Type.getType(Class.class));
     private static final String RETURN_BOOLEAN = Type.getMethodDescriptor(Type.BOOLEAN_TYPE);
     private static final String RETURN_OBJECT = Type.getMethodDescriptor(OBJECT);
-    private static final String RETURN_MANAGED_FACTORY = Type.getMethodDescriptor(Type.getType(Managed.Factory.class));
+    private static final String RETURN_MANAGED_FACTORY = Type.getMethodDescriptor(Type.getType(ManagedFactory.class));
     private static final String RETURN_VOID_FROM_STRING = Type.getMethodDescriptor(Type.VOID_TYPE, STRING);
     private static final String RETURN_OBJECT_FROM_STRING = Type.getMethodDescriptor(OBJECT, STRING);
     private static final String NAME_FIELD = "_gr_name_";

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -99,15 +99,19 @@ public class NamedObjectInstantiator implements ManagedFactory {
 
     @Override
     public <T> T fromState(Class<T> type, Object state) {
-        if (!canCreate(type)) {
+        if (!publicType().isAssignableFrom(type)) {
             return null;
         }
         return named(Cast.uncheckedCast(type), (String) state);
     }
 
+    private Class<?> publicType() {
+        return Named.class;
+    }
+
     @Override
     public boolean canCreate(Class<?> type) {
-        return Named.class.isAssignableFrom(type);
+        return publicType().isAssignableFrom(type);
     }
 
     private ClassGeneratingLoader loaderFor(Class<?> publicClass) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -64,7 +64,6 @@ public class NamedObjectInstantiator implements ManagedFactory {
     private static final String RETURN_CLASS = Type.getMethodDescriptor(Type.getType(Class.class));
     private static final String RETURN_BOOLEAN = Type.getMethodDescriptor(Type.BOOLEAN_TYPE);
     private static final String RETURN_OBJECT = Type.getMethodDescriptor(OBJECT);
-    private static final String RETURN_MANAGED_FACTORY = Type.getMethodDescriptor(Type.getType(ManagedFactory.class));
     private static final String RETURN_VOID_FROM_STRING = Type.getMethodDescriptor(Type.VOID_TYPE, STRING);
     private static final String RETURN_OBJECT_FROM_STRING = Type.getMethodDescriptor(OBJECT, STRING);
     private static final String NAME_FIELD = "_gr_name_";
@@ -100,10 +99,15 @@ public class NamedObjectInstantiator implements ManagedFactory {
 
     @Override
     public <T> T fromState(Class<T> type, Object state) {
-        if (!Named.class.isAssignableFrom(type)) {
+        if (!canCreate(type)) {
             return null;
         }
         return named(Cast.uncheckedCast(type), (String) state);
+    }
+
+    @Override
+    public boolean canCreate(Class<?> type) {
+        return Named.class.isAssignableFrom(type);
     }
 
     private ClassGeneratingLoader loaderFor(Class<?> publicClass) {
@@ -220,16 +224,6 @@ public class NamedObjectInstantiator implements ManagedFactory {
         methodVisitor = visitor.visitMethod(ACC_PUBLIC, "immutable", RETURN_BOOLEAN, null, EMPTY_STRINGS);
         methodVisitor.visitLdcInsn(true);
         methodVisitor.visitInsn(IRETURN);
-        methodVisitor.visitMaxs(0, 0);
-        methodVisitor.visitEnd();
-
-        //
-        // Add `managedFactory()`
-        //
-
-        methodVisitor = visitor.visitMethod(ACC_PUBLIC, "managedFactory", RETURN_MANAGED_FACTORY, null, EMPTY_STRINGS);
-        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, generator.getGeneratedType().getInternalName(), FACTORY_FIELD, NAMED_OBJECT_INSTANTIATOR.getDescriptor());
-        methodVisitor.visitInsn(Opcodes.ARETURN);
         methodVisitor.visitMaxs(0, 0);
         methodVisitor.visitEnd();
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -20,12 +20,13 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.state.Managed;
+import org.gradle.internal.state.ManagedFactory;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
 
 public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>, Managed {
-    private static final Factory FACTORY = new Factory() {
+    private static final ManagedFactory FACTORY = new ManagedFactory() {
         @Nullable
         @Override
         public <T> T fromState(Class<T> type, Object state) {
@@ -101,7 +102,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     }
 
     @Override
-    public Factory managedFactory() {
+    public ManagedFactory managedFactory() {
         return FACTORY;
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -90,6 +90,11 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
         return getOrNull();
     }
 
+    @Override
+    public int getFactoryId() {
+        return ManagedFactories.ProviderManagedFactory.FACTORY_ID;
+    }
+
     private static class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
         private final Provider<? extends T> provider;
         private final Transformer<? extends Provider<? extends S>, ? super T> transformer;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -20,27 +20,11 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.state.Managed;
-import org.gradle.internal.state.ManagedFactory;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
 
 public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>, Managed {
-    private static final ManagedFactory FACTORY = new ManagedFactory() {
-        @Nullable
-        @Override
-        public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(Provider.class)) {
-                return null;
-            }
-            if (state == null) {
-                return type.cast(Providers.notDefined());
-            } else {
-                return type.cast(Providers.of(state));
-            }
-        }
-    };
-
     @Override
     public <S> ProviderInternal<S> map(final Transformer<? extends S, ? super T> transformer) {
         return new TransformBackedProvider<S, T>(transformer, this);
@@ -99,11 +83,6 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Override
     public Class<?> publicType() {
         return Provider.class;
-    }
-
-    @Override
-    public ManagedFactory managedFactory() {
-        return FACTORY;
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -34,6 +34,11 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     }
 
     @Override
+    public int getFactoryId() {
+        return ManagedFactories.ListPropertyManagedFactory.FACTORY_ID;
+    }
+
+    @Override
     protected List<T> fromValue(Collection<T> values) {
         return ImmutableList.copyOf(values);
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -19,9 +19,7 @@ package org.gradle.api.internal.provider;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.state.ManagedFactory;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -33,22 +31,6 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     @Override
     public Class<?> publicType() {
         return ListProperty.class;
-    }
-
-    @Override
-    public ManagedFactory managedFactory() {
-        return new ManagedFactory() {
-            @Nullable
-            @Override
-            public <S> S fromState(Class<S> type, Object state) {
-                if (!type.isAssignableFrom(ListProperty.class)) {
-                    return null;
-                }
-                DefaultListProperty<T> property = new DefaultListProperty<>(DefaultListProperty.this.getElementType());
-                property.set((List<T>) state);
-                return type.cast(property);
-            }
-        };
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -35,8 +36,8 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     }
 
     @Override
-    public Factory managedFactory() {
-        return new Factory() {
+    public ManagedFactory managedFactory() {
+        return new ManagedFactory() {
             @Nullable
             @Override
             public <S> S fromState(Class<S> type, Object state) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -78,8 +79,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     }
 
     @Override
-    public Factory managedFactory() {
-        return new Factory() {
+    public ManagedFactory managedFactory() {
+        return new ManagedFactory() {
             @Nullable
             @Override
             public <S> S fromState(Class<S> type, Object state) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -76,22 +75,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     @Override
     public Class<?> publicType() {
         return MapProperty.class;
-    }
-
-    @Override
-    public ManagedFactory managedFactory() {
-        return new ManagedFactory() {
-            @Nullable
-            @Override
-            public <S> S fromState(Class<S> type, Object state) {
-                if (!type.isAssignableFrom(MapProperty.class)) {
-                    return null;
-                }
-                DefaultMapProperty<K, V> property = new DefaultMapProperty<>(DefaultMapProperty.this.keyType, DefaultMapProperty.this.valueType);
-                property.set((Map<K, V>) state);
-                return type.cast(property);
-            }
-        };
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -78,6 +78,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     }
 
     @Override
+    public int getFactoryId() {
+        return ManagedFactories.MapPropertyManagedFactory.FACTORY_ID;
+    }
+
+    @Override
     public boolean isPresent() {
         beforeRead();
         if (!value.present()) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 
@@ -40,8 +41,8 @@ public class DefaultPropertyState<T> extends AbstractProperty<T> implements Prop
     }
 
     @Override
-    public Factory managedFactory() {
-        return new Factory() {
+    public ManagedFactory managedFactory() {
+        return new ManagedFactory() {
             @Nullable
             @Override
             public <S> S fromState(Class<S> type, Object state) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
@@ -38,6 +38,11 @@ public class DefaultPropertyState<T> extends AbstractProperty<T> implements Prop
     }
 
     @Override
+    public int getFactoryId() {
+        return ManagedFactories.PropertyManagedFactory.FACTORY_ID;
+    }
+
+    @Override
     public Class<T> getType() {
         return type;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
@@ -20,9 +20,6 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.state.ManagedFactory;
-
-import javax.annotation.Nullable;
 
 public class DefaultPropertyState<T> extends AbstractProperty<T> implements Property<T> {
     private final Class<T> type;
@@ -38,20 +35,6 @@ public class DefaultPropertyState<T> extends AbstractProperty<T> implements Prop
     @Override
     public Class<?> publicType() {
         return Property.class;
-    }
-
-    @Override
-    public ManagedFactory managedFactory() {
-        return new ManagedFactory() {
-            @Nullable
-            @Override
-            public <S> S fromState(Class<S> type, Object state) {
-                if (!type.isAssignableFrom(Property.class)) {
-                    return null;
-                }
-                return type.cast(new DefaultPropertyState<T>(DefaultPropertyState.this.type).value((T) state));
-            }
-        };
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -19,9 +19,7 @@ package org.gradle.api.internal.provider;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
-import org.gradle.internal.state.ManagedFactory;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Set;
 
@@ -38,22 +36,6 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     @Override
     public Class<?> publicType() {
         return SetProperty.class;
-    }
-
-    @Override
-    public ManagedFactory managedFactory() {
-        return new ManagedFactory() {
-            @Nullable
-            @Override
-            public <S> S fromState(Class<S> type, Object state) {
-                if (!type.isAssignableFrom(SetProperty.class)) {
-                    return null;
-                }
-                DefaultSetProperty<T> property = new DefaultSetProperty<>(DefaultSetProperty.this.getElementType());
-                property.set((Set<T>) state);
-                return type.cast(property);
-            }
-        };
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -39,6 +39,11 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     }
 
     @Override
+    public int getFactoryId() {
+        return ManagedFactories.SetPropertyManagedFactory.FACTORY_ID;
+    }
+
+    @Override
     public SetProperty<T> empty() {
         super.empty();
         return this;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -40,8 +41,8 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     }
 
     @Override
-    public Factory managedFactory() {
-        return new Factory() {
+    public ManagedFactory managedFactory() {
+        return new ManagedFactory() {
             @Nullable
             @Override
             public <S> S fromState(Class<S> type, Object state) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.internal.state.ManagedFactory;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class ManagedFactories {
+    public static class ProviderManagedFactory implements ManagedFactory {
+        @Nullable
+        @Override
+        public <T> T fromState(Class<T> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            if (state == null) {
+                return type.cast(Providers.notDefined());
+            } else {
+                return type.cast(Providers.of(state));
+            }
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(Provider.class);
+        }
+    }
+
+    public static class PropertyManagedFactory implements ManagedFactory {
+        @Nullable
+        @Override
+        public <S> S fromState(Class<S> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            return type.cast(new DefaultPropertyState<>(Object.class).value(state));
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(Property.class);
+        }
+    }
+
+    public static class ListPropertyManagedFactory implements ManagedFactory {
+        @Nullable
+        @Override
+        public <S> S fromState(Class<S> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            DefaultListProperty<?> property = new DefaultListProperty<>(Object.class);
+            property.set((Iterable) state);
+            return type.cast(property);
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(ListProperty.class);
+        }
+    }
+
+    public static class SetPropertyManagedFactory implements ManagedFactory {
+        @Nullable
+        @Override
+        public <T> T fromState(Class<T> type, Object state) {
+            if (!type.isAssignableFrom(SetProperty.class)) {
+                return null;
+            }
+            DefaultSetProperty<?> property = new DefaultSetProperty<>(Object.class);
+            property.set((Iterable) state);
+            return type.cast(property);
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return false;
+        }
+    }
+
+    public static class MapPropertyManagedFactory implements ManagedFactory {
+        @Nullable
+        @Override
+        public <S> S fromState(Class<S> type, Object state) {
+            if (!canCreate(type)) {
+                return null;
+            }
+            DefaultMapProperty<?, ?> property = new DefaultMapProperty<>(Object.class, Object.class);
+            property.set((Map) state);
+            return type.cast(property);
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type.isAssignableFrom(MapProperty.class);
+        }
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -15,6 +15,7 @@
  */
 
 package org.gradle.api.internal.provider;
+import com.google.common.base.Objects;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -26,15 +27,14 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 public class ManagedFactories {
-    public static class ProviderManagedFactory extends ManagedFactory.TypedManagedFactory {
-        public ProviderManagedFactory() {
-            super(Provider.class);
-        }
+    public static class ProviderManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = Provider.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
         @Nullable
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             if (state == null) {
@@ -43,71 +43,92 @@ public class ManagedFactories {
                 return type.cast(Providers.of(state));
             }
         }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
+        }
     }
 
-    public static class PropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
-        public PropertyManagedFactory() {
-            super(Property.class);
-        }
+    public static class PropertyManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = Property.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
         @Nullable
         @Override
         public <S> S fromState(Class<S> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             return type.cast(new DefaultPropertyState<>(Object.class).value(state));
         }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
+        }
     }
 
-    public static class ListPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
-        public ListPropertyManagedFactory() {
-            super(ListProperty.class);
-        }
+    public static class ListPropertyManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = ListProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
         @Nullable
         @Override
         public <S> S fromState(Class<S> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             DefaultListProperty<?> property = new DefaultListProperty<>(Object.class);
             property.set((Iterable) state);
             return type.cast(property);
         }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
+        }
     }
 
-    public static class SetPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
-        public SetPropertyManagedFactory() {
-            super(SetProperty.class);
-        }
+    public static class SetPropertyManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = SetProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
         @Nullable
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             DefaultSetProperty<?> property = new DefaultSetProperty<>(Object.class);
             property.set((Iterable) state);
             return type.cast(property);
         }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
+        }
     }
 
-    public static class MapPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
-        public MapPropertyManagedFactory() {
-            super(MapProperty.class);
-        }
+    public static class MapPropertyManagedFactory implements ManagedFactory {
+        private static final Class<?> PUBLIC_TYPE = MapProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
         @Nullable
         @Override
         public <S> S fromState(Class<S> type, Object state) {
-            if (!type.isAssignableFrom(publicType)) {
+            if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
             DefaultMapProperty<?, ?> property = new DefaultMapProperty<>(Object.class, Object.class);
             property.set((Map) state);
             return type.cast(property);
+        }
+
+        @Override
+        public int getId() {
+            return FACTORY_ID;
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -26,11 +26,15 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 public class ManagedFactories {
-    public static class ProviderManagedFactory implements ManagedFactory {
+    public static class ProviderManagedFactory extends ManagedFactory.TypedManagedFactory {
+        public ProviderManagedFactory() {
+            super(Provider.class);
+        }
+
         @Nullable
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             if (state == null) {
@@ -39,80 +43,71 @@ public class ManagedFactories {
                 return type.cast(Providers.of(state));
             }
         }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(Provider.class);
-        }
     }
 
-    public static class PropertyManagedFactory implements ManagedFactory {
+    public static class PropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
+        public PropertyManagedFactory() {
+            super(Property.class);
+        }
+
         @Nullable
         @Override
         public <S> S fromState(Class<S> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             return type.cast(new DefaultPropertyState<>(Object.class).value(state));
         }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(Property.class);
-        }
     }
 
-    public static class ListPropertyManagedFactory implements ManagedFactory {
+    public static class ListPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
+        public ListPropertyManagedFactory() {
+            super(ListProperty.class);
+        }
+
         @Nullable
         @Override
         public <S> S fromState(Class<S> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             DefaultListProperty<?> property = new DefaultListProperty<>(Object.class);
             property.set((Iterable) state);
             return type.cast(property);
         }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(ListProperty.class);
-        }
     }
 
-    public static class SetPropertyManagedFactory implements ManagedFactory {
+    public static class SetPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
+        public SetPropertyManagedFactory() {
+            super(SetProperty.class);
+        }
+
         @Nullable
         @Override
         public <T> T fromState(Class<T> type, Object state) {
-            if (!type.isAssignableFrom(SetProperty.class)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             DefaultSetProperty<?> property = new DefaultSetProperty<>(Object.class);
             property.set((Iterable) state);
             return type.cast(property);
         }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return false;
-        }
     }
 
-    public static class MapPropertyManagedFactory implements ManagedFactory {
+    public static class MapPropertyManagedFactory extends ManagedFactory.TypedManagedFactory {
+        public MapPropertyManagedFactory() {
+            super(MapProperty.class);
+        }
+
         @Nullable
         @Override
         public <S> S fromState(Class<S> type, Object state) {
-            if (!canCreate(type)) {
+            if (!type.isAssignableFrom(publicType)) {
                 return null;
             }
             DefaultMapProperty<?, ?> property = new DefaultMapProperty<>(Object.class, Object.class);
             property.set((Map) state);
             return type.cast(property);
-        }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type.isAssignableFrom(MapProperty.class);
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -29,7 +29,8 @@ import java.util.Map;
 public class ManagedFactories {
     public static class ProviderManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = Provider.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = Providers.FixedValueProvider.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         @Nullable
         @Override
@@ -52,7 +53,8 @@ public class ManagedFactories {
 
     public static class PropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = Property.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = DefaultPropertyState.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         @Nullable
         @Override
@@ -71,7 +73,8 @@ public class ManagedFactories {
 
     public static class ListPropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = ListProperty.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = DefaultListProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         @Nullable
         @Override
@@ -92,7 +95,8 @@ public class ManagedFactories {
 
     public static class SetPropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = SetProperty.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = DefaultSetProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         @Nullable
         @Override
@@ -113,7 +117,8 @@ public class ManagedFactories {
 
     public static class MapPropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = MapProperty.class;
-        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private static final Class<?> IMPL_TYPE = MapProperty.class;
+        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         @Nullable
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
@@ -89,7 +89,7 @@ public class Providers {
         return Cast.uncheckedCast(value);
     }
 
-    private static class FixedValueProvider<T> extends AbstractMinimalProvider<T> {
+    public static class FixedValueProvider<T> extends AbstractMinimalProvider<T> {
         private final T value;
 
         FixedValueProvider(T value) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
@@ -55,6 +55,7 @@ import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.internal.service.ServiceLookup;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.state.Managed;
+import org.gradle.internal.state.ManagedFactory;
 import org.gradle.model.internal.asm.AsmClassGenerator;
 import org.gradle.model.internal.asm.ClassGeneratorSuffixRegistry;
 import org.gradle.util.CollectionUtils;
@@ -1072,7 +1073,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
         @Override
         public void addManagedMethods(List<PropertyMetadata> mutableProperties, List<PropertyMetadata> readOnlyProperties) {
-            visitor.visitField(PV_FINAL_STATIC, FACTORY_FIELD, Type.getType(Managed.Factory.class).getDescriptor(), null, null);
+            visitor.visitField(PV_FINAL_STATIC, FACTORY_FIELD, Type.getType(ManagedFactory.class).getDescriptor(), null, null);
 
             // Generate: <init>(Object[] state) { }
             MethodVisitor methodVisitor = visitor.visitMethod(ACC_PUBLIC | ACC_SYNTHETIC, "<init>", Type.getMethodDescriptor(VOID_TYPE, OBJECT_ARRAY_TYPE), null, EMPTY_STRINGS);
@@ -1145,8 +1146,8 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             methodVisitor.visitEnd();
 
             // Generate: Managed.Factory getFactory() { if (<factory-field> == null) { <factory-field> = new ManagedTypeFactory(this.getClass()); }; return <factory-field> }
-            methodVisitor = visitor.visitMethod(ACC_PUBLIC | ACC_SYNCHRONIZED, "managedFactory", Type.getMethodDescriptor(Type.getType(Managed.Factory.class)), null, EMPTY_STRINGS);
-            methodVisitor.visitFieldInsn(GETSTATIC, generatedType.getInternalName(), FACTORY_FIELD, Type.getType(Managed.Factory.class).getDescriptor());
+            methodVisitor = visitor.visitMethod(ACC_PUBLIC | ACC_SYNCHRONIZED, "managedFactory", Type.getMethodDescriptor(Type.getType(ManagedFactory.class)), null, EMPTY_STRINGS);
+            methodVisitor.visitFieldInsn(GETSTATIC, generatedType.getInternalName(), FACTORY_FIELD, Type.getType(ManagedFactory.class).getDescriptor());
             methodVisitor.visitInsn(DUP);
             Label label = new Label();
             methodVisitor.visitJumpInsn(IFNULL, label);
@@ -1158,7 +1159,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, OBJECT_TYPE.getInternalName(), "getClass", RETURN_CLASS, false);
             methodVisitor.visitMethodInsn(INVOKESPECIAL, Type.getType(ManagedTypeFactory.class).getInternalName(), "<init>", Type.getMethodDescriptor(VOID_TYPE, CLASS_TYPE), false);
             methodVisitor.visitInsn(DUP);
-            methodVisitor.visitFieldInsn(PUTSTATIC, generatedType.getInternalName(), FACTORY_FIELD, Type.getType(Managed.Factory.class).getDescriptor());
+            methodVisitor.visitFieldInsn(PUTSTATIC, generatedType.getInternalName(), FACTORY_FIELD, Type.getType(ManagedFactory.class).getDescriptor());
             methodVisitor.visitInsn(ARETURN);
             methodVisitor.visitMaxs(0, 0);
             methodVisitor.visitEnd();

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
@@ -126,7 +126,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator implements M
         super(allKnownAnnotations, enabledAnnotations, generatedClasses);
         this.decorate = decorate;
         this.suffix = suffix;
-        this.factoryId = Objects.hashCode(getClass().getName(), suffix, allKnownAnnotations, enabledAnnotations);
+        this.factoryId = Objects.hashCode(getClass().getName(), suffix, allKnownAnnotations, enabledAnnotations, generatedClasses);
     }
 
     /**
@@ -154,7 +154,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator implements M
         }
 
         AsmBackedClassGenerator generator = new AsmBackedClassGenerator(true, suffix, allKnownAnnotations, enabledAnnotations, generatedClasses);
-        managedFactoryRegistry.register(generator);
+        registerManagedFactory(managedFactoryRegistry, generator);
         return generator;
     }
 
@@ -166,8 +166,16 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator implements M
         // For now, just assign using a counter
         String suffix = ClassGeneratorSuffixRegistry.assign("$Inject");
         AsmBackedClassGenerator generator = new AsmBackedClassGenerator(false, suffix, allKnownAnnotations, enabledAnnotations, cacheFactory.newClassMap());
-        managedFactoryRegistry.register(generator);
+        registerManagedFactory(managedFactoryRegistry, generator);
         return generator;
+    }
+
+    private static void registerManagedFactory(ManagedFactoryRegistry managedFactoryRegistry, AsmBackedClassGenerator generator) {
+        // Don't register the generator if there is already one registered with the same criteria.
+        // (e.g. we reuse the same cache and suffix for decorated generators with empty annotations)
+        if (managedFactoryRegistry.lookup(generator.getId()) == null) {
+            managedFactoryRegistry.register(generator);
+        }
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
@@ -17,12 +17,12 @@
 package org.gradle.internal.instantiation;
 
 import org.gradle.api.reflect.ObjectInstantiationException;
-import org.gradle.internal.state.Managed;
+import org.gradle.internal.state.ManagedFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
-public class ManagedTypeFactory implements Managed.Factory {
+public class ManagedTypeFactory implements ManagedFactory {
     private final Constructor<?> constructor;
 
     // Used by generated code

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
@@ -18,7 +18,6 @@ package org.gradle.internal.instantiation;
 
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.state.Managed;
 import org.gradle.internal.state.ManagedFactory;
 
 import java.lang.reflect.Constructor;
@@ -37,7 +36,7 @@ public class ManagedTypeFactory implements ManagedFactory {
 
     @Override
     public <T> T fromState(Class<T> type, Object state) {
-        if (!canCreate(type)) {
+        if (!type.isAssignableFrom(constructor.getDeclaringClass())) {
             return null;
         }
         try {
@@ -51,16 +50,6 @@ public class ManagedTypeFactory implements ManagedFactory {
 
     @Override
     public boolean canCreate(Class<?> type) {
-        return type.isAssignableFrom(constructor.getDeclaringClass());
-    }
-
-    public static boolean isGeneratedType(Class<?> type) {
-        try {
-            type.getConstructor(Object[].class);
-        } catch (NoSuchMethodException e) {
-            return false;
-        }
-
-        return Managed.class.isAssignableFrom(type);
+        return type == constructor.getDeclaringClass();
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.instantiation;
 
+import com.google.common.base.Objects;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.state.ManagedFactory;
@@ -49,7 +50,7 @@ public class ManagedTypeFactory implements ManagedFactory {
     }
 
     @Override
-    public boolean canCreate(Class<?> type) {
-        return type == constructor.getDeclaringClass();
+    public int getId() {
+        return Objects.hashCode(constructor.getDeclaringClass().getName());
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/ManagedTypeFactory.java
@@ -18,7 +18,6 @@ package org.gradle.internal.instantiation;
 
 import com.google.common.base.Objects;
 import org.gradle.api.reflect.ObjectInstantiationException;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.state.ManagedFactory;
 
 import java.lang.reflect.Constructor;
@@ -31,7 +30,7 @@ public class ManagedTypeFactory implements ManagedFactory {
         try {
             constructor = type.getConstructor(Object[].class);
         } catch (NoSuchMethodException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
+            throw new IllegalArgumentException("The class " + type.getSimpleName() + " does not appear to a be a generated managed class.", e);
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
@@ -388,7 +388,7 @@ public class DefaultValueSnapshotter implements ValueSnapshotter, IsolatableFact
 
         @Override
         public Isolatable<?> managedValue(Managed value, Isolatable<?> state) {
-            return new IsolatedManagedValue(value.publicType(), managedFactoryRegistry.lookup(value.publicType()), state);
+            return new IsolatedManagedValue(value.publicType(), managedFactoryRegistry.lookup(value.getFactoryId()), state);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedImmutableManagedValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedImmutableManagedValue.java
@@ -48,7 +48,7 @@ public class IsolatedImmutableManagedValue extends AbstractIsolatableScalarValue
         if (type.isInstance(getValue())) {
             return type.cast(getValue());
         }
-        ManagedFactory factory = managedFactoryRegistry.lookup(getValue().publicType());
+        ManagedFactory factory = managedFactoryRegistry.lookup(getValue().getFactoryId());
         if (factory == null) {
             return null;
         } else {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedImmutableManagedValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedImmutableManagedValue.java
@@ -48,7 +48,7 @@ public class IsolatedImmutableManagedValue extends AbstractIsolatableScalarValue
         if (type.isInstance(getValue())) {
             return type.cast(getValue());
         }
-        ManagedFactory factory = managedFactoryRegistry.lookup(getValue().getClass());
+        ManagedFactory factory = managedFactoryRegistry.lookup(getValue().publicType());
         if (factory == null) {
             return null;
         } else {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedManagedValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedManagedValue.java
@@ -18,15 +18,15 @@ package org.gradle.internal.snapshot.impl;
 
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
-import org.gradle.internal.state.Managed;
+import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
 
 class IsolatedManagedValue extends AbstractManagedValueSnapshot<Isolatable<?>> implements Isolatable<Object> {
-    private final Managed.Factory factory;
+    private final ManagedFactory factory;
     private final Class<?> targetType;
 
-    public IsolatedManagedValue(Class<?> targetType, Managed.Factory factory, Isolatable<?> state) {
+    public IsolatedManagedValue(Class<?> targetType, ManagedFactory factory, Isolatable<?> state) {
         super(state);
         this.targetType = targetType;
         this.factory = factory;

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.state;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import org.gradle.internal.UncheckedException;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+public class DefaultManagedFactoryRegistry implements ManagedFactoryRegistry {
+    private final List<ManagedFactory> factories = Lists.newArrayList();
+    private final Cache<Class<?>, Optional<ManagedFactory>> managedFactoryCache = CacheBuilder.newBuilder().weakKeys().build();
+
+    public DefaultManagedFactoryRegistry(ManagedFactory... factories) {
+        this.factories.addAll(Arrays.asList(factories));
+    }
+
+    @Override
+    @Nullable
+    public <T> ManagedFactory lookup(Class<T> type) {
+        try {
+            return managedFactoryCache.get(type, new Callable<Optional<ManagedFactory>>() {
+                @Override
+                public Optional<ManagedFactory> call() throws Exception {
+                    for (ManagedFactory factory : factories) {
+                        if (factory.canCreate(type)) {
+                            return Optional.of(factory);
+                        }
+                    }
+
+                    return Optional.empty();
+                }
+            }).orElse(null);
+        } catch (ExecutionException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Override
+    public void register(Class<?> type, ManagedFactory factory) {
+        managedFactoryCache.put(type, Optional.of(factory));
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
@@ -52,6 +52,10 @@ public class DefaultManagedFactoryRegistry implements ManagedFactoryRegistry {
 
     @Override
     public void register(ManagedFactory factory) {
+        ManagedFactory existing = managedFactoryCache.getIfPresent(factory.getId());
+        if (existing != null) {
+            throw new IllegalArgumentException("A managed factory with type " + existing.getClass().getSimpleName() + " (id: " + existing.getId() + ") has already been registered.");
+        }
         managedFactoryCache.put(factory.getId(), factory);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
@@ -25,20 +25,24 @@ public class DefaultManagedFactoryRegistry implements ManagedFactoryRegistry {
     private final ManagedFactoryRegistry parent;
     private final Cache<Integer, ManagedFactory> managedFactoryCache = CacheBuilder.newBuilder().build();
 
-    public DefaultManagedFactoryRegistry(ManagedFactoryRegistry parent, ManagedFactory... factories) {
+    public DefaultManagedFactoryRegistry(ManagedFactoryRegistry parent) {
         this.parent = parent;
-        for (ManagedFactory factory : factories) {
-            managedFactoryCache.put(factory.getId(), factory);
-        }
     }
 
-    public DefaultManagedFactoryRegistry(ManagedFactory... factories) {
-        this(null, factories);
+    public DefaultManagedFactoryRegistry() {
+        this(null);
+    }
+
+    public ManagedFactoryRegistry withFactories(ManagedFactory... factories) {
+        for (ManagedFactory factory : factories) {
+            register(factory);
+        }
+        return this;
     }
 
     @Override
     @Nullable
-    public <T> ManagedFactory lookup(int id) {
+    public ManagedFactory lookup(int id) {
         ManagedFactory factory = managedFactoryCache.getIfPresent(id);
         if (factory == null && parent != null) {
             factory = parent.lookup(id);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.state;
 
-import javax.annotation.Nullable;
-
 /**
  * Implemented by types whose state is fully managed by Gradle. Mixed into generated classes whose state is fully managed.
  */
@@ -43,15 +41,5 @@ public interface Managed {
     /**
      * Returns the factory that can be used to create new instances of this type.
      */
-    Factory managedFactory();
-
-    interface Factory {
-        /**
-         * Creates an instance of the given type from the given state, if possible.
-         *
-         * @return null when the given type is not supported.
-         */
-        @Nullable
-        <T> T fromState(Class<T> type, Object state);
-    }
+    ManagedFactory managedFactory();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
@@ -37,4 +37,9 @@ public interface Managed {
      * Returns the public type of this managed instance. Currently is used to identify the implementation.
      */
     Class<?> publicType();
+
+    /**
+     * Returns the id of a factory that can be used to create new instances of this type.
+     */
+    int getFactoryId();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
@@ -21,7 +21,7 @@ package org.gradle.internal.state;
  */
 public interface Managed {
     /**
-     * Returns a snapshot of the current state of this object. This can be passed to the {@link Factory#fromState(Class, Object)} method to recreate this object from the snapshot.
+     * Returns a snapshot of the current state of this object. This can be passed to the {@link ManagedFactory#fromState(Class, Object)} method to recreate this object from the snapshot.
      * Note that the state may not be immutable, so should be made isolated to reuse in another context. The state can also be fingerprinted to generate a fingerprint of this object.
      *
      * <p><em>Note that currently the state should reference only JVM and core Gradle types when {@link #immutable()} returns true.</em></p>
@@ -37,9 +37,4 @@ public interface Managed {
      * Returns the public type of this managed instance. Currently is used to identify the implementation.
      */
     Class<?> publicType();
-
-    /**
-     * Returns the factory that can be used to create new instances of this type.
-     */
-    ManagedFactory managedFactory();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactory.java
@@ -26,20 +26,7 @@ public interface ManagedFactory {
     <T> T fromState(Class<T> type, Object state);
 
     /**
-     * Whether or not this factory can create a managed object of the given type.
+     * Returns an id for this factory that can be used to retrieve it from a {@link ManagedFactoryRegistry}.
      */
-    boolean canCreate(Class<?> type);
-
-    abstract class TypedManagedFactory implements ManagedFactory {
-        protected final Class<?> publicType;
-
-        public TypedManagedFactory(Class<?> publicType) {
-            this.publicType = publicType;
-        }
-
-        @Override
-        public boolean canCreate(Class<?> type) {
-            return type == publicType;
-        }
-    }
+    int getId();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactory.java
@@ -29,4 +29,17 @@ public interface ManagedFactory {
      * Whether or not this factory can create a managed object of the given type.
      */
     boolean canCreate(Class<?> type);
+
+    abstract class TypedManagedFactory implements ManagedFactory {
+        protected final Class<?> publicType;
+
+        public TypedManagedFactory(Class<?> publicType) {
+            this.publicType = publicType;
+        }
+
+        @Override
+        public boolean canCreate(Class<?> type) {
+            return type == publicType;
+        }
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.state;
+
+import javax.annotation.Nullable;
+
+public interface ManagedFactory {
+    /**
+     * Creates an instance of the given type from the given state, if possible.
+     *
+     * @return null when the given type is not supported.
+     */
+    @Nullable
+    <T> T fromState(Class<T> type, Object state);
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
@@ -16,17 +16,14 @@
 
 package org.gradle.internal.state;
 
-import javax.annotation.Nullable;
-
-public interface ManagedFactory {
+public interface ManagedFactoryRegistry {
     /**
-     * Creates an instance of a managed object from the given state, if possible.
+     * Looks up a {@link ManagedFactory} that can provide the given type.
      */
-    @Nullable
-    <T> T fromState(Class<T> type, Object state);
+    <T> ManagedFactory lookup(Class<T> type);
 
     /**
-     * Whether or not this factory can create a managed object of the given type.
+     * Registers a new factory for the given type
      */
-    boolean canCreate(Class<?> type);
+    void register(Class<?> type, ManagedFactory factory);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
@@ -20,10 +20,10 @@ public interface ManagedFactoryRegistry {
     /**
      * Looks up a {@link ManagedFactory} that can provide the given type.
      */
-    <T> ManagedFactory lookup(Class<T> type);
+    <T> ManagedFactory lookup(int id);
 
     /**
      * Registers a new factory for the given type
      */
-    void register(Class<?> type, ManagedFactory factory);
+    void register(ManagedFactory factory);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
@@ -23,7 +23,7 @@ public interface ManagedFactoryRegistry {
     <T> ManagedFactory lookup(int id);
 
     /**
-     * Registers a new factory for the given type
+     * Registers a new factory
      */
     void register(ManagedFactory factory);
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/model/NamedObjectInstantiatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/model/NamedObjectInstantiatorTest.groovy
@@ -64,7 +64,7 @@ class NamedObjectInstantiatorTest extends ConcurrentSpec {
         def state = n1.unpackState()
         state == "a"
 
-        def n2 = n1.managedFactory().fromState(Named, state)
+        def n2 = factory.fromState(Named, state)
         n2.is(n1)
     }
 
@@ -107,7 +107,7 @@ class NamedObjectInstantiatorTest extends ConcurrentSpec {
         def state = n1.unpackState()
         state == "a"
 
-        def n2 = n1.managedFactory().fromState(CustomNamed, state)
+        def n2 = factory.fromState(CustomNamed, state)
         n2.is(n1)
     }
 
@@ -191,7 +191,7 @@ class NamedObjectInstantiatorTest extends ConcurrentSpec {
         def state = n1.unpackState()
         state == "a"
 
-        def n2 = n1.managedFactory().fromState(AbstractNamed, state)
+        def n2 = factory.fromState(AbstractNamed, state)
         n2.is(n1)
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractProviderTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider
 
 import org.gradle.api.Transformer
+import org.gradle.internal.state.ManagedFactory
 
 class AbstractProviderTest extends ProviderSpec<String> {
     TestProvider provider = new TestProvider()
@@ -41,6 +42,11 @@ class AbstractProviderTest extends ProviderSpec<String> {
     @Override
     String someValue() {
         "s2"
+    }
+
+    @Override
+    ManagedFactory managedFactory() {
+        return new ManagedFactories.ProviderManagedFactory()
     }
 
     def "is present when value is not null"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider
 
 import com.google.common.collect.ImmutableCollection
 import com.google.common.collect.ImmutableList
+import org.gradle.internal.state.ManagedFactory
 
 class DefaultListPropertyTest extends CollectionPropertySpec<List<String>> {
     @Override
@@ -43,5 +44,10 @@ class DefaultListPropertyTest extends CollectionPropertySpec<List<String>> {
     @Override
     protected List<String> toMutable(Collection<String> values) {
         return new ArrayList<String>(values)
+    }
+
+    @Override
+    ManagedFactory managedFactory() {
+        return new ManagedFactories.ListPropertyManagedFactory()
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider
 
 import org.gradle.api.Transformer
 import org.gradle.api.provider.Property
+import org.gradle.internal.state.ManagedFactory
 
 class DefaultPropertyStateTest extends PropertySpec<String> {
     DefaultPropertyState<String> property() {
@@ -54,6 +55,11 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
     @Override
     String someOtherValue() {
         return "value2"
+    }
+
+    @Override
+    ManagedFactory managedFactory() {
+        return new ManagedFactories.PropertyManagedFactory()
     }
 
     def "has no value by default"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider
 
 import org.gradle.api.provider.Provider
+import org.gradle.internal.state.ManagedFactory
 
 class DefaultProviderTest extends ProviderSpec<String> {
     @Override
@@ -37,6 +38,11 @@ class DefaultProviderTest extends ProviderSpec<String> {
     @Override
     String someOtherValue() {
         return "s2"
+    }
+
+    @Override
+    ManagedFactory managedFactory() {
+        return new ManagedFactories.ProviderManagedFactory()
     }
 
     def "toString() does not realize value"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider
 
 import com.google.common.collect.ImmutableCollection
 import com.google.common.collect.ImmutableSet
+import org.gradle.internal.state.ManagedFactory
 
 class DefaultSetPropertyTest extends CollectionPropertySpec<Set<String>> {
     @Override
@@ -43,6 +44,11 @@ class DefaultSetPropertyTest extends CollectionPropertySpec<Set<String>> {
     @Override
     protected Set<String> toMutable(Collection<String> values) {
         return new LinkedHashSet<String>(values)
+    }
+
+    @Override
+    ManagedFactory managedFactory() {
+        return new ManagedFactories.SetPropertyManagedFactory()
     }
 
     def "discards duplicates values and retains iteration order of added elements"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider
 
 import com.google.common.collect.ImmutableMap
+import org.gradle.internal.state.ManagedFactory
 import org.spockframework.util.Assert
 
 class MapPropertySpec extends PropertySpec<Map<String, String>> {
@@ -62,6 +63,11 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     @Override
     protected void setToNull(Object property) {
         property.set((Map) null)
+    }
+
+    @Override
+    ManagedFactory managedFactory() {
+        return new ManagedFactories.MapPropertyManagedFactory()
     }
 
     def property = property()

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -863,7 +863,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property instanceof Managed
         !property.immutable()
         def state = property.unpackState()
-        def copy = property.managedFactory().fromState(property.publicType(), state)
+        def copy = managedFactory().fromState(property.publicType(), state)
         !copy.is(property)
         !copy.present
         copy.getOrNull() == null
@@ -872,7 +872,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         copy.getOrNull() == null
 
         def state2 = property.unpackState()
-        def copy2 = property.managedFactory().fromState(property.publicType(), state2)
+        def copy2 = managedFactory().fromState(property.publicType(), state2)
         !copy2.is(property)
         copy2.get() == someValue()
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider
 import org.gradle.api.Transformer
 import org.gradle.api.provider.Provider
 import org.gradle.internal.state.Managed
+import org.gradle.internal.state.ManagedFactory
 import spock.lang.Specification
 
 abstract class ProviderSpec<T> extends Specification {
@@ -29,6 +30,8 @@ abstract class ProviderSpec<T> extends Specification {
     abstract T someValue()
 
     abstract T someOtherValue()
+
+    abstract ManagedFactory managedFactory()
 
     boolean isNoValueProviderImmutable() {
         return false
@@ -217,7 +220,7 @@ abstract class ProviderSpec<T> extends Specification {
         provider instanceof Managed
         provider.immutable() == noValueProviderImmutable
         def state = provider.unpackState()
-        def copy = provider.managedFactory().fromState(provider.publicType(), state)
+        def copy = managedFactory().fromState(provider.publicType(), state)
         !copy.is(provider) || noValueProviderImmutable
         !copy.present
         copy.getOrNull() == null
@@ -231,7 +234,7 @@ abstract class ProviderSpec<T> extends Specification {
         provider instanceof Managed
         !provider.immutable()
         def state = provider.unpackState()
-        def copy = provider.managedFactory().fromState(provider.publicType(), state)
+        def copy = managedFactory().fromState(provider.publicType(), state)
         !copy.is(provider)
         copy.present
         copy.getOrNull() == someValue()

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ProvidersTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ProvidersTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider
 
 import org.gradle.api.Transformer
 import org.gradle.api.provider.Provider
+import org.gradle.internal.state.ManagedFactory
 
 class ProvidersTest extends ProviderSpec<Integer> {
     @Override
@@ -43,6 +44,11 @@ class ProvidersTest extends ProviderSpec<Integer> {
     @Override
     boolean isNoValueProviderImmutable() {
         return true
+    }
+
+    @Override
+    ManagedFactory managedFactory() {
+        return new ManagedFactories.ProviderManagedFactory()
     }
 
     def "mapped fixed value provider calculates transformed value lazily and caches the result"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.internal.instantiation
 
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
+import org.gradle.internal.state.DefaultManagedFactoryRegistry
 import org.gradle.internal.state.Managed
+import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.ClassRule
@@ -40,11 +42,13 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Inte
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceSetPropertyBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceWithDefaultMethods
 
+
 class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec {
     @ClassRule
     @Shared
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory())
+    final ManagedFactoryRegistry managedFactoryRegistry = new DefaultManagedFactoryRegistry()
+    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), managedFactoryRegistry)
 
     def canConstructInstanceOfAbstractClassWithAbstractPropertyGetterAndSetter() {
         def bean = create(BeanWithAbstractProperty)
@@ -66,7 +70,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state.length == 1
         state[0] == null
 
-        def copy = bean.managedFactory().fromState(BeanWithAbstractProperty, state)
+        def copy = managedFactoryRegistry.lookup(BeanWithAbstractProperty).fromState(BeanWithAbstractProperty, state)
         !copy.is(bean)
         copy.name == null
 
@@ -77,7 +81,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state2.length == 1
         state2[0] == "name"
 
-        def copy2 = bean.managedFactory().fromState(BeanWithAbstractProperty, state2)
+        def copy2 = managedFactoryRegistry.lookup(BeanWithAbstractProperty).fromState(BeanWithAbstractProperty, state2)
         !copy2.is(bean)
         copy2.name == "name"
     }
@@ -107,7 +111,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state[0] == null
         state[1] == null
 
-        def copy = bean.managedFactory().fromState(InterfaceBean, state)
+        def copy = managedFactoryRegistry.lookup(InterfaceBean).fromState(InterfaceBean, state)
         !copy.is(bean)
         copy.name == null
         copy.numbers == null
@@ -122,7 +126,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state2[0] == "name"
         state2[1] == [12] as Set
 
-        def copy2 = bean.managedFactory().fromState(InterfaceBean, state2)
+        def copy2 = managedFactoryRegistry.lookup(InterfaceBean).fromState(InterfaceBean, state2)
         !copy2.is(bean)
         copy2.name == "name"
         copy2.numbers == [12] as Set
@@ -198,7 +202,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state.length == 1
         state[0].is(bean.prop)
 
-        def copy = bean.managedFactory().fromState(type, state)
+        def copy = managedFactoryRegistry.lookup(type).fromState(type, state)
         copy.prop.is(bean.prop)
 
         where:
@@ -229,7 +233,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         def state = bean.unpackState()
         state.length == 0
 
-        def copy = bean.managedFactory().fromState(InterfaceWithDefaultMethods, state)
+        def copy = managedFactoryRegistry.lookup(InterfaceWithDefaultMethods).fromState(InterfaceWithDefaultMethods, state)
         !copy.is(bean)
         copy.name == "name"
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -70,7 +70,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state.length == 1
         state[0] == null
 
-        def copy = managedFactoryRegistry.lookup(BeanWithAbstractProperty).fromState(BeanWithAbstractProperty, state)
+        def copy = managedFactoryRegistry.lookup(bean.getFactoryId()).fromState(BeanWithAbstractProperty, state)
         !copy.is(bean)
         copy.name == null
 
@@ -81,7 +81,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state2.length == 1
         state2[0] == "name"
 
-        def copy2 = managedFactoryRegistry.lookup(BeanWithAbstractProperty).fromState(BeanWithAbstractProperty, state2)
+        def copy2 = managedFactoryRegistry.lookup(bean.getFactoryId()).fromState(BeanWithAbstractProperty, state2)
         !copy2.is(bean)
         copy2.name == "name"
     }
@@ -111,7 +111,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state[0] == null
         state[1] == null
 
-        def copy = managedFactoryRegistry.lookup(InterfaceBean).fromState(InterfaceBean, state)
+        def copy = managedFactoryRegistry.lookup(bean.getFactoryId()).fromState(InterfaceBean, state)
         !copy.is(bean)
         copy.name == null
         copy.numbers == null
@@ -126,7 +126,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state2[0] == "name"
         state2[1] == [12] as Set
 
-        def copy2 = managedFactoryRegistry.lookup(InterfaceBean).fromState(InterfaceBean, state2)
+        def copy2 = managedFactoryRegistry.lookup(bean.getFactoryId()).fromState(InterfaceBean, state2)
         !copy2.is(bean)
         copy2.name == "name"
         copy2.numbers == [12] as Set
@@ -202,7 +202,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         state.length == 1
         state[0].is(bean.prop)
 
-        def copy = managedFactoryRegistry.lookup(type).fromState(type, state)
+        def copy = managedFactoryRegistry.lookup(bean.getFactoryId()).fromState(type, state)
         copy.prop.is(bean.prop)
 
         where:
@@ -233,7 +233,7 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         def state = bean.unpackState()
         state.length == 0
 
-        def copy = managedFactoryRegistry.lookup(InterfaceWithDefaultMethods).fromState(InterfaceWithDefaultMethods, state)
+        def copy = managedFactoryRegistry.lookup(bean.getFactoryId()).fromState(InterfaceWithDefaultMethods, state)
         !copy.is(bean)
         copy.name == "name"
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.IConventionAware
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.BiAction
+import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.internal.util.BiFunction
 import org.gradle.util.ConfigureUtil
 import spock.lang.Issue
@@ -31,7 +32,7 @@ import spock.lang.Issue
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Bean
 
 class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory())
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
     def "can attach nested extensions to object"() {
         given:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
 
 import javax.inject.Inject
@@ -38,7 +39,7 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.NonG
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.PrivateInjectBean
 
 class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory())
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
     def "can inject service using @Inject on a getter method with dummy method body"() {
         given:
@@ -229,7 +230,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         def services = defaultServices()
         _ * services.get(Number, CustomInject) >> 12
 
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
         when:
         def obj = create(generator, BeanWithCustomServices, services)
@@ -245,7 +246,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         def services = defaultServices()
         _ * services.get(Number, CustomInject) >> 12
 
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
         when:
         def obj = create(generator, AbstractBeanWithCustomServices, services)
@@ -257,7 +258,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot use multiple inject annotations on getter"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
         when:
         create(generator, MultipleInjectAnnotations)
@@ -326,7 +327,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom annotation that is known but not enabled to getter method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory())
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
         when:
         create(generator, BeanWithCustomServices)
@@ -337,7 +338,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom annotation that is known but not enabled to static method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory())
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
         when:
         create(generator, StaticCustomInjectBean)
@@ -348,7 +349,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom inject annotation to methods of ExtensionAware"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
         when:
         generator.generate(ExtensibleBeanWithCustomInject)
@@ -359,7 +360,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom inject annotation to static method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory())
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
         when:
         generator.generate(StaticCustomInjectBean)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.IConventionAware
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.ServiceLookup
+import org.gradle.internal.state.ManagedFactoryRegistry
 
 import javax.inject.Inject
 
@@ -30,7 +31,7 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Abst
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.BeanWithServiceGetters
 
 class AsmBackedClassGeneratorInjectUndecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory())
+    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
 
     def "returns original class when class is not abstract and no service getter methods present"() {
         expect:
@@ -83,8 +84,8 @@ class AsmBackedClassGeneratorInjectUndecoratedTest extends AbstractClassGenerato
         services.get(Number) >> 12
 
         expect:
-        def decorated = create(AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory()), BeanWithServiceGetters)
-        def undecorated = create(AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory()), BeanWithServiceGetters)
+        def decorated = create(AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry)), BeanWithServiceGetters)
+        def undecorated = create(AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry)), BeanWithServiceGetters)
         decorated.class != undecorated.class
         decorated instanceof ExtensionAware
         !(undecorated instanceof ExtensionAware)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
@@ -53,6 +53,7 @@ import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.util.TestUtil;
 import org.junit.Rule;
@@ -101,7 +102,7 @@ import static org.junit.Assert.fail;
 public class AsmBackedClassGeneratorTest {
     @Rule
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject(Collections.emptyList(), Collections.emptyList(), new TestCrossBuildInMemoryCacheFactory());
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject(Collections.emptyList(), Collections.emptyList(), new TestCrossBuildInMemoryCacheFactory(), new DefaultManagedFactoryRegistry());
 
     private <T> T newInstance(Class<T> clazz, Object... args) throws Exception {
         DefaultServiceRegistry services = new DefaultServiceRegistry();

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiatorFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiatorFactoryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.instantiation
 
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
+import org.gradle.internal.state.ManagedFactoryRegistry
 import spock.lang.Specification
 
 import javax.inject.Inject
@@ -26,7 +27,7 @@ import java.lang.annotation.RetentionPolicy
 
 
 class DefaultInstantiatorFactoryTest extends Specification {
-    def instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), [handler(Annotation1), handler(Annotation2)])
+    def instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), [handler(Annotation1), handler(Annotation2)], Mock(ManagedFactoryRegistry))
 
     def "creates scheme with requested annotations"() {
         expect:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DependencyInjectionUsingClassGeneratorBackedInstantiatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DependencyInjectionUsingClassGeneratorBackedInstantiatorTest.groovy
@@ -19,13 +19,14 @@ import org.gradle.cache.internal.CrossBuildInMemoryCache
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceLookup
+import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import javax.inject.Inject
 
 class DependencyInjectionUsingClassGeneratorBackedInstantiatorTest extends Specification {
-    final ClassGenerator classGenerator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory())
+    final ClassGenerator classGenerator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
     final CrossBuildInMemoryCache cache = new TestCrossBuildInMemoryCacheFactory().newCache()
     final ServiceLookup services = new DefaultServiceRegistry()
     final DependencyInjectingInstantiator instantiator = new DependencyInjectingInstantiator(new Jsr330ConstructorSelector(classGenerator, cache), services)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/ManagedTypeFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/ManagedTypeFactoryTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instantiation
+
+import spock.lang.Specification
+
+class ManagedTypeFactoryTest extends Specification {
+    def "can generate a managed type instance from state"() {
+        def factory = new ManagedTypeFactory(ManagedThing)
+
+        expect:
+        def newManagedThing = factory.fromState(ManagedThing, ["foo"] as Object[])
+        newManagedThing.firstValue == "foo"
+    }
+
+    def "throws an exception when type does not look like a managed type"() {
+        when:
+        new ManagedTypeFactory(AnotherThing)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "The class AnotherThing does not appear to a be a generated managed class."
+        e.cause instanceof NoSuchMethodException
+    }
+
+    static class ManagedThing {
+        final String firstValue
+        public ManagedThing(Object[] values) {
+            this.firstValue = values[0]
+        }
+    }
+
+    static class AnotherThing { }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
@@ -104,13 +104,44 @@ class DefaultManagedFactoryRegistryTest extends Specification {
         registry.lookup(Bar) == barFactory
     }
 
-    def "returns null for unmanaged type"() {
+    def "returns null for unknown type"() {
         def fooFactory = factory(Foo)
         def barFactory = factory(Bar)
         def registry = new DefaultManagedFactoryRegistry(barFactory, fooFactory)
 
         expect:
-        registry.lookup(Fuzz) == null
+        registry.lookup(Buzz) == null
+    }
+
+    def "can lookup factory in parent registry"() {
+        def fooFactory = factory(Foo)
+        def barFactory = factory(Bar)
+        def parent = new DefaultManagedFactoryRegistry(fooFactory)
+        def registry = new DefaultManagedFactoryRegistry(parent, barFactory)
+
+        expect:
+        registry.lookup(Foo) == fooFactory
+    }
+
+    def "prefers factory in child registry"() {
+        def fooFactory1 = factory(Foo)
+        def fooFactory2 = factory(Foo)
+
+        def parent = new DefaultManagedFactoryRegistry(fooFactory1)
+        def registry = new DefaultManagedFactoryRegistry(parent, fooFactory2)
+
+        expect:
+        registry.lookup(Foo) == fooFactory2
+    }
+
+    def "returns null for unknown type in all registries"() {
+        def fooFactory = factory(Foo)
+        def barFactory = factory(Bar)
+        def parent = new DefaultManagedFactoryRegistry(fooFactory)
+        def registry = new DefaultManagedFactoryRegistry(parent, barFactory)
+
+        expect:
+        registry.lookup(Buzz) == null
     }
 
     ManagedFactory factory(Class<?> type) {
@@ -126,6 +157,4 @@ class DefaultManagedFactoryRegistryTest extends Specification {
     static class Baz implements Bar { }
 
     static interface Buzz { }
-
-    static interface Fuzz { }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.state
+
+import spock.lang.Specification
+
+class DefaultManagedFactoryRegistryTest extends Specification {
+
+    def "returns a factory for a given type"() {
+        def fooFactory = factory(Foo)
+        def registry = new DefaultManagedFactoryRegistry(fooFactory)
+
+        expect:
+        registry.lookup(Foo) == fooFactory
+    }
+
+    def "returns a factory for a subtype"() {
+        def fooFactory = factory(Foo)
+        def registry = new DefaultManagedFactoryRegistry(fooFactory)
+
+        expect:
+        registry.lookup(Bar) == fooFactory
+    }
+
+    def "returns a factory for an implementing type"() {
+        def fooFactory = factory(Foo)
+        def registry = new DefaultManagedFactoryRegistry(fooFactory)
+
+        expect:
+        registry.lookup(Baz) == fooFactory
+    }
+
+    def "selects correct factory among multiple factories"() {
+        def fooFactory = factory(Foo)
+        def buzzFactory = factory(Buzz)
+        def registry = new DefaultManagedFactoryRegistry(buzzFactory, fooFactory)
+
+        expect:
+        registry.lookup(Baz) == fooFactory
+    }
+
+    def "selects first matching factory"() {
+        def fooFactory = factory(Foo)
+        def barFactory = factory(Bar)
+
+        when:
+        def registry = new DefaultManagedFactoryRegistry(barFactory, fooFactory)
+
+        then:
+        registry.lookup(Baz) == barFactory
+
+        when:
+        registry = new DefaultManagedFactoryRegistry(fooFactory, barFactory)
+
+        then:
+        registry.lookup(Baz) == fooFactory
+    }
+
+    def "returns a registered factory for a managed type"() {
+        def buzzFactory = factory(Buzz)
+
+        when:
+        def registry = new DefaultManagedFactoryRegistry(buzzFactory)
+
+        then:
+        registry.lookup(Bar) == null
+
+        when:
+        def barFactory = factory(Bar)
+        registry.register(Bar, barFactory)
+
+        then:
+        registry.lookup(Bar) == barFactory
+    }
+
+    def "prefers a registered factory over a known factory for a managed type"() {
+        def fooFactory = factory(Foo)
+
+        when:
+        def registry = new DefaultManagedFactoryRegistry(fooFactory)
+
+        then:
+        registry.lookup(Bar) == fooFactory
+
+        when:
+        def barFactory = factory(Bar)
+        registry.register(Bar, barFactory)
+
+        then:
+        registry.lookup(Bar) == barFactory
+    }
+
+    def "returns null for unmanaged type"() {
+        def fooFactory = factory(Foo)
+        def barFactory = factory(Bar)
+        def registry = new DefaultManagedFactoryRegistry(barFactory, fooFactory)
+
+        expect:
+        registry.lookup(Fuzz) == null
+    }
+
+    ManagedFactory factory(Class<?> type) {
+        return Stub(ManagedFactory) {
+            _ * canCreate(_) >> { args -> type.isAssignableFrom(args[0]) }
+        }
+    }
+
+    static interface Foo { }
+
+    static interface Bar extends Foo { }
+
+    static class Baz implements Bar { }
+
+    static interface Buzz { }
+
+    static interface Fuzz { }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
@@ -19,11 +19,12 @@ package org.gradle.internal.state
 import spock.lang.Specification
 
 class DefaultManagedFactoryRegistryTest extends Specification {
+    def registry = new DefaultManagedFactoryRegistry()
 
     def "returns a factory for a given type"() {
         def fooFactory = factory(Foo)
         def buzzFactory = factory(Buzz)
-        def registry = new DefaultManagedFactoryRegistry(buzzFactory, fooFactory)
+        registry.withFactories(buzzFactory, fooFactory)
 
         expect:
         registry.lookup(fooFactory.id) == fooFactory
@@ -34,7 +35,7 @@ class DefaultManagedFactoryRegistryTest extends Specification {
         def barFactory = factory(Bar)
 
         when:
-        def registry = new DefaultManagedFactoryRegistry(buzzFactory)
+        registry.withFactories(buzzFactory)
 
         then:
         registry.lookup(barFactory.id) == null
@@ -50,7 +51,7 @@ class DefaultManagedFactoryRegistryTest extends Specification {
         def fooFactory = factory(Foo)
         def barFactory = factory(Bar)
         def buzzFactory = factory(Buzz)
-        def registry = new DefaultManagedFactoryRegistry(barFactory, fooFactory)
+        registry.withFactories(barFactory, fooFactory)
 
         expect:
         registry.lookup(buzzFactory.id) == null
@@ -59,8 +60,8 @@ class DefaultManagedFactoryRegistryTest extends Specification {
     def "can lookup factory in parent registry"() {
         def fooFactory = factory(Foo)
         def barFactory = factory(Bar)
-        def parent = new DefaultManagedFactoryRegistry(fooFactory)
-        def registry = new DefaultManagedFactoryRegistry(parent, barFactory)
+        def parent = new DefaultManagedFactoryRegistry().withFactories(fooFactory)
+        def registry = new DefaultManagedFactoryRegistry(parent).withFactories(barFactory)
 
         expect:
         registry.lookup(fooFactory.id) == fooFactory
@@ -70,8 +71,8 @@ class DefaultManagedFactoryRegistryTest extends Specification {
         def fooFactory1 = factory(Foo)
         def fooFactory2 = factory(Foo)
 
-        def parent = new DefaultManagedFactoryRegistry(fooFactory1)
-        def registry = new DefaultManagedFactoryRegistry(parent, fooFactory2)
+        def parent = new DefaultManagedFactoryRegistry().withFactories(fooFactory1)
+        def registry = new DefaultManagedFactoryRegistry(parent).withFactories(fooFactory2)
 
         expect:
         registry.lookup(fooFactory1.id) == fooFactory2
@@ -81,8 +82,8 @@ class DefaultManagedFactoryRegistryTest extends Specification {
         def fooFactory = factory(Foo)
         def barFactory = factory(Bar)
         def buzzFactory = factory(Buzz)
-        def parent = new DefaultManagedFactoryRegistry(fooFactory)
-        def registry = new DefaultManagedFactoryRegistry(parent, barFactory)
+        def parent = new DefaultManagedFactoryRegistry().withFactories(fooFactory)
+        def registry = new DefaultManagedFactoryRegistry(parent).withFactories(barFactory)
 
         expect:
         registry.lookup(buzzFactory.id) == null
@@ -90,7 +91,7 @@ class DefaultManagedFactoryRegistryTest extends Specification {
 
     ManagedFactory factory(Class<?> type) {
         return Stub(ManagedFactory) {
-            _ * getId() >> Objects.hashCode(type)
+            _ * getId() >> Objects.hashCode(type.name)
         }
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
@@ -89,6 +89,19 @@ class DefaultManagedFactoryRegistryTest extends Specification {
         registry.lookup(buzzFactory.id) == null
     }
 
+    def "throws exception when a factory with the same id is registered twice"() {
+        def fooFactory1 = factory(Foo)
+        def fooFactory2 = factory(Foo)
+        registry.withFactories(fooFactory1)
+
+        when:
+        registry.register(fooFactory2)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.matches("A managed factory with type [^\\s]+ \\(id: [^\\s]+\\) has already been registered.")
+    }
+
     ManagedFactory factory(Class<?> type) {
         return Stub(ManagedFactory) {
             _ * getId() >> Objects.hashCode(type.name)

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -19,7 +19,6 @@ package org.gradle.workers.internal;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.WorkerSharedGlobalScopeServices;
-import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.process.internal.worker.request.RequestArgumentSerializers;
 
 import javax.inject.Inject;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -19,6 +19,7 @@ package org.gradle.workers.internal;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
 import org.gradle.internal.service.scopes.WorkerSharedGlobalScopeServices;
+import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.process.internal.worker.request.RequestArgumentSerializers;
 
 import javax.inject.Inject;


### PR DESCRIPTION
This is in preparation for using the isolation framework when isolating worker api executions.  We need to be able to reconstruct the managed factory in a worker process so that the isolated values can be transformed back into managed objects again.