### PR TITLE
Delete temporary files on exit

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultTemporaryFileProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultTemporaryFileProvider.java
@@ -44,7 +44,9 @@ public class DefaultTemporaryFileProvider implements TemporaryFileProvider, Seri
         File dir = new File(baseDirFactory.create(), CollectionUtils.join("/", path));
         GFileUtils.mkdirs(dir);
         try {
-            return File.createTempFile(prefix, suffix, dir);
+            File tempFile = File.createTempFile(prefix, suffix, dir);
+            tempFile.deleteOnExit();
+            return tempFile;
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Related to https://github.com/gradle/gradle-private/issues/2366#issuecomment-504732482
As the docs recommend:
> This method provides only part of a temporary-file facility.  To arrange for a file created by this method to be deleted automatically, use the `deleteOnExit` method.