### PR TITLE
Fix small typo in the feature variants chapter of the user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/feature_variants.adoc
+++ b/subprojects/docs/src/docs/userguide/feature_variants.adoc
@@ -88,8 +88,8 @@ Gradle will automatically setup a number of things for you, in a very similar wa
 
 - the configuration `mongodbSupportApi`, used to _declare API dependencies_ for this feature
 - the configuration `mongodbSupportImplementation`, used to _declare implementation dependencies_ for this feature
-- the configuration `mongodyDbSupportApiElements`, used by consumers to fetch the artifacts and API dependencies of this feature
-- the configuration `mongodyDbSupportRuntimeElements`, used by consumers to fetch the artifacts and runtime dependencies of this feature
+- the configuration `mongodbSupportApiElements`, used by consumers to fetch the artifacts and API dependencies of this feature
+- the configuration `mongodbSupportRuntimeElements`, used by consumers to fetch the artifacts and runtime dependencies of this feature
 
 Most users will only need to care about the first two configurations, to declare the specific dependencies of this feature:
 


### PR DESCRIPTION
### Context
There is a small typo in one of the code examples (mongodyDb -> mongodb).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
