### PR TITLE
Change a few Groovy HTTP links in docs to HTTPS

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/LinkRenderer.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/LinkRenderer.java
@@ -102,7 +102,7 @@ public class LinkRenderer {
 
         if (className.startsWith("groovy.")) {
             Element linkElement = document.createElement("ulink");
-            linkElement.setAttribute("url", String.format("http://docs.groovy-lang.org/%s/html/gapi/%s.html", groovyVersion, className.replace(
+            linkElement.setAttribute("url", String.format("https://docs.groovy-lang.org/%s/html/gapi/%s.html", groovyVersion, className.replace(
                     ".", "/")));
             Element classNameElement = document.createElement("classname");
             classNameElement.appendChild(document.createTextNode(StringUtils.substringAfterLast(className, ".")));

--- a/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/docbook/LinkRendererTest.groovy
+++ b/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/docbook/LinkRendererTest.groovy
@@ -72,7 +72,7 @@ class LinkRendererTest extends XmlSpecification {
         def link = renderer.link(type('groovy.lang.Closure'), listener)
 
         then:
-        format(link) == '<ulink url="http://docs.groovy-lang.org/groovyVersion/html/gapi/groovy/lang/Closure.html"><classname>Closure</classname></ulink>'
+        format(link) == '<ulink url="https://docs.groovy-lang.org/groovyVersion/html/gapi/groovy/lang/Closure.html"><classname>Closure</classname></ulink>'
     }
 
     def rendersLinkToGroovyClassArray() {
@@ -80,7 +80,7 @@ class LinkRendererTest extends XmlSpecification {
         def link = renderer.link(type('groovy.lang.Closure', true), listener)
 
         then:
-        format(link) == '<classname><ulink url="http://docs.groovy-lang.org/groovyVersion/html/gapi/groovy/lang/Closure.html"><classname>Closure</classname></ulink>[]</classname>'
+        format(link) == '<classname><ulink url="https://docs.groovy-lang.org/groovyVersion/html/gapi/groovy/lang/Closure.html"><classname>Closure</classname></ulink>[]</classname>'
     }
 
     def rendersLinkToExternalClass() {

--- a/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/model/ReportNode.groovy
+++ b/subprojects/diagnostics/src/testFixtures/groovy/org/gradle/api/reporting/model/ReportNode.groovy
@@ -20,7 +20,7 @@ package org.gradle.api.reporting.model
  * Represents a node of a hierarchical report
  * Extends from groovy's {@code groovy.util.Node} and hence GPath expressions can be used to search and identify report nodes and values.
  *
- * See http://www.groovy-lang.org/processing-xml.html#_gpath
+ * See https://www.groovy-lang.org/processing-xml.html#_gpath
  *
  * E.g:
  * <pre>

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -295,7 +295,7 @@ def userguideSinglePage = tasks.register("userguideSinglePage", CacheableAsciido
 }
 
 def javaApiUrl = "https://docs.oracle.com/javase/8/docs/api"
-def groovyApiUrl = "http://docs.groovy-lang.org/docs/groovy-${groovyVersion}/html/gapi"
+def groovyApiUrl = "https://docs.groovy-lang.org/docs/groovy-${groovyVersion}/html/gapi"
 def mavenApiUrl = "https://maven.apache.org/ref/${libraries.maven3.version}/maven-model/apidocs"
 
 def javadocAll = tasks.register("javadocAll", Javadoc) {

--- a/subprojects/docs/src/docs/userguide/ant.adoc
+++ b/subprojects/docs/src/docs/userguide/ant.adoc
@@ -75,7 +75,7 @@ include::sample[dir="userguide/ant/useAntType/groovy",files="build.gradle"]
 include::sample[dir="userguide/ant/useAntType/kotlin",files="build.gradle.kts"]
 ====
 
-More information about `AntBuilder` can be found in 'Groovy in Action' 8.4 or at the http://groovy-lang.org/scripting-ant.html[Groovy Wiki].
+More information about `AntBuilder` can be found in 'Groovy in Action' 8.4 or at the https://groovy-lang.org/scripting-ant.html[Groovy Wiki].
 
 [[sec:using_custom_ant_tasks]]
 === Using custom Ant tasks in your build

--- a/subprojects/docs/src/docs/userguide/groovy_build_script_primer.adoc
+++ b/subprojects/docs/src/docs/userguide/groovy_build_script_primer.adoc
@@ -163,7 +163,7 @@ Both are based on Groovy language features and we explain them in the following 
 You can easily identify a method as the implementation behind a block by its signature, or more specifically, its argument types. If a method corresponds to a block:
 
  * It must have at least one argument.
- * The _last_ argument must be of type http://docs.groovy-lang.org/latest/html/gapi/groovy/lang/Closure.html[`groovy.lang.Closure`] or link:{javadocPath}/org/gradle/api/Action.html[org.gradle.api.Action].
+ * The _last_ argument must be of type https://docs.groovy-lang.org/latest/html/gapi/groovy/lang/Closure.html[`groovy.lang.Closure`] or link:{javadocPath}/org/gradle/api/Action.html[org.gradle.api.Action].
 
 For example, link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:copy(org.gradle.api.Action)[Project.copy(Action)] matches these requirements, so you can use the syntax:
 

--- a/subprojects/docs/src/docs/userguide/groovy_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/groovy_plugin.adoc
@@ -241,10 +241,10 @@ systemProp.org.gradle.groovy.compilation.avoidance=true
 If a dependent project has changed in an https://en.wikipedia.org/wiki/Application_binary_interface[ABI]-compatible way (only its private API has changed), then Groovy compilation tasks will be up-to-date.
 This means that if project `A` depends on project `B` and a class in `B` is changed in an ABI-compatible way (typically, changing only the body of a method), then Gradle won't recompile `A`.
 
-See <<java_plugin.adoc#sec:java_compile_avoidance,Java compile avoidance>> for a detailed list of the types of changes that do not affect the ABI and are ignored. 
+See <<java_plugin.adoc#sec:java_compile_avoidance,Java compile avoidance>> for a detailed list of the types of changes that do not affect the ABI and are ignored.
 
 However, similar to Java's annotation processing, there are various ways to https://melix.github.io/blog/2011/05/12/customizing_groovy_compilation_process.html[customize the Groovy compilation process], for which implementation details matter.
-Some well-known examples are http://groovy-lang.org/metaprogramming.html#_code_generation_transformations[Groovy AST transformations].
+Some well-known examples are https://groovy-lang.org/metaprogramming.html#_code_generation_transformations[Groovy AST transformations].
 In these cases, these dependencies must be declared separately in a classpath called `astTransformationClasspath`:
 
 .Declaring AST transformations

--- a/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
@@ -481,10 +481,10 @@ See the <<plugins#sec:plugin_management,Plugin Management>> section of the Gradl
 // [PL] It seems to me that this block of content should really be in a more generic part
 //      of the user manual as it discusses techniques that apply outside of the Kotlin DSL.
 //      In fact, it indicates missing content that this chapter should be able to link to.
-// 
+//
 // In the case of multi-project builds, this approach is similar to using a `buildscript {}` block in the root project build script to depend on third party plugins and then using `plugins {}` in your sub project build scripts to apply them.
 // The main difference is that this approach means that the root project can also benefit from the `plugins {}` block and it is more aligned with Gradle best practices.
-// 
+//
 // [PL] We should also aim to avoid temporary information in the user manual that could
 //      be out of date at any time.
 // The same approach can be used to resolve plugins from composite builds, which link:https://github.com/gradle/gradle/issues/2528[do not expose plugin markers] yet.
@@ -866,7 +866,7 @@ In addition, the Kotlin DSL provides several ways to opt into Groovy semantics, 
 
 === Static extensions
 
-Both the Groovy and Kotlin languages support extending existing classes via link:http://groovy-lang.org/metaprogramming.html#_extension_modules[Groovy Extension modules] and link:{kotlin-reference}extensions.html[Kotlin extensions].
+Both the Groovy and Kotlin languages support extending existing classes via link:https://groovy-lang.org/metaprogramming.html#_extension_modules[Groovy Extension modules] and link:{kotlin-reference}extensions.html[Kotlin extensions].
 
 To call a Kotlin extension function from Groovy, call it as a static function, passing the receiver as the first parameter:
 
@@ -889,7 +889,7 @@ include::sample[dir="kotlinDsl/interoperability/static-extensions",files="build.
 
 Both the Groovy and Kotlin languages support named function parameters and default arguments, although they are implemented very differently.
 Kotlin has fully-fledged support for both, as described in the Kotlin language reference under link:{kotlin-reference}functions.html#named-arguments[named arguments] and link:{kotlin-reference}functions.html#default-arguments[default arguments].
-Groovy implements link:http://groovy-lang.org/objectorientation.html#_named_arguments[named arguments] in a non-type-safe way based on a `Map<String, ?>` parameter, which means they cannot be combined with link:http://groovy-lang.org/objectorientation.html#_default_arguments[default arguments].
+Groovy implements link:https://groovy-lang.org/objectorientation.html#_named_arguments[named arguments] in a non-type-safe way based on a `Map<String, ?>` parameter, which means they cannot be combined with link:https://groovy-lang.org/objectorientation.html#_default_arguments[default arguments].
 In other words, you can only use one or the other in Groovy for any given method.
 
 ==== Calling Kotlin from Groovy
@@ -920,7 +920,7 @@ To call a Groovy function with default arguments from Kotlin, always pass values
 
 === Groovy closures from Kotlin
 
-You may sometimes have to call Groovy methods that take link:http://groovy-lang.org/closures.html[Closure] arguments from Kotlin code.
+You may sometimes have to call Groovy methods that take link:https://groovy-lang.org/closures.html[Closure] arguments from Kotlin code.
 For example, some third-party plugins written in Groovy expect closure arguments.
 
 [NOTE]
@@ -965,7 +965,7 @@ Also see the link:{kotlin-dsl-samples}groovy-interop[groovy-interop] sample.
 
 === The Kotlin DSL Groovy Builder
 
-If some plugin makes heavy use of link:http://groovy-lang.org/metaprogramming.html[Groovy metaprogramming], then using it from Kotlin or Java or any statically-compiled language can be very cumbersome.
+If some plugin makes heavy use of link:https://groovy-lang.org/metaprogramming.html[Groovy metaprogramming], then using it from Kotlin or Java or any statically-compiled language can be very cumbersome.
 
 The Kotlin DSL provides a `withGroovyBuilder {}` utility extension that attaches the Groovy metaprogramming semantics to objects of type `Any`.
 The following example demonstrates several features of the method on the object `target`:
@@ -974,7 +974,7 @@ The following example demonstrates several features of the method on the object 
 ====
 include::sample[dir="kotlinDsl/interoperability/groovy-builder",files="build.gradle.kts[tags=withGroovyBuilder]"]
 ====
-<1> The receiver is a link:http://docs.groovy-lang.org/latest/html/api/groovy/lang/GroovyObject.html[GroovyObject] and provides Kotlin helpers
+<1> The receiver is a link:https://docs.groovy-lang.org/latest/html/api/groovy/lang/GroovyObject.html[GroovyObject] and provides Kotlin helpers
 <2> The `GroovyObject` API is available
 <3> Invoke the `methodName` method, passing some parameters
 <4> Configure the `blockName` property, maps to a `Closure` taking method invocation

--- a/subprojects/docs/src/docs/userguide/migrating_from_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/migrating_from_maven.adoc
@@ -157,7 +157,7 @@ You'll find that the new Gradle build includes the following:
  * All the custom repositories that are specified in the POM
  * Your external and inter-project dependencies
  * The appropriate plugins to build the project (limited to one or more of the <<publishing_maven,Maven Publish>>, <<java_plugin,Java>> and <<war_plugin,War>> Plugins)
- 
+
 See the <<build_init_plugin#sec:pom_maven_conversion_,Build Init Plugin chapter>> for a complete list of the automatic conversion features.
 
 One thing to bear in mind is that assemblies are not automatically converted.
@@ -333,7 +333,7 @@ If you're more interested in controlling which version of a dependency is actual
 [[migmvn:optional_deps]]
 === Handling optional dependencies
 
-You are likely to encounter two situations regarding optional dependencies: 
+You are likely to encounter two situations regarding optional dependencies:
 
  * Some of your transitive dependencies are declared as optional
  * You want to declare some of your direct dependencies as optional in your project's published POM
@@ -483,7 +483,7 @@ The Java plugin for Gradle provides a `processResources` task to do the same thi
 This is a link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[Copy] task that copies files from the configured resources directory -- `src/main/resources` by default -- to an output directory.
 And as with any `Copy` task, you can configure it to perform <<working_with_files#filtering_files,file filtering>>, <<working_with_files#sec:renaming_files,renaming>>, and <<working_with_files#sec:filtering_files,content filtering>>.
 
-As an example, here's a configuration that treats the source files as http://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html#_simpletemplateengine[Groovy `SimpleTemplateEngine`] templates, providing `version` and `buildNumber` properties to those templates:
+As an example, here's a configuration that treats the source files as https://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html#_simpletemplateengine[Groovy `SimpleTemplateEngine`] templates, providing `version` and `buildNumber` properties to those templates:
 
 .Filtering the content of resources via the `processResources` task
 ====

--- a/subprojects/docs/src/docs/userguide/plugin_reference.adoc
+++ b/subprojects/docs/src/docs/userguide/plugin_reference.adoc
@@ -29,7 +29,7 @@ Provides support for building a Java library.
 Provides support for building a Java platform.
 
 <<groovy_plugin.adoc#,Groovy>>::
-Provides support for building any type of http://groovy-lang.org/[Groovy] project.
+Provides support for building any type of https://groovy-lang.org/[Groovy] project.
 
 <<scala_plugin.adoc#,Scala>>::
 Provides support for building any type of https://www.scala-lang.org/[Scala] project.

--- a/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
@@ -220,7 +220,7 @@ Use the link:{javadocPath}/org/gradle/api/provider/Property.html#set-T-[Property
 
  * You can no longer use GPath syntax with link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#withType-java.lang.Class-[tasks.withType()].
 +
-Use http://docs.groovy-lang.org/latest/html/documentation/#_spread_operator[Groovy's spread operator] instead. For example, you would replace `tasks.withType(JavaCompile).name` with `tasks.withType(JavaCompile)*.name`.
+Use https://docs.groovy-lang.org/latest/html/documentation/#_spread_operator[Groovy's spread operator] instead. For example, you would replace `tasks.withType(JavaCompile).name` with `tasks.withType(JavaCompile)*.name`.
 
 [[changes_4.8]]
 == Upgrading from 4.7 and earlier
@@ -407,7 +407,7 @@ We recommend configuring a ruleset explicitly, though.
 === [5.0] Library upgrades
 Several libraries that are used by Gradle have been upgraded:
 
- * Groovy was upgraded from 2.4.15 to http://groovy-lang.org/releasenotes/groovy-2.5.html[2.5.4].
+ * Groovy was upgraded from 2.4.15 to https://groovy-lang.org/releasenotes/groovy-2.5.html[2.5.4].
  * Ant has been upgraded from 1.9.11 to https://archive.apache.org/dist/ant/RELEASE-NOTES-1.9.13.html[1.9.13].
  * The AWS SDK used to access S3-backed Maven/Ivy repositories has been upgraded from 1.11.267 to https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111407-2018-09-11[1.11.407].
  * The BND library used by the OSGi Plugin has been upgraded from 3.4.0 to https://github.com/bndtools/bnd/wiki/Changes-in-4.0.0[4.0.0].

--- a/subprojects/docs/src/docs/userguide/userguide.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide.adoc
@@ -14,7 +14,7 @@
 
 = Gradle User Manual
 
-Gradle is an open-source build automation tool focused on flexibility and performance. Gradle build scripts are written using a link:http://groovy-lang.org/[Groovy] or link:https://kotlinlang.org/[Kotlin] DSL. Read about link:{website}/features/[Gradle features] to learn what is possible with Gradle.
+Gradle is an open-source build automation tool focused on flexibility and performance. Gradle build scripts are written using a link:https://groovy-lang.org/[Groovy] or link:https://kotlinlang.org/[Kotlin] DSL. Read about link:{website}/features/[Gradle features] to learn what is possible with Gradle.
 
  * **Highly customizable** — Gradle is modeled in a way that is customizable and extensible in the most fundamental ways.
  * **Fast** — Gradle completes tasks quickly by reusing outputs from previous executions, processing only inputs that changed, and executing tasks in parallel.
@@ -63,4 +63,4 @@ link:https://scans.gradle.com/[Gradle build scans] help you understand build res
 
 [.legalnotice]
 Gradle build tool source code is open and licensed under the link:https://github.com/gradle/gradle/blob/master/LICENSE[Apache License 2.0].
-Gradle user manual and DSL references are licensed under link:http://creativecommons.org/licenses/by-nc-sa/4.0/[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License].
+Gradle user manual and DSL references are licensed under link:https://creativecommons.org/licenses/by-nc-sa/4.0/[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License].

--- a/subprojects/docs/src/docs/userguide/working_with_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/working_with_dependencies.adoc
@@ -65,7 +65,7 @@ As part of the dependency resolution process, Gradle downloads the metadata file
 
 The artifact query API provides access to the raw files of a module. Currently, it allows getting a handle to the metadata file and some selected, additional artifacts (e.g. a JVM-based module's source and Javadoc files). The main API entry point is link:{groovyDslPath}/org.gradle.api.artifacts.query.ArtifactResolutionQuery.html[ArtifactResolutionQuery].
 
-Let's say you wanted to post-process the metadata file of a Maven module. The group, name and version of the module component serve as input to the artifact resolution query. After executing the query, you get a handle to all components that match the criteria and their underlying files. Additionally, it's very easy to post-process the metadata file. The example code uses Groovy's link:http://docs.groovy-lang.org/latest/html/api/groovy/util/XmlSlurper.html[XmlSlurper] to ask for POM element values.
+Let's say you wanted to post-process the metadata file of a Maven module. The group, name and version of the module component serve as input to the artifact resolution query. After executing the query, you get a handle to all components that match the criteria and their underlying files. Additionally, it's very easy to post-process the metadata file. The example code uses Groovy's link:https://docs.groovy-lang.org/latest/html/api/groovy/util/XmlSlurper.html[XmlSlurper] to ask for POM element values.
 
 .Accessing a Maven module's metadata artifact
 

--- a/subprojects/docs/src/docs/userguide/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/working_with_files.adoc
@@ -633,7 +633,7 @@ The `filter()` method has two variants, which behave differently:
 
 Note that both variants assume the source files are text based. When you use the `ReplaceTokens` class with `filter()`, the result is a template engine that replaces tokens of the form `@tokenName@` (the Ant-style token) with values that you define.
 
-The `expand()` method treats the source files as http://docs.groovy-lang.org/latest/html/api/groovy/text/SimpleTemplateEngine.html[Groovy templates], which evaluate and expand expressions of the form `${expression}`. You can pass in property names and values that are then expanded in the source files. `expand()` allows for more than basic token substitution as the embedded expressions are full-blown Groovy expressions.
+The `expand()` method treats the source files as https://docs.groovy-lang.org/latest/html/api/groovy/text/SimpleTemplateEngine.html[Groovy templates], which evaluate and expand expressions of the form `${expression}`. You can pass in property names and values that are then expanded in the source files. `expand()` allows for more than basic token substitution as the embedded expressions are full-blown Groovy expressions.
 
 NOTE: It's good practice to specify the character set when reading and writing the file, otherwise the transformations won't work properly for non-ASCII text. You configure the character set with the link:{javadocPath}/org/gradle/api/file/CopySpec.html#getFilteringCharset--[CopySpec.getFilteringCharset()] property. If it's not specified, the JVM default character set is used, which is likely to be different from the one you want.
 

--- a/subprojects/docs/src/docs/userguide/writing_build_scripts.adoc
+++ b/subprojects/docs/src/docs/userguide/writing_build_scripts.adoc
@@ -205,7 +205,7 @@ include::{samplesPath}/userguide/tutorial/configureObjectUsingScript/configureOb
 [TIP]
 Looking for some Kotlin basics, the link:https://kotlinlang.org/docs/reference/[Kotlin reference documentation] and link:https://kotlinlang.org/docs/tutorials/koans.html[Kotlin Koans] should be useful to you.
 
-The http://docs.groovy-lang.org/latest/html/documentation/index.html[Groovy language] provides plenty of features for creating DSLs, and the Gradle build language takes advantage of these. Understanding how the build language works will help you when you write your build script, and in particular, when you start to write custom plugins and tasks.
+The https://docs.groovy-lang.org/latest/html/documentation/index.html[Groovy language] provides plenty of features for creating DSLs, and the Gradle build language takes advantage of these. Understanding how the build language works will help you when you write your build script, and in particular, when you start to write custom plugins and tasks.
 
 
 [[sec:groovy_jdk]]
@@ -218,7 +218,7 @@ Groovy adds lots of useful methods to the standard Java classes. For example, `I
 include::sample[dir="userguide/tutorial/groovy",files="build.gradle[tags=groovyJdk]"]
 ====
 
-Have a look at http://groovy-lang.org/gdk.html[] for more details.
+Have a look at https://groovy-lang.org/gdk.html[] for more details.
 
 [[sec:property_accessors]]
 === Property accessors
@@ -255,7 +255,7 @@ include::sample[dir="userguide/tutorial/groovy",files="build.gradle[tags=listAnd
 [[sec:closures_as_the_last_parameter_in_a_method]]
 === Closures as the last parameter in a method
 
-The Gradle DSL uses closures in many places. You can find out more about closures http://docs.groovy-lang.org/latest/html/documentation/index.html#_closures[here]. When the last parameter of a method is a closure, you can place the closure after the method call:
+The Gradle DSL uses closures in many places. You can find out more about closures https://docs.groovy-lang.org/latest/html/documentation/index.html#_closures[here]. When the last parameter of a method is a closure, you can place the closure after the method call:
 
 .Closure as method parameter
 ====

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompileOptions.java
@@ -145,8 +145,8 @@ public class GroovyCompileOptions extends AbstractOptions {
      * The script is executed as Groovy code, with the following context:
      * </p>
      * <ul>
-     * <li>The instance of <a href="http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/CompilerConfiguration.html">CompilerConfiguration</a> available as the {@code configuration} variable.</li>
-     * <li>All static members of <a href="http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/customizers/builder/CompilerCustomizationBuilder.html">CompilerCustomizationBuilder</a> pre imported.</li>
+     * <li>The instance of <a href="https://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/CompilerConfiguration.html">CompilerConfiguration</a> available as the {@code configuration} variable.</li>
+     * <li>All static members of <a href="https://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/customizers/builder/CompilerCustomizationBuilder.html">CompilerCustomizationBuilder</a> pre imported.</li>
      * </ul>
      * <p>
      * This facilitates the following pattern:
@@ -167,14 +167,14 @@ public class GroovyCompileOptions extends AbstractOptions {
      * }
      * </pre>
      * <p>
-     * Please see <a href="http://docs.groovy-lang.org/latest/html/documentation/#compilation-customizers">the Groovy compiler customization builder documentation</a>
+     * Please see <a href="https://docs.groovy-lang.org/latest/html/documentation/#compilation-customizers">the Groovy compiler customization builder documentation</a>
      * for more information about the compiler configuration DSL.
      * </p>
      * <p>
      * <b>This feature is only available if compiling with Groovy 2.1 or later.</b>
      * </p>
-     * @see <a href="http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/CompilerConfiguration.html">CompilerConfiguration</a>
-     * @see <a href="http://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/customizers/builder/CompilerCustomizationBuilder.html">CompilerCustomizationBuilder</a>
+     * @see <a href="https://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/CompilerConfiguration.html">CompilerConfiguration</a>
+     * @see <a href="https://docs.groovy-lang.org/latest/html/gapi/org/codehaus/groovy/control/customizers/builder/CompilerCustomizationBuilder.html">CompilerCustomizationBuilder</a>
      */
     @Nullable
     @Optional

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/application/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/application/CreateStartScripts.java
@@ -57,7 +57,7 @@ package org.gradle.api.tasks.application;
  * The default generators are of the type {@link org.gradle.jvm.application.scripts.TemplateBasedScriptGenerator}, with default templates.
  * This templates can be changed via the {@link org.gradle.jvm.application.scripts.TemplateBasedScriptGenerator#setTemplate(org.gradle.api.resources.TextResource)} method.
  * <p>
- * The default implementations used by this task use <a href="http://docs.groovy-lang.org/latest/html/documentation/template-engines.html#_simpletemplateengine">Groovy's SimpleTemplateEngine</a>
+ * The default implementations used by this task use <a href="https://docs.groovy-lang.org/latest/html/documentation/template-engines.html#_simpletemplateengine">Groovy's SimpleTemplateEngine</a>
  * to parse the template, with the following variables available:
  * <ul>
  * <li>{@code applicationName}</li>

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -79,7 +79,7 @@ import java.util.Collections;
  * The default generators are of the type {@link org.gradle.jvm.application.scripts.TemplateBasedScriptGenerator}, with default templates.
  * This templates can be changed via the {@link org.gradle.jvm.application.scripts.TemplateBasedScriptGenerator#setTemplate(org.gradle.api.resources.TextResource)} method.
  * <p>
- * The default implementations used by this task use <a href="http://docs.groovy-lang.org/latest/html/documentation/template-engines.html#_simpletemplateengine">Groovy's SimpleTemplateEngine</a>
+ * The default implementations used by this task use <a href="https://docs.groovy-lang.org/latest/html/documentation/template-engines.html#_simpletemplateengine">Groovy's SimpleTemplateEngine</a>
  * to parse the template, with the following variables available:
  *
  * <ul>


### PR DESCRIPTION
Saw some warnings from link checker after todays' release for a few HTTP urls on the main documentation page, thought I'll address this.
cc: @JLLeitschuh, @lacasseio 