### PR TITLE
Fix incorrect simplification of intersection of unions

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
@@ -73,23 +73,28 @@ class Intersections {
             Set<ExcludeSpec> rightComponents = ((ExcludeAnyOf) right).getComponents();
             common.retainAll(rightComponents);
             if (common.size() >= 1) {
-                Set<ExcludeSpec> toIntersect = Sets.newHashSet();
-                for (ExcludeSpec component : left.getComponents()) {
-                    if (!common.contains(component)) {
-                        toIntersect.add(component);
-                    }
+                Set<ExcludeSpec> remainderLeft = Sets.newHashSet(left.getComponents());
+                remainderLeft.removeAll(common);
+                ExcludeSpec alpha = asUnion(common);
+                if (remainderLeft.isEmpty()) {
+                    return alpha;
                 }
-                for (ExcludeSpec component : rightComponents) {
-                    if (!common.contains(component)) {
-                        toIntersect.add(component);
-                    }
+                Set<ExcludeSpec> remainderRight = Sets.newHashSet(rightComponents);
+                remainderRight.removeAll(common);
+                if (remainderRight.isEmpty()) {
+                    return alpha;
                 }
-                ExcludeSpec alpha = common.size() == 1 ? common.iterator().next() : factory.anyOf(common);
-                ExcludeSpec beta = toIntersect.size() == 1 ? toIntersect.iterator().next() : factory.allOf(toIntersect);
+                ExcludeSpec unionLeft = asUnion(remainderLeft);
+                ExcludeSpec unionRight = asUnion(remainderRight);
+                ExcludeSpec beta = factory.allOf(unionLeft, unionRight);
                 return factory.anyOf(alpha, beta);
             }
         }
         return null;
+    }
+
+    private ExcludeSpec asUnion(Set<ExcludeSpec> remainderLeft) {
+        return remainderLeft.size() == 1 ? remainderLeft.iterator().next() : factory.anyOf(remainderLeft);
     }
 
     private ExcludeSpec intersectModuleIdSet(ModuleIdSetExclude left, ExcludeSpec right) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactory.java
@@ -292,7 +292,8 @@ public class NormalizingExcludeFactory extends DelegatingExcludeFactory {
                 }
             }
             if (simplified) {
-                result = Arrays.stream(asArray).filter(Objects::nonNull).collect(toSet());
+                Set<ExcludeSpec> tmp = Arrays.stream(asArray).filter(Objects::nonNull).collect(toSet());
+                result = tmp;
             }
         }
         return Optimizations.optimizeCollection(this, result, delegate::allOf);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/IntersectionsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/IntersectionsTest.groovy
@@ -55,34 +55,37 @@ class IntersectionsTest extends Specification {
         ops.tryIntersect(other, one) == expected
 
         where:
-        one                                                     | other                                                         | expected
-        group("org")                                            | group("foo")                                                  | factory.nothing()
-        group("org")                                            | group("org")                                                  | group("org")
-        group("org")                                            | groupSet("foo", "org")                                        | group("org")
-        group("org")                                            | groupSet("foo", "org", "baz")                                 | group("org")
-        group("org")                                            | groupSet("foo", "baz")                                        | factory.nothing()
-        group("org")                                            | moduleId("org", "bar")                                        | moduleId("org", "bar")
-        group("org")                                            | moduleId("com", "bar")                                        | factory.nothing()
-        group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"])                   | moduleId("org", "bar")
-        group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"], ["org", "baz"])   | moduleIdSet(["org", "bar"], ["org", "baz"])
-        group("org")                                            | module("mod")                                                 | null
-        group("org")                                            | moduleSet("mod", "mod2")                                      | null
-        module("foo")                                           | module("bar")                                                 | factory.nothing()
-        module("foo")                                           | moduleSet("foo", "bar")                                       | module("foo")
-        module("foo")                                           | moduleId("org", "foo")                                        | moduleId("org", "foo")
-        module("foo")                                           | moduleId("org", "bar")                                        | factory.nothing()
-        module("foo")                                           | moduleIdSet(["org", "foo"], ["org", "bar"])                   | moduleId("org", "foo")
-        module("foo")                                           | moduleIdSet(["org", "foo"], ["org", "bar"], ["com", "foo"])   | moduleIdSet(["org", "foo"], ["com", "foo"])
-        groupSet("org", "org2")                                 | groupSet("org2", "org3")                                      | group("org2")
-        groupSet("org", "org2", "org3")                         | groupSet("org", "org3", "org4")                               | groupSet("org", "org3")
-        groupSet("org", "org2")                                 | moduleId("org", "foo")                                        | moduleId("org", "foo")
-        groupSet("org", "org2")                                 | moduleIdSet(["org", "foo"], ["org2", "bar"], ["org3", "baz"]) | moduleIdSet(["org", "foo"], ["org2", "bar"])
-        moduleIdSet(["org", "foo"], ["org", "bar"])             | moduleIdSet(["org", "bar"], ["org2", "baz"])                  | moduleId("org", "bar")
-        moduleIdSet(["org", "foo"], ["org", "bar"])             | moduleIdSet(["org", "bar"], ["org2", "baz"], ["org", "foo"])  | moduleIdSet(["org", "bar"], ["org", "foo"])
+        one                                                     | other                                                                                                    | expected
+        group("org")                                            | group("foo")                                                                                             | factory.nothing()
+        group("org")                                            | group("org")                                                                                             | group("org")
+        group("org")                                            | groupSet("foo", "org")                                                                                   | group("org")
+        group("org")                                            | groupSet("foo", "org", "baz")                                                                            | group("org")
+        group("org")                                            | groupSet("foo", "baz")                                                                                   | factory.nothing()
+        group("org")                                            | moduleId("org", "bar")                                                                                   | moduleId("org", "bar")
+        group("org")                                            | moduleId("com", "bar")                                                                                   | factory.nothing()
+        group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"])                                                              | moduleId("org", "bar")
+        group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"], ["org", "baz"])                                              | moduleIdSet(["org", "bar"], ["org", "baz"])
+        group("org")                                            | module("mod")                                                                                            | null
+        group("org")                                            | moduleSet("mod", "mod2")                                                                                 | null
+        module("foo")                                           | module("bar")                                                                                            | factory.nothing()
+        module("foo")                                           | moduleSet("foo", "bar")                                                                                  | module("foo")
+        module("foo")                                           | moduleId("org", "foo")                                                                                   | moduleId("org", "foo")
+        module("foo")                                           | moduleId("org", "bar")                                                                                   | factory.nothing()
+        module("foo")                                           | moduleIdSet(["org", "foo"], ["org", "bar"])                                                              | moduleId("org", "foo")
+        module("foo")                                           | moduleIdSet(["org", "foo"], ["org", "bar"], ["com", "foo"])                                              | moduleIdSet(["org", "foo"], ["com", "foo"])
+        groupSet("org", "org2")                                 | groupSet("org2", "org3")                                                                                 | group("org2")
+        groupSet("org", "org2", "org3")                         | groupSet("org", "org3", "org4")                                                                          | groupSet("org", "org3")
+        groupSet("org", "org2")                                 | moduleId("org", "foo")                                                                                   | moduleId("org", "foo")
+        groupSet("org", "org2")                                 | moduleIdSet(["org", "foo"], ["org2", "bar"], ["org3", "baz"])                                            | moduleIdSet(["org", "foo"], ["org2", "bar"])
+        moduleIdSet(["org", "foo"], ["org", "bar"])             | moduleIdSet(["org", "bar"], ["org2", "baz"])                                                             | moduleId("org", "bar")
+        moduleIdSet(["org", "foo"], ["org", "bar"])             | moduleIdSet(["org", "bar"], ["org2", "baz"], ["org", "foo"])                                             | moduleIdSet(["org", "bar"], ["org", "foo"])
+
+        anyOf(group("org.slf4j"), module("py4j"))               | anyOf(group("org.slf4j"), module("py4j"), moduleIdSet(["org.jboss.netty", "netty"], ["jline", "jline"])) | anyOf(group("org.slf4j"), module("py4j"))
+        anyOf(group("G1"), module("M1"), group("G2"))           | anyOf(group("G1"), module("M2"))                                                                         | anyOf(group("G1"), allOf(anyOf(module("M1"), group("G2")), module("M2")))
 
         // for operations below the result can be further simplified, but it's not this class responsibility to do it
-        anyOf(group("foo"), group("bar"))                       | anyOf(group("foo"), group("baz"))                             | anyOf(group("foo"), allOf(group("bar"), group("baz")))
-        anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "c"])) | anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "d"]))       | anyOf(group("g1"), allOf(moduleIdSet(["a", "b"], ["a", "c"]), moduleIdSet(["a", "b"], ["a", "d"])))
+        anyOf(group("foo"), group("bar"))                       | anyOf(group("foo"), group("baz"))                                                                        | anyOf(group("foo"), allOf(group("bar"), group("baz")))
+        anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "c"])) | anyOf(group("g1"), moduleIdSet(["a", "b"], ["a", "d"]))                                                  | anyOf(group("g1"), allOf(moduleIdSet(["a", "b"], ["a", "c"]), moduleIdSet(["a", "b"], ["a", "d"])))
     }
 
     @Unroll("intersection of #one with #other = #expected using normalizing factory")


### PR DESCRIPTION
The result of simplification was only correct if there was one
item not in common on both hands of the intersection.

Fixes #9718

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
