### PR TITLE
Fix EclipseModelBuilder compatibility with Gradle 5.5 ToolingApi clients

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -63,6 +63,7 @@ import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultEclipseSourceDirec
 import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultEclipseTask;
 import org.gradle.plugins.ide.internal.tooling.java.DefaultInstalledJdk;
 import org.gradle.plugins.ide.internal.tooling.model.DefaultGradleProject;
+import org.gradle.tooling.model.UnsupportedMethodException;
 import org.gradle.tooling.model.eclipse.EclipseRuntime;
 import org.gradle.tooling.model.eclipse.EclipseWorkspace;
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
@@ -121,9 +122,18 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
         List<EclipseWorkspaceProject> projects = eclipseRuntime.getWorkspace().getProjects();
         HashSet<EclipseWorkspaceProject> projectsInBuild = new HashSet<>(projects);
         projectsInBuild.removeAll(gatherExternalProjects(project.getRootProject(), projects));
-        projectOpenStatus = projectsInBuild.stream().collect(Collectors.toMap(EclipseWorkspaceProject::getName, EclipseWorkspaceProject::isOpen, (a, b) -> a | b));
+        projectOpenStatus = projectsInBuild.stream().collect(Collectors.toMap(EclipseWorkspaceProject::getName, EclipseModelBuilder::isProjectOpen, (a, b) -> a | b));
 
         return buildAll(modelName, project);
+    }
+
+    public static boolean isProjectOpen(EclipseWorkspaceProject project) {
+        try {
+            return project.isOpen();
+        } catch (UnsupportedMethodException e) {
+            // isOpen was added in gradle 5.6. for 5.5 we default to true
+            return true;
+        }
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
@@ -48,7 +48,7 @@ public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingMode
     @Override
     public RunClosedProjectBuildDependencies buildAll(String modelName, EclipseRuntime eclipseRuntime, Project project) {
         this.projectOpenStatus = eclipseRuntime.getWorkspace().getProjects().stream()
-            .collect(Collectors.toMap(EclipseWorkspaceProject::getName, EclipseWorkspaceProject::isOpen));
+            .collect(Collectors.toMap(EclipseWorkspaceProject::getName, EclipseModelBuilder::isProjectOpen, (a, b) -> a | b));
 
         List<TaskDependency> buildDependencies = populate(project.getRootProject());
         if (!buildDependencies.isEmpty()) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/BackwardsCompatibilityEclipseRuntimeCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/BackwardsCompatibilityEclipseRuntimeCrossVersionSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r56
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.eclipse.EclipseWorkspace
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
+
+import java.util.regex.Pattern
+
+@TargetGradleVersion(">=5.6")
+@ToolingApiVersion("=5.5")
+class BackwardsCompatibilityEclipseRuntimeCrossVersionSpec extends ToolingApiSpecification {
+
+    def "will not fail with older tooling versions"() {
+        setup:
+        multiProjectBuildInRootFolder("root", ["child1", "child2"]) {
+            buildFile << """
+            subprojects {
+                apply plugin: 'java-library'
+            }
+            project(":child2") {
+                dependencies {
+                    implementation project(":child1");
+                }
+            }
+        """
+        }
+
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([gradleProject("child1"), gradleProject("child2")])
+        when:
+        withConnection { connection ->
+            connection.action(new LoadEclipseModel(workspace))
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        !taskExecuted(out, ":eclipseClosedDependencies")
+    }
+
+    private static def taskExecuted(ByteArrayOutputStream out, String taskPath) {
+        out.toString().find("(?m)> Task ${Pattern.quote(taskPath)}\$") != null
+    }
+
+    EclipseWorkspace eclipseWorkspace(List<EclipseWorkspaceProject> projects) {
+        new DefaultEclipseWorkspace(temporaryFolder.file("workspace"), projects)
+    }
+
+    EclipseWorkspaceProject gradleProject(String name) {
+        project(name, file(name))
+    }
+
+    static EclipseWorkspaceProject project(String name, File location) {
+        // use map coercion here as this otherwise wouldn't compile against gradle 5.6+
+        [getName: { name }, getLocation: { location }] as EclipseWorkspaceProject
+    }
+
+}


### PR DESCRIPTION
EclipseModelBuilder needs to handle Gradle 5.5 ToolingAPI clients. These use EclipseWorkspaceProject instances that do not have the new `isOpen()` method.

This change also adds the safety against duplicate projects names that is already present in EclipseModelBuilder to RunBuildDependenciesTaskBuilder.

When running an gradle 5.5 tooling model against a 5.6 daemon this exception is thrown:
```
Unsupported method: EclipseWorkspaceProject.isOpen().
The version of Gradle you connect to does not support that method.
To resolve the problem you can change/upgrade the target version of Gradle you connect to.
Alternatively, you can ignore this exception and read other information from the model.
* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Exception is:
org.gradle.tooling.model.UnsupportedMethodException: Unsupported method: EclipseWorkspaceProject.isOpen().
The version of Gradle you connect to does not support that method.
To resolve the problem you can change/upgrade the target version of Gradle you connect to.
Alternatively, you can ignore this exception and read other information from the model.
    at org.gradle.tooling.model.internal.Exceptions.unsupportedMethod(Exceptions.java:33)
    at org.gradle.tooling.internal.adapter.ProtocolToModelAdapter$InvocationHandlerImpl.invoke(ProtocolToModelAdapter.java:362)
    at com.sun.proxy.$Proxy52.isOpen(Unknown Source)
    at org.gradle.plugins.ide.internal.tooling.EclipseModelBuilder.buildAll(EclipseModelBuilder.java:124)
    at org.gradle.plugins.ide.internal.tooling.EclipseModelBuilder.buildAll(EclipseModelBuilder.java:84)
    at org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry$ParameterizedBuildOperationWrappingToolingModelBuilder$1$1.create(DefaultToolingModelBuilderRegistry.java:140)
```
The Gradle error message in this case is actually misleading/wrong - Gradle does support that particular method, its the ToolingApi that is missing it.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This PR fixes an incompatibility introduced by https://github.com/gradle/gradle/pull/9405

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
