### PR TITLE
Allow the contents of a FileCollection to be viewed as a Provider

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/AbstractFindBugsPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/findbugs/AbstractFindBugsPluginIntegrationTest.groovy
@@ -16,19 +16,17 @@
 package org.gradle.api.plugins.quality.findbugs
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Matchers
 import org.gradle.util.Resources
 import org.hamcrest.Matcher
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.util.Matchers.containsLine
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 import static org.hamcrest.CoreMatchers.containsString
-import static org.hamcrest.CoreMatchers.startsWith
 import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.CoreMatchers.startsWith
 
 abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegrationSpec {
 
@@ -90,7 +88,6 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
         file("build/reports/findbugs/test.xml").assertContents(containsClass("org.gradle.BadClassTest"))
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "is incremental"() {
         given:
         goodCode()
@@ -292,7 +289,6 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
         file("build/reports/findbugs/test.xml").assertContents(containsClass("org.gradle.Class800Test"))
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "is incremental for reporting settings"() {
         given:
         buildFile << """
@@ -332,7 +328,6 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
         executedAndNotSkipped(":findbugsMain" )
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "is incremental for withMessage"() {
         given:
         buildFile << """
@@ -385,7 +380,6 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
         executedAndNotSkipped(":findbugsMain")
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "is withMessage ignored for non-XML report setting"() {
         given:
         buildFile << """
@@ -524,7 +518,6 @@ abstract class AbstractFindBugsPluginIntegrationTest extends AbstractIntegration
         failure.assertThatCause(Matchers.matchesRegexp("Process 'Gradle FindBugs Worker [0-9]+' finished with non-zero exit value 1"))
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "out-of-date with mixed Java and Groovy sources"() {
         given:
         goodCode()

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/jdepend/JDependPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/jdepend/JDependPluginIntegrationTest.groovy
@@ -16,8 +16,6 @@
 package org.gradle.api.plugins.quality.jdepend
 
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
 
 import static org.hamcrest.CoreMatchers.containsString
 
@@ -56,7 +54,6 @@ class JDependPluginIntegrationTest extends WellBehavedPluginTest {
         file("build/reports/jdepend/test.xml").assertContents(containsString("org.gradle.Class1Test"))
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "is incremental"() {
         given:
         goodCode()
@@ -76,7 +73,6 @@ class JDependPluginIntegrationTest extends WellBehavedPluginTest {
         executedAndNotSkipped(":jdependMain")
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "out-of-date when mixed with Java and Groovy code"() {
         given:
         goodCode()

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollection.java
@@ -17,6 +17,8 @@ package org.gradle.api.file;
 
 import groovy.lang.Closure;
 import org.gradle.api.Buildable;
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.AntBuilderAware;
 import org.gradle.internal.HasInternalProtocol;
@@ -25,8 +27,14 @@ import java.io.File;
 import java.util.Set;
 
 /**
- * <p>A {@code FileCollection} represents a collection of files which you can query in certain ways. A file collection
- * is often used to define a classpath, or to add files to a container.</p>
+ * <p>A {@code FileCollection} represents a collection of file system locations which you can query in certain ways. A file collection
+ * is can be used to define a classpath, or a set of source files, or to add files to an archive.</p>
+ *
+ * <p>There are no methods on this interface that allow the contents of the collection to be modified. However, there are a number of sub-interfaces, such as {@link ConfigurableFileCollection} that
+ * allow changes to be made.</p>
+ *
+ * <p>A file collection may contain task outputs. The file collection tracks not just a set of files, but also the tasks that produce those files. When a file collection is used as a task input
+ * property, Gradle will take care of automatically adding dependencies between the consuming task and the producing tasks.</p>
  *
  * <p>You can obtain a {@code FileCollection} instance using {@link org.gradle.api.Project#files}.</p>
  */
@@ -41,7 +49,12 @@ public interface FileCollection extends Iterable<File>, AntBuilderAware, Buildab
     File getSingleFile() throws IllegalStateException;
 
     /**
-     * Returns the contents of this collection as a Set.
+     * Returns the contents of this collection as a {@link Set}. The contents of a file collection may change over time.
+     *
+     * <p>Note that this method returns {@link File} objects that represent locations on the file system. These {@link File} objects do not necessarily refer to regular files.
+     * Depending on the implementation of this file collection and how it has been configured, the returned set may contain directories, or missing files, or any other kind of
+     * file system element.
+     * </p>
      *
      * @return The files. Returns an empty set if this collection is empty.
      */
@@ -115,13 +128,25 @@ public interface FileCollection extends Iterable<File>, AntBuilderAware, Buildab
     boolean isEmpty();
 
     /**
-     * Converts this collection to a {@link FileTree}. Generally, for each file in this collection, the resulting file
+     * Converts this collection to a {@link FileTree}, if not already. For each file in this collection, the resulting file
      * tree will contain the source file at the root of the tree. For each directory in this collection, the resulting
      * file tree will contain all the files under the source directory.
+     *
+     * <p>The returned {@link FileTree} is live, and tracks changes to this file collection and the producer tasks of this file collection.</p>
      *
      * @return this collection as a {@link FileTree}. Never returns null.
      */
     FileTree getAsFileTree();
+
+    /**
+     * Returns the contents of this file collection as a {@link Provider} of {@link FileSystemLocation} instances. See {@link #getFiles()} for more details.
+     *
+     * <p>The returned {@link Provider} is live, and tracks changes to this file collection and the producer tasks of this file collection.</p>
+     *
+     * @since 5.6
+     */
+    @Incubating
+    Provider<Set<FileSystemLocation>> getElements();
 
     /**
      * Ant types which a {@code FileCollection} can be mapped to.
@@ -158,7 +183,7 @@ public interface FileCollection extends Iterable<File>, AntBuilderAware, Buildab
 
     /**
      * Adds this collection to an Ant task as a nested node. Equivalent to calling {@code addToAntBuilder(builder,
-     *nodeName,AntType.ResourceCollection)}.
+     * nodeName,AntType.ResourceCollection)}.
      */
     @Override
     Object addToAntBuilder(Object builder, String nodeName);

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -19,11 +19,9 @@ package org.gradle.api.tasks
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Matchers
 import org.gradle.util.ToBeImplemented
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -978,7 +976,6 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2838")
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "include empty dirs works when nested"() {
         given:
         file("a/a.txt") << "foo"
@@ -1007,7 +1004,6 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         destinationDir.listFiles().findAll { it.directory }*.name.toSet() == ["dirA"].toSet()
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "include empty dirs is overridden by subsequent"() {
         given:
         file("a/a.txt") << "foo"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -26,7 +26,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.provider.AbstractCombiningProvider;
 import org.gradle.api.internal.provider.AbstractMappingProvider;
 import org.gradle.api.internal.provider.AbstractReadOnlyProvider;
-import org.gradle.api.internal.provider.DefaultPropertyState;
+import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
@@ -205,7 +205,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
     }
 
-    static abstract class AbstractFileVar<T extends FileSystemLocation> extends DefaultPropertyState<T> implements FileSystemLocationProperty<T> {
+    static abstract class AbstractFileVar<T extends FileSystemLocation> extends DefaultProperty<T> implements FileSystemLocationProperty<T> {
 
         public AbstractFileVar(Class<T> type) {
             super(type);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -34,7 +34,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.provider.DefaultListProperty;
 import org.gradle.api.internal.provider.DefaultMapProperty;
-import org.gradle.api.internal.provider.DefaultPropertyState;
+import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.provider.DefaultSetProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -145,7 +145,7 @@ public class DefaultObjectFactory implements ObjectFactory {
             DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() method to create a property of type RegularFile", "ObjectFactory.fileProperty()");
         }
 
-        return new DefaultPropertyState<T>(valueType);
+        return new DefaultProperty<T>(valueType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -23,7 +23,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.internal.provider.DefaultPropertyState;
+import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
@@ -71,7 +71,7 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
 
     @Override
     public <T> Property<T> property(Class<T> valueType) {
-        return new DefaultPropertyState<T>(valueType);
+        return new DefaultProperty<T>(valueType);
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -23,12 +23,9 @@ import org.gradle.api.internal.tasks.TaskDependencyInternal
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GUtil
 import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
-import org.junit.Rule
-import spock.lang.Specification
 
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContains
 import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForFileSet
@@ -38,44 +35,24 @@ import static org.gradle.util.WrapUtil.toLinkedSet
 import static org.gradle.util.WrapUtil.toList
 import static org.gradle.util.WrapUtil.toSet
 import static org.hamcrest.CoreMatchers.equalTo
-import static org.hamcrest.CoreMatchers.instanceOf
-import static org.hamcrest.CoreMatchers.sameInstance
-import static org.junit.Assert.assertFalse
+import static org.hamcrest.core.IsInstanceOf.instanceOf
 import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
-import static org.junit.Assert.fail
 
 @UsesNativeServices
-class AbstractFileCollectionTest extends Specification {
-    @Rule
-    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+class AbstractFileCollectionTest extends FileCollectionSpec {
     final TaskDependency dependency = Mock(TaskDependency.class)
 
-    void usesDisplayNameAsToString() {
-        TestFileCollection collection = new TestFileCollection()
-
-        expect:
-        assertThat(collection.toString(), equalTo("collection-display-name"))
-    }
-
-    void canIterateOverFiles() {
-        File file1 = new File("f1")
-        File file2 = new File("f2")
-        TestFileCollection collection = new TestFileCollection(file1, file2)
-
-        expect:
-        Iterator<File> iterator = collection.iterator()
-        assertThat(iterator.next(), sameInstance(file1))
-        assertThat(iterator.next(), sameInstance(file2))
-        assertFalse(iterator.hasNext())
+    @Override
+    AbstractFileCollection containing(File... files) {
+        return new TestFileCollection(files)
     }
 
     void canGetSingleFile() {
-        File file = new File("f1")
-        TestFileCollection collection = new TestFileCollection(file)
+        def file = new File("f1")
+        def collection = new TestFileCollection(file)
 
         expect:
-        assertThat(collection.getSingleFile(), sameInstance(file))
+        collection.getSingleFile().is(file)
     }
 
     void failsToGetSingleFileWhenCollectionContainsMultipleFiles() {
@@ -105,12 +82,12 @@ class AbstractFileCollectionTest extends Specification {
     }
 
     void containsFile() {
-        File file1 = new File("f1")
-        TestFileCollection collection = new TestFileCollection(file1)
+        def file1 = new File("f1")
+        def collection = new TestFileCollection(file1)
 
         expect:
-        assertTrue(collection.contains(file1))
-        assertFalse(collection.contains(new File("f2")))
+        collection.contains(file1)
+        !collection.contains(new File("f2"))
     }
 
     void canGetFilesAsAPath() {
@@ -262,12 +239,6 @@ class AbstractFileCollectionTest extends Specification {
         expect:
         assertSetContainsForFileSet(collection, toSet("f1", "f2"))
         assertSetContainsForMatchingTask(collection, toSet("f1", "f2"))
-    }
-
-    void isEmptyWhenFilesIsEmpty() {
-        expect:
-        assertTrue(new TestFileCollection().isEmpty())
-        assertFalse(new TestFileCollection(new File("f1")).isEmpty())
     }
 
     void canConvertToCollectionTypes() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
 @UsesNativeServices
-public class AbstractFileTreeTest extends Specification {
+class AbstractFileTreeTest extends Specification {
     def isEmptyWhenVisitsNoFiles() {
         def tree = new TestFileTree([])
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/FileCollectionSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/FileCollectionSpec.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+abstract class FileCollectionSpec extends Specification {
+    @Rule
+    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+
+    abstract AbstractFileCollection containing(File... files)
+
+    def isEmptyWhenContainsNoFiles() {
+        expect:
+        containing().isEmpty()
+        !containing(new File("f1")).isEmpty()
+    }
+
+    def usesDisplayNameAsToString() {
+        def collection = containing(new File("f1"))
+
+        expect:
+        collection.toString() == collection.displayName
+    }
+
+    def canQueryFilesAndRetainOrder() {
+        def file1 = new File("f1")
+        def file2 = new File("f2")
+        def collection = containing(file1, file2, file1, file2)
+
+        expect:
+        collection.files as List == [file1, file2]
+    }
+
+    def canIterateOverFilesRetainingOrder() {
+        def file1 = new File("f1")
+        def file2 = new File("f2")
+        def collection = containing(file1, file2, file1, file2)
+        def iterator = collection.iterator()
+
+        expect:
+        iterator.next() == file1
+        iterator.next() == file2
+        !iterator.hasNext()
+    }
+
+    def canViewElementsOfEmptyCollectionAsProvider() {
+        def collection = containing()
+        def elements = collection.elements
+
+        expect:
+        elements.present
+        elements.get().empty
+    }
+
+    def canViewElementsAsProviderRetainingOrder() {
+        def file1 = new File("f1")
+        def file2 = new File("f2")
+        def collection = containing(file1, file2, file1, file2)
+        def elements = collection.elements
+
+        expect:
+        elements.present
+        elements.get()*.asFile == [file1, file2]
+    }
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -149,4 +149,19 @@ trait TasksWithInputsAndOutputs {
             }
         """
     }
+
+    def taskTypeWithInputFileListProperty() {
+        buildFile << """
+            class InputFilesTask extends DefaultTask {
+                @InputFiles
+                final ListProperty<FileSystemLocation> inFiles = project.objects.listProperty(FileSystemLocation)
+                @OutputFile
+                final RegularFileProperty outFile = project.objects.fileProperty()
+                @TaskAction
+                def go() {
+                    outFile.get().asFile.text = inFiles.get()*.asFile.text.sort().join(',')
+                }
+            }
+        """
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -18,10 +18,8 @@ package org.gradle.integtests.resolve
 import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FluidDependenciesResolveRunner
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.junit.runner.RunWith
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 @RunWith(FluidDependenciesResolveRunner)
@@ -542,7 +540,6 @@ project('c') {
 
     // this test is largely covered by other tests, but does ensure that there is nothing special about
     // project dependencies that are “built” by built in plugins like the Java plugin's created jars
-    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "can use zip files as project dependencies"() {
         given:
         file("settings.gradle") << "include 'a'; include 'b'"

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -81,14 +81,21 @@ you can connect the output of the first task as an input of the second task, and
 
 See the [user manual](userguide/lazy_configuration.html#sec:working_with_task_dependencies_in_lazy_properties) for examples and more details.
 
+### Convert a `FileCollection` to a `Provider`
+
+A new method `FileCollection.getElements()` has been added to allow the contents of the file collection to be viewed as a `Provider`. This `Provider` tracks the elements of the file collection and tasks that
+produce these files and can be connected to a `Property` instance.
+ 
 ### Finalize the value of a `ConfigurableFileCollection`
 
-A new method `ConfigurableFileCollection.finalizeValue()` has been added. This method resolves any deferred values, such as Groovy closures or Kotlin functions, that may be present in the collection 
+A new method `ConfigurableFileCollection.finalizeValue()` has been added. This method resolves deferred values, such as Groovy closures or Kotlin functions, that may be present in the collection 
 to their final file locations and prevents further changes to the collection.
+
+This method works similarly to other `finalizeValue()` methods, such as `Property.finalizeValue()`.
 
 ### Prevent changes to a `Property` or `ConfigurableFileCollection`
 
-New methods `Property.disallowChanges()` and `ConfigurableFileCollection.disallowChanges()` have been added. These methods disallow furyher changes to the property or collection.
+New methods `Property.disallowChanges()` and `ConfigurableFileCollection.disallowChanges()` have been added. These methods disallow further changes to the property or collection.
 
 ### Worker API improvements
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -41,7 +41,16 @@ Some plugins will break with this new version of Gradle, for example because the
 ==== Changing the contents of `ConfigurableFileCollection` task properties after task starts execution
 
 When a task property has type `ConfigurableFileCollection`, then the file collection referenced by the property will ignore changes made to the contents of the collection once the task
-starts execution. This will become an error in Gradle 6.0.
+starts execution. This has two benefits. Firstly, this prevents accidental changes to the property value during task execution which can cause Gradle up-to-date checks and build cache lookup
+using different values to those used by the task action. Secondly, this improves performance as Gradle can calculate the value once and cache the result.
+
+This will become an error in Gradle 6.0.
+
+==== Creating `SignOperation` instances
+
+Creating `SignOperation` instances directly is now deprecated. Instead, the methods of `SigningExtension` should be used to create these instances.
+
+This will become an error in Gradle 6.0.
 
 === Potential breaking changes
 

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -16,16 +16,20 @@
 package org.gradle.api.internal.file;
 
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.FileBackedDirectoryFileTree;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.ResolvableFileCollectionResolveContext;
+import org.gradle.api.internal.provider.AbstractReadOnlyProvider;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
@@ -85,6 +89,41 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
     @Override
     public FileCollection plus(FileCollection collection) {
         return new UnionFileCollection(this, collection);
+    }
+
+    @Override
+    public Provider<Set<FileSystemLocation>> getElements() {
+        return new AbstractReadOnlyProvider<Set<FileSystemLocation>>() {
+            @Nullable
+            @Override
+            public Class<Set<FileSystemLocation>> getType() {
+                return null;
+            }
+
+            @Override
+            public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+                // TODO - visit dependencies of this collection instead
+                context.add(AbstractFileCollection.this.getBuildDependencies());
+                return true;
+            }
+
+            @Override
+            public Set<FileSystemLocation> getOrNull() {
+                // TODO - visit the contents of this collection instead.
+                // This is just a super simple implementation for now
+                Set<File> files = getFiles();
+                ImmutableSet.Builder<FileSystemLocation> builder = ImmutableSet.builderWithExpectedSize(files.size());
+                for (File file : files) {
+                    builder.add(new FileSystemLocation() {
+                        @Override
+                        public File getAsFile() {
+                            return file;
+                        }
+                    });
+                }
+                return builder.build();
+            }
+        };
     }
 
     @Override

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
@@ -33,10 +33,18 @@ public abstract class ImmutableFileCollection extends AbstractFileCollection {
         }
     };
 
+    /**
+     * Please use {@link org.gradle.api.file.ProjectLayout#files(Object...)} (for plugins) or {@link org.gradle.api.internal.file.FileCollectionFactory} (for core code) instead.
+     * This method will be removed eventually.
+     */
     public static ImmutableFileCollection of() {
         return EMPTY;
     }
 
+    /**
+     * Please use {@link org.gradle.api.file.ProjectLayout#files(Object...)} (for plugins) or {@link org.gradle.api.internal.file.FileCollectionFactory} (for core code) instead.
+     * This method will be removed eventually.
+     */
     public static ImmutableFileCollection of(File... files) {
         if (files.length == 0) {
             return EMPTY;
@@ -44,6 +52,10 @@ public abstract class ImmutableFileCollection extends AbstractFileCollection {
         return new FileOnlyImmutableFileCollection(ImmutableSet.copyOf(files));
     }
 
+    /**
+     * Please use {@link org.gradle.api.file.ProjectLayout#files(Object...)} (for plugins) or {@link org.gradle.api.internal.file.FileCollectionFactory} (for core code) instead.
+     * This method will be removed eventually.
+     */
     public static ImmutableFileCollection of(Iterable<? extends File> files) {
         if (Iterables.isEmpty(files)) {
             return EMPTY;

--- a/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -17,24 +17,26 @@ package org.gradle.api.internal.file.collections
 
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.file.FileCollectionSpec
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.api.tasks.TaskDependency
-import spock.lang.Specification
 
 import java.util.concurrent.Callable
 
-class DefaultConfigurableFileCollectionSpec extends Specification {
+class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
     def fileResolver = Mock(FileResolver)
     def taskResolver = Mock(TaskResolver)
     def collection = new DefaultConfigurableFileCollection("<display>", fileResolver, taskResolver)
 
-    def canCreateEmptyCollection() {
-        expect:
-        collection.from.empty
-        collection.files.empty
+    @Override
+    AbstractFileCollection containing(File... files) {
+        def resolver = Stub(FileResolver)
+        _ * resolver.resolve(_) >> { File f -> f }
+        return new DefaultConfigurableFileCollection("<display>", resolver, taskResolver, files as List)
     }
 
     def resolvesSpecifiedFilesUsingFileResolver() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -22,7 +22,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.provider.DefaultListProperty
-import org.gradle.api.internal.provider.DefaultPropertyState
+import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -104,7 +104,7 @@ class BeanPropertyReader(
                 })
             }
             Property::class.java -> { bean, value ->
-                field.set(bean, DefaultPropertyState(Any::class.java).apply {
+                field.set(bean, DefaultProperty(Any::class.java).apply {
                     set(value)
                 })
             }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
@@ -17,12 +17,10 @@
 package org.gradle.api.publish.ivy
 
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
+import org.gradle.test.fixtures.ivy.IvyDescriptor
 import spock.lang.Unroll
 
 import javax.xml.namespace.QName
-import org.gradle.test.fixtures.ivy.IvyDescriptor
 
 class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishIntegTest {
 
@@ -53,7 +51,6 @@ class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishInteg
         """
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "can customize descriptor xml during publication"() {
         when:
         succeeds 'publish'

--- a/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/coffeescript/CoffeeScriptBasePluginIntegrationTest.groovy
+++ b/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/coffeescript/CoffeeScriptBasePluginIntegrationTest.groovy
@@ -19,11 +19,9 @@
 package org.gradle.plugins.javascript.coffeescript
 
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
 
-import static org.gradle.plugins.javascript.base.JavaScriptBasePluginTestFixtures.*
-import static org.gradle.plugins.javascript.coffeescript.CoffeeScriptBasePluginTestFixtures.*
+import static org.gradle.plugins.javascript.base.JavaScriptBasePluginTestFixtures.addGradlePublicJsRepoScript
+import static org.gradle.plugins.javascript.coffeescript.CoffeeScriptBasePluginTestFixtures.addApplyPluginScript
 
 class CoffeeScriptBasePluginIntegrationTest extends WellBehavedPluginTest {
 
@@ -55,7 +53,6 @@ class CoffeeScriptBasePluginIntegrationTest extends WellBehavedPluginTest {
         js.text.contains("CoffeeScript Compiler")
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "can compile coffeescript"() {
         given:
         file("src/main/coffeescript/dir1/thing1.coffee") << "number = 1"

--- a/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/jshint/JsHintPluginIntegrationTest.groovy
+++ b/subprojects/javascript/src/integTest/groovy/org/gradle/plugins/javascript/jshint/JsHintPluginIntegrationTest.groovy
@@ -16,12 +16,10 @@
 
 package org.gradle.plugins.javascript.jshint
 
+import groovy.json.JsonSlurper
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
 
 import static org.gradle.plugins.javascript.base.JavaScriptBasePluginTestFixtures.addGradlePublicJsRepoScript
-import groovy.json.JsonSlurper
 
 class JsHintPluginIntegrationTest extends WellBehavedPluginTest {
     @Override
@@ -75,7 +73,6 @@ class JsHintPluginIntegrationTest extends WellBehavedPluginTest {
         json[file("src/main/js/dir1/f1.js").absolutePath] instanceof Map
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "can analyse good javascript"() {
         given:
         file("src/main/js/dir1/f1.js") << """

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/integtests/language/AbstractJvmLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/integtests/language/AbstractJvmLanguageIncrementalBuildIntegrationTest.groovy
@@ -18,12 +18,10 @@ package org.gradle.integtests.language
 
 import org.apache.commons.lang.StringUtils
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.JvmSourceFile
 import org.gradle.integtests.fixtures.jvm.TestJvmComponent
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.file.TestFile
-import spock.lang.IgnoreIf
 
 abstract class AbstractJvmLanguageIncrementalBuildIntegrationTest extends AbstractIntegrationSpec {
     abstract TestJvmComponent getTestComponent();
@@ -65,7 +63,6 @@ abstract class AbstractJvmLanguageIncrementalBuildIntegrationTest extends Abstra
         jarFile("build/jars/main/jar/main.jar").hasDescendants(testComponent.expectedOutputs*.fullPath as String[])
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "does not re-execute build with no change"() {
         given:
         run "mainJar"

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIncrementalBuildIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.assembler
 
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
@@ -25,7 +25,6 @@ import org.gradle.nativeplatform.fixtures.app.MixedLanguageHelloWorldApp
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
 @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
 class AssemblyLanguageIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
@@ -66,7 +65,6 @@ class AssemblyLanguageIncrementalBuildIntegrationTest extends AbstractInstalledT
         install = installation("build/install/main")
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "does not re-execute build with no change"() {
         when:
         run "mainExecutable"
@@ -116,7 +114,6 @@ class AssemblyLanguageIncrementalBuildIntegrationTest extends AbstractInstalledT
         // Need to have valid x86-64 sources, so that we can verify the output: currently we're producing a binary that won't work on x86-64
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "cleans up stale object files when source file renamed"() {
         def oldObjFile = objectFileFor(asmSourceFile, "build/objs/hello/shared/helloAsm")
         def newObjFile = objectFileFor(file('src/hello/asm/changed_sum.s'), "build/objs/hello/shared/helloAsm")
@@ -135,7 +132,6 @@ class AssemblyLanguageIncrementalBuildIntegrationTest extends AbstractInstalledT
         newObjFile.file
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "reassembles binary with source comment change"() {
         when:
         asmSourceFile << "# A comment at the end of the file\n"

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.language.nativeplatform
 
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.test.fixtures.file.TestDirectoryProvider
@@ -24,7 +23,6 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
-import spock.lang.IgnoreIf
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPATIBLE
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32_AND_64
@@ -49,7 +47,6 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
     }
 
     @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "assembler"() {
         given:
         sample assembler

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -21,12 +21,12 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 
-public class DefaultPropertyState<T> extends AbstractProperty<T> implements Property<T> {
+public class DefaultProperty<T> extends AbstractProperty<T> implements Property<T> {
     private final Class<T> type;
     private final ValueSanitizer<T> sanitizer;
     private ProviderInternal<? extends T> provider;
 
-    public DefaultPropertyState(Class<T> type) {
+    public DefaultProperty(Class<T> type) {
         applyDefaultValue();
         this.type = type;
         this.sanitizer = ValueSanitizers.forType(type);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -53,7 +53,7 @@ public class ManagedFactories {
 
     public static class PropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = Property.class;
-        private static final Class<?> IMPL_TYPE = DefaultPropertyState.class;
+        private static final Class<?> IMPL_TYPE = DefaultProperty.class;
         public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
 
         @Nullable
@@ -62,7 +62,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new DefaultPropertyState<>(Object.class).value(state));
+            return type.cast(new DefaultProperty<>(Object.class).value(state));
         }
 
         @Override

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -20,23 +20,23 @@ import org.gradle.api.Transformer
 import org.gradle.api.provider.Property
 import org.gradle.internal.state.ManagedFactory
 
-class DefaultPropertyStateTest extends PropertySpec<String> {
-    DefaultPropertyState<String> property() {
-        return new DefaultPropertyState<String>(String)
+class DefaultPropertyTest extends PropertySpec<String> {
+    DefaultProperty<String> property() {
+        return new DefaultProperty<String>(String)
     }
 
     @Override
-    DefaultPropertyState<String> propertyWithNoValue() {
+    DefaultProperty<String> propertyWithNoValue() {
         return property()
     }
 
     @Override
-    DefaultPropertyState<String> propertyWithDefaultValue() {
+    DefaultProperty<String> propertyWithDefaultValue() {
         return property()
     }
 
     @Override
-    DefaultPropertyState<String> providerWithValue(String value) {
+    DefaultProperty<String> providerWithValue(String value) {
         def p = property()
         p.set(value)
         return p
@@ -103,7 +103,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
     }
 
     def "fails when get method is called when the property has no initial value"() {
-        def property = new DefaultPropertyState<String>(String)
+        def property = new DefaultProperty<String>(String)
 
         when:
         property.get()
@@ -114,7 +114,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
     }
 
     def "fails when value is set using incompatible type"() {
-        def property = new DefaultPropertyState<Boolean>(Boolean)
+        def property = new DefaultProperty<Boolean>(Boolean)
 
         when:
         property.set(12)
@@ -128,8 +128,8 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
     }
 
     def "fails when value set using provider whose type is known to be incompatible"() {
-        def property = new DefaultPropertyState<Boolean>(Boolean)
-        def other = new DefaultPropertyState<Number>(Number)
+        def property = new DefaultProperty<Boolean>(Boolean)
+        def other = new DefaultProperty<Number>(Number)
 
         when:
         property.set(other)
@@ -149,7 +149,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
         provider.get() >>> ["a", "b", "c"]
         provider.map(_) >> provider
 
-        def propertyState = new DefaultPropertyState<String>(String)
+        def propertyState = new DefaultProperty<String>(String)
 
         when:
         propertyState.set(provider)
@@ -167,7 +167,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
         provider.getType() >> Integer
         provider.get() >>> [1, 2, 3]
 
-        def propertyState = new DefaultPropertyState<Number>(Number)
+        def propertyState = new DefaultProperty<Number>(Number)
 
         when:
         propertyState.set(provider)
@@ -187,7 +187,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
         provider.get() >> { transform.transform(12) }
         provider.getOrNull() >> { transform.transform(12) }
 
-        def propertyState = new DefaultPropertyState<Boolean>(Boolean)
+        def propertyState = new DefaultProperty<Boolean>(Boolean)
         propertyState.set(provider)
 
         when:
@@ -209,7 +209,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
         def transformer = Mock(Transformer)
         def provider = Mock(ProviderInternal)
 
-        def property = new DefaultPropertyState<String>(String)
+        def property = new DefaultProperty<String>(String)
 
         when:
         def p = property.map(transformer)
@@ -251,7 +251,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
     }
 
     private Property<Boolean> createBooleanPropertyState(Boolean value) {
-        def propertyState = new DefaultPropertyState<Boolean>(Boolean)
+        def propertyState = new DefaultProperty<Boolean>(Boolean)
         propertyState.set(value)
         propertyState
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.api.internal.provider.DefaultListProperty
 import org.gradle.api.internal.provider.DefaultMapProperty
-import org.gradle.api.internal.provider.DefaultPropertyState
+import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.DefaultSetProperty
 import org.gradle.api.internal.provider.ManagedFactories
 import org.gradle.api.internal.provider.Providers
@@ -534,7 +534,7 @@ class DefaultValueSnapshotterTest extends Specification {
 
     def "creates isolated property"() {
         def originalValue = "123"
-        def original = new DefaultPropertyState(String)
+        def original = new DefaultProperty(String)
         original.set(originalValue)
 
         given:

--- a/subprojects/osgi/src/integTest/groovy/org/gradle/api/plugins/osgi/OsgiPluginIntegrationSpec.groovy
+++ b/subprojects/osgi/src/integTest/groovy/org/gradle/api/plugins/osgi/OsgiPluginIntegrationSpec.groovy
@@ -19,9 +19,7 @@ package org.gradle.api.plugins.osgi
 import aQute.bnd.osgi.Analyzer
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.archive.JarTestFixture
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import java.util.jar.JarFile
@@ -68,7 +66,6 @@ class OsgiPluginIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2237")
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "jar task remains incremental"() {
         given:
         // Unsure why, but this problem doesn't show if we don't wait a little bit

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 class JavaExecIntegrationTest extends AbstractIntegrationSpec {
@@ -68,7 +66,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "java exec is not incremental by default"() {
         when:
         run "run"

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -17,13 +17,11 @@
 package org.gradle.api.reporting.plugins
 
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import spock.lang.IgnoreIf
 
 class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
 
@@ -240,7 +238,6 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         !buildDashboardFile.exists()
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     void 'buildDashboard is incremental'() {
         given:
         goodCode()
@@ -260,7 +257,6 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         executedAndNotSkipped(':buildDashboard')
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     void 'enabling an additional report renders buildDashboard out-of-date'() {
         given:
         goodCode()
@@ -293,7 +289,6 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         hasReport(':codenarcMain', 'text')
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     void 'generating a report that was previously not available renders buildDashboard out-of-date'() {
         given:
         goodCode()

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
@@ -15,8 +15,7 @@
  */
 package org.gradle.plugins.signing
 
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
+
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -42,7 +41,6 @@ class NoSigningCredentialsIntegrationSpec extends SigningIntegrationSpec {
         failureHasCause "Cannot perform signing task ':signJar' because it has no configured signatory"
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "trying to perform a signing operation without a signatory when not required does not error, and other artifacts still uploaded"() {
         when:
         buildFile << """

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningOperationIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningOperationIntegrationSpec.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.signing
+
+class SigningOperationIntegrationSpec extends SigningIntegrationSpec {
+    def "direct creation of SignOperation is deprecated"() {
+        buildFile << """
+            new SignOperation()
+        """
+
+        when:
+        executer.expectDeprecationWarning()
+        succeeds()
+
+        then:
+        outputContains("Creating instances of SignOperation has been deprecated. This will fail with an error in Gradle 6.0.")
+    }
+}

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
@@ -19,11 +19,9 @@ package org.gradle.plugins.signing
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.util.Requires
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
@@ -58,7 +56,6 @@ class SigningSamplesSpec extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample('signing/conditional')
-    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "conditional signing with dsl #dsl"() {
         given:
         inDirectory(sample.dir.file(dsl))

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
@@ -15,12 +15,10 @@
  */
 package org.gradle.plugins.signing
 
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.plugins.signing.signatory.internal.gnupg.GnupgSignatoryProvider
 import org.gradle.plugins.signing.signatory.pgp.PgpSignatoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import static org.gradle.plugins.signing.SigningIntegrationSpec.SignMethod.GPG_CMD
@@ -28,7 +26,6 @@ import static org.gradle.plugins.signing.SigningIntegrationSpec.SignMethod.OPEN_
 
 class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "sign jar with default signatory"() {
         given:
         buildFile << """
@@ -56,7 +53,6 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
         skipped(":signJar")
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "sign multiple jars with default signatory"() {
         given:
         buildFile << """
@@ -307,7 +303,6 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
         failureHasCause "You cannot sign tasks that are not 'archive' tasks, such as 'jar', 'zip' etc. (you tried to sign task ':clean')"
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "changes to task information after signing block are respected"() {
         given:
         buildFile << """
@@ -335,7 +330,6 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "sign with subkey"() {
         given:
         buildFile << """

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SignOperation.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.plugins.signing.signatory.Signatory;
 import org.gradle.plugins.signing.type.SignatureType;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -53,6 +54,10 @@ public class SignOperation implements SignatureSpec {
     private boolean required;
 
     private final List<Signature> signatures = new ArrayList<Signature>();
+
+    public SignOperation() {
+        DeprecationLogger.nagUserOfDiscontinuedInvocation("Creating instances of SignOperation");
+    }
 
     public String getDisplayName() {
         return "SignOperation";

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -44,6 +44,7 @@ import org.gradle.plugins.signing.type.DefaultSignatureTypeProvider;
 import org.gradle.plugins.signing.type.SignatureType;
 import org.gradle.plugins.signing.type.SignatureTypeProvider;
 import org.gradle.util.DeferredUtil;
+import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -608,7 +609,7 @@ public class SigningExtension {
     }
 
     protected SignOperation doSignOperation(Action<SignOperation> setup) {
-        SignOperation operation = instantiator().newInstance(SignOperation.class);
+        SignOperation operation = DeprecationLogger.whileDisabled(() -> instantiator().newInstance(SignOperation.class));
         addSignatureSpecConventions(operation);
         setup.execute(operation);
         operation.execute();

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestReportIntegrationTest.groovy
@@ -17,10 +17,8 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.*
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -86,7 +84,6 @@ public class LoggingTest {
         htmlReport.testClass("org.gradle.sample.UtilTest").assertTestCount(1, 0, 0).assertTestPassed("ok").assertStdout(equalTo("hello from UtilTest.\n"))
     }
 
-    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "merges report with duplicated classes and methods"() {
         given:
         ignoreWhenJupiter()
@@ -184,7 +181,6 @@ public class SubClassTests extends SuperClassTests {
     }
 
     @Issue("https://issues.gradle.org//browse/GRADLE-2821")
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "test report task can handle test tasks that did not run tests"() {
         given:
         buildScript """
@@ -237,7 +233,6 @@ public class SubClassTests extends SuperClassTests {
         succeeds "testReport"
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "test report task is skipped when there are no results"() {
         given:
         buildScript """
@@ -258,7 +253,6 @@ public class SubClassTests extends SuperClassTests {
     }
 
     @Unroll
-    @IgnoreIf({GradleContextualExecuter.parallel})
     "#type report files are considered outputs"() {
         given:
         buildScript """
@@ -296,7 +290,6 @@ public class SubClassTests extends SuperClassTests {
         "html" | "build/reports/tests"
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "results or reports are linked to in error output"() {
         given:
         buildScript """
@@ -334,7 +327,6 @@ public class SubClassTests extends SuperClassTests {
         failure.assertHasNoCause("See the")
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "output per test case flag invalidates outputs"() {
         when:
         buildScript """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -18,12 +18,10 @@ package org.gradle.testing
 import org.apache.commons.lang.RandomStringUtils
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.hamcrest.CoreMatchers
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -37,7 +35,6 @@ import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE_JUPITER
 class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-1948")
-    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "test interrupting its own thread does not kill test execution"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest.groovy
@@ -19,9 +19,7 @@ package org.gradle.testing.cucumberjvm
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 class CucumberJVMReportIntegrationTest extends AbstractSampleIntegrationTest {
@@ -30,7 +28,6 @@ class CucumberJVMReportIntegrationTest extends AbstractSampleIntegrationTest {
     public final TestResources resources = new TestResources(temporaryFolder)
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2739")
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def testReportingSupportsCucumberStepsWithSlashes() {
         when:
         run "test"

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -17,8 +17,6 @@ package org.gradle.testing.fixture
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -203,7 +201,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         succeeds("test", "--tests", 'FooTest.missingMethod')
     }
 
-    @IgnoreIf({GradleContextualExecuter.parallel})
     def "task is out of date when --tests argument changes"() {
         file("src/test/java/FooTest.java") << """import $imports;
             public class FooTest {


### PR DESCRIPTION
### Context

Add `FileCollection.getElements()`, which returns a `Provider` whose value is the contents of the file collection. This can be used to add the contents of a `FileCollection` to a `ListProperty` or `SetProperty`.

This PR also includes some not-so-related changes:

- Deprecate direct instantiation of `SignOperation` instances. These should be created only via `SigningExtension`.
- Some renames.
- Clean up some int test requirements.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
