### PR TITLE
Enable Groovy compilation avoidance for Groovy template project

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -120,6 +120,9 @@ abstract class FileContentGenerator {
         compilerMemory=${config.compilerMemory}
         testRunnerMemory=${config.testRunnerMemory}
         testForkEvery=${config.testForkEvery}
+        ${->
+            config.systemProperties.entrySet().collect { "systemProp.${it.key}=${it.value}" }.join("\n")
+        }
         """
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProject.groovy
@@ -50,6 +50,7 @@ enum JavaTestProject {
         .withSubProjects(0)
         .withDaemonMemory('3g')
         .withCompilerMemory('6g')
+        .withSystemProperties(['org.gradle.groovy.compilation.avoidance': 'true'])
         .assembleChangeFile(-1)
         .testChangeFile(-1).create()),
     LARGE_GROOVY_MULTI_PROJECT(new TestProjectGeneratorConfigurationBuilder("largeGroovyMultiProject", Language.GROOVY)
@@ -57,6 +58,7 @@ enum JavaTestProject {
         .withSubProjects(500)
         .withDaemonMemory('1536m')
         .withCompilerMemory('256m')
+        .withSystemProperties(['org.gradle.groovy.compilation.avoidance': 'true'])
         .assembleChangeFile()
         .testChangeFile(450, 2250, 45000).create()),
     LARGE_JAVA_MULTI_PROJECT_NO_BUILD_SRC(

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
@@ -47,6 +47,7 @@ class TestProjectGeneratorConfiguration {
     String daemonMemory
     String compilerMemory
     String testRunnerMemory
+    Map<String, String> systemProperties
     boolean parallel
     int maxWorkers
     int maxParallelForks
@@ -82,6 +83,7 @@ class TestProjectGeneratorConfigurationBuilder {
         this.dsl = GradleDsl.GROOVY
         this.buildSrc = true
         this.fileToChangeByScenario = [:]
+        this.systemProperties = [:]
     }
 
     TestProjectGeneratorConfigurationBuilder assembleChangeFile(int project = 0, int pkg = 0, int file = 0) {
@@ -131,6 +133,7 @@ class TestProjectGeneratorConfigurationBuilder {
         config.compilerMemory = this.compilerMemory
         config.testRunnerMemory = '256m'
         config.parallel = this.subProjects > 0
+        config.systemProperties = this.systemProperties
 
         config.maxWorkers = 4
         config.maxParallelForks = this.subProjects > 0 ? 1 : 4

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
@@ -33,7 +33,6 @@ class JavaABIChangePerformanceTest extends AbstractCrossVersionPerformanceTest {
         given:
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
-        runner.args = ["-Dorg.gradle.groovy.compilation.avoidance=true"]
         runner.tasksToRun = ['assemble']
         runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
         runner.targetVersions = ["5.6-20190626000031+0000"]


### PR DESCRIPTION
### Context

This PR adds a "systemProperties" field to TestProjectGeneratorConfigurationBuilder
so that the system properties can be configured for performance template projects.

We also enable compilation avoidance for Groovy projects.