### PR TITLE
Allow property replacement in version strings in the `plugins` block

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/plugin/use/PluginDependenciesSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/plugin/use/PluginDependenciesSpec.java
@@ -33,6 +33,7 @@ package org.gradle.plugin.use;
  * <p>
  * When used in a build script, the <code>plugins {}</code> block only allows a strict subset of the full build script programming language.
  * Only the API of this type can be used, and values must be literal (e.g. constant strings, not variables).
+ * Interpolated strings are permitted for {@link PluginDependencySpec#version(String)}, however replacement values must be sourced from Gradle properties.
  * Moreover, the <code>plugins {}</code> block must be the first code of a build script.
  * There is one exception to this, in that the {@code buildscript {}} block (used for declaring script dependencies) must precede it.
  * </p>

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginUseScriptBlockMetadataCompiler.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginUseScriptBlockMetadataCompiler.java
@@ -20,7 +20,9 @@ import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.GStringExpression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
@@ -35,7 +37,8 @@ import static org.gradle.groovy.scripts.internal.AstUtils.isOfType;
 public class PluginUseScriptBlockMetadataCompiler {
 
     public static final String NEED_SINGLE_BOOLEAN = "argument list must be exactly 1 literal boolean";
-    public static final String NEED_SINGLE_STRING = "argument list must be exactly 1 literal string";
+    public static final String NEED_LITERAL_STRING = "argument list must be exactly 1 literal String or String with property replacement";
+    public static final String NEED_INTERPOLATED_STRING = "argument list must be exactly 1 literal String or String with property replacement";
     public static final String BASE_MESSAGE = "only id(String) method calls allowed in plugins {} script block";
     public static final String EXTENDED_MESSAGE = "only version(String) and apply(boolean) method calls allowed in plugins {} script block";
     private static final String NOT_LITERAL_METHOD_NAME = "method name must be literal (i.e. not a variable)";
@@ -75,26 +78,28 @@ public class PluginUseScriptBlockMetadataCompiler {
                     ConstantExpression methodName = (ConstantExpression) call.getMethod();
                     if (isOfType(methodName, String.class)) {
                         String methodNameText = methodName.getText();
-                        if (methodNameText.equals("id") || methodNameText.equals("version")) {
+                        if (methodNameText.equals("id")) {
                             ConstantExpression argumentExpression = hasSingleConstantArgOfType(call, String.class);
                             if (argumentExpression == null) {
-                                restrict(call, formatErrorMessage(NEED_SINGLE_STRING));
+                                restrict(call, formatErrorMessage(NEED_LITERAL_STRING));
                                 return;
                             }
 
-                            if (methodName.getText().equals("id")) {
-                                if (!call.isImplicitThis()) {
-                                    restrict(call, formatErrorMessage(BASE_MESSAGE));
-                                } else {
-                                    ConstantExpression lineNumberExpression = new ConstantExpression(call.getLineNumber(), true);
-                                    call.setArguments(new ArgumentListExpression(argumentExpression, lineNumberExpression));
-                                }
+                            if (!call.isImplicitThis()) {
+                                restrict(call, formatErrorMessage(BASE_MESSAGE));
+                            } else {
+                                ConstantExpression lineNumberExpression = new ConstantExpression(call.getLineNumber(), true);
+                                call.setArguments(new ArgumentListExpression(argumentExpression, lineNumberExpression));
                             }
 
-                            if (methodName.getText().equals("version")) {
-                                if (call.isImplicitThis()) {
-                                    restrict(call, formatErrorMessage(BASE_MESSAGE));
-                                }
+                        } else if (methodNameText.equals("version")) {
+                            if (!hasSimpleInterpolatedStringType(call)) {
+                                restrict(call, formatErrorMessage(NEED_INTERPOLATED_STRING));
+                                return;
+                            }
+
+                            if (call.isImplicitThis()) {
+                                restrict(call, formatErrorMessage(BASE_MESSAGE));
                             }
                         } else if (methodNameText.equals("apply")) {
                             ConstantExpression arguments = hasSingleConstantArgOfType(call, boolean.class);
@@ -123,6 +128,33 @@ public class PluginUseScriptBlockMetadataCompiler {
                 statement.getExpression().visit(this);
             }
         });
+    }
+
+    /**
+     * Checks if this method has a single argument that is either:
+     * a) A constant String expression
+     * b) A GString expression containing only variable expressions
+     */
+    private static boolean hasSimpleInterpolatedStringType(MethodCallExpression call) {
+        if (hasSingleConstantArgOfType(call, String.class) != null) {
+            return true;
+        }
+
+        ArgumentListExpression argumentList = (ArgumentListExpression) call.getArguments();
+        if (argumentList.getExpressions().size() == 1) {
+            Expression argumentExpression = argumentList.getExpressions().get(0);
+            if (argumentExpression instanceof GStringExpression) {
+                GStringExpression gStringExpression = (GStringExpression) argumentExpression;
+                for (Expression value : gStringExpression.getValues()) {
+                    if (!(value instanceof VariableExpression)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+        return false;
     }
 
     public String formatErrorMessage(String message) {

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
@@ -186,14 +186,15 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         2          | "def a = null"                         | BASE_MESSAGE
         2          | "def a = id('foo')"                    | BASE_MESSAGE
         2          | "delegate.id('a')"                     | BASE_MESSAGE
-        2          | "id()"                                 | NEED_SINGLE_STRING
-        2          | "id(1)"                                | NEED_SINGLE_STRING
-        2          | "id(System.getProperty('foo'))"        | NEED_SINGLE_STRING
-        2          | "id('a' + 'b')"                        | NEED_SINGLE_STRING
-        2          | "id(\"\${'foo'}\")"                    | NEED_SINGLE_STRING
+        2          | "id()"                                 | NEED_LITERAL_STRING
+        2          | "id(1)"                                | NEED_LITERAL_STRING
+        2          | "id(System.getProperty('foo'))"        | NEED_LITERAL_STRING
+        2          | "id('a' + 'b')"                        | NEED_LITERAL_STRING
+        2          | "id(\"\${'foo'}\")"                    | NEED_LITERAL_STRING
         2          | "version('foo')"                       | BASE_MESSAGE
-        2          | "id('foo').version(1)"                 | NEED_SINGLE_STRING
-        2          | "id 'foo' version 1"                   | NEED_SINGLE_STRING
+        2          | "id('foo').version(1)"                 | NEED_INTERPOLATED_STRING
+        2          | "id 'foo' version 1"                   | NEED_INTERPOLATED_STRING
+        2          | "id 'foo' version \"\${foo.bar}\""     | NEED_INTERPOLATED_STRING
         2          | "id 'foo' bah '1'"                     | EXTENDED_MESSAGE
         2          | "foo 'foo' version '1'"                | BASE_MESSAGE
         3          | "id('foo')\nfoo 'bar'"                 | BASE_MESSAGE
@@ -202,8 +203,8 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         2          | "apply false"                          | BASE_MESSAGE
         2          | "id 'foo' apply"                       | BASE_MESSAGE
         2          | "id 'foo' apply('foo')"                | NEED_SINGLE_BOOLEAN
-        2          | "id null"                              | NEED_SINGLE_STRING
-        2          | "id 'foo' version null"                | NEED_SINGLE_STRING
+        2          | "id null"                              | NEED_LITERAL_STRING
+        2          | "id 'foo' version null"                | NEED_INTERPOLATED_STRING
         2          | "file('foo')" /* script api */         | BASE_MESSAGE
         2          | "getVersion()" /* script target api */ | BASE_MESSAGE
     }
@@ -258,4 +259,43 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         2          | "id 'foo..bar'"                        | DOUBLE_SEPARATOR
         2          | "id 'foo' version ''"                  | EMPTY_VALUE
     }
+
+    def "can interpolate properties in plugins block"() {
+        when:
+        file("gradle.properties") << """
+    foo = 333
+    bar = 444
+    foo.bar = 555
+"""
+        buildScript("""plugins {\n$code\n}""")
+
+        then:
+        succeeds "help"
+
+        where:
+        code << [
+                'id("noop").version("${foo}")',
+                'id("noop").version("0.${foo}")',
+                'id("noop").version("${foo}.0")',
+                'id("noop").version("0.${foo}.1")',
+        ]
+    }
+
+    def "fails to interpolate unknown property in plugins block"() {
+        when:
+        buildScript("""plugins {\n$code\n}""")
+
+        then:
+        fails "help"
+        failure.assertHasLineNumber lineNumber
+        failure.assertHasFileName("Build file '${buildFile}'")
+        failure.assertThatCause(containsString(msg))
+
+        where:
+        lineNumber | code                                         | msg
+        2          | 'id("noop").version("${unknown}")'           | "Could not get unknown property 'unknown'"
+        2          | 'id("noop").version("part-${unknown}-part")' | "Could not get unknown property 'unknown'"
+    }
+
+
 }

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/VersionedPluginUseIntegrationTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/VersionedPluginUseIntegrationTest.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugin.use
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.plugin.PluginBuilder
+import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
+import org.junit.Rule
+
+class VersionedPluginUseIntegrationTest extends AbstractIntegrationSpec {
+
+    public static final String PLUGIN_ID = "org.myplugin"
+    public static final String GROUP = "my"
+    public static final String ARTIFACT = "plugin"
+
+    def pluginBuilder = new PluginBuilder(file(ARTIFACT))
+
+    @Rule
+    MavenHttpPluginRepository pluginRepo = MavenHttpPluginRepository.asGradlePluginPortal(executer, mavenRepo)
+
+    def setup() {
+        publishPlugin("1.0")
+        publishPlugin("2.0")
+    }
+
+    def "can specify plugin version"() {
+        when:
+        buildScript "plugins { id '$PLUGIN_ID' version '1.0' }"
+
+        then:
+        verifyPluginApplied('1.0')
+    }
+
+    def "can specify plugin version using gradle properties"() {
+        when:
+        file("gradle.properties") << "myPluginVersion=2.0"
+        buildScript """
+            plugins {
+                id '$PLUGIN_ID' version "\${myPluginVersion}"
+            }
+"""
+
+        then:
+        verifyPluginApplied('2.0')
+    }
+
+    def "can specify plugin version using command-line project property"() {
+        when:
+        buildScript """
+            plugins {
+                id '$PLUGIN_ID' version "\${myPluginVersion}"
+            }
+"""
+
+        args("-PmyPluginVersion=2.0")
+        then:
+
+        verifyPluginApplied('2.0')
+    }
+
+    def "can specify plugin version using buildSrc"() {
+        when:
+        file("buildSrc/src/main/java/MyVersions.java") << """
+            public class MyVersions {
+                public static final String MY_PLUGIN_VERSION = "2.0";
+            }
+"""
+        buildScript """
+            import static MyVersions.*
+            plugins {
+                id '$PLUGIN_ID' version "\${MY_PLUGIN_VERSION}"
+            }
+"""
+        then:
+
+        verifyPluginApplied('2.0')
+    }
+
+    def "can specify plugin version using buildSrc constant"() {
+        when:
+        file("buildSrc/src/main/java/MyVersions.java") << """
+            public class MyVersions {
+                public static final String MY_PLUGIN_VERSION = "2.0";
+            }
+"""
+        buildScript """
+            import static MyVersions.*
+            plugins {
+                id '$PLUGIN_ID' version "\${MY_PLUGIN_VERSION}"
+            }
+"""
+        then:
+        verifyPluginApplied('2.0')
+    }
+
+    def "can use different plugin versions in sibling projects"() {
+        when:
+        settingsFile << "include 'p1', 'p2'"
+
+        file("p1/build.gradle") << """
+            plugins { 
+                id '$PLUGIN_ID' version '1.0'
+            }
+            ${verifyPluginTask('1.0')}
+"""
+        file("p2/build.gradle") << """
+            plugins { 
+                id '$PLUGIN_ID' version '2.0'
+            }
+            ${verifyPluginTask('2.0')}
+"""
+
+        then:
+        succeeds "verify"
+    }
+
+    def verifyPluginApplied(String version) {
+        buildFile << verifyPluginTask(version)
+        succeeds "verify"
+    }
+
+    def verifyPluginTask(String version) {
+        """
+            task verify {
+                doLast {
+                    assert project.pluginVersion == "$version"
+                }
+            }
+"""
+    }
+
+    void publishPlugin(String version) {
+        publishPlugin("project.ext.pluginVersion = '$version'", version)
+    }
+
+    void publishPlugin(String impl, String version) {
+        pluginBuilder.addPlugin(impl, PLUGIN_ID, "TestPlugin${version.replace('.', '_')}")
+        pluginBuilder.publishAs(GROUP, ARTIFACT, version, pluginRepo, executer).allowAll()
+    }
+}


### PR DESCRIPTION
Fixes #1697 (currently most 👍 for Gradle Build Tool)

There remain some limitations in the implementation.

- Property replacement is not supported for Kotlin DSL: the project properties are not in scope when invoking the `plugins` block.
- The Groovy DSL leaks the (not-yet-initialized) `Project` instance into the `plugins` block. This is mitigated by:
    - the version syntax [is still heavily constrained](https://github.com/gradle/gradle/blob/cab5e05d702e995a33fa85ad3421f840d23c7ced/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginUseScriptBlockMetadataCompiler.java#L133-L158)
    - the same project instance leaks into the `buildscript` block