### PR TITLE
WIP #9832 Lazy task configuration by type

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
@@ -269,6 +269,28 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
     <S extends T> NamedDomainObjectProvider<S> named(String name, Class<S> type, Action<? super S> configurationAction) throws UnknownDomainObjectException;
 
     /**
+     * Configures all objects in this collection that match or will match the given type.
+     *
+     * Applies to already known, realized task, pending tasks and tasks that are added later.
+     *
+     * @param type The type of objects to find.
+     * @param configureAction The action to execute for each object that matches the type, if the object is or will be realized.
+     * @since 5.6
+     */
+    <S extends T> void typed(Class<S> type, Action<? super S> configureAction);
+
+    /**
+     * Configures all objects in this collection that match or will match the given type.
+     *
+     * Applies to already known, realized task, pending tasks and tasks that are added later.
+     *
+     * @param type The type of objects to find.
+     * @param configureClosure The closure to execute for each object that matches the type, if the object is or will be realized.
+     * @since 5.6
+     */
+    <S extends T> void typed(Class<S> type, Closure configureClosure);
+
+    /**
      * Provides access to the schema of all created or registered named domain objects in this collection.
      *
      * @since 4.10

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
@@ -60,6 +60,10 @@ public interface TaskCollection<T extends Task> extends NamedDomainObjectSet<T> 
     @Override
     <S extends T> TaskCollection<S> withType(Class<S> type);
 
+    <S extends T> void typed(Class<S> type, Action<? super S> configureAction);
+
+    <S extends T> void typed(Class<S> type, Closure configureClosure);
+
     /**
      * Adds an {@code Action} to be executed when a task is added to this collection.
      * <p>

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
@@ -140,6 +140,16 @@ public class TypedDomainObjectContainerWrapper<U> implements NamedDomainObjectCo
     }
 
     @Override
+    public <S extends U> void typed(Class<S> type, Action<? super S> configureAction) {
+        delegate.typed(type, configureAction);
+    }
+
+    @Override
+    public <S extends U> void typed(Class<S> type, Closure configureClosure) {
+        delegate.typed(type, configureClosure);
+    }
+
+    @Override
     public boolean add(U e) {
         return delegate.add(e);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultRealizableTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultRealizableTaskCollection.java
@@ -110,6 +110,16 @@ public class DefaultRealizableTaskCollection<T extends Task> implements TaskColl
     }
 
     @Override
+    public <S extends T> void typed(Class<S> type, Closure configureClosure) {
+        delegate.typed(type, configureClosure);
+    }
+
+    @Override
+    public <S extends T> void typed(Class<S> type, Action<? super S> configureAction) {
+        delegate.typed(type, configureAction);
+    }
+
+    @Override
     public Action<? super T> whenTaskAdded(Action<? super T> action) {
         return delegate.whenTaskAdded(action);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -45,7 +45,7 @@ import static org.gradle.api.reflect.TypeOf.typeOf;
 public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObjectSet<T> implements TaskCollection<T> {
     private static final Task.Namer NAMER = new Task.Namer();
 
-    protected final ProjectInternal project;
+    public final ProjectInternal project;
 
     private final MutationGuard parentMutationGuard;
 
@@ -124,6 +124,16 @@ public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObj
     @Override
     public <S extends T> TaskProvider<S> named(String name, Class<S> type, Action<? super S> configurationAction) throws UnknownTaskException {
         return (TaskProvider<S>) super.named(name, type, configurationAction);
+    }
+
+    @Override
+    public <S extends T> void typed(Class<S> type, Closure configureClosure) {
+        super.typed(type, configureClosure);
+    }
+
+    @Override
+    public <S extends T> void typed(Class<S> type, Action<? super S> configureAction) {
+        super.typed(type, configureAction);
     }
 
     @Override

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/NamedDomainObjectContainerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/NamedDomainObjectContainerDelegate.kt
@@ -172,6 +172,12 @@ abstract class NamedDomainObjectContainerDelegate<T> : NamedDomainObjectContaine
     override fun <S : T> withType(type: Class<S>, configureAction: Action<in S>): DomainObjectCollection<S> =
         delegate.withType(type, configureAction)
 
+    override fun <S : T> typed(type: Class<S>, configureClosure: Closure<Any>) =
+        delegate.typed(type, configureClosure)
+
+    override fun <S : T> typed(type: Class<S>, configureAction: Action<in S>) =
+        delegate.typed(type, configureAction)
+
     override fun findByName(name: String): T? =
         delegate.findByName(name)
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/TaskContainerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/TaskContainerDelegate.kt
@@ -216,6 +216,12 @@ abstract class TaskContainerDelegate : TaskContainer {
     override fun <S : Task> withType(type: Class<S>, configureClosure: Closure<Any>): DomainObjectCollection<S> =
         delegate.withType(type, configureClosure)
 
+    override fun <S : Task> typed(type: Class<S>, configureAction: Action<in S>) =
+        delegate.typed(type, configureAction)
+
+    override fun <S : Task> typed(type: Class<S>, configureClosure: Closure<Any>) =
+        delegate.typed(type, configureClosure)
+
     override fun findByName(name: String): Task? =
         delegate.findByName(name)
 


### PR DESCRIPTION
Fixes #9832

Allows lazy configuration of tasks filtered by its type. Applies to tasks that are already realized, "pending" and to tasks that will be added later.

This is a replacement for `tasks.withType(...)` for proper 'task configuration avoidance'.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
