### PR TITLE
More optimizations of intersections of excludes

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.fact
 
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeAnyOf;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.GroupExclude;
@@ -136,6 +137,15 @@ class Intersections {
         } else if (right instanceof ModuleIdSetExclude) {
             Set<ModuleIdentifier> moduleIds = ((ModuleIdSetExclude) right).getModuleIds().stream().filter(id -> id.getGroup().equals(group)).collect(toSet());
             return moduleIdSet(moduleIds);
+        } else if (right instanceof ModuleExclude) {
+            return factory.moduleId(DefaultModuleIdentifier.newId(left.getGroup(), ((ModuleExclude) right).getModule()));
+        } else if (right instanceof ModuleSetExclude) {
+            ModuleSetExclude moduleSet = (ModuleSetExclude) right;
+            return factory.moduleIdSet(moduleSet.getModules()
+                .stream()
+                .map(module -> DefaultModuleIdentifier.newId(left.getGroup(), module))
+                .collect(toSet())
+            );
         }
         return null;
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/IntersectionsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/IntersectionsTest.groovy
@@ -65,8 +65,8 @@ class IntersectionsTest extends Specification {
         group("org")                                            | moduleId("com", "bar")                                                                                   | factory.nothing()
         group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"])                                                              | moduleId("org", "bar")
         group("org")                                            | moduleIdSet(["foo", "bar"], ["org", "bar"], ["org", "baz"])                                              | moduleIdSet(["org", "bar"], ["org", "baz"])
-        group("org")                                            | module("mod")                                                                                            | null
-        group("org")                                            | moduleSet("mod", "mod2")                                                                                 | null
+        group("org")                                            | module("mod")                                                                                            | moduleId("org", "mod")
+        group("org")                                            | moduleSet("mod", "mod2")                                                                                 | moduleIdSet(["org", "mod"], ["org", "mod2"])
         module("foo")                                           | module("bar")                                                                                            | factory.nothing()
         module("foo")                                           | moduleSet("foo", "bar")                                                                                  | module("foo")
         module("foo")                                           | moduleId("org", "foo")                                                                                   | moduleId("org", "foo")


### PR DESCRIPTION
Optimize intersect(group, module) -> moduleId(group, module)
Optimize intersect(group, module names) -> moduleIdSet(group + name...)

PR intentionally done on `master` to reduce the changeset on `release`.