### PR TITLE
Fix LinkageError when using BytecodeExpression in Groovy AST transformations

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -100,6 +100,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         FilteringClassLoader.Spec groovyCompilerClassLoaderSpec = new FilteringClassLoader.Spec();
         groovyCompilerClassLoaderSpec.allowPackage("org.codehaus.groovy");
         groovyCompilerClassLoaderSpec.allowPackage("groovy");
+        groovyCompilerClassLoaderSpec.allowPackage("groovyjarjarasm");
         // Disallow classes from Groovy Jar that reference external classes. Such classes must be loaded from astTransformClassLoader,
         // or a NoClassDefFoundError will occur. Essentially this is drawing a line between the Groovy compiler and the Groovy
         // library, albeit only for selected classes that run a high risk of being statically referenced from a transform.

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec.groovy
@@ -94,4 +94,17 @@ abstract class GroovyCompilerIntegrationSpec extends BasicGroovyCompilerIntegrat
         groovyClassFile("GroovyCode.class").exists()
         groovyClassFile("JavaCode.class").exists()
     }
+
+    @Issue("gradle/gradle#5908")
+    def "canUseAstTransformWithAsm"() {
+        if (versionLowerThan('1.6')) {
+            return
+        }
+
+        when:
+        run("test")
+
+        then:
+        noExceptionThrown()
+    }
 }

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: "groovy"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation "junit:junit:4.12"
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/src/main/groovy/GroovyMagicField.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/src/main/groovy/GroovyMagicField.groovy
@@ -1,0 +1,4 @@
+import org.codehaus.groovy.transform.GroovyASTTransformationClass
+
+@GroovyASTTransformationClass(["GroovyMagicFieldTransform"])
+public @interface GroovyMagicField {}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/src/main/groovy/GroovyMagicFieldTransform.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/src/main/groovy/GroovyMagicFieldTransform.groovy
@@ -1,0 +1,28 @@
+import groovyjarjarasm.asm.MethodVisitor
+import groovyjarjarasm.asm.Opcodes
+import org.codehaus.groovy.ast.ASTNode
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.classgen.BytecodeExpression
+import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.transform.ASTTransformation
+import org.codehaus.groovy.transform.GroovyASTTransformation
+
+@GroovyASTTransformation
+class GroovyMagicFieldTransform implements ASTTransformation, Opcodes {
+    void visit(ASTNode[] nodes, SourceUnit source) {
+        def clazz = (ClassNode) nodes[1]
+        clazz.addField("magicField", ACC_PUBLIC, ClassHelper.STRING_TYPE, new StringExpressionThroughAsm())
+    }
+
+    private class StringExpressionThroughAsm extends BytecodeExpression {
+        StringExpressionThroughAsm() {
+            super(ClassHelper.STRING_TYPE)
+        }
+
+        @Override
+        void visit(MethodVisitor methodVisitor) {
+            methodVisitor.visitLdcInsn("magicValue")
+        }
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/src/test/groovy/GroovyMagicFieldTransformTest.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformWithAsm/src/test/groovy/GroovyMagicFieldTransformTest.groovy
@@ -1,0 +1,10 @@
+import org.junit.Test
+
+@GroovyMagicField
+class GroovyMagicFieldTransformTest {
+    @Test
+    void transformHasBeenApplied() {
+        assert getClass().declaredFields.find { it.name == "magicField" }
+        assert magicField == "magicValue"
+    }
+}


### PR DESCRIPTION
Groovy embeds the ASM classes for use in the compiler, though they are relocated under the groovyjarjarasm top level package name. These classes are not explicitly allowed in the Groovy compiler class loader, where the rest of the compiler classes would be loaded. When trying to use them in an AST transformation, e.g. through the standard Groovy class BytecodeExpression, it will lead to loader constraint violations like this in Gradle:

```
Caused by: java.lang.LinkageError: loader constraint violation: loader (instance of groovy/lang/GroovyClassLoader) previously initiated loading for a different type with name "groovyjarjarasm/asm/MethodVisitor"
        at gradle.asm.example.GroovyMagicFieldTransform.visit(GroovyMagicFieldTransform.groovy:17)
        at org.gradle.api.internal.tasks.compile.ApiGroovyCompiler.execute(ApiGroovyCompiler.java:179)
        at org.gradle.api.internal.tasks.compile.ApiGroovyCompiler.execute(ApiGroovyCompiler.java:57)
        at org.gradle.api.internal.tasks.compile.GroovyCompilerFactory$DaemonSideCompiler.execute(GroovyCompilerFactory.java:81)
        at org.gradle.api.internal.tasks.compile.GroovyCompilerFactory$DaemonSideCompiler.execute(GroovyCompilerFactory.java:69)
        at org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler$CompilerCallable.call(AbstractDaemonCompiler.java:86)
        at org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler$CompilerCallable.call(AbstractDaemonCompiler.java:74)
        at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:42)
        at org.gradle.workers.internal.WorkerDaemonServer.execute(WorkerDaemonServer.java:38)
        at org.gradle.process.internal.worker.request.WorkerAction.run(WorkerAction.java:111)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:175)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:157)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
        ... 3 more
```

This PR allows classes under the groovyjarjarasm top level package name to be loaded in the Groovy compiler class loader in Gradle. I have manually verified that those classes do not reference any classes outside this package and the standard SDK. They should thereby be safe to allow.

I've added an integration test that reproduces the problem (and verifies the fix). There were some integration tests for AST transformations already in the "plugin" subproject, so I've added the new one here as well to be consistent, even though I would have thought they would better belong in the "language-groovy" subproject. But maybe there is good reason for them being where they are.

Fixes issue #5908

### Context
I am creating a plugin for integrating OpenClover (http://openclover.org/) in Gradle. OpenClover makes use BytecodeExpressions in AST transformations that fails with the above loader constraint violations.

More information available from Cédric on the Gradle forums here: https://discuss.gradle.org/t/working-around-a-loader-constraint-violation/3138

See issue #5908 for another example of this problem.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
