### PR TITLE
Fail on deprecation warning

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -155,6 +155,10 @@ On case-insensitive file systems (e.g. NTFS and APFS), a file/folder rename wher
 For example, renaming an input of a `Copy` task called `file.txt` to `FILE.txt` will now cause `FILE.txt` being created in the destination directory. 
 The `Sync` task and `Project.copy()` and `sync()` operations now also handle case-renames as expected.
 
+## Fail the build on deprecation warnings
+
+The `warning-mode` command line option now has a [new `fail` value](userguide/command_line_interface.html#sec:command_line_warnings) that will behave like `all` and in addition fail the build if any deprecation warning was reported during the execution.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/userguide/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/command_line_interface.adoc
@@ -427,13 +427,15 @@ Deprecated Gradle features were used in this build, making it incompatible with 
 
 You can control the verbosity of warnings on the console with the following options:
 
-`-Dorg.gradle.warning.mode=(all,none,summary)`::
+`-Dorg.gradle.warning.mode=(all,fail,none,summary)`::
 Specify warning mode via <<build_environment.adoc#sec:gradle_configuration_properties, Gradle properties>>. Different modes described immediately below.
 
-`--warning-mode=(all,none,summary)`::
+`--warning-mode=(all,fail,none,summary)`::
 Specifies how to log warnings. Default is `summary`.
 +
 Set to `all` to log all warnings.
++
+Set to `fail` to log all warnings and fail the build if there are any warnings.
 +
 Set to `summary` to suppress all warnings and log a summary at the end of the build.
 +

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
+import org.gradle.util.GradleVersion
 import spock.lang.Unroll
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
@@ -93,7 +94,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
             executer.expectDeprecationWarnings(warningsCountInConsole)
         }
         executer.withWarningMode(warnings)
-        run('deprecated', 'broken')
+        warnings == WarningMode.Fail ? fails('deprecated', 'broken') : succeeds('deprecated', 'broken')
 
         then:
         output.contains('build.gradle:2)') == warningsCountInConsole > 0
@@ -121,6 +122,11 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         and:
         assertFullStacktraceResult(fullStacktraceEnabled, warningsCountInConsole)
 
+        and:
+        if (warnings == WarningMode.Fail) {
+            failure.assertHasDescription("Deprecated Gradle features were used in this build, making it incompatible with Gradle ${GradleVersion.current().nextMajor.version}")
+        }
+
         where:
         scenario                                        | warnings            | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
         'without stacktrace and --warning-mode=all'     | WarningMode.All     | 4                      | 0                      | false
@@ -129,6 +135,31 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         'with stacktrace and --warning-mode=no'         | WarningMode.None    | 0                      | 0                      | true
         'without stacktrace and --warning-mode=summary' | WarningMode.Summary | 0                      | 4                      | false
         'with stacktrace and --warning-mode=summary'    | WarningMode.Summary | 0                      | 4                      | true
+        'without stacktrace and --warning-mode=fail'    | WarningMode.Fail    | 4                      | 0                      | false
+        'with stacktrace and --warning-mode=fail'       | WarningMode.Fail    | 4                      | 0                      | true
+    }
+
+    def 'build error and deprecation failure combined'() {
+        given:
+        buildFile << """
+            apply plugin: DeprecatedPlugin // line 2
+            
+            task broken() {
+                doLast {
+                    throw new IllegalStateException("Can't do that")
+                }
+            }
+        """.stripIndent()
+
+        when:
+        executer.expectDeprecationWarnings(1)
+        executer.withWarningMode(WarningMode.Fail)
+
+        then:
+        fails('broken')
+        output.contains('build.gradle:2)')
+        failure.assertHasCause("Can't do that")
+        failure.assertHasDescription('Deprecated Gradle features were used in this build')
     }
 
     def 'DeprecatedPlugin from init script - without full stacktrace.'() {

--- a/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningMode.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/logging/configuration/WarningMode.java
@@ -28,15 +28,39 @@ public enum WarningMode {
     /**
      * Show all warnings.
      */
-    All,
+    All(true),
 
     /**
      * Display a summary at the end of the build instead of rendering all warnings into the console output.
      */
-    Summary,
+    Summary(false),
 
     /**
      * No deprecation warnings at all.
      */
-    None
+    None(false),
+
+    /**
+     * Show all warnings and fail the build if any warning present
+     *
+     * @since 5.6
+     */
+    Fail(true);
+
+    private boolean displayMessages;
+
+    WarningMode(boolean displayMessages) {
+        this.displayMessages = displayMessages;
+    }
+
+    /**
+     * Indicates whether deprecation messages are to be printed in-line
+     *
+     * @return {@code true} if messages are to be printed, {@code false} otherwise
+     *
+     * @since 5.6
+     */
+    public boolean shouldDisplayMessages() {
+        return displayMessages;
+    }
 }

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -368,4 +368,9 @@ public class SingleMessageLogger {
     public static void incubatingFeatureUsed(String incubatingFeature) {
         nagUserWith(incubatingFeatureHandler, new IncubatingFeatureUsage(incubatingFeature, SingleMessageLogger.class));
     }
+
+    @Nullable
+    public static Throwable getDeprecationFailure() {
+        return deprecatedFeatureHandler.getDeprecationFailure();
+    }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -81,7 +81,8 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         event.logLevel == LogLevel.WARN
     }
 
-    def "no warnings should be displayed in #mode"() {
+    @Unroll
+    def "no warnings should be displayed in #type"() {
         when:
         handler.init(locationReporter, type, progressBroadcaster)
         handler.featureUsed(deprecatedFeatureUsage('feature1'))
@@ -90,7 +91,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
         outputEventListener.events.empty
 
         where:
-        type << [WarningMode.None, null]
+        type << WarningMode.values().findAll { !it.shouldDisplayMessages() }
     }
 
     @Unroll


### PR DESCRIPTION
* Adds one more option to warning-mode: fail
* If fail is activated, the build will fail at the end if any
deprecation warnings were reported