### PR TITLE
Add methods to disallow further changes to property and file collection instances

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -719,7 +719,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * <li>A {@link File}. Interpreted relative to the project directory, as per {@link #file(Object)}.</li>
      *
-     * <li>A {@link java.nio.file.Path} as defined by {@link #file(Object)}.</li>
+     * <li>A {@link java.nio.file.Path}, as per {@link #file(Object)}.</li>
      *
      * <li>A {@link java.net.URI} or {@link java.net.URL}. The URL's path is interpreted as a file path. Only {@code file:} URLs are supported.</li>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -24,6 +24,8 @@ import java.util.Set;
  * <p>A {@code ConfigurableFileCollection} is a mutable {@code FileCollection}.</p>
  *
  * <p>You can obtain an instance of {@code ConfigurableFileCollection} by calling {@link org.gradle.api.Project#files(Object...)} or {@link ObjectFactory#fileCollection()}.</p>
+ *
+ * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.</p>
  */
 public interface ConfigurableFileCollection extends FileCollection, HasConfigurableValue {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -16,10 +16,8 @@
 
 package org.gradle.api.file;
 
-import groovy.lang.Closure;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 
@@ -88,44 +86,7 @@ public interface ProjectLayout {
     Provider<RegularFile> file(Provider<File> file);
 
     /**
-     * <p>Creates a {@link FileCollection} for the given targets. You can pass any of the following
-     * types to this method:</p>
-     *
-     * <ul> <li>A {@link CharSequence}, including {@link String} or {@link groovy.lang.GString}. Interpreted relative to the project directory, as per {@link Project#file(Object)}. A string that starts with {@code file:} is treated as a file URL.</li>
-     *
-     * <li>A {@link File}. Interpreted relative to the project directory, as per {@link Project#file(Object)}.</li>
-     *
-     * <li>A {@link java.nio.file.Path} as defined by {@link Project#file(Object)}.</li>
-     *
-     * <li>A {@link java.net.URI} or {@link java.net.URL}. The URL's path is interpreted as a file path. Only {@code file:} URLs are supported.</li>
-     *
-     * <li>A {@link org.gradle.api.file.Directory} or {@link org.gradle.api.file.RegularFile}.</li>
-     *
-     * <li>A {@link java.util.Collection}, {@link Iterable}, or an array that contains objects of any supported type. The elements of the collection are recursively converted to files.</li>
-     *
-     * <li>A {@link org.gradle.api.file.FileCollection}. The contents of the collection are included in the returned collection.</li>
-     *
-     * <li>A {@link Provider} of any supported type. The provider's value is recursively converted to files. If the provider represents an output of a task, that task is executed if the file collection is used as an input to another task.
-     *
-     * <li>A {@link java.util.concurrent.Callable} that returns any supported type. The return value of the {@code call()} method is recursively converted to files. A {@code null} return value is treated as an empty collection.</li>
-     *
-     * <li>A {@link Closure} that returns any of the types listed here. The return value of the closure is recursively converted to files. A {@code null} return value is treated as an empty collection.</li>
-     *
-     * <li>A {@link Task}. Converted to the task's output files. The task is executed if the file collection is used as an input to another task.</li>
-     *
-     * <li>A {@link org.gradle.api.tasks.TaskOutputs}. Converted to the output files the related task. The task is executed if the file collection is used as an input to another task.</li>
-     *
-     * <li>Anything else is treated as a failure.</li>
-     *
-     * </ul>
-     *
-     * <p>The returned file collection is lazy, so that the paths are evaluated only when the contents of the file
-     * collection are queried. The file collection is also live, so that it evaluates the above each time the contents
-     * of the collection is queried.</p>
-     *
-     * <p>The returned file collection maintains the iteration order of the supplied paths.</p>
-     *
-     * <p>The returned file collection maintains the details of the tasks that produce the files, so that these tasks are executed if this file collection is used as an input to some task.</p>
+     * <p>Creates a {@link FileCollection} containing the given files, as defined by {@link Project#files(Object...)}.
      *
      * <p>This method can also be used to create an empty collection, but the collection may not be mutated later.</p>
      *
@@ -136,44 +97,7 @@ public interface ProjectLayout {
     FileCollection files(Object... paths);
 
     /**
-     * <p>Returns a {@link ConfigurableFileCollection} containing the given files. You can pass any of the following
-     * types to this method:</p>
-     *
-     * <ul> <li>A {@link CharSequence}, including {@link String} or {@link groovy.lang.GString}. Interpreted relative to the project directory, as per {@link Project#file(Object)}. A string that starts with {@code file:} is treated as a file URL.</li>
-     *
-     * <li>A {@link File}. Interpreted relative to the project directory, as per {@link Project#file(Object)}.</li>
-     *
-     * <li>A {@link java.nio.file.Path} as defined by {@link Project#file(Object)}.</li>
-     *
-     * <li>A {@link java.net.URI} or {@link java.net.URL}. The URL's path is interpreted as a file path. Only {@code file:} URLs are supported.</li>
-     *
-     * <li>A {@link org.gradle.api.file.Directory} or {@link org.gradle.api.file.RegularFile}.</li>
-     *
-     * <li>A {@link java.util.Collection}, {@link Iterable}, or an array that contains objects of any supported type. The elements of the collection are recursively converted to files.</li>
-     *
-     * <li>A {@link org.gradle.api.file.FileCollection}. The contents of the collection are included in the returned collection.</li>
-     *
-     * <li>A {@link Provider} of any supported type. The provider's value is recursively converted to files. If the provider represents an output of a task, that task is executed if the file collection is used as an input to another task.
-     *
-     * <li>A {@link java.util.concurrent.Callable} that returns any supported type. The return value of the {@code call()} method is recursively converted to files. A {@code null} return value is treated as an empty collection.</li>
-     *
-     * <li>A {@link Closure} that returns any of the types listed here. The return value of the closure is recursively converted to files. A {@code null} return value is treated as an empty collection.</li>
-     *
-     * <li>A {@link Task}. Converted to the task's output files. The task is executed if the file collection is used as an input to another task.</li>
-     *
-     * <li>A {@link org.gradle.api.tasks.TaskOutputs}. Converted to the output files the related task. The task is executed if the file collection is used as an input to another task.</li>
-     *
-     * <li>Anything else is treated as a failure.</li>
-     *
-     * </ul>
-     *
-     * <p>The returned file collection is lazy, so that the paths are evaluated only when the contents of the file
-     * collection are queried. The file collection is also live, so that it evaluates the above each time the contents
-     * of the collection is queried.</p>
-     *
-     * <p>The returned file collection maintains the iteration order of the supplied paths.</p>
-     *
-     * <p>The returned file collection maintains the details of the tasks that produce the files, so that these tasks are executed if this file collection is used as an input to some task.</p>
+     * <p>Returns a {@link ConfigurableFileCollection} containing the given files, as defined by {@link Project#files(Object...)}.
      *
      * <p>This method can also be used to create an empty collection, which can later be mutated to add elements.</p>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
@@ -28,6 +28,8 @@ import org.gradle.api.Incubating;
  *
  * <p>When a task property has a value of this type, it will be implicitly finalized when the task starts execution, to prevent accidental changes to the task parameters as the task runs.</p>
  *
+ * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.</p>
+ *
  * @since 5.6
  */
 @Incubating

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
@@ -22,16 +22,33 @@ import org.gradle.api.Incubating;
  * Represents an object that holds a value that is configurable, meaning that the value or some source for the value, such as a {@link Provider},
  * can be specified directly on the object.
  *
+ * <p>This interface provides methods to manage the lifecycle of the value. Using these methods, the value of the object can be <em>finalized</em>, which means that the value will
+ * no longer change. Note that this is not the same as an <em>immutable</em> value. You can think of a finalized value as similar to a {@code final} variable in Java. While the value does not change,
+ * the value itself may still be mutable.</p>
+ *
+ * <p>When a task property has a value of this type, it will be implicitly finalized when the task starts execution, to prevent accidental changes to the task parameters as the task runs.</p>
+ *
  * @since 5.6
  */
 @Incubating
 public interface HasConfigurableValue {
     /**
-     * Disallows further changes to the value of this object. Subsequent calls to methods that change the value of this object or the source from
-     * which the value is derived will fail with an exception.
+     * Calculates the final value of this object and disallows further changes to this object.
      *
-     * <p>Note that although the value of this object will not change, the value may itself be mutable.
+     * <p>To calculate the final value of this object, any source for the value is queried and the result used as the final value for this object. The source is discarded.</p>
+     *
+     * <p>Subsequent attempts to change the value of this object or the source from which the value is derived will fail with an exception.
+     *
+     * <p>Note that although the value of this object will no longer change, the value may itself be mutable.
      * Calling this method does not guarantee that the value will become immutable, though some implementations may support this.</p>
      */
     void finalizeValue();
+
+    /**
+     * Disallows further direct changes to this object.
+     *
+     * <p>This differs from {@link #finalizeValue()} in that it does not calculate the final value of this object, and so any source for the value will continue to be used until
+     * the value is finalized.</p>
+     */
+    void disallowChanges();
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -56,15 +56,23 @@ dependencies {
 
 ### Task dependencies are honored for `@Input` properties of type `Property`
 
-TBD - honors dependencies on `@Input` properties.
+Gradle can automatically calculate task dependencies based on the value of certain task input properties. For example, for a property of type `FileCollection` or `Provider<Set<RegularFile>>` 
+and that is annotated with `@InputFiles`, Gradle will inspect the value of the property and automatically add task dependencies for any task output files or directories in the collection. 
+
+In this release, Gradle also performs this analysis on task properties of type `Property<T>` and that are annotated with `@Input`. This allow you to connect an output of a task to a non-file input parameter of another task.
+For example, you might have a task that runs the `git` command to determine the name of the current branch, and another task that uses the branch name to produce an application bundle. With this change
+you can connect the output of the first task as an input of the second task, and avoid running the `git` command at configuration time. 
+
+See the [user manual](userguide/lazy_configuration.html#sec:working_with_task_dependencies_in_lazy_properties) for examples and more details.
 
 ### Finalize the value of a `ConfigurableFileCollection`
 
-TBD - added `ConfigurableFileCollection.finalizeValue()`
+A new method `ConfigurableFileCollection.finalizeValue()` has been added. This method resolves any deferred values, such as Groovy closures or Kotlin functions, that may be present in the collection 
+to their final file locations and prevents further changes to the collection.
 
-### Property methods
+### Prevent changes to a `Property` or `ConfigurableFileCollection`
 
-TBD - added `getLocationOnly()`. 
+New methods `Property.disallowChanges()` and `ConfigurableFileCollection.disallowChanges()` have been added. These methods disallow furyher changes to the property or collection.
 
 ### Worker API improvements
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -36,13 +36,20 @@ Some plugins will break with this new version of Gradle, for example because the
 [[changes_5.6]]
 == Upgrading from 5.5 and earlier
 
+=== Deprecations
+
+==== Changing the contents of `ConfigurableFileCollection` task properties after task starts execution
+
+When a task property has type `ConfigurableFileCollection`, then the file collection referenced by the property will ignore changes made to the contents of the collection once the task
+starts execution. This will become an error in Gradle 6.0.
+
 === Potential breaking changes
 
 ==== Task dependencies are honored for task `@Input` properties whose value is a `Property`
 
 Previously, task dependencies would be ignored for task `@Input` properties of type `Property<T>`. These are now honored, so that it is possible to attach a task output property to a task `@Input` property.
 
-This may introduce unexpected cycles in the task dependency graph.
+This may introduce unexpected cycles in the task dependency graph, where the value of an output property is mapped to produce a value for an input property.
 
 ==== Declaring task dependencies using a file `Provider` that does not represent a task output
 
@@ -50,7 +57,7 @@ Previously, it was possible to pass `Task.dependsOn()` a `Provider<File>`, `Prov
 
 This is now an error because Gradle does not know how to build files that are not task outputs.
 
-*Note* that it is still possible to to pass `dependsOn()` a `Provider` that returns a file and that represents a task output, for example `myTask.dependsOn(jar.archiveFile)` or `myTask.dependsOn(taskProvider.flatMap { it.outputDirectory })`, when the `Provider` is an annotated `@OutputFile` or `@OutputDirectory` property of a task.
+*Note* that it is still possible to to pass `Task.dependsOn()` a `Provider` that returns a file and that represents a task output, for example `myTask.dependsOn(jar.archiveFile)` or `myTask.dependsOn(taskProvider.flatMap { it.outputDirectory })`, when the `Provider` is an annotated `@OutputFile` or `@OutputDirectory` property of a task.
 
 ==== Enhanced validation of names for `publishing.publications` and `publishing.repositories`
 
@@ -72,13 +79,24 @@ Contributed by link:https://github.com/wreulicke[wreulicke]
 
 Previously, all copies of a configuration always had the name `<OriginConfigurationName>Copy`. Now when creating multiple copies, each will have a unique name by adding an index starting from the second copy. (e.g. `CompileOnlyCopy2`)
 
-
-=== Changed classpath filtering for Eclipse
+==== Changed classpath filtering for Eclipse
 
 Gradle 5.6 no longer supplies custom classpath attributes in the Eclipse model. Instead, it provides the attributes for link:https://www.eclipse.org/eclipse/news/4.8/jdt.php#jdt-test-sources[Eclipse test sources]. This change requires Buildship version 3.1.1 or later.
 
 [[changes_5.5]]
 == Upgrading from 5.4 and earlier
+
+=== Deprecations
+
+==== Play
+
+The built-in <<play_plugin.adoc#play_plugin, Play plugin>> has been deprecated and will be replaced by a new link:https://gradle.github.io/playframework[Play Framework plugin] available from the plugin portal.
+
+==== Build Comparison
+
+The <<comparing_builds.adoc#comparing_builds, build comparison>> plugin has been deprecated and will be removed in the next major version of Gradle.
+
+link:https://gradle.com/build-scans[Build scans] show much deeper insights into your build and you can use link:https://gradle.com/[Gradle Enterprise] to directly compare two build's build-scans.
 
 === Potential breaking changes
 
@@ -117,22 +135,10 @@ In some rare cases this may cause some differences in resolution, due to the cor
 
 The system classpath for worker daemons started by the <<custom_tasks.adoc#worker_api, Worker API>> when using `PROCESS` isolation has been reduced to a minimum set of Gradle infrastructure. User code is still segregated into a separate classloader to isolate it from the Gradle runtime. This should be a transparent change for tasks using the worker API, but previous versions of Gradle mixed user code and Gradle internals in the worker process. Worker actions that rely on things like the `java.class.path` system property may be affected, since `java.class.path` now represents only the classpath of the Gradle internals.
 
-=== Deprecations
-
-==== Play
-
-The built-in <<play_plugin.adoc#play_plugin, Play plugin>> has been deprecated and will be replaced by a new link:https://gradle.github.io/playframework[Play Framework plugin] available from the plugin portal.
-
-==== Build Comparison
-
-The <<comparing_builds.adoc#comparing_builds, build comparison>> plugin has been deprecated and will be removed in the next major version of Gradle.
-
-link:https://gradle.com/build-scans[Build scans] show much deeper insights into your build and you can use link:https://gradle.com/[Gradle Enterprise] to directly compare two build's build-scans.
-
 [[changes_5.4]]
 == Upgrading from 5.3 and earlier
 
-=== Deprecated classes, methods and properties
+=== Deprecations
 
 ==== Using custom local build cache implementations
 
@@ -217,6 +223,18 @@ none
 [[changes_5.1]]
 == Upgrading from 5.0 and earlier
 
+=== Deprecations
+
+Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
+
+ * Setters for `classes` and `classpath` on link:{javadocPath}/org/gradle/plugin/devel/tasks/ValidateTaskProperties.html[`ValidateTaskProperties`]
+
+ * There should not be setters for lazy properties like link:{javadocPath}/org/gradle/api/file/ConfigurableFileCollection.html[`ConfigurableFileCollection`].  Use `setFrom` instead. For example,
+----
+    validateTaskProperties.getClasses().setFrom(fileCollection)
+    validateTaskProperties.getClasspath().setFrom(fileCollection)
+----
+
 === Potential breaking changes
 
 The following changes were not previously deprecated:
@@ -263,28 +281,11 @@ This may break plugins that relied on the previous behaviour.
 
 The incubating `operatingSystems` property on native components has been replaced with the link:{javadocPath}/org/gradle/language/cpp/CppComponent.html#getTargetMachines()[targetMachines] property.
 
-### Change in behavior for tasks extending `AbstractArchiveTask` or subtypes (`Zip`, `Jar`, `War`, `Ear`, `Tar`)
+==== Change in behavior for tasks extending `AbstractArchiveTask` or subtypes (`Zip`, `Jar`, `War`, `Ear`, `Tar`)
 
 The `AbstractArchiveTask` has several new properties using the <<lazy_configuration.adoc#provider-files-api-reference,Provider API>>. Plugins that extend these types and override methods from the base class may no longer behave the same way. Internally, `AbstractArchiveTask` prefers the new properties and methods like `getArchiveName()` are façades over the new properties.
 
 If your plugin/build only uses these types (and does not extend them), nothing has changed.
-
-////
-The following breaking changes will appear as deprecation warnings with Gradle 5.X:
- *
-////
-
-=== Deprecated classes, methods and properties
-
-Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
-
- * Setters for `classes` and `classpath` on link:{javadocPath}/org/gradle/plugin/devel/tasks/ValidateTaskProperties.html[`ValidateTaskProperties`]
-
- * There should not be setters for lazy properties like link:{javadocPath}/org/gradle/api/file/ConfigurableFileCollection.html[`ConfigurableFileCollection`].  Use `setFrom` instead. For example,
-----
-    validateTaskProperties.getClasses().setFrom(fileCollection)
-    validateTaskProperties.getClasspath().setFrom(fileCollection)
-----
 
 ////
 == Changes in detail

--- a/subprojects/files/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/files/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
@@ -122,7 +122,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         fails('broken')
 
         then:
-        failure.assertHasCause("The value for file collection is final and cannot be changed.")
+        failure.assertHasCause("The value for this file collection is final and cannot be changed.")
     }
 
     def "can disallow changes to file collection without finalizing value"() {
@@ -147,7 +147,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         fails('broken')
 
         then:
-        failure.assertHasCause("The value for file collection cannot be changed.")
+        failure.assertHasCause("The value for this file collection cannot be changed.")
     }
 
     def "task @InputFiles file collection property is implicitly finalized and changes ignored when task starts execution"() {

--- a/subprojects/files/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/files/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
@@ -125,6 +125,31 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         failure.assertHasCause("The value for file collection is final and cannot be changed.")
     }
 
+    def "can disallow changes to file collection without finalizing value"() {
+        buildFile << """
+            def files = objects.fileCollection()
+            def name = 'other'
+            files.from { name }
+            
+            def names = ['b', 'c']
+            files.from(names)
+
+            files.disallowChanges()
+            name = 'a'
+            names.clear()
+            
+            assert files.files as List == [file('a')]
+            
+            files.from('broken')
+        """
+
+        when:
+        fails('broken')
+
+        then:
+        failure.assertHasCause("The value for file collection cannot be changed.")
+    }
+
     def "task @InputFiles file collection property is implicitly finalized and changes ignored when task starts execution"() {
         taskTypeWithInputFileCollection()
         buildFile << """

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -70,8 +70,7 @@ public interface FileCollectionFactory {
      *
      * The collection is not live. The provided {@link Iterable} is queried on construction and discarded.
      */
-    // TODO - should return FileCollectionInternal, but Kotlin-dsl uses this method and the compiled bytecode expects FileCollection
-    FileCollection fixed(String displayName, Collection<File> files);
+    FileCollectionInternal fixed(String displayName, Collection<File> files);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -54,22 +54,22 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     private boolean disallowChanges;
 
     public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver) {
-        this("file collection", fileResolver, taskResolver, null);
+        this(null, fileResolver, taskResolver, null);
     }
 
     public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, Collection<?> files) {
-        this("file collection", fileResolver, taskResolver, files);
+        this(null, fileResolver, taskResolver, files);
     }
 
     public DefaultConfigurableFileCollection(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, Object[] files) {
         this("file collection", fileResolver, taskResolver, Arrays.asList(files));
     }
 
-    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver) {
+    public DefaultConfigurableFileCollection(@Nullable String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver) {
         this(displayName, fileResolver, taskResolver, null);
     }
 
-    public DefaultConfigurableFileCollection(String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable Collection<?> files) {
+    public DefaultConfigurableFileCollection(@Nullable String displayName, PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver, @Nullable Collection<?> files) {
         this.displayName = displayName;
         this.resolver = fileResolver;
         this.files = new LinkedHashSet<Object>();
@@ -122,7 +122,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
 
     @Override
     public String getDisplayName() {
-        return displayName;
+        return displayName == null ? "file collection" : displayName;
     }
 
     @Override
@@ -156,15 +156,19 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
 
     private boolean assertMutable() {
         if (state == State.Final && disallowChanges) {
-            throw new IllegalStateException("The value for " + displayName + " is final and cannot be changed.");
+            throw new IllegalStateException("The value for " + displayNameForThisCollection() + " is final and cannot be changed.");
         } else if (disallowChanges) {
-            throw new IllegalStateException("The value for " + displayName + " cannot be changed.");
+            throw new IllegalStateException("The value for " + displayNameForThisCollection() + " cannot be changed.");
         } else if (state == State.Final) {
             DeprecationLogger.nagUserOfDiscontinuedInvocation("Changing the value for a FileCollection with a final value");
             return false;
         } else {
             return true;
         }
+    }
+
+    private String displayNameForThisCollection() {
+        return displayName == null ? "this file collection" : displayName;
     }
 
     @Override

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
@@ -101,6 +101,31 @@ property.set([1])
         failure.assertHasCause("The value for this property is final and cannot be changed any further.")
     }
 
+    def "can disallow changes to a property using API without finalizing value"() {
+        given:
+        buildFile << """
+Integer counter = 0
+def provider = providers.provider { [++counter, ++counter] }
+
+def property = objects.listProperty(Integer)
+property.set(provider)
+
+assert property.get() == [1, 2] 
+assert property.get() == [3, 4] 
+property.disallowChanges()
+assert property.get() == [5, 6]
+assert property.get() == [7, 8]
+
+property.set([1])
+"""
+
+        when:
+        fails()
+
+        then:
+        failure.assertHasCause("The value for this property cannot be changed any further.")
+    }
+
     def "task @Input property is implicitly finalized and changes ignored when task starts execution"() {
         given:
         buildFile << """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -126,6 +126,31 @@ class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause('The value for this property is final and cannot be changed any further.')
     }
 
+    def "can disallow changes to a property using API without finalizing the value"() {
+        given:
+        buildFile << '''
+            int counter = 0
+            def provider = providers.provider { [(++counter): ++counter] }
+            
+            def property = objects.mapProperty(Integer, Integer)
+            property.set(provider)
+            
+            assert property.get() == [1: 2]
+            assert property.get() == [3: 4]
+            property.disallowChanges()
+            assert property.get() == [5: 6]
+            assert property.get() == [7: 8]
+            
+            property.set([1: 2])
+            '''.stripIndent()
+
+        when:
+        fails()
+
+        then:
+        failure.assertHasCause('The value for this property cannot be changed any further.')
+    }
+
     def "task @Input property is implicitly finalized and changes ignored when task starts execution"() {
         given:
         buildFile << '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -122,6 +122,31 @@ property.set(12)
         failure.assertHasCause("The value for this property is final and cannot be changed any further.")
     }
 
+    def "can disallow changes to a property using API without finalizing the value"() {
+        given:
+        buildFile << """
+Integer counter = 0
+def provider = providers.provider { ++counter }
+
+def property = objects.property(Integer)
+property.set(provider)
+
+assert property.get() == 1 
+assert property.get() == 2 
+property.disallowChanges()
+assert property.get() == 3
+assert property.get() == 4 
+
+property.set(12)
+"""
+
+        when:
+        fails()
+
+        then:
+        failure.assertHasCause("The value for this property cannot be changed any further.")
+    }
+
     def "task @Input property is implicitly finalized and changes ignored when task starts execution"() {
         given:
         buildFile << """


### PR DESCRIPTION
### Context

Add `HasConfigurableValue.disallowChanges()`, which prevents any further direct changes to the object, but does not finalize the value. This applies to the various `Property` types and `ConfigurableFileCollection`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
