### PR TITLE
Remove messaging dependency in :build-cache

### DIFF
--- a/subprojects/build-cache/build-cache.gradle.kts
+++ b/subprojects/build-cache/build-cache.gradle.kts
@@ -24,7 +24,6 @@ plugins {
 dependencies {
     implementation(project(":baseServices"))
     implementation(project(":coreApi"))
-    implementation(project(":messaging"))
     implementation(project(":native"))
     implementation(project(":persistentCache"))
     implementation(project(":resources"))

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
@@ -49,6 +49,8 @@ public class OriginMetadataFactory {
     private final Consumer<Properties> additionalProperties;
     private final File rootDir;
 
+    private volatile String localHostName;
+
     public OriginMetadataFactory(File rootDir, String userName, String operatingSystem, String currentBuildInvocationId, Consumer<Properties> additionalProperties) {
         this.rootDir = rootDir;
         this.userName = userName;
@@ -77,12 +79,15 @@ public class OriginMetadataFactory {
         };
     }
 
-    private static String determineHostName() {
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            return "<unknown>";
+    private String determineHostName() {
+        if (localHostName == null) {
+            try {
+                localHostName = InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException e) {
+                localHostName = "<unknown>";
+            }
         }
+        return localHostName;
     }
 
     public OriginReader createReader(CacheableEntity entry) {

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
@@ -17,7 +17,6 @@
 package org.gradle.caching.internal.origin;
 
 import org.gradle.caching.internal.CacheableEntity;
-import org.gradle.internal.remote.internal.inet.InetAddressFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Properties;
 import java.util.function.Consumer;
 
@@ -42,15 +43,13 @@ public class OriginMetadataFactory {
     private static final String HOST_NAME_KEY = "hostName";
     private static final String USER_NAME_KEY = "userName";
 
-    private final InetAddressFactory inetAddressFactory;
     private final String userName;
     private final String operatingSystem;
     private final String currentBuildInvocationId;
     private final Consumer<Properties> additionalProperties;
     private final File rootDir;
 
-    public OriginMetadataFactory(InetAddressFactory inetAddressFactory, File rootDir, String userName, String operatingSystem, String currentBuildInvocationId, Consumer<Properties> additionalProperties) {
-        this.inetAddressFactory = inetAddressFactory;
+    public OriginMetadataFactory(File rootDir, String userName, String operatingSystem, String currentBuildInvocationId, Consumer<Properties> additionalProperties) {
         this.rootDir = rootDir;
         this.userName = userName;
         this.operatingSystem = operatingSystem;
@@ -70,12 +69,20 @@ public class OriginMetadataFactory {
                 properties.setProperty(EXECUTION_TIME_KEY, Long.toString(elapsedTime));
                 properties.setProperty(ROOT_PATH_KEY, rootDir.getAbsolutePath());
                 properties.setProperty(OPERATING_SYSTEM_KEY, operatingSystem);
-                properties.setProperty(HOST_NAME_KEY, inetAddressFactory.getHostname());
+                properties.setProperty(HOST_NAME_KEY, determineHostName());
                 properties.setProperty(USER_NAME_KEY, userName);
                 additionalProperties.accept(properties);
                 properties.store(outputStream, "Generated origin information");
             }
         };
+    }
+
+    private static String determineHostName() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return "<unknown>";
+        }
     }
 
     public OriginReader createReader(CacheableEntity entry) {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/origin/OriginMetadataFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/origin/OriginMetadataFactoryTest.groovy
@@ -17,18 +17,15 @@
 package org.gradle.caching.internal.origin
 
 import org.gradle.caching.internal.CacheableEntity
-import org.gradle.internal.remote.internal.inet.InetAddressFactory
 import spock.lang.Specification
 
 class OriginMetadataFactoryTest extends Specification {
     def entry = Mock(CacheableEntity)
-    def inetAddressFactory = Mock(InetAddressFactory)
     def rootDir = Mock(File)
     def buildInvocationId = UUID.randomUUID().toString()
-    def factory = new OriginMetadataFactory(inetAddressFactory, rootDir, "user", "os", buildInvocationId, { it.gradleVersion = "3.0" })
+    def factory = new OriginMetadataFactory(rootDir, "user", "os", buildInvocationId, { it.gradleVersion = "3.0" })
 
     def "converts to origin metadata"() {
-        inetAddressFactory.hostname >> "host"
         entry.identity >> "identity"
         rootDir.absolutePath >> "root"
         def origin = new Properties()
@@ -49,7 +46,7 @@ class OriginMetadataFactoryTest extends Specification {
         origin.executionTime == "10"
         origin.rootPath == "root"
         origin.operatingSystem == "os"
-        origin.hostName == "host"
+        origin.hostName == InetAddress.localHost.hostName
         origin.userName == "user"
         origin.buildInvocationId == buildInvocationId
     }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
@@ -37,7 +37,6 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.internal.remote.internal.inet.InetAddressFactory;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.FileSystemMirror;
@@ -61,13 +60,11 @@ public class BuildCacheServices {
     }
 
     OriginMetadataFactory createOriginMetadataFactory(
-        InetAddressFactory inetAddressFactory,
         GradleInternal gradleInternal,
         BuildInvocationScopeId buildInvocationScopeId
     ) {
         File rootDir = gradleInternal.getRootProject().getRootDir();
         return new OriginMetadataFactory(
-            inetAddressFactory,
             rootDir,
             SystemProperties.getInstance().getUserName(),
             OperatingSystem.current().getName(),


### PR DESCRIPTION
It's fine if we can't detect the hostname in problematic cases.