### PR TITLE
Excluded unreadable file/directory in the output of the copy task shouldn't throw

### DIFF
--- a/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/hash/TestFileHasher.groovy
+++ b/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/hash/TestFileHasher.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.hash
 
 import com.google.common.io.Files
-import org.gradle.api.UncheckedIOException
 
 class TestFileHasher implements FileHasher {
     @Override

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
@@ -68,7 +68,7 @@ The following types/formats are supported:
                 from 'src'
                 into 'dest'
             }
-'''
+        '''
 
         ExecutionFailure failure = inTestDirectory().withTasks('copy').runWithFailure()
         failure.assertHasDescription("Execution failed for task ':copy'.")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -23,8 +23,6 @@ import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 import spock.lang.Unroll
 
-import java.nio.file.Files
-
 import static org.junit.Assert.assertTrue
 
 @Unroll
@@ -233,9 +231,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec {
         def input = file("readableFile.txt").createFile()
 
         def outputDirectory = file("output")
-        def unreadableOutput = create(file("${outputDirectory.name}/unreadable${type.capitalize()}"))
-        unreadableOutput.setReadable(false, false)
-        assert !Files.isReadable(unreadableOutput.toPath())
+        def unreadableOutput = create(file("${outputDirectory.name}/unreadable${type.capitalize()}")).makeUnreadable()
 
         buildFile << """
             task copy(type: Copy) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -15,12 +15,13 @@
  */
 package org.gradle.api.internal.tasks.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.execution.TaskExecutionListener;
-import org.gradle.api.internal.OverlappingOutputs;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.taskfactory.IncrementalInputsTaskAction;
 import org.gradle.api.internal.project.taskfactory.IncrementalTaskInputsTaskAction;
@@ -56,12 +57,16 @@ import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.execution.impl.OutputFilterUtil;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.fingerprint.FileCollectionFingerprint;
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.ExecutingBuildOperation;
 import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.work.AsyncWorkTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,9 +126,9 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     }
 
     @Override
-    public TaskExecuterResult execute(final TaskInternal task, final TaskStateInternal state, final TaskExecutionContext context) {
-        final TaskExecution work = new TaskExecution(task, context, executionHistoryStore);
-        final CachingResult result = workExecutor.execute(new IncrementalContext() {
+    public TaskExecuterResult execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        TaskExecution work = new TaskExecution(task, context, executionHistoryStore);
+        CachingResult result = workExecutor.execute(new IncrementalContext() {
             @Override
             public UnitOfWork getWork() {
                 return work;
@@ -163,7 +168,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             public Optional<OriginMetadata> getReusedOutputOriginMetadata() {
                 return result.isReused()
                     ? Optional.of(result.getOriginMetadata())
-                    : Optional.<OriginMetadata>empty();
+                    : Optional.empty();
             }
 
             @Override
@@ -299,6 +304,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             return Optional.ofNullable(task.getTimeout().getOrNull());
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public InputChangeTrackingStrategy getInputChangeTrackingStrategy() {
             for (InputChangesAwareTaskAction taskAction : task.getTaskActions()) {
@@ -328,19 +334,29 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
 
         @Override
         public ImmutableSortedMap<String, CurrentFileCollectionFingerprint> snapshotAfterOutputsGenerated() {
-            final AfterPreviousExecutionState afterPreviousExecutionState = context.getAfterPreviousExecution();
-            final ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputsAfterExecution = taskFingerprinter.fingerprintTaskFiles(task, context.getTaskProperties().getOutputFileProperties());
-            return context.getOverlappingOutputs()
-                .map(new Function<OverlappingOutputs, ImmutableSortedMap<String, CurrentFileCollectionFingerprint>>() {
-                    @Override
-                    public ImmutableSortedMap<String, CurrentFileCollectionFingerprint> apply(OverlappingOutputs overlappingOutputs) {
-                        return OutputFilterUtil.filterOutputFingerprints(
-                            afterPreviousExecutionState == null ? null : afterPreviousExecutionState.getOutputFileProperties(),
-                            context.getOutputFilesBeforeExecution(),
-                            outputsAfterExecution
-                        );
+            AfterPreviousExecutionState afterPreviousExecutionState = context.getAfterPreviousExecution();
+            ImmutableSortedMap<String, FileSystemSnapshot> outputsAfterExecution = taskFingerprinter.snapshotTaskFiles(task, context.getTaskProperties().getOutputFileProperties());
+            return createFilteredOutputFingerprints(afterPreviousExecutionState, context.getOutputFilesBeforeExecution(), outputsAfterExecution, context.getOverlappingOutputs().isPresent());
+        }
+
+        private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> createFilteredOutputFingerprints(@Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> beforeExecutionOutputSnapshots, ImmutableSortedMap<String, FileSystemSnapshot> afterExecutionOutputSnapshots, boolean hasOverlappingOutputs) {
+            ImmutableSortedMap<String, FileCollectionFingerprint> afterLastExecutionFingerprints = afterPreviousExecutionState == null ? ImmutableSortedMap.of() : afterPreviousExecutionState.getOutputFileProperties();
+
+            return ImmutableSortedMap.copyOfSorted(
+                Maps.transformEntries(afterExecutionOutputSnapshots, (propertyName, afterExecutionOutputSnapshot) -> {
+                        FileCollectionFingerprint afterLastExecutionFingerprint = afterLastExecutionFingerprints.get(propertyName);
+                        FileSystemSnapshot beforeExecutionOutputSnapshot = beforeExecutionOutputSnapshots.get(propertyName);
+                        return fingerprintOutputSnapshot(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot, afterExecutionOutputSnapshot, hasOverlappingOutputs);
                     }
-                }).orElse(outputsAfterExecution);
+                )
+            );
+        }
+
+        private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(@Nullable FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot, FileSystemSnapshot afterExecutionOutputSnapshot, boolean hasOverlappingOutputs) {
+            List<FileSystemSnapshot> roots = hasOverlappingOutputs
+                ? OutputFilterUtil.filterOutputSnapshotAfterExecution(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot, afterExecutionOutputSnapshot)
+                : ImmutableList.of(afterExecutionOutputSnapshot);
+            return DefaultCurrentFileCollectionFingerprint.from(roots, AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
         }
 
         @Override
@@ -349,7 +365,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
 
         @Override
-        public void markSnapshottingInputsFinished(final CachingState cachingState) {
+        public void markSnapshottingInputsFinished(CachingState cachingState) {
             // TODO:lptr this should be added only if the scan plugin is applied, but SnapshotTaskInputsOperationIntegrationTest
             //   expects it to be added also when the build cache is enabled (but not the scan plugin)
             if (buildCacheEnabled || scanPluginApplied) {
@@ -391,7 +407,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
     }
 
-    private void executeAction(final String actionDisplayName, final TaskInternal task, final InputChangesAwareTaskAction action, @Nullable InputChangesInternal inputChanges, boolean hasMoreWork) {
+    private void executeAction(String actionDisplayName, TaskInternal task, InputChangesAwareTaskAction action, @Nullable InputChangesInternal inputChanges, boolean hasMoreWork) {
         if (inputChanges != null) {
             action.setInputChanges(inputChanges);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
@@ -87,7 +87,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         return delegate.execute(task, state, context);
     }
 
-    private BeforeExecutionState createExecutionState(TaskInternal task, TaskProperties properties, @Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> outputFileSnapshots, boolean hasOverlappingOutputs) {
+    private BeforeExecutionState createExecutionState(TaskInternal task, TaskProperties properties, @Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> beforeExecutionOutputSnapshots, boolean hasOverlappingOutputs) {
         Class<? extends TaskInternal> taskClass = task.getClass();
         List<InputChangesAwareTaskAction> taskActions = task.getTaskActions();
         ImplementationSnapshot taskImplementation = ImplementationSnapshot.of(taskClass, classLoaderHierarchyHasher);
@@ -103,7 +103,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         ImmutableSortedMap<String, ValueSnapshot> inputProperties = snapshotTaskInputProperties(task, properties, previousInputProperties, valueSnapshotter);
 
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFiles = taskFingerprinter.fingerprintTaskFiles(task, properties.getInputFileProperties());
-        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFiles = createFilteredOutputFingerprints(afterPreviousExecutionState, outputFileSnapshots, hasOverlappingOutputs);
+        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFiles = createFilteredOutputFingerprints(afterPreviousExecutionState, beforeExecutionOutputSnapshots, hasOverlappingOutputs);
         return new DefaultBeforeExecutionState(
             taskImplementation,
             taskActionImplementations,
@@ -113,24 +113,24 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         );
     }
 
-    private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> createFilteredOutputFingerprints(@Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> outputFileSnapshots, boolean hasOverlappingOutputs) {
-        ImmutableSortedMap<String, FileCollectionFingerprint> previousOutputs = afterPreviousExecutionState == null ? ImmutableSortedMap.of() : afterPreviousExecutionState.getOutputFileProperties();
+    private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> createFilteredOutputFingerprints(@Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> beforeExecutionOutputSnapshots, boolean hasOverlappingOutputs) {
+        ImmutableSortedMap<String, FileCollectionFingerprint> afterLastExecutionFingerprints = afterPreviousExecutionState == null ? ImmutableSortedMap.of() : afterPreviousExecutionState.getOutputFileProperties();
 
         return ImmutableSortedMap.copyOfSorted(
-            Maps.transformEntries(outputFileSnapshots, (key, outputSnapshot) -> {
-                    FileCollectionFingerprint previousOutputFingerprint = previousOutputs.get(key);
-                    return previousOutputFingerprint == null
+            Maps.transformEntries(beforeExecutionOutputSnapshots, (key, beforeExecutionOutputSnapshot) -> {
+                    FileCollectionFingerprint afterLastExecutionFingerprint = afterLastExecutionFingerprints.get(key);
+                    return afterLastExecutionFingerprint == null
                         ? AbsolutePathFingerprintingStrategy.IGNORE_MISSING.getEmptyFingerprint()
-                        : fingerprintOutputSnapshot(outputSnapshot, previousOutputFingerprint, hasOverlappingOutputs);
+                        : fingerprintOutputSnapshot(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot, hasOverlappingOutputs);
                 }
             )
         );
     }
 
-    private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(FileSystemSnapshot outputSnapshot, FileCollectionFingerprint previousOutputFingerprint, boolean hasOverlappingOutputs) {
+    private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot, boolean hasOverlappingOutputs) {
         List<FileSystemSnapshot> roots = hasOverlappingOutputs
-            ? OutputFilterUtil.filterOutputSnapshotBeforeExecution(previousOutputFingerprint, outputSnapshot)
-            : ImmutableList.of(outputSnapshot);
+            ? OutputFilterUtil.filterOutputSnapshotBeforeExecution(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot)
+            : ImmutableList.of(beforeExecutionOutputSnapshot);
         return DefaultCurrentFileCollectionFingerprint.from(roots, AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
@@ -129,7 +129,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
 
     private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(FileSystemSnapshot outputSnapshot, FileCollectionFingerprint previousOutputFingerprint, boolean hasOverlappingOutputs) {
         List<FileSystemSnapshot> roots = hasOverlappingOutputs
-            ? OutputFilterUtil.filterOutputSnapshot(previousOutputFingerprint, outputSnapshot)
+            ? OutputFilterUtil.filterOutputSnapshotBeforeExecution(previousOutputFingerprint, outputSnapshot)
             : ImmutableList.of(outputSnapshot);
         return DefaultCurrentFileCollectionFingerprint.from(roots, AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -76,7 +76,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkTracker = Mock(AsyncWorkTracker)
     def taskFingerprinter = Stub(TaskFingerprinter) {
-        fingerprintTaskFiles(task, _) >> ImmutableSortedMap.of()
+        snapshotTaskFiles(task, _) >> ImmutableSortedMap.of()
     }
     def executionHistoryStore = Mock(ExecutionHistoryStore)
     def buildId = UniqueId.generate()

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
@@ -42,12 +42,12 @@ import java.util.function.Predicate;
  */
 public class OutputFilterUtil {
 
-    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotBeforeExecution(FileCollectionFingerprint previousOutputs, FileSystemSnapshot currentSnapshots) {
-        Map<String, FileSystemLocationFingerprint> fingerprints = previousOutputs.getFingerprints();
+    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotBeforeExecution(FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot) {
+        Map<String, FileSystemLocationFingerprint> fingerprints = afterLastExecutionFingerprint.getFingerprints();
         SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> {
             return snapshot.getType() != FileType.Missing && fingerprints.containsKey(snapshot.getAbsolutePath());
         });
-        currentSnapshots.accept(filteringVisitor);
+        beforeExecutionOutputSnapshot.accept(filteringVisitor);
         return filteringVisitor.getNewRoots();
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
@@ -16,16 +16,11 @@
 
 package org.gradle.internal.execution.impl;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
 import org.gradle.internal.file.FileType;
-import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
-import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
-import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
@@ -33,9 +28,7 @@ import org.gradle.internal.snapshot.FileSystemSnapshotVisitor;
 import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -49,60 +42,34 @@ import java.util.function.Predicate;
  */
 public class OutputFilterUtil {
 
-    public static ImmutableSortedMap<String, CurrentFileCollectionFingerprint> filterOutputFingerprints(
-        final @Nullable ImmutableSortedMap<String, FileCollectionFingerprint> outputsAfterPreviousExecution,
-        ImmutableSortedMap<String, FileSystemSnapshot> outputsBeforeExecution,
-        final ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputsAfterExecution
-    ) {
-        return ImmutableSortedMap.copyOfSorted(Maps.transformEntries(outputsBeforeExecution, new Maps.EntryTransformer<String, FileSystemSnapshot, CurrentFileCollectionFingerprint>() {
-            @Override
-            @SuppressWarnings("NullableProblems")
-            public CurrentFileCollectionFingerprint transformEntry(String propertyName, FileSystemSnapshot outputBeforeExecution) {
-                CurrentFileCollectionFingerprint outputAfterExecution = outputsAfterExecution.get(propertyName);
-                FileCollectionFingerprint outputAfterPreviousExecution = getFingerprintForProperty(outputsAfterPreviousExecution, propertyName);
-                return filterOutputFingerprint(outputAfterPreviousExecution, outputBeforeExecution, outputAfterExecution);
-            }
-        }));
+    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotBeforeExecution(FileCollectionFingerprint previousOutputs, FileSystemSnapshot currentSnapshots) {
+        Map<String, FileSystemLocationFingerprint> fingerprints = previousOutputs.getFingerprints();
+        SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> {
+            return snapshot.getType() != FileType.Missing && fingerprints.containsKey(snapshot.getAbsolutePath());
+        });
+        currentSnapshots.accept(filteringVisitor);
+        return filteringVisitor.getNewRoots();
     }
 
-    private static FileCollectionFingerprint getFingerprintForProperty(@Nullable ImmutableSortedMap<String, FileCollectionFingerprint> fingerprinters, String propertyName) {
-        if (fingerprinters != null) {
-            FileCollectionFingerprint afterPreviousExecution = fingerprinters.get(propertyName);
-            if (afterPreviousExecution != null) {
-                return afterPreviousExecution;
-            }
+    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotAfterExecution(@Nullable FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot, FileSystemSnapshot afterExecutionOutputSnapshot) {
+        Map<String, FileSystemLocationSnapshot> beforeExecutionSnapshots = getAllSnapshots(beforeExecutionOutputSnapshot);
+        if (beforeExecutionSnapshots.isEmpty()) {
+            return ImmutableList.of(afterExecutionOutputSnapshot);
         }
-        return FileCollectionFingerprint.EMPTY;
-    }
 
-    @VisibleForTesting
-    static CurrentFileCollectionFingerprint filterOutputFingerprint(
-        @Nullable FileCollectionFingerprint afterPreviousExecution,
-        FileSystemSnapshot beforeExecution,
-        CurrentFileCollectionFingerprint afterExecution
-    ) {
-        CurrentFileCollectionFingerprint filesFingerprint;
-        final Map<String, FileSystemLocationSnapshot> beforeExecutionSnapshots = getAllSnapshots(beforeExecution);
-        if (!beforeExecutionSnapshots.isEmpty() && !afterExecution.getFingerprints().isEmpty()) {
-            @SuppressWarnings("RedundantTypeArguments")
-            final Map<String, FileSystemLocationFingerprint> afterPreviousFingerprints = afterPreviousExecution != null
-                ? afterPreviousExecution.getFingerprints()
-                : ImmutableMap.<String, FileSystemLocationFingerprint>of();
+        Map<String, FileSystemLocationFingerprint> afterLastExecutionFingerprints = afterLastExecutionFingerprint != null
+            ? afterLastExecutionFingerprint.getFingerprints()
+            : ImmutableMap.of();
 
-            SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> isOutputEntry(snapshot, beforeExecutionSnapshots, afterPreviousFingerprints));
-            afterExecution.accept(filteringVisitor);
+        SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(afterExecutionSnapshot -> isOutputEntry(afterLastExecutionFingerprints, beforeExecutionSnapshots, afterExecutionSnapshot));
+        afterExecutionOutputSnapshot.accept(filteringVisitor);
 
-
-            // Are all file snapshots after execution accounted for as new entries?
-            if (!filteringVisitor.hasBeenFiltered()) {
-                filesFingerprint = afterExecution;
-            } else {
-                filesFingerprint = DefaultCurrentFileCollectionFingerprint.from(filteringVisitor.getNewRoots(), AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
-            }
+        // Are all file snapshots after execution accounted for as new entries?
+        if (filteringVisitor.hasBeenFiltered()) {
+            return filteringVisitor.getNewRoots();
         } else {
-            filesFingerprint = afterExecution;
+            return ImmutableList.of(afterExecutionOutputSnapshot);
         }
-        return filesFingerprint;
     }
 
     private static Map<String, FileSystemLocationSnapshot> getAllSnapshots(FileSystemSnapshot fingerprint) {
@@ -114,30 +81,21 @@ public class OutputFilterUtil {
     /**
      * Decide whether an entry should be considered to be part of the output. See class Javadoc for definition of what is considered output.
      */
-    private static boolean isOutputEntry(FileSystemLocationSnapshot snapshot, Map<String, FileSystemLocationSnapshot> beforeSnapshots, Map<String, FileSystemLocationFingerprint> afterPreviousFingerprints) {
-        if (snapshot.getType() == FileType.Missing) {
+    private static boolean isOutputEntry(Map<String, FileSystemLocationFingerprint> afterPreviousExecutionFingerprints, Map<String, FileSystemLocationSnapshot> beforeExecutionSnapshots, FileSystemLocationSnapshot afterExecutionSnapshot) {
+        if (afterExecutionSnapshot.getType() == FileType.Missing) {
             return false;
         }
-        FileSystemLocationSnapshot beforeSnapshot = beforeSnapshots.get(snapshot.getAbsolutePath());
+        FileSystemLocationSnapshot beforeSnapshot = beforeExecutionSnapshots.get(afterExecutionSnapshot.getAbsolutePath());
         // Was it created during execution?
         if (beforeSnapshot == null) {
             return true;
         }
         // Was it updated during execution?
-        if (!snapshot.isContentAndMetadataUpToDate(beforeSnapshot)) {
+        if (!afterExecutionSnapshot.isContentAndMetadataUpToDate(beforeSnapshot)) {
             return true;
         }
         // Did we already consider it as an output after the previous execution?
-        return afterPreviousFingerprints.containsKey(snapshot.getAbsolutePath());
-    }
-
-    public static List<FileSystemSnapshot> filterOutputSnapshot(FileCollectionFingerprint previousOutputs, FileSystemSnapshot currentSnapshots) {
-        Map<String, FileSystemLocationFingerprint> fingerprints = previousOutputs.getFingerprints();
-        SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> {
-            return snapshot.getType() != FileType.Missing && fingerprints.containsKey(snapshot.getAbsolutePath());
-        });
-        currentSnapshots.accept(filteringVisitor);
-        return filteringVisitor.getNewRoots();
+        return afterPreviousExecutionFingerprints.containsKey(afterExecutionSnapshot.getAbsolutePath());
     }
 
     private static class GetAllSnapshotsVisitor implements FileSystemSnapshotVisitor {
@@ -165,7 +123,7 @@ public class OutputFilterUtil {
 
     private static class SnapshotFilteringVisitor implements FileSystemSnapshotVisitor {
         private final Predicate<FileSystemLocationSnapshot> predicate;
-        private final List<FileSystemSnapshot> newRoots = new ArrayList<FileSystemSnapshot>();
+        private final ImmutableList.Builder<FileSystemSnapshot> newRootsBuilder = ImmutableList.builder();
 
         private boolean hasBeenFiltered;
         private MerkleDirectorySnapshotBuilder merkleBuilder;
@@ -195,7 +153,7 @@ public class OutputFilterUtil {
                 return;
             }
             if (merkleBuilder == null) {
-                newRoots.add(fileSnapshot);
+                newRootsBuilder.add(fileSnapshot);
             } else {
                 merkleBuilder.visit(fileSnapshot);
             }
@@ -212,14 +170,14 @@ public class OutputFilterUtil {
             if (merkleBuilder.isRoot()) {
                 FileSystemLocationSnapshot result = merkleBuilder.getResult();
                 if (result != null) {
-                    newRoots.add(currentRootFiltered ? result : currentRoot);
+                    newRootsBuilder.add(currentRootFiltered ? result : currentRoot);
                 }
                 merkleBuilder = null;
                 currentRoot = null;
             }
         }
-        public List<FileSystemSnapshot> getNewRoots() {
-            return newRoots;
+        public ImmutableList<FileSystemSnapshot> getNewRoots() {
+            return newRootsBuilder.build();
         }
 
         public boolean hasBeenFiltered() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
@@ -34,6 +34,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputSnapshotAfterExecution
+import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputSnapshotBeforeExecution
 
 class OutputFilterUtilTest extends Specification {
 
@@ -152,6 +153,17 @@ class OutputFilterUtilTest extends Specification {
 
         expect:
         collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [outputDir, outputDirFile]
+    }
+
+    def "overlapping files are not part of the before execution snapshot"() {
+        def outputDir = temporaryFolder.file("outputDir").createDir()
+        def outputDirFile = outputDir.createFile("outputDirFile")
+        def afterLastExecution = fingerprintOutput(outputDir)
+        outputDir.createFile("not-in-output")
+        def beforeExecution = snapshotOutput(outputDir)
+
+        expect:
+        collectFiles(filterOutputSnapshotBeforeExecution(afterLastExecution, beforeExecution)) == [outputDir, outputDirFile]
     }
 
     private FileSystemSnapshot snapshotOutput(File output) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
@@ -16,65 +16,70 @@
 
 package org.gradle.internal.execution.impl
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
-import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
-import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter
+import org.gradle.internal.fingerprint.FileCollectionFingerprint
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
+import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
+import org.gradle.internal.snapshot.DirectorySnapshot
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot
+import org.gradle.internal.snapshot.FileSystemSnapshot
+import org.gradle.internal.snapshot.FileSystemSnapshotVisitor
 import org.gradle.internal.snapshot.WellKnownFileLocations
 import org.gradle.internal.snapshot.impl.DefaultFileSystemMirror
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputFingerprint
+import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputSnapshotAfterExecution
 
 class OutputFilterUtilTest extends Specification {
+
+    private static final FileCollectionFingerprint EMPTY_OUTPUT_FINGERPRINT = AbsolutePathFingerprintingStrategy.IGNORE_MISSING.emptyFingerprint
 
     @Rule
     final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
 
     def fileSystemMirror = new DefaultFileSystemMirror(Stub(WellKnownFileLocations))
-    def fsSnapshotter = TestFiles.fileSystemSnapshotter(fileSystemMirror, new StringInterner())
-    def snapshotter = new DefaultFileCollectionSnapshotter(fsSnapshotter, TestFiles.fileSystem())
-    def outputFingerprinter = new OutputFileCollectionFingerprinter(snapshotter)
+    def snapshotter = TestFiles.fileSystemSnapshotter(fileSystemMirror, new StringInterner())
 
     def "pre-existing directories are filtered"() {
         def outputDir = temporaryFolder.file("outputDir").createDir()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
         outputDir.file()
 
         when:
-        def filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, beforeExecution)
+        def filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution)
         then:
         filteredOutputs.empty
 
         when:
         def outputDirFile = outputDir.file("in-output-dir").createFile()
         fileSystemMirror.beforeBuildFinished()
-        def afterExecution = fingerprintOutput(outputDir)
-        filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution)
+        def afterExecution = snapshotOutput(outputDir)
+        filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)
         then:
-        filteredOutputs.fingerprints.keySet() == [outputDir.absolutePath, outputDirFile.absolutePath] as Set
+        collectFiles(filteredOutputs) == [outputDir, outputDirFile]
     }
 
     def "only newly created files in directory are part of filtered outputs"() {
         def outputDir = temporaryFolder.file("outputDir").createDir()
         outputDir.file("outputOfOther").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
 
         when:
-        def filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, beforeExecution)
+        def filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution)
         then:
         filteredOutputs.empty
 
         when:
         def outputOfCurrent = outputDir.file("outputOfCurrent").createFile()
-        def afterExecution = fingerprintOutput(outputDir)
-        filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution)
+        def afterExecution = snapshotOutput(outputDir)
+        filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)
         then:
-        filteredOutputs.fingerprints.keySet() == [outputDir.absolutePath, outputOfCurrent.absolutePath] as Set
+        collectFiles(filteredOutputs) == [outputDir, outputOfCurrent]
     }
 
     def "previous outputs remain outputs"() {
@@ -82,73 +87,102 @@ class OutputFilterUtilTest extends Specification {
         def outputDirFile = outputDir.file("outputOfCurrent").createFile()
         def previousExecution = fingerprintOutput(outputDir)
         outputDir.file("outputOfOther").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
 
         when:
-        def filteredOutputs = filterOutputFingerprint(previousExecution, beforeExecution, beforeExecution)
+        def filteredOutputs = filterOutputSnapshotAfterExecution(previousExecution, beforeExecution, beforeExecution)
         then:
-        filteredOutputs.fingerprints.keySet() == [outputDir, outputDirFile]*.absolutePath as Set
+        collectFiles(filteredOutputs) == [outputDir, outputDirFile]
     }
-    
+
     def "missing files are ignored"() {
         def missingFile = temporaryFolder.file("missing")
-        def beforeExecution = fingerprintOutput(missingFile)
+        def beforeExecution = snapshotOutput(missingFile)
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, beforeExecution).empty
+        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution).empty
     }
 
     def "added empty dir is captured"() {
         def emptyDir = temporaryFolder.file("emptyDir").createDir()
-        def afterExecution = fingerprintOutput(emptyDir)
+        def afterExecution = snapshotOutput(emptyDir)
+        def beforeExecution = FileSystemSnapshot.EMPTY
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), outputFingerprinter.empty(), afterExecution).fingerprints.keySet() == [emptyDir.absolutePath] as Set
-        filterOutputFingerprint(outputFingerprinter.empty(), afterExecution, afterExecution).empty
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [emptyDir]
+        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterExecution, afterExecution).empty
     }
 
-    private CurrentFileCollectionFingerprint fingerprintOutput(File output) {
-        fileSystemMirror.beforeBuildFinished()
-        outputFingerprinter.fingerprint(ImmutableFileCollection.of(output))
-    }
-    
     def "updated files in output directory are part of the output"() {
         def outputDir = temporaryFolder.createDir("outputDir")
         def existingFile = outputDir.file("some").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
         existingFile << "modified"
-        def afterExecution = fingerprintOutput(outputDir)
+        def afterExecution = snapshotOutput(outputDir)
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution).fingerprints.keySet() == [outputDir, existingFile]*.absolutePath as Set
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [outputDir, existingFile]
     }
 
     def "updated files are part of the output"() {
         def existingFile = temporaryFolder.file("some").createFile()
-        def beforeExecution = fingerprintOutput(existingFile)
+        def beforeExecution = snapshotOutput(existingFile)
         existingFile << "modified"
-        def afterExecution = fingerprintOutput(existingFile)
+        def afterExecution = snapshotOutput(existingFile)
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution).fingerprints.keySet() == [existingFile.absolutePath] as Set
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [existingFile]
     }
 
     def "removed files are not considered outputs"() {
         def outputDir = temporaryFolder.createDir("outputDir")
         def outputDirFile = outputDir.file("toBeDeleted").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def afterPreviousExecutionFingerprint = fingerprintOutput(outputDir)
+        def beforeExecutionSnapshot = snapshotOutput(outputDir)
         outputDirFile.delete()
-        def afterExecution = fingerprintOutput(outputDir)
+        def afterExecution = snapshotOutput(outputDir)
 
         expect:
-        filterOutputFingerprint(beforeExecution, beforeExecution, afterExecution).fingerprints.keySet() == [outputDir.absolutePath] as Set
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution).empty
+        collectFiles(filterOutputSnapshotAfterExecution(afterPreviousExecutionFingerprint, beforeExecutionSnapshot, afterExecution)) == [outputDir]
+        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterPreviousExecutionFingerprint, afterExecution).empty
     }
 
     def "overlapping directories are not included"() {
         def outputDir = temporaryFolder.createDir("outputDir")
         outputDir.createDir("output-dir-2")
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
         def outputDirFile = outputDir.createFile("outputDirFile")
-        def afterExecution1 = fingerprintOutput(outputDir)
+        def afterExecution = snapshotOutput(outputDir)
 
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution1).fingerprints.keySet() == [outputDir, outputDirFile]*.absolutePath as Set
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [outputDir, outputDirFile]
+    }
+
+    private FileSystemSnapshot snapshotOutput(File output) {
+        fileSystemMirror.beforeBuildFinished()
+        snapshotter.snapshot(output)
+    }
+
+    private CurrentFileCollectionFingerprint fingerprintOutput(File outputDir) {
+        DefaultCurrentFileCollectionFingerprint.from([snapshotOutput(outputDir)], AbsolutePathFingerprintingStrategy.IGNORE_MISSING)
+    }
+
+    List<File> collectFiles(ImmutableList<FileSystemSnapshot> fileSystemSnapshots) {
+        def result = []
+        fileSystemSnapshots.each {
+            it.accept(new FileSystemSnapshotVisitor() {
+                @Override
+                boolean preVisitDirectory(DirectorySnapshot directorySnapshot) {
+                    result.add(directorySnapshot)
+                    return true
+                }
+
+                @Override
+                void visit(FileSystemLocationSnapshot fileSnapshot) {
+                    result.add(fileSnapshot)
+                }
+
+                @Override
+                void postVisitDirectory(DirectorySnapshot directorySnapshot) {
+                }
+            })
+        }
+        result.collect { it.absolutePath as File }
     }
 }

--- a/subprojects/files/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
+++ b/subprojects/files/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
@@ -145,30 +145,6 @@ abstract class AbstractDirectoryWalkerTest<T> extends Specification {
         walkerInstance << walkers
     }
 
-    @Requires(TestPrecondition.SYMLINKS)
-    @Unroll
-    def "missing symbolic link causes an exception - walker: #walkerInstance.class.simpleName"() {
-        given:
-        def rootDir = tmpDir.createDir("root")
-        def dir = rootDir.createDir("a/b")
-        def link = rootDir.file("a/d")
-        link.createLink(dir)
-
-        when:
-        dir.deleteDir()
-        walkDirForPaths(walkerInstance, rootDir, new PatternSet())
-
-        then:
-        def e = thrown Exception
-        e.message.contains("Could not list contents of '${link.absolutePath}'.")
-
-        cleanup:
-        link.delete()
-
-        where:
-        walkerInstance << walkers
-    }
-
     @Issue("GRADLE-3400")
     @Requires(TestPrecondition.SYMLINKS)
     @Unroll

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -709,6 +709,12 @@ public class TestFile extends File {
         return this;
     }
 
+    public TestFile makeUnreadable() {
+        setReadable(false, false);
+        assert !Files.isReadable(toPath());
+        return this;
+    }
+
     public TestFile createFile(Object path) {
         return file(path).createFile();
     }

--- a/subprojects/pineapple/src/main/java/org/gradle/internal/file/FileType.java
+++ b/subprojects/pineapple/src/main/java/org/gradle/internal/file/FileType.java
@@ -19,5 +19,6 @@ package org.gradle.internal.file;
 public enum FileType {
     RegularFile,
     Directory,
-    Missing
+    Missing,
+    Unavailable
 }

--- a/subprojects/snapshots/snapshots.gradle.kts
+++ b/subprojects/snapshots/snapshots.gradle.kts
@@ -25,6 +25,7 @@ description = "Tools to take immutable, comparable snapshots of files and other 
 dependencies {
     implementation(library("guava"))
     implementation(library("jsr305"))
+    implementation(library("slf4j_api"))
     implementation(project(":pineapple"))
 
     testImplementation(project(":processServices"))
@@ -36,7 +37,7 @@ dependencies {
     testImplementation(testFixtures(project(":baseServices")))
     testImplementation(testFixtures(project(":files")))
     testImplementation(testFixtures(project(":messaging")))
-    
+
     testRuntimeOnly(project(":runtimeApiInfo"))
     testRuntimeOnly(project(":workers"))
     testRuntimeOnly(project(":dependencyManagement"))

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FileSystemLocationFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FileSystemLocationFingerprint.java
@@ -32,6 +32,7 @@ import org.gradle.internal.hash.Hashing;
 public interface FileSystemLocationFingerprint extends Comparable<FileSystemLocationFingerprint>, Hashable {
     HashCode DIR_SIGNATURE = Hashing.signature("DIR");
     HashCode MISSING_FILE_SIGNATURE = Hashing.signature("MISSING");
+    HashCode UNAVAILABLE_FILE_SIGNATURE = Hashing.signature("UNAVAILABLE");
 
     String getNormalizedPath();
     HashCode getNormalizedContentHash();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileSystemLocationFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileSystemLocationFingerprint.java
@@ -41,8 +41,6 @@ public class DefaultFileSystemLocationFingerprint implements FileSystemLocationF
                 return DIR_SIGNATURE;
             case Missing:
                 return MISSING_FILE_SIGNATURE;
-            case Unavailable:
-                return UNAVAILABLE_FILE_SIGNATURE;
             case RegularFile:
                 return hash;
             default:

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileSystemLocationFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileSystemLocationFingerprint.java
@@ -41,6 +41,8 @@ public class DefaultFileSystemLocationFingerprint implements FileSystemLocationF
                 return DIR_SIGNATURE;
             case Missing:
                 return MISSING_FILE_SIGNATURE;
+            case Unavailable:
+                return UNAVAILABLE_FILE_SIGNATURE;
             case RegularFile:
                 return hash;
             default:

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/UnavailableFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/UnavailableFileSnapshot.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot;
+
+import org.gradle.internal.file.FileType;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hashing;
+
+/**
+ * A snapshot of an unavailable file or directory.
+ */
+public class UnavailableFileSnapshot extends AbstractFileSystemLocationSnapshot {
+    public static final HashCode SIGNATURE = Hashing.signature(UnavailableFileSnapshot.class);
+
+    public UnavailableFileSnapshot(String absolutePath, String name) {
+        super(absolutePath, name);
+    }
+
+    @Override
+    public FileType getType() {
+        return FileType.Unavailable;
+    }
+
+    @Override
+    public HashCode getHash() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isContentAndMetadataUpToDate(FileSystemLocationSnapshot other) {
+        return other instanceof UnavailableFileSnapshot;
+    }
+
+    @Override
+    public void accept(FileSystemSnapshotVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -29,6 +29,8 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.SnapshottingFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -47,6 +49,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 public class DirectorySnapshotter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DirectorySnapshotter.class);
+
     private final FileHasher hasher;
     private final Interner<String> stringInterner;
     private final DefaultExcludes defaultExcludes;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -156,9 +156,9 @@ public class DirectorySnapshotter {
         @Override
         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
             String fileName = getFilename(dir);
-            String name = stringInterner.intern(fileName);
+            String name = intern(fileName);
             if (builder.isRoot() || isAllowed(dir, name, true, attrs, builder.getRelativePath())) {
-                builder.preVisitDirectory(internedAbsolutePath(dir), name);
+                builder.preVisitDirectory(intern(dir.toString()), name);
                 return FileVisitResult.CONTINUE;
             } else {
                 return FileVisitResult.SKIP_SUBTREE;
@@ -173,7 +173,7 @@ public class DirectorySnapshotter {
 
         @Override
         public FileVisitResult visitFile(Path file, @Nullable BasicFileAttributes attrs) {
-            String name = stringInterner.intern(file.getFileName().toString());
+            String name = intern(file.getFileName().toString());
             if (isAllowed(file, name, false, attrs, builder.getRelativePath())) {
                 if (attrs == null) {
                     throw new FileSnapshottingException(String.format("Cannot read file '%s': not authorized.", file));
@@ -217,12 +217,12 @@ public class DirectorySnapshotter {
         private void addFileSnapshot(Path file, String name, BasicFileAttributes attrs) {
             Preconditions.checkNotNull(attrs, "Unauthorized access to %", file);
             HashCode hash = hasher.hash(file.toFile(), attrs.size(), attrs.lastModifiedTime().toMillis());
-            RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(internedAbsolutePath(file), name, hash, FileMetadata.from(attrs));
+            RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(intern(file.toString()), name, hash, FileMetadata.from(attrs));
             builder.visit(fileSnapshot);
         }
 
-        private String internedAbsolutePath(Path file) {
-            return stringInterner.intern(file.toString());
+        private String intern(String string) {
+            return stringInterner.intern(string);
         }
 
         private boolean isAllowed(Path path, String name, boolean isDirectory, @Nullable BasicFileAttributes attrs, Iterable<String> relativePath) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.snapshot.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Lists;
@@ -200,9 +199,16 @@ public class DirectorySnapshotter {
                     // when FileVisitOption.FOLLOW_LINKS, we only get here when link couldn't be followed
                     throw new FileSnapshottingException(String.format("Could not list contents of '%s'. Couldn't follow symbolic link.", file));
                 }
-                addFileSnapshot(file, name, attrs);
+                builder.visit(snapshot(file, name, attrs));
             }
             return FileVisitResult.CONTINUE;
+        }
+
+        private FileSystemLocationSnapshot snapshot(Path absoluteFilePath, String name, BasicFileAttributes attrs) {
+            String internedAbsoluteFilePath = intern(absoluteFilePath.toString());
+            HashCode hash = hasher.hash(absoluteFilePath.toFile(), attrs.size(), attrs.lastModifiedTime().toMillis());
+            FileMetadata metadata = FileMetadata.from(attrs);
+            return new RegularFileSnapshot(internedAbsoluteFilePath, name, hash, metadata);
         }
 
         @Override
@@ -210,8 +216,10 @@ public class DirectorySnapshotter {
             // File loop exceptions are ignored. When we encounter a loop (via symbolic links), we continue
             // so we include all the other files apart from the loop.
             // This way, we include each file only once.
-            if (isNotFileSystemLoopException(exc) && isAllowed(file, file.getFileName().toString(), false, null, builder.getRelativePath())) {
-                throw new UncheckedIOException(String.format("Could not read path '%s'.", file), exc);
+            if (isNotFileSystemLoopException(exc)) {
+                if (isAllowed(file, file.getFileName().toString(), false, null, builder.getRelativePath())) {
+                    throw new UncheckedIOException(String.format("Could not read path '%s'.", file), exc);
+                }
             }
             return FileVisitResult.CONTINUE;
         }
@@ -232,13 +240,6 @@ public class DirectorySnapshotter {
             return e != null && !(e instanceof FileSystemLoopException);
         }
 
-        private void addFileSnapshot(Path file, String name, BasicFileAttributes attrs) {
-            Preconditions.checkNotNull(attrs, "Unauthorized access to %", file);
-            HashCode hash = hasher.hash(file.toFile(), attrs.size(), attrs.lastModifiedTime().toMillis());
-            RegularFileSnapshot fileSnapshot = new RegularFileSnapshot(intern(file.toString()), name, hash, FileMetadata.from(attrs));
-            builder.visit(fileSnapshot);
-        }
-
         private String intern(String string) {
             return stringInterner.intern(string);
         }
@@ -251,6 +252,7 @@ public class DirectorySnapshotter {
             } else if (defaultExcludes.excludeFile(name)) {
                 return false;
             }
+
             if (predicate == null) {
                 return true;
             }


### PR DESCRIPTION
Fixes: https://github.com/gradle/gradle/issues/9576

Follow up:
- [ ] Disallow unavailable files in fingerprints [comment](https://github.com/gradle/gradle/pull/9746#discussion_r298253156): https://github.com/gradle/gradle/pull/9862
- [ ] Split FileType into SnapshotFileType and FingerprintFileType: https://github.com/gradle/gradle/pull/9873

Moved to: https://github.com/gradle/gradle/pull/9878