### PR TITLE
Tweak behaviour of property convention

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -33,7 +33,8 @@ public interface HasMultipleValues<T> extends HasConfigurableValue {
     /**
      * Sets the value of the property to the elements of the given iterable, and replaces any existing value. This property will query the elements of the iterable each time the value of this property is queried.
      *
-     * <p>This method can also be used to clear the value of the property, by passing {@code null} as the value.
+     * <p>This method can also be used to discard the value of the property, by passing {@code null} as the value.
+     * The convention for this property, if any, will be used to provide the value instead.
      *
      * @param elements The elements, can be null.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -68,7 +68,8 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      * Sets the value of this property to the entries of the given Map, and replaces any existing value.
      * This property will query the entries of the map each time the value of this property is queried.
      *
-     * <p>This method can also be used to clear the value of the property, by passing {@code null} as the value.
+     * <p>This method can also be used to discard the value of the property, by passing {@code null} as the value.
+     * The convention for this property, if any, will be used to provide the value instead.
      *
      * @param entries the entries, can be {@code null}
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -39,7 +39,8 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue {
     /**
      * Sets the value of the property the given value, replacing whatever value the property already had.
      *
-     * <p>This method can also be used to clear the value of the property, by passing {@code null} as the value.
+     * <p>This method can also be used to discard the value of the property, by passing {@code null} as the value.
+     * The convention for this property, if any, will be used to provide the value instead.
      *
      * @param value The value, can be null.
      */

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -68,6 +68,11 @@ This is now an error because Gradle does not know how to build files that are no
 
 *Note* that it is still possible to to pass `Task.dependsOn()` a `Provider` that returns a file and that represents a task output, for example `myTask.dependsOn(jar.archiveFile)` or `myTask.dependsOn(taskProvider.flatMap { it.outputDirectory })`, when the `Provider` is an annotated `@OutputFile` or `@OutputDirectory` property of a task.
 
+==== Setting `Property` value to `null` uses the property convention
+
+Previously, calling `Property.set(null)` would always reset the value of the property to 'not defined'. Now, the convention that is associated with the property using the `convention()` method
+will be used to determine the value of the property.
+
 ==== Enhanced validation of names for `publishing.publications` and `publishing.repositories`
 
 The repository and publication names are used to construct task names for publishing. It was possible to supply a name that would result in an invalid task name. Names for publications and repositories are now restricted to `[A-Za-z0-9_\\-.]+`.

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -22,10 +22,10 @@ import org.gradle.util.DeprecationLogger;
 
 public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> implements PropertyInternal<T> {
     private enum State {
-        InitialValue, Convention, Mutable, Final
+        ImplicitValue, ExplicitValue, Final
     }
 
-    private State state = State.InitialValue;
+    private State state = State.ImplicitValue;
     private boolean finalizeOnNextGet;
     private boolean disallowChanges;
     private Task producer;
@@ -87,6 +87,38 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
      * Call prior to mutating the value of this property.
      */
     protected boolean beforeMutate() {
+        if (canMutate()) {
+            if (state == State.ImplicitValue) {
+                applyDefaultValue();
+                state = State.ExplicitValue;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Call prior to discarding the value of this property.
+     */
+    protected boolean beforeReset() {
+        if (canMutate()) {
+            state = State.ImplicitValue;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Call prior to applying a convention to this property.
+     */
+    protected boolean shouldApplyConvention() {
+        if (canMutate()) {
+            return state == State.ImplicitValue;
+        }
+        return false;
+    }
+
+    private boolean canMutate() {
         if (state == State.Final && disallowChanges) {
             throw new IllegalStateException("The value for this property is final and cannot be changed any further.");
         } else if (disallowChanges) {
@@ -94,33 +126,7 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
         } else if (state == State.Final) {
             DeprecationLogger.nagUserOfDiscontinuedInvocation("Changing the value for a property with a final value");
             return false;
-        } else if (state == State.Convention) {
-            applyDefaultValue();
-            state = State.InitialValue;
         }
         return true;
-    }
-
-    /**
-     * Call immediately after mutating the value of this property.
-     */
-    protected void afterMutate() {
-        if (state == State.InitialValue || state == State.Convention) {
-            state = State.Mutable;
-        }
-    }
-
-    /**
-     * Call prior to applying a convention to this property.
-     */
-    protected boolean shouldApplyConvention() {
-        if (!beforeMutate()) {
-            return false;
-        }
-        if (state == State.InitialValue) {
-            state = State.Convention;
-            return true;
-        }
-        return state == State.Convention;
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -603,6 +603,20 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
         property.get() == toImmutable(someValue())
     }
 
+    def "cannot set to empty list after changes disallowed"() {
+        given:
+        def property = property()
+        property.set(someValue())
+        property.disallowChanges()
+
+        when:
+        property.empty()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
+    }
+
     def "cannot add element after value finalized"() {
         given:
         def property = property()

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -534,7 +534,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
         then:
         1 * function.call() >> someValue()
-        0 * Specification._
+        0 * _
 
         when:
         def present = property.present
@@ -543,10 +543,10 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         present
         result == someValue()
-        0 * Specification._
+        0 * _
     }
 
-    def "replaces provider with fixed value when value finalized on next read"() {
+    def "replaces provider with fixed value when value finalized on next read of value"() {
         def property = propertyWithNoValue()
         def function = Mock(Callable)
         def provider = new DefaultProvider<T>(function)
@@ -558,19 +558,73 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.implicitFinalizeValue()
 
         then:
-        0 * Specification._
+        0 * _
 
         when:
+        def result = property.get()
         def present = property.present
-        def result = property.getOrNull()
 
         then:
         1 * function.call() >> someValue()
-        0 * Specification._
+        0 * _
+
+        and:
+        result == someValue()
+        present
+    }
+
+    def "replaces provider with fixed value when value finalized on next read of nullable value"() {
+        def property = propertyWithNoValue()
+        def function = Mock(Callable)
+        def provider = new DefaultProvider<T>(function)
+
+        given:
+        property.set(provider)
+
+        when:
+        property.implicitFinalizeValue()
+
+        then:
+        0 * _
+
+        when:
+        def result = property.getOrNull()
+        def present = property.present
+
+        then:
+        1 * function.call() >> someValue()
+        0 * _
+
+        and:
+        result == someValue()
+        present
+    }
+
+    def "replaces provider with fixed value when value finalized on next read of `present` property"() {
+        def property = propertyWithNoValue()
+        def function = Mock(Callable)
+        def provider = new DefaultProvider<T>(function)
+
+        given:
+        property.set(provider)
+
+        when:
+        property.implicitFinalizeValue()
+
+        then:
+        0 * _
+
+        when:
+        def present = property.present
+        def value = property.get()
+
+        then:
+        1 * function.call() >> someValue()
+        0 * _
 
         and:
         present
-        result == someValue()
+        value == someValue()
     }
 
     def "replaces provider with fixed value when value finalized after finalize on next read"() {


### PR DESCRIPTION
### Context

Change the behaviour of `Property.set(null)` so that the property's convention is used, if registered, instead of 'not defined'.

<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
