### PR TITLE
Filter output snapshot before creating fingerprint

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -15,12 +15,13 @@
  */
 package org.gradle.api.internal.tasks.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.execution.TaskExecutionListener;
-import org.gradle.api.internal.OverlappingOutputs;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.taskfactory.IncrementalInputsTaskAction;
 import org.gradle.api.internal.project.taskfactory.IncrementalTaskInputsTaskAction;
@@ -56,12 +57,16 @@ import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.execution.impl.OutputFilterUtil;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.fingerprint.FileCollectionFingerprint;
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.ExecutingBuildOperation;
 import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.work.AsyncWorkTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,9 +126,9 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     }
 
     @Override
-    public TaskExecuterResult execute(final TaskInternal task, final TaskStateInternal state, final TaskExecutionContext context) {
-        final TaskExecution work = new TaskExecution(task, context, executionHistoryStore);
-        final CachingResult result = workExecutor.execute(new IncrementalContext() {
+    public TaskExecuterResult execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        TaskExecution work = new TaskExecution(task, context, executionHistoryStore);
+        CachingResult result = workExecutor.execute(new IncrementalContext() {
             @Override
             public UnitOfWork getWork() {
                 return work;
@@ -163,7 +168,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             public Optional<OriginMetadata> getReusedOutputOriginMetadata() {
                 return result.isReused()
                     ? Optional.of(result.getOriginMetadata())
-                    : Optional.<OriginMetadata>empty();
+                    : Optional.empty();
             }
 
             @Override
@@ -304,6 +309,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             return Optional.ofNullable(task.getTimeout().getOrNull());
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public InputChangeTrackingStrategy getInputChangeTrackingStrategy() {
             for (InputChangesAwareTaskAction taskAction : task.getTaskActions()) {
@@ -333,19 +339,29 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
 
         @Override
         public ImmutableSortedMap<String, CurrentFileCollectionFingerprint> snapshotAfterOutputsGenerated() {
-            final AfterPreviousExecutionState afterPreviousExecutionState = context.getAfterPreviousExecution();
-            final ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputsAfterExecution = taskFingerprinter.fingerprintTaskFiles(task, context.getTaskProperties().getOutputFileProperties());
-            return context.getOverlappingOutputs()
-                .map(new Function<OverlappingOutputs, ImmutableSortedMap<String, CurrentFileCollectionFingerprint>>() {
-                    @Override
-                    public ImmutableSortedMap<String, CurrentFileCollectionFingerprint> apply(OverlappingOutputs overlappingOutputs) {
-                        return OutputFilterUtil.filterOutputFingerprints(
-                            afterPreviousExecutionState == null ? null : afterPreviousExecutionState.getOutputFileProperties(),
-                            context.getOutputFilesBeforeExecution(),
-                            outputsAfterExecution
-                        );
+            AfterPreviousExecutionState afterPreviousExecutionState = context.getAfterPreviousExecution();
+            ImmutableSortedMap<String, FileSystemSnapshot> outputsAfterExecution = taskFingerprinter.snapshotTaskFiles(task, context.getTaskProperties().getOutputFileProperties());
+            return createFilteredOutputFingerprints(afterPreviousExecutionState, context.getOutputFilesBeforeExecution(), outputsAfterExecution, context.getOverlappingOutputs().isPresent());
+        }
+
+        private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> createFilteredOutputFingerprints(@Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> beforeExecutionOutputSnapshots, ImmutableSortedMap<String, FileSystemSnapshot> afterExecutionOutputSnapshots, boolean hasOverlappingOutputs) {
+            ImmutableSortedMap<String, FileCollectionFingerprint> afterLastExecutionFingerprints = afterPreviousExecutionState == null ? ImmutableSortedMap.of() : afterPreviousExecutionState.getOutputFileProperties();
+
+            return ImmutableSortedMap.copyOfSorted(
+                Maps.transformEntries(afterExecutionOutputSnapshots, (propertyName, afterExecutionOutputSnapshot) -> {
+                        FileCollectionFingerprint afterLastExecutionFingerprint = afterLastExecutionFingerprints.get(propertyName);
+                        FileSystemSnapshot beforeExecutionOutputSnapshot = beforeExecutionOutputSnapshots.get(propertyName);
+                        return fingerprintOutputSnapshot(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot, afterExecutionOutputSnapshot, hasOverlappingOutputs);
                     }
-                }).orElse(outputsAfterExecution);
+                )
+            );
+        }
+
+        private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(@Nullable FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot, FileSystemSnapshot afterExecutionOutputSnapshot, boolean hasOverlappingOutputs) {
+            List<FileSystemSnapshot> roots = hasOverlappingOutputs
+                ? OutputFilterUtil.filterOutputSnapshotAfterExecution(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot, afterExecutionOutputSnapshot)
+                : ImmutableList.of(afterExecutionOutputSnapshot);
+            return DefaultCurrentFileCollectionFingerprint.from(roots, AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
         }
 
         @Override
@@ -354,7 +370,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
 
         @Override
-        public void markSnapshottingInputsFinished(final CachingState cachingState) {
+        public void markSnapshottingInputsFinished(CachingState cachingState) {
             // TODO:lptr this should be added only if the scan plugin is applied, but SnapshotTaskInputsOperationIntegrationTest
             //   expects it to be added also when the build cache is enabled (but not the scan plugin)
             if (buildCacheEnabled || scanPluginApplied) {
@@ -396,7 +412,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         }
     }
 
-    private void executeAction(final String actionDisplayName, final TaskInternal task, final InputChangesAwareTaskAction action, @Nullable InputChangesInternal inputChanges, boolean hasMoreWork) {
+    private void executeAction(String actionDisplayName, TaskInternal task, InputChangesAwareTaskAction action, @Nullable InputChangesInternal inputChanges, boolean hasMoreWork) {
         if (inputChanges != null) {
             action.setInputChanges(inputChanges);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
@@ -87,7 +87,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         return delegate.execute(task, state, context);
     }
 
-    private BeforeExecutionState createExecutionState(TaskInternal task, TaskProperties properties, @Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> outputFileSnapshots, boolean hasOverlappingOutputs) {
+    private BeforeExecutionState createExecutionState(TaskInternal task, TaskProperties properties, @Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> beforeExecutionOutputSnapshots, boolean hasOverlappingOutputs) {
         Class<? extends TaskInternal> taskClass = task.getClass();
         List<InputChangesAwareTaskAction> taskActions = task.getTaskActions();
         ImplementationSnapshot taskImplementation = ImplementationSnapshot.of(taskClass, classLoaderHierarchyHasher);
@@ -103,7 +103,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         ImmutableSortedMap<String, ValueSnapshot> inputProperties = snapshotTaskInputProperties(task, properties, previousInputProperties, valueSnapshotter);
 
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFiles = taskFingerprinter.fingerprintTaskFiles(task, properties.getInputFileProperties());
-        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFiles = createFilteredOutputFingerprints(afterPreviousExecutionState, outputFileSnapshots, hasOverlappingOutputs);
+        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFiles = createFilteredOutputFingerprints(afterPreviousExecutionState, beforeExecutionOutputSnapshots, hasOverlappingOutputs);
         return new DefaultBeforeExecutionState(
             taskImplementation,
             taskActionImplementations,
@@ -113,24 +113,24 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         );
     }
 
-    private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> createFilteredOutputFingerprints(@Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> outputFileSnapshots, boolean hasOverlappingOutputs) {
-        ImmutableSortedMap<String, FileCollectionFingerprint> previousOutputs = afterPreviousExecutionState == null ? ImmutableSortedMap.of() : afterPreviousExecutionState.getOutputFileProperties();
+    private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> createFilteredOutputFingerprints(@Nullable AfterPreviousExecutionState afterPreviousExecutionState, ImmutableSortedMap<String, FileSystemSnapshot> beforeExecutionOutputSnapshots, boolean hasOverlappingOutputs) {
+        ImmutableSortedMap<String, FileCollectionFingerprint> afterLastExecutionFingerprints = afterPreviousExecutionState == null ? ImmutableSortedMap.of() : afterPreviousExecutionState.getOutputFileProperties();
 
         return ImmutableSortedMap.copyOfSorted(
-            Maps.transformEntries(outputFileSnapshots, (key, outputSnapshot) -> {
-                    FileCollectionFingerprint previousOutputFingerprint = previousOutputs.get(key);
-                    return previousOutputFingerprint == null
+            Maps.transformEntries(beforeExecutionOutputSnapshots, (key, beforeExecutionOutputSnapshot) -> {
+                    FileCollectionFingerprint afterLastExecutionFingerprint = afterLastExecutionFingerprints.get(key);
+                    return afterLastExecutionFingerprint == null
                         ? AbsolutePathFingerprintingStrategy.IGNORE_MISSING.getEmptyFingerprint()
-                        : fingerprintOutputSnapshot(outputSnapshot, previousOutputFingerprint, hasOverlappingOutputs);
+                        : fingerprintOutputSnapshot(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot, hasOverlappingOutputs);
                 }
             )
         );
     }
 
-    private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(FileSystemSnapshot outputSnapshot, FileCollectionFingerprint previousOutputFingerprint, boolean hasOverlappingOutputs) {
+    private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot, boolean hasOverlappingOutputs) {
         List<FileSystemSnapshot> roots = hasOverlappingOutputs
-            ? OutputFilterUtil.filterOutputSnapshotBeforeExecution(previousOutputFingerprint, outputSnapshot)
-            : ImmutableList.of(outputSnapshot);
+            ? OutputFilterUtil.filterOutputSnapshotBeforeExecution(afterLastExecutionFingerprint, beforeExecutionOutputSnapshot)
+            : ImmutableList.of(beforeExecutionOutputSnapshot);
         return DefaultCurrentFileCollectionFingerprint.from(roots, AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
@@ -129,7 +129,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
 
     private CurrentFileCollectionFingerprint fingerprintOutputSnapshot(FileSystemSnapshot outputSnapshot, FileCollectionFingerprint previousOutputFingerprint, boolean hasOverlappingOutputs) {
         List<FileSystemSnapshot> roots = hasOverlappingOutputs
-            ? OutputFilterUtil.filterOutputSnapshot(previousOutputFingerprint, outputSnapshot)
+            ? OutputFilterUtil.filterOutputSnapshotBeforeExecution(previousOutputFingerprint, outputSnapshot)
             : ImmutableList.of(outputSnapshot);
         return DefaultCurrentFileCollectionFingerprint.from(roots, AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -76,7 +76,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkTracker = Mock(AsyncWorkTracker)
     def taskFingerprinter = Stub(TaskFingerprinter) {
-        fingerprintTaskFiles(task, _) >> ImmutableSortedMap.of()
+        snapshotTaskFiles(task, _) >> ImmutableSortedMap.of()
     }
     def executionHistoryStore = Mock(ExecutionHistoryStore)
     def buildId = UniqueId.generate()

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
@@ -42,12 +42,12 @@ import java.util.function.Predicate;
  */
 public class OutputFilterUtil {
 
-    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotBeforeExecution(FileCollectionFingerprint previousOutputs, FileSystemSnapshot currentSnapshots) {
-        Map<String, FileSystemLocationFingerprint> fingerprints = previousOutputs.getFingerprints();
+    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotBeforeExecution(FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot) {
+        Map<String, FileSystemLocationFingerprint> fingerprints = afterLastExecutionFingerprint.getFingerprints();
         SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> {
             return snapshot.getType() != FileType.Missing && fingerprints.containsKey(snapshot.getAbsolutePath());
         });
-        currentSnapshots.accept(filteringVisitor);
+        beforeExecutionOutputSnapshot.accept(filteringVisitor);
         return filteringVisitor.getNewRoots();
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/OutputFilterUtil.java
@@ -16,16 +16,11 @@
 
 package org.gradle.internal.execution.impl;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
 import org.gradle.internal.file.FileType;
-import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
-import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
-import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
@@ -33,9 +28,7 @@ import org.gradle.internal.snapshot.FileSystemSnapshotVisitor;
 import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -49,60 +42,34 @@ import java.util.function.Predicate;
  */
 public class OutputFilterUtil {
 
-    public static ImmutableSortedMap<String, CurrentFileCollectionFingerprint> filterOutputFingerprints(
-        final @Nullable ImmutableSortedMap<String, FileCollectionFingerprint> outputsAfterPreviousExecution,
-        ImmutableSortedMap<String, FileSystemSnapshot> outputsBeforeExecution,
-        final ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputsAfterExecution
-    ) {
-        return ImmutableSortedMap.copyOfSorted(Maps.transformEntries(outputsBeforeExecution, new Maps.EntryTransformer<String, FileSystemSnapshot, CurrentFileCollectionFingerprint>() {
-            @Override
-            @SuppressWarnings("NullableProblems")
-            public CurrentFileCollectionFingerprint transformEntry(String propertyName, FileSystemSnapshot outputBeforeExecution) {
-                CurrentFileCollectionFingerprint outputAfterExecution = outputsAfterExecution.get(propertyName);
-                FileCollectionFingerprint outputAfterPreviousExecution = getFingerprintForProperty(outputsAfterPreviousExecution, propertyName);
-                return filterOutputFingerprint(outputAfterPreviousExecution, outputBeforeExecution, outputAfterExecution);
-            }
-        }));
+    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotBeforeExecution(FileCollectionFingerprint previousOutputs, FileSystemSnapshot currentSnapshots) {
+        Map<String, FileSystemLocationFingerprint> fingerprints = previousOutputs.getFingerprints();
+        SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> {
+            return snapshot.getType() != FileType.Missing && fingerprints.containsKey(snapshot.getAbsolutePath());
+        });
+        currentSnapshots.accept(filteringVisitor);
+        return filteringVisitor.getNewRoots();
     }
 
-    private static FileCollectionFingerprint getFingerprintForProperty(@Nullable ImmutableSortedMap<String, FileCollectionFingerprint> fingerprinters, String propertyName) {
-        if (fingerprinters != null) {
-            FileCollectionFingerprint afterPreviousExecution = fingerprinters.get(propertyName);
-            if (afterPreviousExecution != null) {
-                return afterPreviousExecution;
-            }
+    public static ImmutableList<FileSystemSnapshot> filterOutputSnapshotAfterExecution(@Nullable FileCollectionFingerprint afterLastExecutionFingerprint, FileSystemSnapshot beforeExecutionOutputSnapshot, FileSystemSnapshot afterExecutionOutputSnapshot) {
+        Map<String, FileSystemLocationSnapshot> beforeExecutionSnapshots = getAllSnapshots(beforeExecutionOutputSnapshot);
+        if (beforeExecutionSnapshots.isEmpty()) {
+            return ImmutableList.of(afterExecutionOutputSnapshot);
         }
-        return FileCollectionFingerprint.EMPTY;
-    }
 
-    @VisibleForTesting
-    static CurrentFileCollectionFingerprint filterOutputFingerprint(
-        @Nullable FileCollectionFingerprint afterPreviousExecution,
-        FileSystemSnapshot beforeExecution,
-        CurrentFileCollectionFingerprint afterExecution
-    ) {
-        CurrentFileCollectionFingerprint filesFingerprint;
-        final Map<String, FileSystemLocationSnapshot> beforeExecutionSnapshots = getAllSnapshots(beforeExecution);
-        if (!beforeExecutionSnapshots.isEmpty() && !afterExecution.getFingerprints().isEmpty()) {
-            @SuppressWarnings("RedundantTypeArguments")
-            final Map<String, FileSystemLocationFingerprint> afterPreviousFingerprints = afterPreviousExecution != null
-                ? afterPreviousExecution.getFingerprints()
-                : ImmutableMap.<String, FileSystemLocationFingerprint>of();
+        Map<String, FileSystemLocationFingerprint> afterLastExecutionFingerprints = afterLastExecutionFingerprint != null
+            ? afterLastExecutionFingerprint.getFingerprints()
+            : ImmutableMap.of();
 
-            SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> isOutputEntry(snapshot, beforeExecutionSnapshots, afterPreviousFingerprints));
-            afterExecution.accept(filteringVisitor);
+        SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(afterExecutionSnapshot -> isOutputEntry(afterLastExecutionFingerprints, beforeExecutionSnapshots, afterExecutionSnapshot));
+        afterExecutionOutputSnapshot.accept(filteringVisitor);
 
-
-            // Are all file snapshots after execution accounted for as new entries?
-            if (!filteringVisitor.hasBeenFiltered()) {
-                filesFingerprint = afterExecution;
-            } else {
-                filesFingerprint = DefaultCurrentFileCollectionFingerprint.from(filteringVisitor.getNewRoots(), AbsolutePathFingerprintingStrategy.IGNORE_MISSING);
-            }
+        // Are all file snapshots after execution accounted for as new entries?
+        if (filteringVisitor.hasBeenFiltered()) {
+            return filteringVisitor.getNewRoots();
         } else {
-            filesFingerprint = afterExecution;
+            return ImmutableList.of(afterExecutionOutputSnapshot);
         }
-        return filesFingerprint;
     }
 
     private static Map<String, FileSystemLocationSnapshot> getAllSnapshots(FileSystemSnapshot fingerprint) {
@@ -114,30 +81,21 @@ public class OutputFilterUtil {
     /**
      * Decide whether an entry should be considered to be part of the output. See class Javadoc for definition of what is considered output.
      */
-    private static boolean isOutputEntry(FileSystemLocationSnapshot snapshot, Map<String, FileSystemLocationSnapshot> beforeSnapshots, Map<String, FileSystemLocationFingerprint> afterPreviousFingerprints) {
-        if (snapshot.getType() == FileType.Missing) {
+    private static boolean isOutputEntry(Map<String, FileSystemLocationFingerprint> afterPreviousExecutionFingerprints, Map<String, FileSystemLocationSnapshot> beforeExecutionSnapshots, FileSystemLocationSnapshot afterExecutionSnapshot) {
+        if (afterExecutionSnapshot.getType() == FileType.Missing) {
             return false;
         }
-        FileSystemLocationSnapshot beforeSnapshot = beforeSnapshots.get(snapshot.getAbsolutePath());
+        FileSystemLocationSnapshot beforeSnapshot = beforeExecutionSnapshots.get(afterExecutionSnapshot.getAbsolutePath());
         // Was it created during execution?
         if (beforeSnapshot == null) {
             return true;
         }
         // Was it updated during execution?
-        if (!snapshot.isContentAndMetadataUpToDate(beforeSnapshot)) {
+        if (!afterExecutionSnapshot.isContentAndMetadataUpToDate(beforeSnapshot)) {
             return true;
         }
         // Did we already consider it as an output after the previous execution?
-        return afterPreviousFingerprints.containsKey(snapshot.getAbsolutePath());
-    }
-
-    public static List<FileSystemSnapshot> filterOutputSnapshot(FileCollectionFingerprint previousOutputs, FileSystemSnapshot currentSnapshots) {
-        Map<String, FileSystemLocationFingerprint> fingerprints = previousOutputs.getFingerprints();
-        SnapshotFilteringVisitor filteringVisitor = new SnapshotFilteringVisitor(snapshot -> {
-            return snapshot.getType() != FileType.Missing && fingerprints.containsKey(snapshot.getAbsolutePath());
-        });
-        currentSnapshots.accept(filteringVisitor);
-        return filteringVisitor.getNewRoots();
+        return afterPreviousExecutionFingerprints.containsKey(afterExecutionSnapshot.getAbsolutePath());
     }
 
     private static class GetAllSnapshotsVisitor implements FileSystemSnapshotVisitor {
@@ -165,7 +123,7 @@ public class OutputFilterUtil {
 
     private static class SnapshotFilteringVisitor implements FileSystemSnapshotVisitor {
         private final Predicate<FileSystemLocationSnapshot> predicate;
-        private final List<FileSystemSnapshot> newRoots = new ArrayList<FileSystemSnapshot>();
+        private final ImmutableList.Builder<FileSystemSnapshot> newRootsBuilder = ImmutableList.builder();
 
         private boolean hasBeenFiltered;
         private MerkleDirectorySnapshotBuilder merkleBuilder;
@@ -195,7 +153,7 @@ public class OutputFilterUtil {
                 return;
             }
             if (merkleBuilder == null) {
-                newRoots.add(fileSnapshot);
+                newRootsBuilder.add(fileSnapshot);
             } else {
                 merkleBuilder.visit(fileSnapshot);
             }
@@ -212,14 +170,14 @@ public class OutputFilterUtil {
             if (merkleBuilder.isRoot()) {
                 FileSystemLocationSnapshot result = merkleBuilder.getResult();
                 if (result != null) {
-                    newRoots.add(currentRootFiltered ? result : currentRoot);
+                    newRootsBuilder.add(currentRootFiltered ? result : currentRoot);
                 }
                 merkleBuilder = null;
                 currentRoot = null;
             }
         }
-        public List<FileSystemSnapshot> getNewRoots() {
-            return newRoots;
+        public ImmutableList<FileSystemSnapshot> getNewRoots() {
+            return newRootsBuilder.build();
         }
 
         public boolean hasBeenFiltered() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
@@ -34,6 +34,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputSnapshotAfterExecution
+import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputSnapshotBeforeExecution
 
 class OutputFilterUtilTest extends Specification {
 
@@ -152,6 +153,17 @@ class OutputFilterUtilTest extends Specification {
 
         expect:
         collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [outputDir, outputDirFile]
+    }
+
+    def "overlapping files are not part of the before execution snapshot"() {
+        def outputDir = temporaryFolder.file("outputDir").createDir()
+        def outputDirFile = outputDir.createFile("outputDirFile")
+        def afterLastExecution = fingerprintOutput(outputDir)
+        outputDir.createFile("not-in-output")
+        def beforeExecution = snapshotOutput(outputDir)
+
+        expect:
+        collectFiles(filterOutputSnapshotBeforeExecution(afterLastExecution, beforeExecution)) == [outputDir, outputDirFile]
     }
 
     private FileSystemSnapshot snapshotOutput(File output) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
@@ -16,65 +16,70 @@
 
 package org.gradle.internal.execution.impl
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
-import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
-import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter
+import org.gradle.internal.fingerprint.FileCollectionFingerprint
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
+import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
+import org.gradle.internal.snapshot.DirectorySnapshot
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot
+import org.gradle.internal.snapshot.FileSystemSnapshot
+import org.gradle.internal.snapshot.FileSystemSnapshotVisitor
 import org.gradle.internal.snapshot.WellKnownFileLocations
 import org.gradle.internal.snapshot.impl.DefaultFileSystemMirror
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputFingerprint
+import static org.gradle.internal.execution.impl.OutputFilterUtil.filterOutputSnapshotAfterExecution
 
 class OutputFilterUtilTest extends Specification {
+
+    private static final FileCollectionFingerprint EMPTY_OUTPUT_FINGERPRINT = AbsolutePathFingerprintingStrategy.IGNORE_MISSING.emptyFingerprint
 
     @Rule
     final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
 
     def fileSystemMirror = new DefaultFileSystemMirror(Stub(WellKnownFileLocations))
-    def fsSnapshotter = TestFiles.fileSystemSnapshotter(fileSystemMirror, new StringInterner())
-    def snapshotter = new DefaultFileCollectionSnapshotter(fsSnapshotter, TestFiles.fileSystem())
-    def outputFingerprinter = new OutputFileCollectionFingerprinter(snapshotter)
+    def snapshotter = TestFiles.fileSystemSnapshotter(fileSystemMirror, new StringInterner())
 
     def "pre-existing directories are filtered"() {
         def outputDir = temporaryFolder.file("outputDir").createDir()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
         outputDir.file()
 
         when:
-        def filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, beforeExecution)
+        def filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution)
         then:
         filteredOutputs.empty
 
         when:
         def outputDirFile = outputDir.file("in-output-dir").createFile()
         fileSystemMirror.beforeBuildFinished()
-        def afterExecution = fingerprintOutput(outputDir)
-        filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution)
+        def afterExecution = snapshotOutput(outputDir)
+        filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)
         then:
-        filteredOutputs.fingerprints.keySet() == [outputDir.absolutePath, outputDirFile.absolutePath] as Set
+        collectFiles(filteredOutputs) == [outputDir, outputDirFile]
     }
 
     def "only newly created files in directory are part of filtered outputs"() {
         def outputDir = temporaryFolder.file("outputDir").createDir()
         outputDir.file("outputOfOther").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
 
         when:
-        def filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, beforeExecution)
+        def filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution)
         then:
         filteredOutputs.empty
 
         when:
         def outputOfCurrent = outputDir.file("outputOfCurrent").createFile()
-        def afterExecution = fingerprintOutput(outputDir)
-        filteredOutputs = filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution)
+        def afterExecution = snapshotOutput(outputDir)
+        filteredOutputs = filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)
         then:
-        filteredOutputs.fingerprints.keySet() == [outputDir.absolutePath, outputOfCurrent.absolutePath] as Set
+        collectFiles(filteredOutputs) == [outputDir, outputOfCurrent]
     }
 
     def "previous outputs remain outputs"() {
@@ -82,73 +87,102 @@ class OutputFilterUtilTest extends Specification {
         def outputDirFile = outputDir.file("outputOfCurrent").createFile()
         def previousExecution = fingerprintOutput(outputDir)
         outputDir.file("outputOfOther").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
 
         when:
-        def filteredOutputs = filterOutputFingerprint(previousExecution, beforeExecution, beforeExecution)
+        def filteredOutputs = filterOutputSnapshotAfterExecution(previousExecution, beforeExecution, beforeExecution)
         then:
-        filteredOutputs.fingerprints.keySet() == [outputDir, outputDirFile]*.absolutePath as Set
+        collectFiles(filteredOutputs) == [outputDir, outputDirFile]
     }
-    
+
     def "missing files are ignored"() {
         def missingFile = temporaryFolder.file("missing")
-        def beforeExecution = fingerprintOutput(missingFile)
+        def beforeExecution = snapshotOutput(missingFile)
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, beforeExecution).empty
+        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, beforeExecution).empty
     }
 
     def "added empty dir is captured"() {
         def emptyDir = temporaryFolder.file("emptyDir").createDir()
-        def afterExecution = fingerprintOutput(emptyDir)
+        def afterExecution = snapshotOutput(emptyDir)
+        def beforeExecution = FileSystemSnapshot.EMPTY
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), outputFingerprinter.empty(), afterExecution).fingerprints.keySet() == [emptyDir.absolutePath] as Set
-        filterOutputFingerprint(outputFingerprinter.empty(), afterExecution, afterExecution).empty
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [emptyDir]
+        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterExecution, afterExecution).empty
     }
 
-    private CurrentFileCollectionFingerprint fingerprintOutput(File output) {
-        fileSystemMirror.beforeBuildFinished()
-        outputFingerprinter.fingerprint(ImmutableFileCollection.of(output))
-    }
-    
     def "updated files in output directory are part of the output"() {
         def outputDir = temporaryFolder.createDir("outputDir")
         def existingFile = outputDir.file("some").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
         existingFile << "modified"
-        def afterExecution = fingerprintOutput(outputDir)
+        def afterExecution = snapshotOutput(outputDir)
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution).fingerprints.keySet() == [outputDir, existingFile]*.absolutePath as Set
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [outputDir, existingFile]
     }
 
     def "updated files are part of the output"() {
         def existingFile = temporaryFolder.file("some").createFile()
-        def beforeExecution = fingerprintOutput(existingFile)
+        def beforeExecution = snapshotOutput(existingFile)
         existingFile << "modified"
-        def afterExecution = fingerprintOutput(existingFile)
+        def afterExecution = snapshotOutput(existingFile)
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution).fingerprints.keySet() == [existingFile.absolutePath] as Set
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [existingFile]
     }
 
     def "removed files are not considered outputs"() {
         def outputDir = temporaryFolder.createDir("outputDir")
         def outputDirFile = outputDir.file("toBeDeleted").createFile()
-        def beforeExecution = fingerprintOutput(outputDir)
+        def afterPreviousExecutionFingerprint = fingerprintOutput(outputDir)
+        def beforeExecutionSnapshot = snapshotOutput(outputDir)
         outputDirFile.delete()
-        def afterExecution = fingerprintOutput(outputDir)
+        def afterExecution = snapshotOutput(outputDir)
 
         expect:
-        filterOutputFingerprint(beforeExecution, beforeExecution, afterExecution).fingerprints.keySet() == [outputDir.absolutePath] as Set
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution).empty
+        collectFiles(filterOutputSnapshotAfterExecution(afterPreviousExecutionFingerprint, beforeExecutionSnapshot, afterExecution)) == [outputDir]
+        filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, afterPreviousExecutionFingerprint, afterExecution).empty
     }
 
     def "overlapping directories are not included"() {
         def outputDir = temporaryFolder.createDir("outputDir")
         outputDir.createDir("output-dir-2")
-        def beforeExecution = fingerprintOutput(outputDir)
+        def beforeExecution = snapshotOutput(outputDir)
         def outputDirFile = outputDir.createFile("outputDirFile")
-        def afterExecution1 = fingerprintOutput(outputDir)
+        def afterExecution = snapshotOutput(outputDir)
 
         expect:
-        filterOutputFingerprint(outputFingerprinter.empty(), beforeExecution, afterExecution1).fingerprints.keySet() == [outputDir, outputDirFile]*.absolutePath as Set
+        collectFiles(filterOutputSnapshotAfterExecution(EMPTY_OUTPUT_FINGERPRINT, beforeExecution, afterExecution)) == [outputDir, outputDirFile]
+    }
+
+    private FileSystemSnapshot snapshotOutput(File output) {
+        fileSystemMirror.beforeBuildFinished()
+        snapshotter.snapshot(output)
+    }
+
+    private CurrentFileCollectionFingerprint fingerprintOutput(File outputDir) {
+        DefaultCurrentFileCollectionFingerprint.from([snapshotOutput(outputDir)], AbsolutePathFingerprintingStrategy.IGNORE_MISSING)
+    }
+
+    List<File> collectFiles(ImmutableList<FileSystemSnapshot> fileSystemSnapshots) {
+        def result = []
+        fileSystemSnapshots.each {
+            it.accept(new FileSystemSnapshotVisitor() {
+                @Override
+                boolean preVisitDirectory(DirectorySnapshot directorySnapshot) {
+                    result.add(directorySnapshot)
+                    return true
+                }
+
+                @Override
+                void visit(FileSystemLocationSnapshot fileSnapshot) {
+                    result.add(fileSnapshot)
+                }
+
+                @Override
+                void postVisitDirectory(DirectorySnapshot directorySnapshot) {
+                }
+            })
+        }
+        result.collect { it.absolutePath as File }
     }
 }


### PR DESCRIPTION
So that unavailable files don't have to be snapshotted.

See #9746.