### PR TITLE
Restore runtime classpath separation for previous Buildship releases

### DIFF
--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r44/ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r44/ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.model.eclipse.EclipseProject
 
 @ToolingApiVersion('>=4.4')
-@TargetGradleVersion(">=4.4 <5.5")
+@TargetGradleVersion(">=4.4")
 class ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec extends ToolingApiSpecification {
 
     def "Source folder contains source set information in classpath attributes"() {
@@ -37,17 +37,10 @@ class ToolingApiEclipseModelSourceFolderClasspathAttributesCrossVersionSpec exte
         def testDirAttributes = project.sourceDirectories.find { it.path == 'src/test/java' }.classpathAttributes
 
         then:
-        mainDirAttributes.size() == 2
-        mainDirAttributes[0].name == 'gradle_scope'
-        mainDirAttributes[0].value == 'main'
-        mainDirAttributes[1].name == 'gradle_used_by_scope'
-        mainDirAttributes[1].value == 'main,test'
-
-        testDirAttributes.size() == 2
-        testDirAttributes[0].name == 'gradle_scope'
-        testDirAttributes[0].value == 'test'
-        testDirAttributes[1].name == 'gradle_used_by_scope'
-        testDirAttributes[1].value == 'test'
+        mainDirAttributes.find { it.name == 'gradle_scope' && it.value == 'main' }
+        mainDirAttributes.find { it.name == 'gradle_used_by_scope' && it.value == 'main,test' }
+        testDirAttributes.find { it.name == 'gradle_scope' && it.value == 'test' }
+        testDirAttributes.find { it.name == 'gradle_used_by_scope' && it.value == 'test' }
     }
 
     def "Source folder defines additional classpath attributes"() {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourceSetIntegrationSpec.groovy
@@ -24,6 +24,81 @@ class EclipseSourceSetIntegrationSpec extends AbstractEclipseIntegrationSpec {
     @Rule
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
+    def "Source set defined on dependencies"() {
+        setup:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+
+            ${jcenterRepository()}
+
+            dependencies {
+                implementation 'com.google.guava:guava:18.0'
+                compileOnly 'commons-logging:commons-logging:1.2'
+                testImplementation 'junit:junit:4.12'
+            }
+        """
+
+        when:
+        run 'eclipse'
+
+        then:
+        EclipseClasspathFixture classpath = classpath('.')
+        classpath.lib('guava-18.0.jar').assertHasAttribute('gradle_used_by_scope', 'main,test')
+        classpath.lib('commons-logging-1.2.jar').assertHasAttribute('gradle_used_by_scope', '')
+        classpath.lib('junit-4.12.jar').assertHasAttribute('gradle_used_by_scope', 'test')
+    }
+
+    def "Source sets defined on source folders"() {
+        setup:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+        """
+        file('src/main/java').mkdirs()
+        file('src/test/java').mkdirs()
+
+        when:
+        run 'eclipse'
+
+        then:
+        EclipseClasspathFixture classpath = classpath('.')
+        classpath.sourceDir('src/main/java').assertHasAttribute('gradle_used_by_scope', 'main,test')
+        classpath.sourceDir('src/test/java').assertHasAttribute('gradle_used_by_scope', 'test')
+    }
+
+    def "Source set information is customizable in whenMerged block"() {
+        setup:
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'eclipse'
+
+            ${jcenterRepository()}
+
+            dependencies {
+                implementation 'com.google.guava:guava:18.0'
+                testImplementation 'junit:junit:4.12'
+            }
+
+            eclipse.classpath.file.whenMerged {
+                def testDir = entries.find { entry -> entry.path == 'src/test/java' }
+                def guavaDep = entries.find { entry -> entry.path.contains 'guava-18.0.jar' }
+                testDir.entryAttributes['gradle_used_by_scope'] = 'test,integTest'
+                guavaDep.entryAttributes['gradle_used_by_scope'] = 'main,test,integTest'
+            }
+        """
+        file('src/test/java').mkdirs()
+
+        when:
+        run 'eclipse'
+
+        then:
+        EclipseClasspathFixture classpath = classpath('.')
+        classpath.sourceDir('src/test/java').assertHasAttribute('gradle_used_by_scope', 'test,integTest')
+        classpath.lib('junit-4.12.jar').assertHasAttribute('gradle_used_by_scope', 'test')
+        classpath.lib('guava-18.0.jar').assertHasAttribute('gradle_used_by_scope', 'main,test,integTest')
+    }
+
     def "Source dirs have default output locations"() {
         setup:
         buildFile << """

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/apiClasspath.xml
@@ -1,34 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin/default"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/java"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/resources"/>
+	<classpathentry output="bin/main" kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry output="bin/main" kind="src" path="src/main/resources">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry output="bin/test" kind="src" path="src/test/java">
 		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry output="bin/test" kind="src" path="src/test/resources">
 		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry output="bin/integTest" kind="src" path="src/integTest/java">
 		<attributes>
+			<attribute name="gradle_scope" value="integTest"/>
+			<attribute name="gradle_used_by_scope" value="integTest"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
-			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
 		<attributes>
-			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
+			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonClasspath.xml
@@ -1,10 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin/default"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/java"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/resources"/>
+	<classpathentry output="bin/main" kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry output="bin/main" kind="src" path="src/main/resources">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry output="bin/test" kind="src" path="src/test/java">
 		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
@@ -17,24 +29,28 @@
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-javadoc.jar!/"/>
-			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
-		</attributes>
-	</classpathentry>
-	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+		</attributes>
+	</classpathentry>
+	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/junit/junit/4.12/@SHA1@/junit-4.12-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/junit/junit/4.12/@SHA1@/junit-4.12.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/junit/junit/4.12/@SHA1@/junit-4.12-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
@@ -42,6 +58,7 @@
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/org.hamcrest/hamcrest-core/1.3/@SHA1@/hamcrest-core-1.3-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/org.hamcrest/hamcrest-core/1.3/@SHA1@/hamcrest-core-1.3.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/org.hamcrest/hamcrest-core/1.3/@SHA1@/hamcrest-core-1.3-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/groovyprojectClasspath.xml
@@ -1,16 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin/default"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/java"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/groovy"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/resources"/>
+	<classpathentry output="bin/main" kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry output="bin/main" kind="src" path="src/main/groovy">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry output="bin/main" kind="src" path="src/main/resources">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry output="bin/test" kind="src" path="src/test/java">
 		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry output="bin/test" kind="src" path="src/test/resources">
 		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
@@ -18,10 +37,12 @@
 	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
 		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppJava6Classpath.xml
@@ -1,7 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin/default"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/java"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="src" path="/common">
@@ -9,27 +13,30 @@
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="/api">
+	<classpathentry kind="src" path="/api" >
 		<attributes>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-sources.jar" kind="lib" path="@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-javadoc.jar!/"/>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/log4j/log4j/1.2.17/@SHA1@/log4j-1.2.17-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-javadoc.jar!/"/>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/joda-time/joda-time/2.5/@SHA1@/joda-time-2.5-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
 		<attributes>
-			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
 </classpath>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webAppWithVarsClasspath.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin/default"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/java"/>
+	<classpathentry output="bin/main" kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="GRADLE_USER_HOME/@CACHE@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="var" path="GRADLE_USER_HOME/@CACHE@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
 		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/webserviceClasspath.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="output" path="bin/default"/>
-	<classpathentry output="bin/main" kind="src" path="src/main/java"/>
+	<classpathentry output="bin/main" kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7/"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="src" path="/api">
@@ -11,29 +16,34 @@
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8-sources.jar" kind="lib" path="@CACHE_DIR@/org.slf4j/slf4j-api/1.5.8/@SHA1@/slf4j-api-1.5.8.jar">
 		<attributes>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
-		</attributes>
-	</classpathentry>
-	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
-		<attributes>
-			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
-			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-io/commons-io/1.2/@SHA1@/commons-io-1.2-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-sources.jar" kind="lib" path="@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-lang/commons-lang/2.5/@SHA1@/commons-lang-2.5-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry sourcepath="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-sources.jar" kind="lib" path="@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:file:@CACHE_DIR@/commons-collections/commons-collections/3.2.2/@SHA1@/commons-collections-3.2.2-javadoc.jar!/"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry sourcepath="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7-sources.jar" kind="lib" path="@CACHE_DIR@/junit/junit/4.7/@SHA1@/junit-4.7.jar">
 		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/internal/EclipsePluginConstants.java
@@ -22,6 +22,10 @@ public class EclipsePluginConstants {
     public static final String TEST_SOURCES_ATTRIBUTE_KEY = "test";
     public static final String TEST_SOURCES_ATTRIBUTE_VALUE = "true";
 
+    // TODO The scope information is superseded by test attributes. We can delete the corresponding code bits once we make sure that the majority of Buildship users use test sources.
+    public static final String GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME = "gradle_used_by_scope";
+    public static final String GRADLE_SCOPE_ATTRIBUTE_NAME = "gradle_scope";
+
     private EclipsePluginConstants() {
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -16,7 +16,11 @@
 
 package org.gradle.plugins.ide.eclipse.model.internal;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -26,6 +30,7 @@ import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
@@ -38,12 +43,16 @@ import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencySet;
 import org.gradle.plugins.ide.internal.resolver.IdeDependencyVisitor;
 import org.gradle.plugins.ide.internal.resolver.UnresolvedIdeDependencyHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 public class EclipseDependenciesCreator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EclipseDependenciesCreator.class);
     private final EclipseClasspath classpath;
     private final ProjectDependencyBuilder projectDependencyBuilder;
     private final ProjectComponentIdentifier currentProjectId;
@@ -65,6 +74,7 @@ public class EclipseDependenciesCreator {
         private final List<AbstractClasspathEntry> projects = Lists.newArrayList();
         private final List<AbstractClasspathEntry> modules = Lists.newArrayList();
         private final List<AbstractClasspathEntry> files = Lists.newArrayList();
+        private final Multimap<String, String> pathToSourceSets = collectLibraryToSourceSetMapping();
         private final UnresolvedIdeDependencyHandler unresolvedIdeDependencyHandler = new UnresolvedIdeDependencyHandler();
         private final Project project;
 
@@ -108,18 +118,18 @@ public class EclipseDependenciesCreator {
             File javaDocFile = javaDoc.isEmpty() ? null : javaDoc.iterator().next().getFile();
             ModuleComponentIdentifier componentIdentifier = (ModuleComponentIdentifier) artifact.getId().getComponentIdentifier();
             ModuleVersionIdentifier moduleVersionIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier.getModuleIdentifier(), componentIdentifier.getVersion());
-            modules.add(createLibraryEntry(artifact.getFile(), sourceFile, javaDocFile, classpath, moduleVersionIdentifier, testDependency));
+            modules.add(createLibraryEntry(artifact.getFile(), sourceFile, javaDocFile, classpath, moduleVersionIdentifier, pathToSourceSets, testDependency));
         }
 
         @Override
         public void visitFileDependency(ResolvedArtifactResult artifact, boolean testDependency) {
-            files.add(createLibraryEntry(artifact.getFile(), null, null, classpath, null, testDependency));
+            files.add(createLibraryEntry(artifact.getFile(), null, null, classpath, null, pathToSourceSets, testDependency));
         }
 
         @Override
         public void visitUnresolvedDependency(UnresolvedDependencyResult unresolvedDependency) {
             File unresolvedFile = unresolvedIdeDependencyHandler.asFile(unresolvedDependency, project.getProjectDir());
-            files.add(createLibraryEntry(unresolvedFile, null, null, classpath, null, false));
+            files.add(createLibraryEntry(unresolvedFile, null, null, classpath, null, pathToSourceSets, false));
             unresolvedIdeDependencyHandler.log(unresolvedDependency);
         }
 
@@ -137,24 +147,64 @@ public class EclipseDependenciesCreator {
             return dependencies;
         }
 
-        private AbstractLibrary createLibraryEntry(File binary, File source, File javadoc, EclipseClasspath classpath, ModuleVersionIdentifier id, boolean testDependency) {
-            FileReferenceFactory referenceFactory = classpath.getFileReferenceFactory();
+        private Multimap<String, String> collectLibraryToSourceSetMapping() {
+            Multimap<String, String> pathToSourceSetNames = LinkedHashMultimap.create();
+            Iterable<SourceSet> sourceSets = classpath.getSourceSets();
 
-            FileReference binaryRef = referenceFactory.fromFile(binary);
-            FileReference sourceRef = referenceFactory.fromFile(source);
-            FileReference javadocRef = referenceFactory.fromFile(javadoc);
-
-            final AbstractLibrary out = binaryRef.isRelativeToPathVariable() ? new Variable(binaryRef) : new Library(binaryRef);
-
-            out.setJavadocPath(javadocRef);
-            out.setSourcePath(sourceRef);
-            out.setExported(false);
-            out.setModuleVersion(id);
-
-            // Using the test sources feature introduced in Eclipse Photon
-            if (testDependency) {
-                out.getEntryAttributes().put(EclipsePluginConstants.TEST_SOURCES_ATTRIBUTE_KEY, EclipsePluginConstants.TEST_SOURCES_ATTRIBUTE_VALUE);
+            // for non-java projects there are no source sets configured
+            if (sourceSets == null) {
+                return pathToSourceSetNames;
             }
+
+            for (SourceSet sourceSet : sourceSets) {
+                for (File f : collectClasspathFiles(sourceSet)) {
+                    pathToSourceSetNames.put(f.getAbsolutePath(), sourceSet.getName().replace(",", ""));
+                }
+            }
+            return pathToSourceSetNames;
+        }
+
+        /*
+         * SourceSet has no access to configurations where we could ask for a lenient view. This
+                * means we have to deal with possible dependency resolution issues here. We catch and
+                * log the exceptions here so that the Eclipse model can be generated even if there are
+         * unresolvable dependencies defined in the configuration.
+         *
+         * We can probably do better by inspecting the runtime classpath and finding out which
+         * Configurations are part of it and only traversing any extra file collections manually.
+                */
+            private Collection<File> collectClasspathFiles(SourceSet sourceSet) {
+                ImmutableList.Builder<File> result = ImmutableList.builder();
+                try {
+                    result.addAll(sourceSet.getRuntimeClasspath());
+                } catch (Exception e) {
+                    LOGGER.debug("Failed to collect source sets for Eclipse dependencies", e);
+                }
+                return result.build();
+            }
+
+            private AbstractLibrary createLibraryEntry(File binary, File source, File javadoc, EclipseClasspath classpath, ModuleVersionIdentifier id, Multimap<String, String> pathToSourceSets, boolean testDependency) {
+                FileReferenceFactory referenceFactory = classpath.getFileReferenceFactory();
+
+                FileReference binaryRef = referenceFactory.fromFile(binary);
+                FileReference sourceRef = referenceFactory.fromFile(source);
+                FileReference javadocRef = referenceFactory.fromFile(javadoc);
+
+                final AbstractLibrary out = binaryRef.isRelativeToPathVariable() ? new Variable(binaryRef) : new Library(binaryRef);
+
+                out.setJavadocPath(javadocRef);
+                out.setSourcePath(sourceRef);
+                out.setExported(false);
+                out.setModuleVersion(id);
+
+                Collection<String> sourceSets = pathToSourceSets.get(binary.getAbsolutePath());
+                if (sourceSets != null) {
+                    out.getEntryAttributes().put(EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME, Joiner.on(',').join(sourceSets));
+                }
+
+                if (testDependency) {
+                    out.getEntryAttributes().put(EclipsePluginConstants.TEST_SOURCES_ATTRIBUTE_KEY, EclipsePluginConstants.TEST_SOURCES_ATTRIBUTE_VALUE);
+                }
 
             return out;
         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java
@@ -17,18 +17,22 @@
 package org.gradle.plugins.ide.eclipse.model.internal;
 
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.gradle.api.file.DirectoryTree;
+import org.gradle.api.file.FileCollection;
+import org.gradle.internal.metaobject.DynamicObjectUtil;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Pair;
-import org.gradle.internal.metaobject.DynamicObjectUtil;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
 import org.gradle.plugins.ide.eclipse.model.SourceFolder;
@@ -108,6 +112,7 @@ public class SourceFoldersCreator {
         ArrayList<SourceFolder> entries = Lists.newArrayList();
         List<SourceSet> sortedSourceSets = sortSourceSetsAsPerUsualConvention(sourceSets);
         Map<SourceSet, String> sourceSetOutputPaths = collectSourceSetOutputPaths(sortedSourceSets, defaultOutputPath);
+        Multimap<SourceSet, SourceSet> sourceSetUsages = getSourceSetUsages(sortedSourceSets);
         for (SourceSet sourceSet : sortedSourceSets) {
             List<DirectoryTree> sortedSourceDirs = sortSourceDirsAsPerUsualConvention(sourceSet.getAllSource().getSrcDirTrees());
             for (DirectoryTree tree : sortedSourceDirs) {
@@ -120,6 +125,7 @@ public class SourceFoldersCreator {
                     folder.setIncludes(getIncludesForTree(sourceSet, tree));
                     folder.setExcludes(getExcludesForTree(sourceSet, tree));
                     folder.setOutput(sourceSetOutputPaths.get(sourceSet));
+                    addScopeAttributes(folder, sourceSet, sourceSetUsages);
                     addSourceSetAttribute(folder);
                     entries.add(folder);
                 }
@@ -162,6 +168,53 @@ public class SourceFoldersCreator {
             trimmedSourceFolders.add(folder);
         }
         return trimmedSourceFolders;
+    }
+
+    private void addScopeAttributes(SourceFolder folder, SourceSet sourceSet, Multimap<SourceSet, SourceSet> sourceSetUsages) {
+        folder.getEntryAttributes().put(EclipsePluginConstants.GRADLE_SCOPE_ATTRIBUTE_NAME, sanitizeNameForAttribute(sourceSet));
+        folder.getEntryAttributes().put(EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME, Joiner.on(',').join(getUsingSourceSetNames(sourceSet, sourceSetUsages)));
+    }
+
+    private List<String> getUsingSourceSetNames(SourceSet sourceSet, Multimap<SourceSet, SourceSet> sourceSetUsages) {
+        Collection<SourceSet> usingSourceSets = sourceSetUsages.get(sourceSet);
+        List<String> usingSourceSetNames = Lists.newArrayList();
+        for (SourceSet usingSourceSet : usingSourceSets) {
+            usingSourceSetNames.add(sanitizeNameForAttribute(usingSourceSet));
+        }
+        return usingSourceSetNames;
+    }
+
+    private String sanitizeNameForAttribute(SourceSet sourceSet) {
+        return sourceSet.getName().replaceAll(",", "");
+    }
+
+    private Multimap<SourceSet, SourceSet> getSourceSetUsages(Iterable<SourceSet> sourceSets) {
+        Multimap<SourceSet, SourceSet> usages = LinkedHashMultimap.create();
+        for (SourceSet sourceSet : sourceSets) {
+            for (SourceSet otherSourceSet : sourceSets) {
+                if (containsOutputOf(sourceSet, otherSourceSet)) {
+                    usages.put(otherSourceSet, sourceSet);
+                }
+            }
+        }
+        return usages;
+    }
+
+    private boolean containsOutputOf(SourceSet sourceSet, SourceSet otherSourceSet) {
+        try {
+            return containsAll(sourceSet.getRuntimeClasspath(), otherSourceSet.getOutput());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean containsAll(FileCollection first, FileCollection second) {
+        for (File file : second) {
+            if (!first.contains(file)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void addSourceSetAttribute(SourceFolder folder) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -206,8 +206,8 @@ public class IdeDependencySet {
 
         private void visitArtifacts(IdeDependencyVisitor visitor) {
             for (ResolvedArtifactResult artifact : resolvedArtifacts.values()) {
+                ComponentIdentifier componentIdentifier = artifact.getId().getComponentIdentifier();
                 ComponentArtifactIdentifier artifactIdentifier = artifact.getId();
-                ComponentIdentifier componentIdentifier = artifactIdentifier.getComponentIdentifier();
                 if (componentIdentifier instanceof ProjectComponentIdentifier) {
                     visitor.visitProjectDependency(artifact);
                 } else if (componentIdentifier instanceof ModuleComponentIdentifier) {


### PR DESCRIPTION
Restore runtime classpath separation for previous Buildship releases

We introduced test sources feature for Buildship in commit
35f8114ecbf9f1112bdbdbd8522fc083db1ef742. This change, however,
removed the scope information from the classpath used by previous
Buildship releases. To restore backward compatibility, this commit
restores scope information in the Eclipse plugin.