### PR TITLE
Add documentation for Java test fixtures

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -34,6 +34,21 @@ See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html#changes_@b
 
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. --> 
 
+<a name="test-fixtures"/>
+
+## Test fixtures for Java projects
+
+Gradle 5.6 introduces a new [Java test fixtures plugin](userguide/java_testing.html#sec:java_test_fixtures), which, when applied in combination with the `java` or `java-library` plugin, will create a conventional `testFixtures` source set.
+Gradle will automatically perform the wiring so that the `test` compilation depends on test fixtures, but more importantly, it allows other projects to depend on the test fixtures of a library.
+For example:
+
+```groovy
+dependencies {
+   // this will add the test fixtures of "my-lib" on the compile classpath of the tests of _this_ project
+   testImplementation(testFixtures(project(":my-lib")))
+}
+```
+
 ## Improvements for plugin authors
 
 ### Task dependencies are honored for `@Input` properties of type `Property`

--- a/subprojects/docs/src/docs/release/release-features.txt
+++ b/subprojects/docs/src/docs/release/release-features.txt
@@ -1,3 +1,3 @@
  - PMD incremental analysis support
  - JavaExec supports executable jar
- - TBD
+ - Test fixtures for Java projects

--- a/subprojects/docs/src/docs/userguide/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/java_testing.adoc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+:metadata-file-spec: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+
 [[java_testing]]
 = Testing in Java & JVM projects
 
@@ -469,3 +471,89 @@ You can force tests to run in this situation by cleaning the output of the relev
 On the few occasions that you want to debug your code while the tests are running, it can be helpful if you can attach a debugger at that point. You can either set the link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:debug[Test.getDebug()] property to `true` or use the `--debug-jvm` command line option.
 
 When debugging for tests is enabled, Gradle will start the test process suspended and listening on port 5005.
+
+[[sec:java_test_fixtures]]
+== Using test fixtures
+
+=== Producing and using test fixtures within a single project
+
+Test fixtures are commonly used to setup the code under test, or provide utilities aimed at facilitating the tests of a component.
+Java projects can enable test fixtures support by applying the `java-test-fixtures` plugin, in addition to the `java` or `java-library` plugins:
+
+.Applying the Java test fixtures plugin
+====
+include::sample[dir="userguide/java/fixtures/groovy",files="lib/build.gradle[tags=use-plugin]"]
+include::sample[dir="userguide/java/fixtures/kotlin",files="lib/build.gradle.kts[tags=use-plugin]"]
+====
+
+This will automatically create a `testFixtures` source set, in which you can write your test fixtures.
+Test fixtures are configured so that:
+
+- they can see the _main_ source set classes
+- _test_ sources can see the _test fixtures_ classes
+
+For example for this main class:
+
+[source,java,indent=0]
+.src/main/java/com/acme/Person.java
+----
+include::{samplesPath}/userguide/java/fixtures/groovy/lib/src/main/java/com/acme/Person.java[tags=sample]
+----
+
+A test fixture can be written in `src/testFixtures/java`:
+
+[source,java,indent=0]
+.src/testFixtures/java/com/acme/Simpsons.java
+----
+include::{samplesPath}/userguide/java/fixtures/groovy/lib/src/testFixtures/java/com/acme/Simpsons.java[tags=sample]
+----
+
+=== Declaring dependencies of test fixtures
+
+Similarly to the link:java_library_plugin.html[Java Library Plugin], test fixtures expose an API and an implementation configuration:
+
+.Declaring test fixture dependencies
+====
+include::sample[dir="userguide/java/fixtures/groovy",files="lib/build.gradle[tags=test_fixtures_deps]"]
+include::sample[dir="userguide/java/fixtures/kotlin",files="lib/build.gradle.kts[tags=test_fixtures_deps]"]
+====
+
+It's worth noticing that if a dependency is an _implementation_ dependency of test fixtures, then _when compiling tests that depend on those test fixtures_, the implementation dependencies will _not leak_ into the compile classpath.
+This results in improved separation of concerns and better compile avoidance.
+
+=== Consuming test fixtures of another project
+
+Test fixtures are not limited to a single project.
+It is often the case that a dependent project tests also needs the test fixtures of the dependency.
+This can be achieved very easily using the `testFixtures` keyword:
+
+.Adding a dependency on test fixtures of another project
+====
+include::sample[dir="userguide/java/fixtures/groovy",files="build.gradle[tags=consumer_dependencies]"]
+include::sample[dir="userguide/java/fixtures/kotlin",files="build.gradle.kts[tags=consumer_dependencies]"]
+====
+
+=== Publishing test fixtures
+
+One of the advantages of using the `java-test-fixtures` plugin is that test fixtures are published.
+By convention, test fixtures will be published with an artifact having the `test-fixtures` classifier.
+For both Maven and Ivy, an artifact with that classifier is simply published alongside the regular artifacts.
+However, if you use the `maven-publish` or `ivy-publish` plugins and enable {metadata-file-spec}[experimental Gradle metadata], then test fixtures are published as additional variants, which implies that you can directly depend on test fixtures of external libraries:
+
+.Adding a dependency on test fixtures of an external library
+====
+include::sample[dir="userguide/java/fixtures/groovy",files="build.gradle[tags=external-test-fixtures-dependency]"]
+include::sample[dir="userguide/java/fixtures/kotlin",files="build.gradle.kts[tags=external-test-fixtures-dependency]"]
+====
+
+It's worth noting that if the external project is _not_ publishing Gradle module metadata, then resolution will fail with an error indicating that such a variant cannot be found:
+
+.Output of **`gradle dependencyInsight --configuration functionalTestClasspath --dependency gson`**
+----
+> gradle dependencyInsight --configuration functionalTestClasspath --dependency gson
+include::{samplesPath}/userguide/java/fixtures/dependencyInsight.out[]
+----
+
+The error message mentions the missing `com.google.code.gson:gson-test-fixtures` capability, which is indeed not defined for this library.
+That's because by convention, for projects that use the `java-test-fixtures` plugin, Gradle automatically creates test fixtures variants with a capability whose name is the name of the main component, with the appendix `-test-fixtures`.
+

--- a/subprojects/docs/src/samples/userguide/java/fixtures/dependencyInsight.out
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/dependencyInsight.out
@@ -1,0 +1,20 @@
+
+> Task :dependencyInsight
+com.google.code.gson:gson:2.8.5 FAILED
+   Failures:
+      - Could not resolve com.google.code.gson:gson:2.8.5.
+          - Unable to find a variant of com.google.code.gson:gson:2.8.5 providing the requested capability com.google.code.gson:gson-test-fixtures:
+               - Variant compile provides com.google.code.gson:gson:2.8.5
+               - Variant runtime provides com.google.code.gson:gson:2.8.5
+               - Variant platform-compile provides com.google.code.gson:gson-derived-platform:2.8.5
+               - Variant platform-runtime provides com.google.code.gson:gson-derived-platform:2.8.5
+               - Variant enforced-platform-compile provides com.google.code.gson:gson-derived-platform:2.8.5
+               - Variant enforced-platform-runtime provides com.google.code.gson:gson-derived-platform:2.8.5
+
+com.google.code.gson:gson:2.8.5 FAILED
+\--- functionalTestClasspath
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/build.gradle
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java-library'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::consumer_dependencies[]
+dependencies {
+    implementation(project(":lib"))
+    
+    testImplementation 'junit:junit:4.12'
+    testImplementation(testFixtures(project(":lib")))
+}
+// end::consumer_dependencies[]
+
+configurations {
+    functionalTest {
+        canBeConsumed = false
+        canBeResolved = false
+    }
+    functionalTestClasspath {
+        extendsFrom(functionalTest)
+        canBeConsumed = false
+        canBeResolved = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+        }
+    }
+}
+
+// tag::external-test-fixtures-dependency[]
+dependencies {
+    // Adds a dependency on the test fixtures of Gson, however this
+    // project doesn't publish such a thing
+    functionalTest testFixtures("com.google.code.gson:gson:2.8.5")
+}
+// end::external-test-fixtures-dependency[]

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/build.gradle
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/build.gradle
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::use-plugin[]
+plugins {
+    // A Java Library
+    id 'java-library'
+    // which produces test fixtures
+    id 'java-test-fixtures'
+    // and is published
+    id 'maven-publish'
+}
+// end::use-plugin[]
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+// tag::test_fixtures_deps[]
+dependencies {
+    testImplementation 'junit:junit:4.12'
+
+    // API dependencies are visible to consumers when building
+    testFixturesApi 'org.apache.commons:commons-lang3:3.9'
+
+    // Implementation dependencies are not leaked to consumers when building
+    testFixturesImplementation 'org.apache.commons:commons-text:1.6'
+}
+// end::test_fixtures_deps[]
+
+// tag::publishing_test_fixtures[]
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}
+// end::publishing_test_fixtures[]

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/src/main/java/com/acme/Person.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/src/main/java/com/acme/Person.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme;
+
+// tag::sample[]
+public class Person {
+    private final String firstName;
+    private final String lastName;
+
+    public Person(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    // ...
+
+// end::sample[]
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        Person person = (Person) object;
+
+        if (!firstName.equals(person.firstName)) {
+            return false;
+        }
+        if (!lastName.equals(person.lastName)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public int hashCode() {
+        int result = firstName.hashCode();
+        result = 31 * result + lastName.hashCode();
+        return result;
+    }
+
+    @java.lang.Override
+    public java.lang.String toString() {
+        return "Person{" +
+            "firstName='" + firstName + '\'' +
+            ", lastName='" + lastName + '\'' +
+            '}';
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/src/test/java/com/acme/PersonTest.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/src/test/java/com/acme/PersonTest.java
@@ -1,0 +1,14 @@
+package com.acme;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PersonTest {
+    @Test
+    public void testPerson() {
+        Person person = Simpsons.homer();
+
+        assertEquals("Homer", person.getFirstName());
+        assertEquals("Simpson", person.getLastName());
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/src/testFixtures/java/com/acme/Simpsons.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/lib/src/testFixtures/java/com/acme/Simpsons.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme;
+
+import java.util.List;
+import java.util.ArrayList;
+import org.apache.commons.text.WordUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+// tag::sample[]
+public class Simpsons {
+    private static final Person HOMER = new Person("Homer", "Simpson");
+    private static final Person MARGE = new Person("Majorie", "Simpson");
+    private static final Person BART = new Person("Bartholomew", "Simpson");
+    private static final Person LISA = new Person("Elisabeth Marie", "Simpson");
+    private static final Person MAGGIE = new Person("Margaret Eve", "Simpson");
+    private static final List<Person> FAMILY = new ArrayList<Person>() {{
+        add(HOMER);
+        add(MARGE);
+        add(BART);
+        add(LISA);
+        add(MAGGIE);
+    }};
+
+    public static Person homer() { return HOMER; }
+
+    public static Person marge() { return MARGE; }
+
+    public static Person bart() { return BART; }
+
+    public static Person lisa() { return LISA; }
+
+    public static Person maggie() { return MAGGIE; }
+
+    // ...
+//end::sample[]
+    public static Person named(String firstName) {
+        String capitalized = WordUtils.capitalizeFully(firstName);
+        for (Person person : FAMILY) {
+            if (capitalized.equals(person.getFirstName())) {
+                return person;
+            }
+        }
+        return null;
+    }
+
+    public static Person of(Pair<String, String> pair) {
+        return new Person(pair.getLeft(), pair.getRight());
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/settings.gradle
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = 'sample-fixtures'
+
+include 'lib'
+
+enableFeaturePreview('GRADLE_METADATA')

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/src/main/java/com/acme/Family.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/src/main/java/com/acme/Family.java
@@ -1,0 +1,31 @@
+package com.acme;
+
+import java.util.List;
+import java.util.Arrays;
+
+public class Family {
+    private final List<Person> members;
+
+    public Family(Person... members) {
+        this.members = Arrays.asList(members);
+    }
+
+    public List<Person> getMembers() {
+        return members;
+    }
+
+    public int size() {
+        return members.size();
+    }
+
+    public boolean contains(Person person) {
+        return members.contains(person);
+    }
+
+    @java.lang.Override
+    public java.lang.String toString() {
+        return "Family{" +
+            "members=" + members +
+            '}';
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/groovy/src/test/java/com/acme/FamilyTest.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/groovy/src/test/java/com/acme/FamilyTest.java
@@ -1,0 +1,24 @@
+package com.acme;
+
+import org.junit.Test;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import static org.junit.Assert.*;
+import static com.acme.Simpsons.*;
+
+public class FamilyTest {
+    @Test
+    public void testFamily() {
+        Family family = new Family(
+            homer(),
+            marge(),
+            bart(),
+            named("elisabeth marie"),
+            of(ImmutablePair.of("Margaret Eve", "Simpson"))
+        );
+        System.out.println("family = " + family);
+        System.out.println("maggie() = " + maggie());
+        assertEquals(5, family.size());
+        assertTrue(family.contains(lisa()));
+        assertTrue(family.contains(maggie()));
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/javaTestFixtures.sample.conf
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/javaTestFixtures.sample.conf
@@ -1,0 +1,13 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: dependencyInsight --configuration functionalTestClasspath --dependency gson
+    expected-output-file: dependencyInsight.out
+    allow-additional-output: true
+},{
+      execution-subdirectory: kotlin
+      executable: gradle
+      args: dependencyInsight --configuration functionalTestClasspath --dependency gson
+      expected-output-file: dependencyInsight.out
+      allow-additional-output: true
+  }]

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/build.gradle.kts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `java-library`
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::consumer_dependencies[]
+dependencies {
+    implementation(project(":lib"))
+    
+    testImplementation("junit:junit:4.12")
+    testImplementation(testFixtures(project(":lib")))
+}
+// end::consumer_dependencies[]
+
+val functionalTest by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+val functionalTestClasspath by configurations.creating {
+    extendsFrom(functionalTest)
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_API))
+    }
+}
+
+// tag::external-test-fixtures-dependency[]
+dependencies {
+    // Adds a dependency on the test fixtures of Gson, however this
+    // project doesn't publish such a thing
+    functionalTest(testFixtures("com.google.code.gson:gson:2.8.5"))
+}
+// end::external-test-fixtures-dependency[]

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/build.gradle.kts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::use-plugin[]
+plugins {
+    // A Java Library
+    `java-library`
+    // which produces test fixtures
+    `java-test-fixtures`
+    // and is published
+    `maven-publish`
+}
+// end::use-plugin[]
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+// tag::test_fixtures_deps[]
+dependencies {
+    testImplementation("junit:junit:4.12")
+
+    // API dependencies are visible to consumers when building
+    testFixturesApi("org.apache.commons:commons-lang3:3.9")
+
+    // Implementation dependencies are not leaked to consumers when building
+    testFixturesImplementation("org.apache.commons:commons-text:1.6")
+}
+// end::test_fixtures_deps[]
+
+// tag::publishing_test_fixtures[]
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+        }
+    }
+}
+// end::publishing_test_fixtures[]

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/src/main/java/com/acme/Person.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/src/main/java/com/acme/Person.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme;
+
+// tag::sample[]
+public class Person {
+    private final String firstName;
+    private final String lastName;
+
+    public Person(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    // ...
+
+// end::sample[]
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        Person person = (Person) object;
+
+        if (!firstName.equals(person.firstName)) {
+            return false;
+        }
+        if (!lastName.equals(person.lastName)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public int hashCode() {
+        int result = firstName.hashCode();
+        result = 31 * result + lastName.hashCode();
+        return result;
+    }
+
+    @java.lang.Override
+    public java.lang.String toString() {
+        return "Person{" +
+            "firstName='" + firstName + '\'' +
+            ", lastName='" + lastName + '\'' +
+            '}';
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/src/test/java/com/acme/PersonTest.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/src/test/java/com/acme/PersonTest.java
@@ -1,0 +1,14 @@
+package com.acme;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PersonTest {
+    @Test
+    public void testPerson() {
+        Person person = Simpsons.homer();
+
+        assertEquals("Homer", person.getFirstName());
+        assertEquals("Simpson", person.getLastName());
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/src/testFixtures/java/com/acme/Simpsons.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/lib/src/testFixtures/java/com/acme/Simpsons.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme;
+
+import java.util.List;
+import java.util.ArrayList;
+import org.apache.commons.text.WordUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+// tag::sample[]
+public class Simpsons {
+    private static final Person HOMER = new Person("Homer", "Simpson");
+    private static final Person MARGE = new Person("Majorie", "Simpson");
+    private static final Person BART = new Person("Bartholomew", "Simpson");
+    private static final Person LISA = new Person("Elisabeth Marie", "Simpson");
+    private static final Person MAGGIE = new Person("Margaret Eve", "Simpson");
+    private static final List<Person> FAMILY = new ArrayList<Person>() {{
+        add(HOMER);
+        add(MARGE);
+        add(BART);
+        add(LISA);
+        add(MAGGIE);
+    }};
+
+    public static Person homer() { return HOMER; }
+
+    public static Person marge() { return MARGE; }
+
+    public static Person bart() { return BART; }
+
+    public static Person lisa() { return LISA; }
+
+    public static Person maggie() { return MAGGIE; }
+
+    // ...
+//end::sample[]
+    public static Person named(String firstName) {
+        String capitalized = WordUtils.capitalizeFully(firstName);
+        for (Person person : FAMILY) {
+            if (capitalized.equals(person.getFirstName())) {
+                return person;
+            }
+        }
+        return null;
+    }
+
+    public static Person of(Pair<String, String> pair) {
+        return new Person(pair.getLeft(), pair.getRight());
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/settings.gradle.kts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "sample-fixtures"
+
+include("lib")
+
+enableFeaturePreview("GRADLE_METADATA")

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/src/main/java/com/acme/Family.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/src/main/java/com/acme/Family.java
@@ -1,0 +1,31 @@
+package com.acme;
+
+import java.util.List;
+import java.util.Arrays;
+
+public class Family {
+    private final List<Person> members;
+
+    public Family(Person... members) {
+        this.members = Arrays.asList(members);
+    }
+
+    public List<Person> getMembers() {
+        return members;
+    }
+
+    public int size() {
+        return members.size();
+    }
+
+    public boolean contains(Person person) {
+        return members.contains(person);
+    }
+
+    @java.lang.Override
+    public java.lang.String toString() {
+        return "Family{" +
+            "members=" + members +
+            '}';
+    }
+}

--- a/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/src/test/java/com/acme/FamilyTest.java
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/kotlin/src/test/java/com/acme/FamilyTest.java
@@ -1,0 +1,24 @@
+package com.acme;
+
+import org.junit.Test;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import static org.junit.Assert.*;
+import static com.acme.Simpsons.*;
+
+public class FamilyTest {
+    @Test
+    public void testFamily() {
+        Family family = new Family(
+            homer(),
+            marge(),
+            bart(),
+            named("elisabeth marie"),
+            of(ImmutablePair.of("Margaret Eve", "Simpson"))
+        );
+        System.out.println("family = " + family);
+        System.out.println("maggie() = " + maggie());
+        assertEquals(5, family.size());
+        assertTrue(family.contains(lisa()));
+        assertTrue(family.contains(maggie()));
+    }
+}


### PR DESCRIPTION
Follow-up to #9632 

This commit adds documentation and samples for producing and
consuming test fixtures using the `java-test-fixtures` plugin.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
