### PR TITLE
Remove includedAdded

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -259,11 +259,6 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
 
         @Override
-        public boolean isAllowOverlappingOutputs() {
-            return true;
-        }
-
-        @Override
         public boolean hasOverlappingOutputs() {
             return context.getOverlappingOutputs().isPresent();
         }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
@@ -37,7 +37,7 @@ class ClasspathFingerprintCompareStrategyTest extends Specification {
         changes(
             [:],
             [:]
-        ) as List == []
+        ) == []
     }
 
     def "trivial addition"() {
@@ -45,7 +45,7 @@ class ClasspathFingerprintCompareStrategyTest extends Specification {
         changes(
             ["one-new": fingerprint("one")],
             [:]
-        ) as List == [added("one-new": "one")]
+        ) == [added("one-new": "one")]
     }
 
     def "non-trivial addition"() {
@@ -61,13 +61,12 @@ class ClasspathFingerprintCompareStrategyTest extends Specification {
         changes(
             [:],
             ["one-old": fingerprint("one")]
-        ) as List == [removed("one-old": "one")]
+        ) == [removed("one-old": "one")]
     }
 
     def "non-trivial removal"() {
         expect:
         changes(
-            
             ["one-new": fingerprint("one")],
             ["one-old": fingerprint("one"), "two-old": fingerprint("two")]
         ) == [removed("two-old": "two")]
@@ -86,7 +85,7 @@ class ClasspathFingerprintCompareStrategyTest extends Specification {
         changes(
             ["two-new": fingerprint("two")],
             ["one-old": fingerprint("one")]
-        ) as List == [removed("one-old": "one"), added("two-new": "two")]
+        ) == [removed("one-old": "one"), added("two-new": "two")]
     }
 
     def "non-trivial replacement"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
@@ -21,224 +21,142 @@ import com.google.common.collect.Iterables
 import org.gradle.internal.execution.history.changes.ClasspathCompareStrategy
 import org.gradle.internal.execution.history.changes.CollectingChangeVisitor
 import org.gradle.internal.execution.history.changes.DefaultFileChange
-import org.gradle.internal.execution.history.changes.FingerprintCompareStrategy
 import org.gradle.internal.execution.history.impl.SerializableFileCollectionFingerprint
 import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.hash.HashCode
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class ClasspathFingerprintCompareStrategyTest extends Specification {
 
     private static final CLASSPATH = ClasspathCompareStrategy.INSTANCE
 
-    @Unroll
-    def "empty snapshots (#strategy, include added: #includeAdded)"() {
+    def "empty snapshots"() {
         expect:
-        changes(strategy, includeAdded,
-            [:],
+        changes([:],
             [:]
         ) as List == []
-
-        where:
-        strategy     | includeAdded
-        CLASSPATH    | true
-        CLASSPATH    | false
     }
 
-    @Unroll
-    def "trivial addition (#strategy, include added: #includeAdded)"() {
+    def "trivial addition"() {
         expect:
-        changes(strategy, includeAdded,
-            ["one-new": fingerprint("one")],
+        changes(["one-new": fingerprint("one")],
             [:]
-        ) as List == results
-
-        where:
-        strategy     | includeAdded | results
-        CLASSPATH    | true         | [added("one-new": "one")]
-        CLASSPATH    | false        | []
+        ) as List == [added("one-new": "one")]
     }
 
-    @Unroll
-    def "non-trivial addition (#strategy, include added: #includeAdded)"() {
+    def "non-trivial addition"() {
         expect:
-        changes(strategy, includeAdded,
-            ["one-new": fingerprint("one"), "two-new": fingerprint("two")],
+        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two")],
             ["one-old": fingerprint("one")]
-        ) == results
-
-        where:
-        strategy   | includeAdded | results
-        CLASSPATH  | true         | [added("two-new": "two")]
-        CLASSPATH  | false        | []
+        ) == [added("two-new": "two")]
     }
 
-    @Unroll
-    def "trivial removal (#strategy, include added: #includeAdded)"() {
+    def "trivial removal"() {
         expect:
-        changes(strategy, includeAdded,
-            [:],
+        changes([:],
             ["one-old": fingerprint("one")]
         ) as List == [removed("one-old": "one")]
-
-        where:
-        strategy   | includeAdded
-        CLASSPATH  | true
-        CLASSPATH  | false
     }
 
-    @Unroll
-    def "non-trivial removal (#strategy, include added: #includeAdded)"() {
+    def "non-trivial removal"() {
         expect:
-        changes(strategy, includeAdded,
-            ["one-new": fingerprint("one")],
+        changes(["one-new": fingerprint("one")],
             ["one-old": fingerprint("one"), "two-old": fingerprint("two")]
         ) == [removed("two-old": "two")]
-
-        where:
-        strategy   | includeAdded
-        CLASSPATH  | true
-        CLASSPATH  | false
     }
 
-    @Unroll
-    def "non-trivial modification (#strategy, include added: #includeAdded)"() {
+    def "non-trivial modification"() {
         expect:
-        changes(strategy, includeAdded,
-            ["one-new": fingerprint("one"), "two-new": fingerprint("two", 0x9876cafe)],
+        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two", 0x9876cafe)],
             ["one-old": fingerprint("one"), "two-old": fingerprint("two", 0xface1234)]
         ) == [modified("two-new": "two", FileType.RegularFile, FileType.RegularFile)]
-
-        where:
-        strategy   | includeAdded
-        CLASSPATH  | true
-        CLASSPATH  | false
     }
 
-    @Unroll
-    def "trivial replacement (#strategy, include added: #includeAdded)"() {
+    def "trivial replacement"() {
         expect:
-        changes(strategy, includeAdded,
-            ["two-new": fingerprint("two")],
+        changes(["two-new": fingerprint("two")],
             ["one-old": fingerprint("one")]
-        ) as List == results
-
-        where:
-        strategy   | includeAdded | results
-        CLASSPATH  | true         | [removed("one-old": "one"), added("two-new": "two")]
-        CLASSPATH  | false        | [removed("one-old": "one")]
+        ) as List == [removed("one-old": "one"), added("two-new": "two")]
     }
 
-    @Unroll
-    def "non-trivial replacement (#strategy, include added: #includeAdded)"() {
+    def "non-trivial replacement"() {
         expect:
-        changes(strategy, includeAdded,
-            ["one-new": fingerprint("one"), "two-new": fingerprint("two"), "four-new": fingerprint("four")],
+        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two"), "four-new": fingerprint("four")],
             ["one-old": fingerprint("one"), "three-old": fingerprint("three"), "four-old": fingerprint("four")]
-        ) == results
-
-        where:
-        strategy   | includeAdded | results
-        CLASSPATH  | true         | [removed("three-old": "three"), added("two-new": "two")]
-        CLASSPATH  | false        | [removed("three-old": "three")]
+        ) == [removed("three-old": "three"), added("two-new": "two")]
     }
 
-    @Unroll
-    def "reordering (#strategy, include added: #includeAdded)"() {
+    def "reordering"() {
         expect:
-        changes(strategy, includeAdded,
-            ["one-new": fingerprint("one"), "two-new": fingerprint("two"), "three-new": fingerprint("three")],
+        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two"), "three-new": fingerprint("three")],
             ["one-old": fingerprint("one"), "three-old": fingerprint("three"), "two-old": fingerprint("two")]
-        ) == results
-
-        where:
-        strategy   | includeAdded | results
-        CLASSPATH  | true         | [removed("three-old": "three"), added("two-new": "two"), removed("two-old": "two"), added("three-new": "three")]
-        CLASSPATH  | false        | [removed("three-old": "three"), removed("two-old": "two")]
+        ) == [removed("three-old": "three"), added("two-new": "two"), removed("two-old": "two"), added("three-new": "three")]
     }
 
-    @Unroll
-    def "handling duplicates (#strategy, include added: #includeAdded)"() {
+    def "handling duplicates"() {
         expect:
-        changes(strategy, includeAdded,
-            ["one-new-1": fingerprint("one"), "one-new-2": fingerprint("one"), "two-new": fingerprint("two")],
+        changes(["one-new-1": fingerprint("one"), "one-new-2": fingerprint("one"), "two-new": fingerprint("two")],
             ["one-old-1": fingerprint("one"), "one-old-2": fingerprint("one"), "two-old": fingerprint("two")]
         ) == []
-
-        where:
-        strategy   | includeAdded
-        CLASSPATH  | true
-        CLASSPATH  | false
     }
 
     def "addition of jar elements"() {
         expect:
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456)],
+        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456)],
             [jar1: jar(1234), jar3: jar(3456)]
         ) == [added("jar2")]
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
+        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
             [jar1: jar(1234), jar4: jar(4567), jar5: jar(5678)]
         ) == [added("jar2"), added("jar3")]
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
+        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
             [jar1: jar(1234), jar3: jar(3456), jar5: jar(5678)]
         ) == [added("jar2"), added("jar4")]
     }
 
     def "removal of jar elements"() {
         expect:
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar3: jar(3456)],
+        changes([jar1: jar(1234), jar3: jar(3456)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456)]
         ) == [removed("jar2")]
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar4: jar(4567), jar5: jar(5678)],
+        changes([jar1: jar(1234), jar4: jar(4567), jar5: jar(5678)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)]
         ) == [removed("jar2"), removed("jar3")]
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar3: jar(3456), jar5: jar(5678)],
+        changes([jar1: jar(1234), jar3: jar(3456), jar5: jar(5678)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)]
         ) == [removed("jar2"), removed("jar4")]
     }
 
     def "modification of jar in same path"() {
         expect:
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar2: jar(2345), jar3: jar(4567), jar4: jar(5678)],
+        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(4567), jar4: jar(5678)],
             [jar1: jar(1234), jar2: jar(3456), jar3: jar(4568), jar4: jar(5678)]
         ) == [modified("jar2"), modified("jar3")]
     }
 
     def "jar never modified for different paths"() {
         expect:
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), 'new-jar2': jar(2345), jar3: jar(4567), jar4: jar(5678)],
+        changes([jar1: jar(1234), 'new-jar2': jar(2345), jar3: jar(4567), jar4: jar(5678)],
             [jar1: jar(1234), 'old-jar2': jar(3456), jar3: jar(4568), jar4: jar(5678)]
         ) == [removed("old-jar2"), added("new-jar2"), modified("jar3")]
     }
 
     def "complex jar changes"() {
         expect:
-        changes(CLASSPATH, true,
-            [jar2: jar(2345), jar1: jar(1234), jar3: jar(3456), jar5: jar(5680), jar7: jar(7890)],
+        changes([jar2: jar(2345), jar1: jar(1234), jar3: jar(3456), jar5: jar(5680), jar7: jar(7890)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678), jar6: jar(6789), jar7: jar(7890)]
         ) == [removed('jar1'), added('jar2'), removed('jar2'), added('jar1'), removed('jar4'), modified('jar5'), removed('jar6')]
-        changes(CLASSPATH, true,
-            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678), jar6: jar(6789), jar7: jar(7890)],
+        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678), jar6: jar(6789), jar7: jar(7890)],
             [jar2: jar(2345), jar1: jar(1234), jar3: jar(3456), jar5: jar(5680), jar7: jar(7890)]
         ) == [removed('jar2'), added('jar1'), removed('jar1'), added('jar2'), added('jar4'), modified('jar5'), added('jar6')]
     }
 
-    def changes(FingerprintCompareStrategy strategy, boolean includeAdded, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
+    def changes(Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
         def visitor = new CollectingChangeVisitor()
         def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)))
         def previousFingerprint = new SerializableFileCollectionFingerprint(previous,  ImmutableMultimap.of("some", HashCode.fromInt(4321)))
-        strategy.visitChangesSince(currentFingerprint, previousFingerprint, "test", includeAdded, visitor)
+        CLASSPATH.visitChangesSince(currentFingerprint, previousFingerprint, "test", visitor)
         visitor.getChanges().toList()
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
@@ -34,120 +34,141 @@ class ClasspathFingerprintCompareStrategyTest extends Specification {
 
     def "empty snapshots"() {
         expect:
-        changes([:],
+        changes(
+            [:],
             [:]
         ) as List == []
     }
 
     def "trivial addition"() {
         expect:
-        changes(["one-new": fingerprint("one")],
+        changes(
+            ["one-new": fingerprint("one")],
             [:]
         ) as List == [added("one-new": "one")]
     }
 
     def "non-trivial addition"() {
         expect:
-        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two")],
+        changes(
+            ["one-new": fingerprint("one"), "two-new": fingerprint("two")],
             ["one-old": fingerprint("one")]
         ) == [added("two-new": "two")]
     }
 
     def "trivial removal"() {
         expect:
-        changes([:],
+        changes(
+            [:],
             ["one-old": fingerprint("one")]
         ) as List == [removed("one-old": "one")]
     }
 
     def "non-trivial removal"() {
         expect:
-        changes(["one-new": fingerprint("one")],
+        changes(
+            
+            ["one-new": fingerprint("one")],
             ["one-old": fingerprint("one"), "two-old": fingerprint("two")]
         ) == [removed("two-old": "two")]
     }
 
     def "non-trivial modification"() {
         expect:
-        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two", 0x9876cafe)],
+        changes(
+            ["one-new": fingerprint("one"), "two-new": fingerprint("two", 0x9876cafe)],
             ["one-old": fingerprint("one"), "two-old": fingerprint("two", 0xface1234)]
         ) == [modified("two-new": "two", FileType.RegularFile, FileType.RegularFile)]
     }
 
     def "trivial replacement"() {
         expect:
-        changes(["two-new": fingerprint("two")],
+        changes(
+            ["two-new": fingerprint("two")],
             ["one-old": fingerprint("one")]
         ) as List == [removed("one-old": "one"), added("two-new": "two")]
     }
 
     def "non-trivial replacement"() {
         expect:
-        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two"), "four-new": fingerprint("four")],
+        changes(
+            ["one-new": fingerprint("one"), "two-new": fingerprint("two"), "four-new": fingerprint("four")],
             ["one-old": fingerprint("one"), "three-old": fingerprint("three"), "four-old": fingerprint("four")]
         ) == [removed("three-old": "three"), added("two-new": "two")]
     }
 
     def "reordering"() {
         expect:
-        changes(["one-new": fingerprint("one"), "two-new": fingerprint("two"), "three-new": fingerprint("three")],
+        changes(
+            ["one-new": fingerprint("one"), "two-new": fingerprint("two"), "three-new": fingerprint("three")],
             ["one-old": fingerprint("one"), "three-old": fingerprint("three"), "two-old": fingerprint("two")]
         ) == [removed("three-old": "three"), added("two-new": "two"), removed("two-old": "two"), added("three-new": "three")]
     }
 
     def "handling duplicates"() {
         expect:
-        changes(["one-new-1": fingerprint("one"), "one-new-2": fingerprint("one"), "two-new": fingerprint("two")],
+        changes(
+            ["one-new-1": fingerprint("one"), "one-new-2": fingerprint("one"), "two-new": fingerprint("two")],
             ["one-old-1": fingerprint("one"), "one-old-2": fingerprint("one"), "two-old": fingerprint("two")]
         ) == []
     }
 
     def "addition of jar elements"() {
         expect:
-        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456)],
+        changes(
+            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456)],
             [jar1: jar(1234), jar3: jar(3456)]
         ) == [added("jar2")]
-        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
+        changes(
+            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
             [jar1: jar(1234), jar4: jar(4567), jar5: jar(5678)]
         ) == [added("jar2"), added("jar3")]
-        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
+        changes(
+            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)],
             [jar1: jar(1234), jar3: jar(3456), jar5: jar(5678)]
         ) == [added("jar2"), added("jar4")]
     }
 
     def "removal of jar elements"() {
         expect:
-        changes([jar1: jar(1234), jar3: jar(3456)],
+        changes(
+            [jar1: jar(1234), jar3: jar(3456)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456)]
         ) == [removed("jar2")]
-        changes([jar1: jar(1234), jar4: jar(4567), jar5: jar(5678)],
+        changes(
+            [jar1: jar(1234), jar4: jar(4567), jar5: jar(5678)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)]
         ) == [removed("jar2"), removed("jar3")]
-        changes([jar1: jar(1234), jar3: jar(3456), jar5: jar(5678)],
+        changes(
+            [jar1: jar(1234), jar3: jar(3456), jar5: jar(5678)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678)]
         ) == [removed("jar2"), removed("jar4")]
     }
 
     def "modification of jar in same path"() {
         expect:
-        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(4567), jar4: jar(5678)],
+        changes(
+            [jar1: jar(1234), jar2: jar(2345), jar3: jar(4567), jar4: jar(5678)],
             [jar1: jar(1234), jar2: jar(3456), jar3: jar(4568), jar4: jar(5678)]
         ) == [modified("jar2"), modified("jar3")]
     }
 
     def "jar never modified for different paths"() {
         expect:
-        changes([jar1: jar(1234), 'new-jar2': jar(2345), jar3: jar(4567), jar4: jar(5678)],
+        changes(
+            [jar1: jar(1234), 'new-jar2': jar(2345), jar3: jar(4567), jar4: jar(5678)],
             [jar1: jar(1234), 'old-jar2': jar(3456), jar3: jar(4568), jar4: jar(5678)]
         ) == [removed("old-jar2"), added("new-jar2"), modified("jar3")]
     }
 
     def "complex jar changes"() {
         expect:
-        changes([jar2: jar(2345), jar1: jar(1234), jar3: jar(3456), jar5: jar(5680), jar7: jar(7890)],
+        changes(
+            [jar2: jar(2345), jar1: jar(1234), jar3: jar(3456), jar5: jar(5680), jar7: jar(7890)],
             [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678), jar6: jar(6789), jar7: jar(7890)]
         ) == [removed('jar1'), added('jar2'), removed('jar2'), added('jar1'), removed('jar4'), modified('jar5'), removed('jar6')]
-        changes([jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678), jar6: jar(6789), jar7: jar(7890)],
+        changes(
+            [jar1: jar(1234), jar2: jar(2345), jar3: jar(3456), jar4: jar(4567), jar5: jar(5678), jar6: jar(6789), jar7: jar(7890)],
             [jar2: jar(2345), jar1: jar(1234), jar3: jar(3456), jar5: jar(5680), jar7: jar(7890)]
         ) == [removed('jar2'), added('jar1'), removed('jar1'), added('jar2'), added('jar4'), modified('jar5'), added('jar6')]
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.internal.execution.history.changes.AbsolutePathFingerprintCompareStrategy
 import org.gradle.internal.execution.history.changes.ChangeTypeInternal
-import org.gradle.internal.execution.history.changes.CollectingChangeVisitor
 import org.gradle.internal.execution.history.changes.DefaultFileChange
 import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.snapshot.WellKnownFileLocations
@@ -95,25 +94,6 @@ class AbsolutePathFileCollectionFingerprinterTest extends Specification {
 
         then:
         1 * listener.added(file2.path)
-        0 * _
-    }
-
-    def doesNotGenerateEventWhenFileAddedAndAddEventsAreFiltered() {
-        given:
-        TestFile file1 = tmpDir.createFile('file1')
-        TestFile file2 = tmpDir.file('file2')
-        TestFile file3 = tmpDir.createFile('file3')
-        TestFile file4 = tmpDir.createDir('file4')
-
-        when:
-        def fingerprint = fingerprinter.fingerprint(files(file1, file2))
-        file2.createFile()
-        def target = fingerprinter.fingerprint(files(file1, file2, file3, file4))
-        def visitor = new CollectingChangeVisitor()
-        AbsolutePathFingerprintCompareStrategy.INSTANCE.visitChangesSince(target, fingerprint, "TYPE", false, visitor)
-        visitor.changes.empty
-
-        then:
         0 * _
     }
 
@@ -281,7 +261,7 @@ class AbsolutePathFileCollectionFingerprinterTest extends Specification {
     }
 
     private static void changes(FileCollectionFingerprint newFingerprint, FileCollectionFingerprint oldFingerprint, ChangeListener<String> listener) {
-        AbsolutePathFingerprintCompareStrategy.INSTANCE.visitChangesSince(newFingerprint, oldFingerprint, "TYPE", true) { DefaultFileChange change ->
+        AbsolutePathFingerprintCompareStrategy.INSTANCE.visitChangesSince(newFingerprint, oldFingerprint, "TYPE") { DefaultFileChange change ->
             switch (change.type) {
                 case ChangeTypeInternal.ADDED:
                     listener.added(change.path)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -389,11 +389,6 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         }
 
         @Override
-        public boolean isAllowOverlappingOutputs() {
-            return false;
-        }
-
-        @Override
         public boolean hasOverlappingOutputs() {
             return false;
         }

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -539,28 +539,6 @@ class IncrementalExecutionIntegrationTest extends Specification {
         outOfDate(unitOfWork, "Input property 'prop2' has been removed for ${unitOfWork.displayName}")
     }
 
-    def "up to date when output file which did not exist now exists"() {
-        given:
-        execute(unitOfWork)
-
-        when:
-        missingOutputFile.touch()
-
-        then:
-        upToDate(unitOfWork)
-    }
-
-    def "up to date when output dir which was empty is no longer empty"() {
-        given:
-        execute(unitOfWork)
-
-        when:
-        emptyOutputDir.file("some-file").touch()
-
-        then:
-        upToDate(unitOfWork)
-    }
-
     def "up to date when no inputs"() {
         when:
         def noInputsTask = builder.withoutInputFiles().build()
@@ -829,10 +807,6 @@ class IncrementalExecutionIntegrationTest extends Specification {
                     }
                 }
 
-                @Override
-                boolean isAllowOverlappingOutputs() {
-                    return true
-                }
 
                 @Override
                 boolean hasOverlappingOutputs() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -85,11 +85,6 @@ public interface UnitOfWork extends CacheableEntity {
     Optional<? extends Iterable<String>> getChangingOutputs();
 
     /**
-     * When overlapping outputs are allowed, output files added between executions are ignored during change detection.
-     */
-    boolean isAllowOverlappingOutputs();
-
-    /**
      * Whether the current execution detected that there are overlapping outputs.
      */
     boolean hasOverlappingOutputs();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/AbsolutePathFingerprintCompareStrategy.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/AbsolutePathFingerprintCompareStrategy.java
@@ -34,7 +34,7 @@ public class AbsolutePathFingerprintCompareStrategy extends AbstractFingerprintC
     }
 
     @Override
-    protected boolean doVisitChangesSince(ChangeVisitor visitor, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous, String propertyTitle, boolean includeAdded) {
+    protected boolean doVisitChangesSince(ChangeVisitor visitor, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous, String propertyTitle) {
         Set<String> unaccountedForPreviousFingerprints = new LinkedHashSet<String>(previous.keySet());
 
         for (Map.Entry<String, FileSystemLocationFingerprint> currentEntry : current.entrySet()) {
@@ -51,7 +51,7 @@ public class AbsolutePathFingerprintCompareStrategy extends AbstractFingerprintC
                     }
                 }
                 // else, unchanged; check next file
-            } else if (includeAdded) {
+            } else {
                 DefaultFileChange added = DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), currentAbsolutePath);
                 if (!visitor.visitChange(added)) {
                     return false;

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/AbstractFingerprintChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/AbstractFingerprintChanges.java
@@ -47,7 +47,8 @@ public abstract class AbstractFingerprintChanges implements ChangeContainer {
         this.title = title;
     }
 
-    protected boolean accept(final ChangeVisitor visitor, final boolean includeAdded) {
+    @Override
+    public boolean accept(ChangeVisitor visitor) {
         return SortedMapDiffUtil.diff(previous, current, new PropertyDiffListener<String, FileCollectionFingerprint, CurrentFileCollectionFingerprint>() {
             @Override
             public boolean removed(String previousProperty) {
@@ -63,7 +64,7 @@ public abstract class AbstractFingerprintChanges implements ChangeContainer {
             public boolean updated(String property, FileCollectionFingerprint previousFingerprint, CurrentFileCollectionFingerprint currentFingerprint) {
                 String propertyTitle = title + " property '" + property + "'";
                 FingerprintCompareStrategy compareStrategy = determineCompareStrategy(currentFingerprint);
-                return compareStrategy.visitChangesSince(currentFingerprint, previousFingerprint, propertyTitle, includeAdded, visitor);
+                return compareStrategy.visitChangesSince(currentFingerprint, previousFingerprint, propertyTitle, visitor);
             }
         });
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ClasspathCompareStrategy.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ClasspathCompareStrategy.java
@@ -35,9 +35,9 @@ public class ClasspathCompareStrategy extends AbstractFingerprintCompareStrategy
     }
 
     @Override
-    protected boolean doVisitChangesSince(ChangeVisitor visitor, Map<String, FileSystemLocationFingerprint> currentSnapshots, Map<String, FileSystemLocationFingerprint> previousSnapshots, String propertyTitle, boolean includeAdded) {
+    protected boolean doVisitChangesSince(ChangeVisitor visitor, Map<String, FileSystemLocationFingerprint> currentSnapshots, Map<String, FileSystemLocationFingerprint> previousSnapshots, String propertyTitle) {
         TrackingVisitor trackingVisitor = new TrackingVisitor(visitor);
-        ChangeState changeState = new ChangeState(propertyTitle, includeAdded, trackingVisitor, currentSnapshots, previousSnapshots);
+        ChangeState changeState = new ChangeState(propertyTitle, trackingVisitor, currentSnapshots, previousSnapshots);
 
         while (trackingVisitor.isConsumeMore() && changeState.hasMoreToProcess()) {
             changeState.processChange();
@@ -69,7 +69,6 @@ public class ClasspathCompareStrategy extends AbstractFingerprintCompareStrategy
     private static class ChangeState {
         private Map.Entry<String, FileSystemLocationFingerprint> current;
         private Map.Entry<String, FileSystemLocationFingerprint> previous;
-        private final boolean includeAdded;
         private final ChangeVisitor changeConsumer;
         private final Iterator<Map.Entry<String, FileSystemLocationFingerprint>> currentEntries;
         private final Map<String, FileSystemLocationFingerprint> currentSnapshots;
@@ -77,9 +76,8 @@ public class ClasspathCompareStrategy extends AbstractFingerprintCompareStrategy
         private final Map<String, FileSystemLocationFingerprint> previousSnapshots;
         private final String propertyTitle;
 
-        private ChangeState(String propertyTitle, boolean includeAdded, ChangeVisitor changeConsumer, Map<String, FileSystemLocationFingerprint> currentSnapshots, Map<String, FileSystemLocationFingerprint> previousSnapshots) {
+        private ChangeState(String propertyTitle, ChangeVisitor changeConsumer, Map<String, FileSystemLocationFingerprint> currentSnapshots, Map<String, FileSystemLocationFingerprint> previousSnapshots) {
             this.propertyTitle = propertyTitle;
-            this.includeAdded = includeAdded;
             this.changeConsumer = changeConsumer;
             this.currentEntries = currentSnapshots.entrySet().iterator();
             this.currentSnapshots = currentSnapshots;
@@ -129,10 +127,8 @@ public class ClasspathCompareStrategy extends AbstractFingerprintCompareStrategy
         }
 
         void added() {
-            if (includeAdded) {
-                DefaultFileChange added = DefaultFileChange.added(current.getKey(), propertyTitle, current.getValue().getType(), current.getValue().getNormalizedPath());
-                changeConsumer.visitChange(added);
-            }
+            DefaultFileChange added = DefaultFileChange.added(current.getKey(), propertyTitle, current.getValue().getType(), current.getValue().getNormalizedPath());
+            changeConsumer.visitChange(added);
             current = nextEntry(currentEntries);
         }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/DefaultExecutionStateChangeDetector.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/DefaultExecutionStateChangeDetector.java
@@ -26,7 +26,7 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 
 public class DefaultExecutionStateChangeDetector implements ExecutionStateChangeDetector {
     @Override
-    public ExecutionStateChanges detectChanges(AfterPreviousExecutionState lastExecution, BeforeExecutionState thisExecution, Describable executable, boolean allowOverlappingOutputs, IncrementalInputProperties incrementalInputProperties) {
+    public ExecutionStateChanges detectChanges(AfterPreviousExecutionState lastExecution, BeforeExecutionState thisExecution, Describable executable, IncrementalInputProperties incrementalInputProperties) {
         // Capture changes in execution outcome
         ChangeContainer previousSuccessState = new PreviousSuccessChanges(
             lastExecution.isSuccessful());
@@ -67,8 +67,8 @@ public class DefaultExecutionStateChangeDetector implements ExecutionStateChange
             executable);
         OutputFileChanges outputFileChanges = new OutputFileChanges(
             lastExecution.getOutputFileProperties(),
-            thisExecution.getOutputFileProperties(),
-            allowOverlappingOutputs);
+            thisExecution.getOutputFileProperties()
+        );
 
         // Collect changes that would trigger a rebuild
         ChangeContainer rebuildTriggeringChanges = errorHandling(executable, new SummarizingChangeContainer(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/DefaultInputFileChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/DefaultInputFileChanges.java
@@ -29,15 +29,10 @@ public class DefaultInputFileChanges extends AbstractFingerprintChanges implemen
     }
 
     @Override
-    public boolean accept(ChangeVisitor visitor) {
-        return accept(visitor, true);
-    }
-
-    @Override
     public boolean accept(String propertyName, ChangeVisitor visitor) {
         CurrentFileCollectionFingerprint currentFileCollectionFingerprint = current.get(propertyName);
         FileCollectionFingerprint previousFileCollectionFingerprint = previous.get(propertyName);
         FingerprintCompareStrategy compareStrategy = determineCompareStrategy(currentFileCollectionFingerprint);
-        return compareStrategy.visitChangesSince(currentFileCollectionFingerprint, previousFileCollectionFingerprint, TITLE, true, visitor);
+        return compareStrategy.visitChangesSince(currentFileCollectionFingerprint, previousFileCollectionFingerprint, TITLE, visitor);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ExecutionStateChangeDetector.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ExecutionStateChangeDetector.java
@@ -27,6 +27,6 @@ public interface ExecutionStateChangeDetector {
         AfterPreviousExecutionState lastExecution,
         BeforeExecutionState thisExecution,
         Describable executable,
-        boolean allowOverlappingOutputs,
-        IncrementalInputProperties incrementalInputProperties);
+        IncrementalInputProperties incrementalInputProperties
+    );
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/FingerprintCompareStrategy.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/FingerprintCompareStrategy.java
@@ -29,5 +29,5 @@ public interface FingerprintCompareStrategy {
      *
      * @return Whether the {@link ChangeVisitor} is looking for further changes. See {@link ChangeVisitor#visitChange(Change)}.
      */
-    boolean visitChangesSince(FileCollectionFingerprint current, FileCollectionFingerprint previous, String propertyTitle, boolean includeAdded, ChangeVisitor visitor);
+    boolean visitChangesSince(FileCollectionFingerprint current, FileCollectionFingerprint previous, String propertyTitle, ChangeVisitor visitor);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/IgnoredPathCompareStrategy.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/IgnoredPathCompareStrategy.java
@@ -51,11 +51,10 @@ public class IgnoredPathCompareStrategy extends AbstractFingerprintCompareStrate
      * <ul>
      *     <li>Determining which content fingerprints are only in the previous or current fingerprint collection.</li>
      *     <li>Those only in the previous fingerprint collection are reported as removed.</li>
-     *     <li>If {@code includeAdded} is {@code true}, the files with content fingerprints which are only in the current collection are reported as added.</li>
      * </ul>
      */
     @Override
-    protected boolean doVisitChangesSince(ChangeVisitor visitor, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous, String propertyTitle, boolean includeAdded) {
+    protected boolean doVisitChangesSince(ChangeVisitor visitor, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous, String propertyTitle) {
         ListMultimap<HashCode, FilePathWithType> unaccountedForPreviousFiles = MultimapBuilder.hashKeys(previous.size()).linkedListValues().build();
         for (Map.Entry<String, FileSystemLocationFingerprint> entry : previous.entrySet()) {
             String absolutePath = entry.getKey();
@@ -69,11 +68,9 @@ public class IgnoredPathCompareStrategy extends AbstractFingerprintCompareStrate
             HashCode normalizedContentHash = currentFingerprint.getNormalizedContentHash();
             List<FilePathWithType> previousFilesForContent = unaccountedForPreviousFiles.get(normalizedContentHash);
             if (previousFilesForContent.isEmpty()) {
-                if (includeAdded) {
-                    DefaultFileChange added = DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH);
-                    if (!visitor.visitChange(added)) {
-                        return false;
-                    }
+                DefaultFileChange added = DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH);
+                if (!visitor.visitChange(added)) {
+                    return false;
                 }
             } else {
                 previousFilesForContent.remove(0);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/NormalizedPathFingerprintCompareStrategy.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/NormalizedPathFingerprintCompareStrategy.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.execution.history.changes;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import org.gradle.internal.file.FileType;
@@ -49,22 +48,10 @@ public class NormalizedPathFingerprintCompareStrategy extends AbstractFingerprin
      *         For those only in the previous fingerprint collection it checks if some entry with the same normalized path is in the current collection.
      *         If it is, file is reported as modified, if not as removed.
      *     </li>
-     *     <li>Finally, {@code includeAdded} is always {@code true}, meaning that the remaining fingerprints which are only in the current collection are reported as added.</li>
      * </ul>
      */
     @Override
     protected boolean doVisitChangesSince(
-        ChangeVisitor visitor,
-        Map<String, FileSystemLocationFingerprint> currentFingerprints,
-        Map<String, FileSystemLocationFingerprint> previousFingerprints,
-        String propertyTitle,
-        boolean includeAdded
-    ) {
-        Preconditions.checkArgument(includeAdded);
-        return doVisitChangesSince(visitor, currentFingerprints, previousFingerprints, propertyTitle);
-    }
-
-    private boolean doVisitChangesSince(
         ChangeVisitor visitor,
         Map<String, FileSystemLocationFingerprint> currentFingerprints,
         Map<String, FileSystemLocationFingerprint> previousFingerprints,

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/OutputFileChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/OutputFileChanges.java
@@ -22,15 +22,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 
 public class OutputFileChanges extends AbstractFingerprintChanges {
 
-    private final boolean includeAdded;
-
-    public OutputFileChanges(ImmutableSortedMap<String, FileCollectionFingerprint> previous, ImmutableSortedMap<String, CurrentFileCollectionFingerprint> current, boolean includeAdded) {
+    public OutputFileChanges(ImmutableSortedMap<String, FileCollectionFingerprint> previous, ImmutableSortedMap<String, CurrentFileCollectionFingerprint> current) {
         super(previous, current, "Output");
-        this.includeAdded = includeAdded;
-    }
-
-    @Override
-    public boolean accept(ChangeVisitor visitor) {
-        return accept(visitor, includeAdded);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -66,7 +66,6 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
                             afterPreviousExecution,
                             beforeExecution,
                             work,
-                            !work.isAllowOverlappingOutputs(),
                             createIncrementalInputProperties(work))
                         )
                         .orElseGet(() -> new RebuildExecutionStateChanges(NO_HISTORY, beforeExecution.getInputFileProperties(), createIncrementalInputProperties(work)))

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreSnapshotsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreSnapshotsStep.java
@@ -79,7 +79,7 @@ public class StoreSnapshotsStep<C extends IncrementalContext> implements Step<C,
 
         // Otherwise do deep compare of outputs
         ChangeDetectorVisitor visitor = new ChangeDetectorVisitor();
-        OutputFileChanges changes = new OutputFileChanges(previous, current, true);
+        OutputFileChanges changes = new OutputFileChanges(previous, current);
         changes.accept(visitor);
         return visitor.hasAnyChanges();
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
@@ -37,7 +37,7 @@ class FingerprintCompareStrategyTest extends Specification {
     private static final ABSOLUTE = AbsolutePathFingerprintCompareStrategy.INSTANCE
     private static final NORMALIZED = NormalizedPathFingerprintCompareStrategy.INSTANCE
     private static final IGNORED_PATH = IgnoredPathCompareStrategy.INSTANCE
-    private static final List<FingerprintCompareStrategy> ALL_STRATEGIES = ImmutableList.of(ABSOLUTE, NORMALIZED, IGNORED_PATH)
+    private static final ALL_STRATEGIES = ImmutableList.of(ABSOLUTE, NORMALIZED, IGNORED_PATH)
 
     def "empty snapshots (#strategy.class.simpleName)"() {
         expect:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.execution.history.changes
 
+import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMultimap
 import com.google.common.collect.Iterables
 import org.gradle.internal.execution.history.impl.SerializableFileCollectionFingerprint
@@ -36,98 +37,79 @@ class FingerprintCompareStrategyTest extends Specification {
     private static final ABSOLUTE = AbsolutePathFingerprintCompareStrategy.INSTANCE
     private static final NORMALIZED = NormalizedPathFingerprintCompareStrategy.INSTANCE
     private static final IGNORED_PATH = IgnoredPathCompareStrategy.INSTANCE
+    private static final List<FingerprintCompareStrategy> ALL_STRATEGIES = ImmutableList.of(ABSOLUTE, NORMALIZED, IGNORED_PATH)
 
-    def "empty snapshots (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "empty snapshots (#strategy.class.simpleName)"() {
         expect:
-        changes(strategy, includeAdded,
+        changes(strategy,
             [:],
             [:]
         ) as List == []
 
         where:
-        strategy     | includeAdded
-        NORMALIZED   | true
-        IGNORED_PATH | true
-        IGNORED_PATH | false
-        ABSOLUTE     | true
-        ABSOLUTE     | false
+        strategy << ALL_STRATEGIES
     }
 
-    def "trivial addition (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "trivial addition (#strategy.class.simpleName)"() {
         expect:
-        changes(strategy, includeAdded,
+        changes(strategy,
             ["new/one": fingerprint("one")],
             [:]
         ) as List == results
 
         where:
-        strategy     | includeAdded | results
-        NORMALIZED   | true         | [added("new/one": "one")]
-        IGNORED_PATH | true         | [added("new/one": "one")]
-        IGNORED_PATH | false        | []
-        ABSOLUTE     | true         | [added("new/one": "one")]
-        ABSOLUTE     | false        | []
+        strategy     | results
+        NORMALIZED   | [added("new/one": "one")]
+        IGNORED_PATH | [added("new/one": "one")]
+        ABSOLUTE     | [added("new/one": "one")]
     }
 
     def "non-trivial addition (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true,
+        changes(NORMALIZED,
             ["new/one": fingerprint("one"), "new/two": fingerprint("two")],
             ["old/one": fingerprint("one")]
         ) == [added("new/two": "two")]
     }
 
-    def "non-trivial addition with absolute paths (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "non-trivial addition with absolute paths (AbsolutePathFingerprintCompareStrategy)"() {
         expect:
-        changes(strategy, includeAdded,
+        changes(ABSOLUTE,
             ["one": fingerprint("one"), "two": fingerprint("two")],
             ["one": fingerprint("one")]
-        ) == results
-
-        where:
-        strategy | includeAdded | results
-        ABSOLUTE | true         | [added("two")]
-        ABSOLUTE | false        | []
+        ) == [added("two")]
     }
 
-    def "trivial removal (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "trivial removal (#strategy.class.simpleName)"() {
         expect:
-        changes(strategy, includeAdded,
+        changes(strategy,
             [:],
             ["old/one": fingerprint("one")]
         ) as List == [removed("old/one": "one")]
 
         where:
-        strategy   | includeAdded
-        NORMALIZED | true
-        ABSOLUTE   | true
-        ABSOLUTE   | false
+        strategy << [NORMALIZED, ABSOLUTE]
     }
 
     def "non-trivial removal (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true,
+        changes(NORMALIZED,
             ["new/one": fingerprint("one")],
             ["old/one": fingerprint("one"), "old/two": fingerprint("two")]
         ) == [removed("old/two": "two")]
     }
 
-    def "non-trivial removal with absolute paths (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "non-trivial removal with absolute paths (AbsolutePathFingerprintCompareStrategy)"() {
         expect:
-        changes(strategy, includeAdded,
+        changes(ABSOLUTE,
             ["one": fingerprint("one")],
             ["one": fingerprint("one"), "two": fingerprint("two")]
         ) == [removed("two")]
-
-        where:
-        strategy | includeAdded
-        ABSOLUTE | true
-        ABSOLUTE | false
     }
 
     def "non-trivial modification (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "new/one": fingerprint("one"),
             "new/two": fingerprint("two", 0x9876cafe)
         ], [
@@ -138,7 +120,7 @@ class FingerprintCompareStrategyTest extends Specification {
 
     def "non-trivial modification with re-ordering and same normalized paths (UNORDERED, NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "new/two/input": fingerprint("input", 0x9876cafe),
             "new/one/input": fingerprint("input")
         ], [
@@ -147,25 +129,20 @@ class FingerprintCompareStrategyTest extends Specification {
         ]) == [removed("old/two/input": "input"), added("new/two/input": "input")]
     }
 
-    def "non-trivial modification with absolute paths (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "non-trivial modification with absolute paths (AbsolutePathFingerprintCompareStrategy)"() {
         expect:
-        changes(strategy, includeAdded, [
+        changes(ABSOLUTE, [
             "one": fingerprint("one"),
             "two": fingerprint("two", 0x9876cafe)
         ], [
             "one": fingerprint("one"),
             "two": fingerprint("two", 0xface1234)
         ]) == [modified("two", FileType.RegularFile, FileType.RegularFile)]
-
-        where:
-        strategy | includeAdded
-        ABSOLUTE | true
-        ABSOLUTE | false
     }
 
     def "trivial replacement (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true,
+        changes(NORMALIZED,
             ["new/two": fingerprint("two")],
             ["old/one": fingerprint("one")]
         ) == [removed("old/one": "one"), added("new/two": "two")]
@@ -173,7 +150,7 @@ class FingerprintCompareStrategyTest extends Specification {
 
     def "non-trivial replacement (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "new/one": fingerprint("one"),
             "new/two": fingerprint("two"),
             "new/four": fingerprint("four")
@@ -184,9 +161,9 @@ class FingerprintCompareStrategyTest extends Specification {
         ]) == [removed("old/three": "three"), added("new/two": "two")]
     }
 
-    def "non-trivial replacement with absolute paths (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "non-trivial replacement with absolute paths (#strategy.class.simpleName)"() {
         expect:
-        changes(strategy, includeAdded, [
+        changes(ABSOLUTE, [
             "one": fingerprint("one"),
             "two": fingerprint("two"),
             "four": fingerprint("four")
@@ -194,17 +171,12 @@ class FingerprintCompareStrategyTest extends Specification {
             "one": fingerprint("one"),
             "three": fingerprint("three"),
             "four": fingerprint("four")
-        ]) == results
-
-        where:
-        strategy | includeAdded | results
-        ABSOLUTE | true         | [added("two"), removed("three")]
-        ABSOLUTE | false        | [removed("three")]
+        ]) == [added("two"), removed("three")]
     }
 
-    def "reordering (NormalizedPathFingerprintCompareStrategy, include added: true)"() {
+    def "reordering (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "new/one": fingerprint("one"),
             "new/two": fingerprint("two"),
             "new/three": fingerprint("three")
@@ -215,9 +187,9 @@ class FingerprintCompareStrategyTest extends Specification {
         ]) == []
     }
 
-    def "reordering with absolute paths (#strategy.class.simpleName, include added: #includeAdded)"() {
+    def "reordering with absolute paths (AbsolutePathFingerprintCompareStrategy)"() {
         expect:
-        changes(strategy, includeAdded, [
+        changes(ABSOLUTE, [
             "one": fingerprint("one"),
             "two": fingerprint("two"),
             "three": fingerprint("three")
@@ -225,17 +197,12 @@ class FingerprintCompareStrategyTest extends Specification {
             "one": fingerprint("one"),
             "three": fingerprint("three"),
             "two": fingerprint("two")
-        ]) == results
-
-        where:
-        strategy | includeAdded | results
-        ABSOLUTE | true         | []
-        ABSOLUTE | false        | []
+        ]) == []
     }
 
     def "detects no change when only absolute path changes (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "new-1/one": fingerprint("one"),
             "new-2/one": fingerprint("one"),
             "new/two": fingerprint("two")
@@ -248,7 +215,7 @@ class FingerprintCompareStrategyTest extends Specification {
 
     def "detects no change when swapping contents between files with same normalized path (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "a/input": fingerprint("input", 2),
             "b/input": fingerprint("input", 0)
         ], [
@@ -258,7 +225,7 @@ class FingerprintCompareStrategyTest extends Specification {
     }
 
     def "detects no change when file move results in unchanged normalized path (NormalizedPathFingerprintCompareStrategy)"() {
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "moved/input": fingerprint("input", 1),
             "unchangedFile": fingerprint("unchangedFile", 2),
             "changedFile": fingerprint("changedFile", 4)
@@ -271,7 +238,7 @@ class FingerprintCompareStrategyTest extends Specification {
 
     def "change file content to collide with content of another file with same normalized path (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "modified-with-collision/input": fingerprint("input", 1),
             "unmodified/input": fingerprint("input", 1)
         ], [
@@ -282,7 +249,7 @@ class FingerprintCompareStrategyTest extends Specification {
 
     def "only report modifications between files with the same absolute paths, otherwise report addition and/or removal (NormalizedPathFingerprintCompareStrategy)"() {
         expect:
-        changes(NORMALIZED, true, [
+        changes(NORMALIZED, [
             "modified-with-collision/input": fingerprint("input", 0),
             "added/input": fingerprint("input", 0),
             "modified/input": fingerprint("input", 2),
@@ -304,8 +271,8 @@ class FingerprintCompareStrategyTest extends Specification {
 
     def "too many elements not handled by trivial comparison (#current.size() current vs #previous.size() previous)"() {
         expect:
-        compareTrivialFingerprints(new CollectingChangeVisitor(), current, previous, "test", true) == null
-        compareTrivialFingerprints(new CollectingChangeVisitor(), current, previous, "test", false) == null
+        compareTrivialFingerprints(new CollectingChangeVisitor(), current, previous, "test") == null
+        compareTrivialFingerprints(new CollectingChangeVisitor(), current, previous, "test") == null
 
         where:
         current                                                | previous
@@ -313,7 +280,7 @@ class FingerprintCompareStrategyTest extends Specification {
         ["one": fingerprint("one"), "two": fingerprint("two")] | ["one": fingerprint("one")]
     }
 
-    def "comparing regular snapshot to empty snapshot shows entries removed (strategy: #strategy, include added: #includeAdded)"() {
+    def "comparing regular snapshot to empty snapshot shows entries removed (strategy: #strategy)"() {
         def fingerprint = Mock(FileCollectionFingerprint) {
             getFingerprints() >> [
                 "file1.txt": new DefaultFileSystemLocationFingerprint("file1.txt", FileType.RegularFile, HashCode.fromInt(123)),
@@ -323,50 +290,36 @@ class FingerprintCompareStrategyTest extends Specification {
         }
         def emptyFingerprint = new EmptyCurrentFileCollectionFingerprint("test")
         expect:
-        changes(strategy, includeAdded, emptyFingerprint, fingerprint).toList() == [
+        changes(strategy, emptyFingerprint, fingerprint).toList() == [
             DefaultFileChange.removed("file1.txt", "test", FileType.RegularFile, "file1.txt"),
             DefaultFileChange.removed("file2.txt", "test", FileType.RegularFile, "file2.txt")
         ]
-        changes(strategy, includeAdded, fingerprint, emptyFingerprint).toList() == (includeAdded
-            ? [
-                DefaultFileChange.added("file1.txt", "test", FileType.RegularFile, "file1.txt"),
-                DefaultFileChange.added("file2.txt", "test", FileType.RegularFile, "file2.txt")
-            ]
-            : [])
+        changes(strategy, fingerprint, emptyFingerprint).toList() == [
+            DefaultFileChange.added("file1.txt", "test", FileType.RegularFile, "file1.txt"),
+            DefaultFileChange.added("file2.txt", "test", FileType.RegularFile, "file2.txt")
+        ]
 
         where:
-        strategy     | includeAdded
-        NORMALIZED   | true
-        NORMALIZED   | false
-        IGNORED_PATH | true
-        IGNORED_PATH | false
-        ABSOLUTE     | true
-        ABSOLUTE     | false
+        strategy << ALL_STRATEGIES
     }
 
-    def "comparing empty fingerprints produces empty (strategy: #strategy, include added: #includeAdded)"() {
+    def "comparing empty fingerprints produces empty (strategy: #strategy)"() {
         expect:
-        changes(strategy, includeAdded, new EmptyCurrentFileCollectionFingerprint("test"), new EmptyCurrentFileCollectionFingerprint("test"),).empty
+        changes(strategy, new EmptyCurrentFileCollectionFingerprint("test"), new EmptyCurrentFileCollectionFingerprint("test"),).empty
 
         where:
-        strategy     | includeAdded
-        NORMALIZED   | true
-        NORMALIZED   | false
-        IGNORED_PATH | true
-        IGNORED_PATH | false
-        ABSOLUTE     | true
-        ABSOLUTE     | false
+        strategy << ALL_STRATEGIES
     }
 
-    def changes(FingerprintCompareStrategy strategy, boolean includeAdded, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
+    def changes(FingerprintCompareStrategy strategy, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
         def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)))
         def previousFingerprint = new SerializableFileCollectionFingerprint(previous,  ImmutableMultimap.of("some", HashCode.fromInt(4321)))
-        changes(strategy, includeAdded, currentFingerprint, previousFingerprint)
+        changes(strategy, currentFingerprint, previousFingerprint)
     }
 
-    def changes(FingerprintCompareStrategy strategy, boolean includeAdded, FileCollectionFingerprint currentFingerprint, FileCollectionFingerprint previousFingerprint) {
+    def changes(FingerprintCompareStrategy strategy, FileCollectionFingerprint currentFingerprint, FileCollectionFingerprint previousFingerprint) {
         def visitor = new CollectingChangeVisitor()
-        strategy.visitChangesSince(currentFingerprint, previousFingerprint, "test", includeAdded, visitor)
+        strategy.visitChangesSince(currentFingerprint, previousFingerprint, "test", visitor)
         visitor.getChanges().toList()
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
@@ -118,8 +118,7 @@ class ResolveChangesStepTest extends StepSpec {
         1 * context.beforeExecutionState >> Optional.of(beforeExecutionState)
         1 * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
         1 * work.inputChangeTrackingStrategy >> UnitOfWork.InputChangeTrackingStrategy.NONE
-        1 * work.allowOverlappingOutputs >> true
-        1 * changeDetector.detectChanges(afterPreviousExecutionState, beforeExecutionState, work, false, _) >> changes
+        1 * changeDetector.detectChanges(afterPreviousExecutionState, beforeExecutionState, work, _) >> changes
         0 * _
     }
 }


### PR DESCRIPTION
Since we filter the before execution output snapshot, we don't need
`includeAdded` any more.