### PR TITLE
Enable incremental compilation for Groovy

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -104,7 +104,6 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
             val availableJavaInstallations = rootProject.the<AvailableJavaInstallations>()
 
             tasks.withType<JavaCompile>().configureEach {
-                options.isIncremental = true
                 configureCompileTask(this, options, availableJavaInstallations)
             }
             tasks.withType<GroovyCompile>().configureEach {
@@ -119,6 +118,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
     fun configureCompileTask(compileTask: AbstractCompile, options: CompileOptions, availableJavaInstallations: AvailableJavaInstallations) {
         options.isFork = true
         options.encoding = "utf-8"
+        options.isIncremental = true
         options.compilerArgs = mutableListOf("-Xlint:-options", "-Xlint:-path")
         val jdkForCompilation = availableJavaInstallations.javaInstallationForCompilation
         if (!jdkForCompilation.current) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.6-20190624000056+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.6-20190627000039+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Context

In https://github.com/gradle/gradle/pull/9616 we did preliminary support for Groovy incremental compilation. This PR enables Groovy incremental compilation for Gradle build.