### PR TITLE
Fix :instantExecutionReport build with JPS

### DIFF
--- a/subprojects/instant-execution-report/instant-execution-report.gradle.kts
+++ b/subprojects/instant-execution-report/instant-execution-report.gradle.kts
@@ -46,9 +46,6 @@ tasks {
             outputFile = "$buildDir/js/instant-execution-report.js"
             metaInfo = false
             sourceMap = false
-            freeCompilerArgs = listOf(
-                "-XXLanguage:+NewInference"
-            )
         }
     }
 

--- a/subprojects/instant-execution-report/src/main/kotlin/InstantExecutionReportPage.kt
+++ b/subprojects/instant-execution-report/src/main/kotlin/InstantExecutionReportPage.kt
@@ -148,10 +148,10 @@ object InstantExecutionReportPage : Component<InstantExecutionReportPage.Model, 
     )
 
     private
-    val errorDecoration = span(" ❌")
+    val errorDecoration: View<Intent> = span(" ❌")
 
     private
-    val warningDecoration = span(" ⚠️")
+    val warningDecoration: View<Intent> = span(" ⚠️")
 
     private
     fun viewNode(node: FailureNode): View<Intent> = when (node) {

--- a/subprojects/instant-execution-report/src/main/kotlin/InstantExecutionReportPage.kt
+++ b/subprojects/instant-execution-report/src/main/kotlin/InstantExecutionReportPage.kt
@@ -131,10 +131,10 @@ object InstantExecutionReportPage : Component<InstantExecutionReportPage.Model, 
             viewChildrenOf(model.tree.focus()) { child ->
                 when (val node = child.tree.label) {
                     is FailureNode.Error -> {
-                        viewLabel(treeIntent, child, node.label, errorDecoration)
+                        viewLabel(treeIntent, child, node.label, span(" ❌"))
                     }
                     is FailureNode.Warning -> {
-                        viewLabel(treeIntent, child, node.label, warningDecoration)
+                        viewLabel(treeIntent, child, node.label, span(" ⚠️"))
                     }
                     is FailureNode.Exception -> {
                         viewException(node)
@@ -146,12 +146,6 @@ object InstantExecutionReportPage : Component<InstantExecutionReportPage.Model, 
             }
         )
     )
-
-    private
-    val errorDecoration: View<Intent> = span(" ❌")
-
-    private
-    val warningDecoration: View<Intent> = span(" ⚠️")
 
     private
     fun viewNode(node: FailureNode): View<Intent> = when (node) {

--- a/subprojects/instant-execution-report/src/main/kotlin/data/Trie.kt
+++ b/subprojects/instant-execution-report/src/main/kotlin/data/Trie.kt
@@ -32,7 +32,7 @@ inline class Trie<T>(
 
     val entries: Sequence<Pair<T, Trie<T>>>
         get() = nestedMaps.asSequence().map { (label, subTrie) ->
-            label to Trie(subTrie.uncheckedCast())
+            label to Trie<T>(subTrie.uncheckedCast())
         }
 }
 

--- a/subprojects/instant-execution-report/src/main/kotlin/elmish/tree/TreeView.kt
+++ b/subprojects/instant-execution-report/src/main/kotlin/elmish/tree/TreeView.kt
@@ -37,7 +37,7 @@ object TreeView {
 
     fun <T> view(model: Model<T>): View<Intent<T>> =
         viewTree(model.tree.focus()) { focus ->
-            div(
+            div<Intent<T>>(
                 attributes {
                     onClick { Intent.Toggle(focus) }
                 },

--- a/subprojects/instant-execution-report/src/main/kotlin/elmish/tree/TreeView.kt
+++ b/subprojects/instant-execution-report/src/main/kotlin/elmish/tree/TreeView.kt
@@ -36,8 +36,8 @@ object TreeView {
     }
 
     fun <T> view(model: Model<T>): View<Intent<T>> =
-        viewTree(model.tree.focus()) { focus ->
-            div<Intent<T>>(
+        viewTree<T, Intent<T>>(model.tree.focus()) { focus ->
+            div(
                 attributes {
                     onClick { Intent.Toggle(focus) }
                 },


### PR DESCRIPTION
Fixed problem is
![image](https://user-images.githubusercontent.com/132773/60529190-644a7580-9cf6-11e9-92a8-2fec45e1bf9d.png)


Tried adding `-XXLanguage:+NewInference` to JPS:
![image](https://user-images.githubusercontent.com/132773/60529068-1c2b5300-9cf6-11e9-9c50-0c53bdf95a44.png)

But then JPS fails for an obscure reason:
![image](https://user-images.githubusercontent.com/132773/60529113-3107e680-9cf6-11e9-91d4-b7d4597abb6e.png)

Moreover, the `idea-ext` plugin we use doesn't support configuring the kotlin compiler.

Easy fix for now: help the old kotlin inference engine by specifying more types explicitly.