### PR TITLE
Fix JUnit Jupiter related typos

### DIFF
--- a/subprojects/docs/src/docs/userguide/build_init_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/build_init_plugin.adoc
@@ -123,7 +123,7 @@ It has the following features:
 
 Alternative test framework can be specified by supplying a `--test-framework` argument value. To use a different test framework, execute one of the following commands:
 
-* `gradle init --type java-application --test-framework junit-jupiter`: Uses http://juni.org[JUnit Jupiter] for testing instead of JUnit 4
+* `gradle init --type java-application --test-framework junit-jupiter`: Uses https://junit.org[JUnit Jupiter] for testing instead of JUnit 4
 * `gradle init --type java-application --test-framework spock`: Uses http://code.google.com/p/spock/[Spock] for testing instead of JUnit 4
 * `gradle init --type java-application --test-framework testng`: Uses http://testng.org/doc/index.html[TestNG] for testing instead of JUnit 4
 
@@ -143,7 +143,7 @@ It has the following features:
 
 Alternative test framework can be specified by supplying a `--test-framework` argument value. To use a different test framework, execute one of the following commands:
 
-* `gradle init --type java-application --test-framework junit-jupiter`: Uses http://juni.org[JUnit Jupiter] for testing instead of JUnit 4
+* `gradle init --type java-library --test-framework junit-jupiter`: Uses https://junit.org[JUnit Jupiter] for testing instead of JUnit 4
 * `gradle init --type java-library --test-framework spock`: Uses http://code.google.com/p/spock/[Spock] for testing instead of JUnit 4
 * `gradle init --type java-library --test-framework testng`: Uses http://testng.org/doc/index.html[TestNG] for testing instead of JUnit 4
 


### PR DESCRIPTION
- Fix broken links to junit.org and use HTTPS
- Use `java-library` type in corresponding section