### PR TITLE
Fix warning about unsafe dependency resolution while writing to the instant execution cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -183,7 +183,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry {
         }
 
         @Override
-        public <T> void withMutableState(Runnable action) {
+        public void withMutableState(Runnable action) {
             withMutableState(Factories.toFactory(action));
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -58,7 +58,7 @@ public interface ProjectState {
     /**
      * Runs the given action against the public mutable state of the project. Applies best effort synchronization to prevent concurrent access to a particular project from multiple threads. However, it is currently easy for state to leak from one project to another so this is not a strong guarantee.
      */
-    <T> void withMutableState(Runnable runnable);
+    void withMutableState(Runnable runnable);
 
     /**
      * Returns whether or not the current thread holds the mutable state for this project.

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     testImplementation(testFixtures(project(":baseServices")))
     testImplementation(testFixtures(project(":snapshots")))
     testImplementation(testFixtures(project(":execution")))
-    
+
     testRuntimeOnly(project(":runtimeApiInfo"))
 
     integTestImplementation(project(":buildOption"))
@@ -105,6 +105,7 @@ dependencies {
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
     testFixturesImplementation(library("slf4j_api"))
+    testFixturesImplementation(library("inject"))
 
     crossVersionTestRuntimeOnly(project(":maven"))
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
@@ -97,13 +97,6 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
         return doResolve(fileCollectionConverter);
     }
 
-    /**
-     * Resolves the contents of this context as a list of atomic {@link MinimalFileCollection} instances.
-     */
-    public List<MinimalFileCollection> resolveAsMinimalFileCollections() {
-        return doResolve(new MinimalFileCollectionConverter());
-    }
-
     private <T> List<T> doResolve(Converter<? extends T> converter) {
         List<T> result = new ArrayList<T>();
         for (Object element : queue) {
@@ -135,7 +128,7 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
                 MinimalFileSet fileSet = (MinimalFileSet) element;
                 result.add(new FileCollectionAdapter(fileSet));
             } else if (element instanceof MinimalFileCollection) {
-                throw new UnsupportedOperationException(String.format("Cannot convert instance of %s to FileTree", element.getClass().getSimpleName()));
+                throw new IllegalArgumentException(String.format("Cannot convert instance of %s to FileCollection", element.getClass().getSimpleName()));
             } else if (element instanceof TaskDependency) {
                 // Ignore
                 return;
@@ -173,7 +166,7 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
                     convertFileToFileTree(file, result);
                 }
             } else if (element instanceof MinimalFileCollection) {
-                throw new UnsupportedOperationException(String.format("Cannot convert instance of %s to FileTree", element.getClass().getSimpleName()));
+                throw new IllegalArgumentException(String.format("Cannot convert instance of %s to FileTree", element.getClass().getSimpleName()));
             } else if (element instanceof TaskDependency) {
                 // Ignore
                 return;
@@ -189,25 +182,6 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
                 result.add(new FileTreeAdapter(new DirectoryFileTree(file, patternSetFactory.create(), FileSystems.getDefault()), patternSetFactory));
             } else if (file.isFile()) {
                 result.add(new FileTreeAdapter(new DefaultSingletonFileTree(file), patternSetFactory));
-            }
-        }
-    }
-
-    public static class MinimalFileCollectionConverter implements Converter<MinimalFileCollection> {
-        @Override
-        public void convertInto(Object element, Collection<? super MinimalFileCollection> result) {
-            if (element instanceof MinimalFileCollection) {
-                MinimalFileCollection collection = (MinimalFileCollection) element;
-                result.add(collection);
-            } else if (element instanceof FileCollection) {
-                throw new UnsupportedOperationException(String.format("Cannot convert instance of %s to MinimalFileCollection", element.getClass().getSimpleName()));
-            } else if (element instanceof TaskDependency) {
-                // Ignore
-                return;
-            } else if (element instanceof File) {
-                result.add(new ListBackedFileSet((File) element));
-            } else {
-                throw new IllegalArgumentException("Dont know how to convert element into a FileCollection: " + element);
             }
         }
     }

--- a/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContextTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContextTest.groovy
@@ -37,11 +37,6 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         context.resolveAsFileTrees() == []
     }
 
-    def "resolve as MinimalFileCollection returns empty List when context is empty"() {
-        expect:
-        context.resolveAsMinimalFileCollections() == []
-    }
-
     def "resolve as FileCollection wraps a MinimalFileSet"() {
         MinimalFileSet fileSet = Mock()
 
@@ -76,17 +71,6 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         1 * fileSet.files >> ([file, dir, doesNotExist] as LinkedHashSet)
     }
 
-    def "resolve as MinimalFileCollection returns MinimalFileSet"() {
-        MinimalFileSet fileSet = Mock()
-
-        when:
-        context.add(fileSet)
-        def result = context.resolveAsMinimalFileCollections()
-
-        then:
-        result == [fileSet]
-    }
-
     def "resolve as FileCollection wraps a MinimalFileTree"() {
         MinimalFileTree fileTree = Mock()
 
@@ -111,17 +95,6 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         result.size() == 1
         result[0] instanceof FileTreeAdapter
         result[0].tree == fileTree
-    }
-
-    def "resolve as MinimalFileCollection wraps a MinimalFileTree"() {
-        MinimalFileTree fileTree = Mock()
-
-        when:
-        context.add(fileTree)
-        def result = context.resolveAsMinimalFileCollections()
-
-        then:
-        result == [fileTree]
     }
 
     def "resolve as FileCollections for a FileCollection"() {
@@ -155,19 +128,6 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         when:
         context.add(composite)
         def result = context.resolveAsFileTrees()
-
-        then:
-        result == [contents]
-        1 * composite.visitContents(!null) >> { it[0].add(contents) }
-    }
-
-    def "resolve as MinimalFileCollections delegates to a CompositeFileCollection"() {
-        FileCollectionContainer composite = Mock()
-        MinimalFileCollection contents = Mock()
-
-        when:
-        context.add(composite)
-        def result = context.resolveAsMinimalFileCollections()
 
         then:
         result == [contents]
@@ -214,17 +174,6 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         result == []
     }
 
-    def "resolve as MinimalFileCollections ignores a TaskDependency"() {
-        TaskDependency dependency = Mock()
-
-        when:
-        context.add(dependency)
-        def result = context.resolveAsMinimalFileCollections()
-
-        then:
-        result == []
-    }
-
     def "resolve as FileCollections uses FileResolver to resolve other types"() {
         File file1 = new File('a')
         File file2 = new File('b')
@@ -258,20 +207,6 @@ class DefaultFileCollectionResolveContextTest extends Specification {
         result[0] instanceof FileTreeAdapter
         result[0].tree instanceof DefaultSingletonFileTree
         result[0].tree.file == file
-        1 * resolver.resolve('a') >> file
-    }
-
-    def "resolve as MinimalFileCollection uses FileResolver to resolve other types"() {
-        File file = file('a')
-
-        when:
-        context.add('a', resolver)
-        def result = context.resolveAsMinimalFileCollections()
-
-        then:
-        result.size() == 1
-        result[0] instanceof ListBackedFileSet
-        result[0].files as List == [file]
         1 * resolver.resolve('a') >> file
     }
 

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))
     integTestImplementation(library("inject"))
+    integTestImplementation(testFixtures(project(":dependencyManagement")))
 
     integTestRuntimeOnly(project(":apiMetadata"))
     integTestRuntimeOnly(project(":toolingApiBuilders"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -28,7 +28,6 @@ class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionInt
 
     def setup() {
         AndroidHome.assumeIsSet()
-        executer.noDeprecationChecks()
     }
 
     def "android 3.5 minimal build assembleDebug"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.integtests.resolve.transform.ArtifactTransformTestFixture
+import spock.lang.Ignore
+
+class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstantExecutionIntegrationTest implements ArtifactTransformTestFixture {
+    @Ignore
+    def "task input files can include artifact transform output"() {
+        setupBuildWithColorTransformAction()
+        settingsFile << """
+            include 'a', 'b'
+        """
+        buildFile << """
+            dependencies {
+                implementation project(':a')
+                implementation project(':b')
+            }
+
+            abstract class MakeGreen implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+                
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.name + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+
+        expect:
+        instantRun(":resolve")
+        instantRun(":resolve")
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -21,11 +21,6 @@ import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterReposito
 
 
 class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionIntegrationTest {
-
-    def setup() {
-        executer.noDeprecationChecks()
-    }
-
     def "build on Groovy build with JUnit tests"() {
 
         def instantExecution = newInstantExecutionFixture()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
@@ -26,7 +26,6 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
 
     def setup() {
         instantExecution = newInstantExecutionFixture()
-        executer.noDeprecationChecks()
     }
 
     def "build on Java build with a single source file and no dependencies"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -121,7 +121,7 @@ class DefaultInstantExecution(
                         val scheduledTasks = build.scheduledTasks
                         writeRelevantProjectsFor(scheduledTasks)
 
-                        TaskGraphCodec().run {
+                        TaskGraphCodec(service()).run {
                             writeTaskGraphOf(build, scheduledTasks)
                         }
                     }
@@ -158,7 +158,7 @@ class DefaultInstantExecution(
 
                     initProjectProvider(build::getProject)
 
-                    val scheduledTasks = TaskGraphCodec().run {
+                    val scheduledTasks = TaskGraphCodec(service()).run {
                         readTaskGraph()
                     }
                     build.scheduleTasks(scheduledTasks)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -105,7 +105,7 @@ class Codecs(
         bind(LoggerCodec)
 
         bind(ConfigurableFileCollectionCodec(fileSetSerializer, fileCollectionFactory))
-        bind(FileCollectionCodec(fileSetSerializer, fileCollectionFactory))
+        bind(FileCollectionCodec(fileSetSerializer, fileCollectionFactory, directoryFileTreeFactory))
         bind(ArtifactCollectionCodec)
 
         bind(DefaultCopySpecCodec(fileResolver, instantiator))


### PR DESCRIPTION
### Context

Also some initial steps towards handling scheduled artifact transforms, or at least not blowing up when they are present.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
