### PR TITLE
Add debug support to TestLauncher

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process;
+
+import org.gradle.api.Incubating;
+
+import java.util.Objects;
+
+/**
+ * Contains a subset of the <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/introclientissues005.html">Java Debug Wire Protocol</a> properties.
+ *
+ * @since 5.6
+ */
+@Incubating
+public class JavaDebugOptions {
+
+    private final int port;
+    private final boolean server;
+    private final boolean suspend;
+
+    public JavaDebugOptions(int port, boolean server, boolean suspend) {
+        this.port = port;
+        this.server = server;
+        this.suspend = suspend;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean isServer() {
+        return server;
+    }
+
+    public boolean isSuspend() {
+        return suspend;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JavaDebugOptions that = (JavaDebugOptions) o;
+        return port == that.port &&
+            server == that.server &&
+            suspend == that.suspend;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(port, server, suspend);
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
@@ -17,55 +17,17 @@
 package org.gradle.process;
 
 import org.gradle.api.Incubating;
-
-import java.util.Objects;
+import org.gradle.api.tasks.Input;
 
 /**
- * Contains a subset of the <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/introclientissues005.html">Java Debug Wire Protocol</a> properties.
+ * Contains a subset of the <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html">Java Debug Wire Protocol</a> properties.
  *
  * @since 5.6
  */
 @Incubating
-public class JavaDebugOptions {
-
-    private final int port;
-    private final boolean server;
-    private final boolean suspend;
-
-    public JavaDebugOptions(int port, boolean server, boolean suspend) {
-        this.port = port;
-        this.server = server;
-        this.suspend = suspend;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public boolean isServer() {
-        return server;
-    }
-
-    public boolean isSuspend() {
-        return suspend;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        JavaDebugOptions that = (JavaDebugOptions) o;
-        return port == that.port &&
-            server == that.server &&
-            suspend == that.suspend;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(port, server, suspend);
-    }
+public interface JavaDebugOptions {
+    @Input boolean isEnabled();
+    @Input int getPort();
+    @Input boolean isServer();
+    @Input boolean isSuspend();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
@@ -17,6 +17,7 @@
 package org.gradle.process;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 
 /**
@@ -26,8 +27,30 @@ import org.gradle.api.tasks.Input;
  */
 @Incubating
 public interface JavaDebugOptions {
-    @Input boolean isEnabled();
-    @Input int getPort();
-    @Input boolean isServer();
-    @Input boolean isSuspend();
+
+    /**
+     * @return Whether to attach a debug agent to the forked process.
+     */
+    @Input Property<Boolean> getEnabled();
+
+    /**
+     * @return The debug port.
+     */
+    @Input Property<Integer> getPort();
+
+    /**
+     * Whether a socket-attach or a socket-listen type of debugger is expected.
+     * <p>
+     * In socked-attach mode (server = true) the process actively waits for the debugger to connect after the JVM
+     * starts up. In socket-listen mode (server = false), the debugger should be already running before startup
+     * waiting for the JVM connecting to it.
+     *
+     * @return Whether the process actively waits for the debugger to be attached.
+     */
+    @Input Property<Boolean> getServer();
+
+    /**
+     * @return Whether the forked process should be suspended until the connection to the debugger is established.
+     */
+    @Input Property<Boolean> getSuspend();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
@@ -29,12 +29,12 @@ import org.gradle.api.tasks.Input;
 public interface JavaDebugOptions {
 
     /**
-     * @return Whether to attach a debug agent to the forked process.
+     * Whether to attach a debug agent to the forked process.
      */
     @Input Property<Boolean> getEnabled();
 
     /**
-     * @return The debug port.
+     * The debug port.
      */
     @Input Property<Integer> getPort();
 
@@ -50,7 +50,7 @@ public interface JavaDebugOptions {
     @Input Property<Boolean> getServer();
 
     /**
-     * @return Whether the forked process should be suspended until the connection to the debugger is established.
+     * Whether the forked process should be suspended until the connection to the debugger is established.
      */
     @Input Property<Boolean> getSuspend();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -16,6 +16,8 @@
 
 package org.gradle.process;
 
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Classpath;
@@ -213,7 +215,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * {@link org.gradle.api.tasks.testing.Test#getForkEvery()}.
      * <p>
      * Since Gradle 5.6, you can configure the port and other Java debug properties via
-     * {@link #setDebugOptions(JavaDebugOptions)}.
+     * {@link #debugOptions(Action)}.
      *
      * @return true when debugging is enabled, false to disable.
      */
@@ -225,22 +227,40 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * 5005.
      * <p>
      * Since Gradle 5.6, you can configure the port and other Java debug properties via
-     * {@link #setDebugOptions(JavaDebugOptions)}.
+     * {@link #debugOptions(Action)}.
      *
      * @param enabled true to enable debugging, false to disable.
      */
     void setDebug(boolean enabled);
 
     /**
+     * Returns the Java Debug Wire Protocol properties for the process. If {@link #setDebug(boolean)} is enabled then
+     * the {@code -agentlib:jdwp=...}  will be appended to the JVM arguments with the configuration from the parameter.
+     *
+     * @since 5.6
+     */
+    @Nested
+    @Incubating
+    JavaDebugOptions getDebugOptions();
+
+    /**
      * Configures Java Debug Wire Protocol properties for the process. If {@link #setDebug(boolean)} is enabled then
      * the {@code -agentlib:jdwp=...}  will be appended to the JVM arguments with the configuration from the parameter.
      *
-     * @param debugOptions the Java debug configuration
+     * @param closure the Java debug configuration
      * @since 5.6
      */
-    @Input
-    @Incubating
-    void setDebugOptions(JavaDebugOptions debugOptions);
+    void debugOptions(Closure closure);
+
+
+    /**
+     * Configures Java Debug Wire Protocol properties for the process. If {@link #setDebug(boolean)} is enabled then
+     * the {@code -agentlib:jdwp=...}  will be appended to the JVM arguments with the configuration from the parameter.
+     *
+     * @param action the Java debug configuration
+     * @since 5.6
+     */
+    void debugOptions(Action<JavaDebugOptions> action);
 
     /**
      * Returns the full set of arguments to use to launch the JVM for the process. This includes arguments to define

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -211,6 +211,9 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * is started in a suspended state, listening on port 5005. You should disable parallel test execution when
      * debugging and you will need to reattach the debugger occasionally if you use a non-zero value for
      * {@link org.gradle.api.tasks.testing.Test#getForkEvery()}.
+     * <p>
+     * Since Gradle 5.6, you can configure the port and other Java debug properties via
+     * {@link #setDebugOptions(JavaDebugOptions)}.
      *
      * @return true when debugging is enabled, false to disable.
      */
@@ -220,19 +223,24 @@ public interface JavaForkOptions extends ProcessForkOptions {
     /**
      * Enable or disable debugging for the process. When enabled, the process is started suspended and listening on port
      * 5005.
+     * <p>
+     * Since Gradle 5.6, you can configure the port and other Java debug properties via
+     * {@link #setDebugOptions(JavaDebugOptions)}.
      *
      * @param enabled true to enable debugging, false to disable.
      */
     void setDebug(boolean enabled);
 
     /**
-     * Enable debugging for the process. When called, the process is started in debug mode with the specified parameters.
+     * Configures Java Debug Wire Protocol properties for the process. If {@link #setDebug(boolean)} is enabled then
+     * the {@code -agentlib:jdwp=...}  will be appended to the JVM arguments with the configuration from the parameter.
      *
-     * @param port The started process will listen on this port.
+     * @param debugOptions the Java debug configuration
      * @since 5.6
      */
+    @Input
     @Incubating
-    void setDebugOptions(int port);
+    void setDebugOptions(JavaDebugOptions debugOptions);
 
     /**
      * Returns the full set of arguments to use to launch the JVM for the process. This includes arguments to define

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -226,6 +226,15 @@ public interface JavaForkOptions extends ProcessForkOptions {
     void setDebug(boolean enabled);
 
     /**
+     * Enable debugging for the process. When called, the process is started in debug mode with the specified parameters.
+     *
+     * @param port The started process will listen on this port.
+     * @since 5.6
+     */
+    @Incubating
+    void setDebugOptions(int port);
+
+    /**
      * Returns the full set of arguments to use to launch the JVM for the process. This includes arguments to define
      * system properties, the minimum/maximum heap size, and the bootstrap classpath.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -16,7 +16,6 @@
 
 package org.gradle.process;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
@@ -242,17 +241,6 @@ public interface JavaForkOptions extends ProcessForkOptions {
     @Nested
     @Incubating
     JavaDebugOptions getDebugOptions();
-
-    /**
-     * Configures Java Debug Wire Protocol properties for the process. If {@link #setDebug(boolean)} is enabled then
-     * the {@code -agentlib:jdwp=...}  will be appended to the JVM arguments with the configuration from the parameter.
-     *
-     * @param closure the Java debug configuration
-     * @since 5.6
-     */
-    @Incubating
-    void debugOptions(Closure closure);
-
 
     /**
      * Configures Java Debug Wire Protocol properties for the process. If {@link #setDebug(boolean)} is enabled then

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -250,6 +250,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * @param closure the Java debug configuration
      * @since 5.6
      */
+    @Incubating
     void debugOptions(Closure closure);
 
 
@@ -260,6 +261,7 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * @param action the Java debug configuration
      * @since 5.6
      */
+    @Incubating
     void debugOptions(Action<JavaDebugOptions> action);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaForkOptions.java
@@ -225,16 +225,15 @@ public interface JavaForkOptions extends ProcessForkOptions {
      * Enable or disable debugging for the process. When enabled, the process is started suspended and listening on port
      * 5005.
      * <p>
-     * Since Gradle 5.6, you can configure the port and other Java debug properties via
-     * {@link #debugOptions(Action)}.
+     * The debug properties (e.g. the port number) can be configured in {@link #debugOptions(Action)}.
      *
      * @param enabled true to enable debugging, false to disable.
      */
     void setDebug(boolean enabled);
 
     /**
-     * Returns the Java Debug Wire Protocol properties for the process. If {@link #setDebug(boolean)} is enabled then
-     * the {@code -agentlib:jdwp=...}  will be appended to the JVM arguments with the configuration from the parameter.
+     * Returns the Java Debug Wire Protocol properties for the process. If enabled then the {@code -agentlib:jdwp=...}
+     * will be appended to the JVM arguments with the configuration from the parameter.
      *
      * @since 5.6
      */

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.tasks;
 
+import groovy.lang.Closure;
 import org.apache.tools.ant.types.Commandline;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
@@ -39,6 +41,8 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import static org.gradle.util.ConfigureUtil.configureUsing;
 
 /**
  * Executes a Java application in a child process.
@@ -307,8 +311,18 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     }
 
     @Override
-    public void setDebugOptions(JavaDebugOptions debugOptions) {
-        javaExecHandleBuilder.setDebugOptions(debugOptions);
+    public JavaDebugOptions getDebugOptions() {
+        return javaExecHandleBuilder.getDebugOptions();
+    }
+
+    @Override
+    public void debugOptions(Closure closure) {
+        debugOptions(configureUsing(closure));
+    }
+
+    @Override
+    public void debugOptions(Action<JavaDebugOptions> action) {
+        javaExecHandleBuilder.debugOptions(action);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.ProcessForkOptions;
@@ -306,8 +307,8 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     }
 
     @Override
-    public void setDebugOptions(int port) {
-        javaExecHandleBuilder.setDebugOptions(port);
+    public void setDebugOptions(JavaDebugOptions debugOptions) {
+        javaExecHandleBuilder.setDebugOptions(debugOptions);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -305,6 +305,11 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
         javaExecHandleBuilder.setDebug(enabled);
     }
 
+    @Override
+    public void setDebugOptions(int port) {
+        javaExecHandleBuilder.setDebugOptions(port);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks;
 
-import groovy.lang.Closure;
 import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
@@ -41,8 +40,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import static org.gradle.util.ConfigureUtil.configureUsing;
 
 /**
  * Executes a Java application in a child process.
@@ -313,11 +310,6 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     @Override
     public JavaDebugOptions getDebugOptions() {
         return javaExecHandleBuilder.getDebugOptions();
-    }
-
-    @Override
-    public void debugOptions(Closure closure) {
-        debugOptions(configureUsing(closure));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -81,6 +81,20 @@ import java.util.Map;
  * <pre>
  * gradle someJavaExecTask --debug-jvm
  * </pre>
+ * <p>
+ * Also, debug configuration can be explicitly set in {@link #debugOptions(Action)}:
+ * <pre>
+ * task runApp(type: JavaExec) {
+ *    ...
+ *
+ *    debugOptions {
+ *        enabled = true
+ *        port = 5566
+ *        server = true
+ *        suspend = false
+ *    }
+ * }
+ * </pre>
  */
 public class JavaExec extends ConventionTask implements JavaExecSpec {
     private final JavaExecAction javaExecHandleBuilder;

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.file.HasScriptServices;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
+import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -99,7 +100,7 @@ public abstract class DefaultScript extends BasicScript {
                 FileResolver resolver = fileLookup.getFileResolver(sourceFile.getParentFile());
                 DefaultFileCollectionFactory fileCollectionFactoryWithBase = new DefaultFileCollectionFactory(resolver, null);
                 fileOperations = new DefaultFileOperations(resolver, null, null, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, textResourceLoader, fileCollectionFactoryWithBase, fileSystem, clock);
-                processOperations = services.get(ExecFactory.class).forContext(resolver, fileCollectionFactoryWithBase, instantiator);
+                processOperations = services.get(ExecFactory.class).forContext(resolver, fileCollectionFactoryWithBase, instantiator, new InstantiatorBackedObjectFactory(instantiator));
             } else {
                 fileOperations = new DefaultFileOperations(fileLookup.getFileResolver(), null, null, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, textResourceLoader, fileCollectionFactory, fileSystem, clock);
                 processOperations = services.get(ExecFactory.class);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -247,8 +247,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new CleanupActionFactory(buildOperationExecutor);
     }
 
-    protected ExecFactory decorateExecFactory(ExecFactory execFactory, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, BuildCancellationToken buildCancellationToken) {
-        return execFactory.forContext(fileResolver, fileCollectionFactory, instantiator, buildCancellationToken);
+    protected ExecFactory decorateExecFactory(ExecFactory execFactory, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, BuildCancellationToken buildCancellationToken, ObjectFactory objectFactory) {
+        return execFactory.forContext(fileResolver, fileCollectionFactory, instantiator, buildCancellationToken, objectFactory);
     }
 
     DeprecatedUsageBuildOperationProgressBroadaster createDeprecatedUsageBuildOperationProgressBroadaster(

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -168,8 +168,8 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultFileOperations(fileResolver, project.getTasks(), temporaryFileProvider, instantiator, fileLookup, directoryFileTreeFactory, streamHasher, fileHasher, textResourceLoader, fileCollectionFactory, fileSystem, clock);
     }
 
-    protected ExecFactory decorateExecFactory(ExecFactory execFactory, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, InstantiatorFactory instantiatorFactory) {
-        return execFactory.forContext(fileResolver, fileCollectionFactory, instantiatorFactory.decorateLenient());
+    protected ExecFactory decorateExecFactory(ExecFactory execFactory, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, InstantiatorFactory instantiatorFactory, ObjectFactory objectFactory) {
+        return execFactory.forContext(fileResolver, fileCollectionFactory, instantiatorFactory.decorateLenient(), objectFactory);
     }
 
     protected TemporaryFileProvider createTemporaryFileProvider() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -18,6 +18,7 @@ package org.gradle.process.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.DefaultFileCollectionFactory;
@@ -355,7 +356,17 @@ public class DefaultExecActionFactory implements ExecFactory {
         }
 
         @Override
-        public void setDebugOptions(JavaDebugOptions debugOptions) {
+        public JavaDebugOptions getDebugOptions() {
+            return delegate.getDebugOptions();
+        }
+
+        @Override
+        public void debugOptions(Closure closure) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void debugOptions(Action<JavaDebugOptions> action) {
             throw new UnsupportedOperationException();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -34,6 +34,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
+import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.ProcessForkOptions;
@@ -354,7 +355,7 @@ public class DefaultExecActionFactory implements ExecFactory {
         }
 
         @Override
-        public void setDebugOptions(int port) {
+        public void setDebugOptions(JavaDebugOptions debugOptions) {
             throw new UnsupportedOperationException();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -354,6 +354,11 @@ public class DefaultExecActionFactory implements ExecFactory {
         }
 
         @Override
+        public void setDebugOptions(int port) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public List<String> getAllJvmArgs() {
             return ImmutableList.copyOf(delegate.getAllJvmArgs());
         }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import org.gradle.process.JavaDebugOptions;
+
+import java.util.Objects;
+
+public class DefaultJavaDebugOptions implements JavaDebugOptions {
+
+    private boolean enabled;
+    private int port = 5005;
+    private boolean server;
+    private boolean suspend;
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public boolean isServer() {
+        return server;
+    }
+
+    public void setServer(boolean server) {
+        this.server = server;
+    }
+
+    public boolean isSuspend() {
+        return suspend;
+    }
+
+    public void setSuspend(boolean suspend) {
+        this.suspend = suspend;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultJavaDebugOptions that = (DefaultJavaDebugOptions) o;
+        return enabled == that.enabled &&
+            port == that.port &&
+            server == that.server &&
+            suspend == that.suspend;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, port, server, suspend);
+    }
+
+    public void applyTo(JavaDebugOptions options) {
+        DefaultJavaDebugOptions defaultOptions = (DefaultJavaDebugOptions) options;
+        defaultOptions.setEnabled(isEnabled());
+        defaultOptions.setServer(isServer());
+        defaultOptions.setSuspend(isSuspend());
+        defaultOptions.setPort(getPort());
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
@@ -22,10 +22,10 @@ import java.util.Objects;
 
 public class DefaultJavaDebugOptions implements JavaDebugOptions {
 
-    private boolean enabled;
+    private boolean enabled = false;
     private int port = 5005;
-    private boolean server;
-    private boolean suspend;
+    private boolean server = true;
+    private boolean suspend = true;
 
     @Override
     public boolean isEnabled() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
@@ -33,10 +33,10 @@ public class DefaultJavaDebugOptions implements JavaDebugOptions {
 
     @Inject
     public DefaultJavaDebugOptions(ObjectFactory objectFactory) {
-        this.enabled = objectFactory.property(Boolean.class).value(false);
-        this.port = objectFactory.property(Integer.class).value(5005);
-        this.server = objectFactory.property(Boolean.class).value(true);
-        this.suspend = objectFactory.property(Boolean.class).value(true);
+        this.enabled = objectFactory.property(Boolean.class).convention(false);
+        this.port = objectFactory.property(Integer.class).convention(5005);
+        this.server = objectFactory.property(Boolean.class).convention(true);
+        this.suspend = objectFactory.property(Boolean.class).convention(true);
     }
 
     public DefaultJavaDebugOptions() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
@@ -16,49 +16,38 @@
 
 package org.gradle.process.internal;
 
+import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.process.JavaDebugOptions;
 
+import javax.inject.Inject;
 import java.util.Objects;
 
 public class DefaultJavaDebugOptions implements JavaDebugOptions {
+    private final Property<Boolean> enabled;
+    private final Property<Integer> port;
+    private final Property<Boolean> server;
+    private final Property<Boolean> suspend;
 
-    private boolean enabled = false;
-    private int port = 5005;
-    private boolean server = true;
-    private boolean suspend = true;
+    @Inject
+    public DefaultJavaDebugOptions(ObjectFactory objectFactory) {
+        this.enabled = objectFactory.property(Boolean.class).value(false);
+        this.port = objectFactory.property(Integer.class).value(5005);
+        this.server = objectFactory.property(Boolean.class).value(true);
+        this.suspend = objectFactory.property(Boolean.class).value(true);
+    }
+
+    public DefaultJavaDebugOptions() {
+        // Ugly, but there are a few places where we need to instantiate a JavaDebugOptions and a regular ObjectFactory service
+        // is not available.
+        this(new InstantiatorBackedObjectFactory(DirectInstantiator.INSTANCE));
+    }
 
     @Override
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    @Override
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-    public boolean isServer() {
-        return server;
-    }
-
-    public void setServer(boolean server) {
-        this.server = server;
-    }
-
-    public boolean isSuspend() {
-        return suspend;
-    }
-
-    public void setSuspend(boolean suspend) {
-        this.suspend = suspend;
+    public int hashCode() {
+        return Objects.hash(getEnabled().get(), getPort().get(), getServer().get(), getSuspend().get());
     }
 
     @Override
@@ -70,22 +59,29 @@ public class DefaultJavaDebugOptions implements JavaDebugOptions {
             return false;
         }
         DefaultJavaDebugOptions that = (DefaultJavaDebugOptions) o;
-        return enabled == that.enabled &&
-            port == that.port &&
-            server == that.server &&
-            suspend == that.suspend;
+        return enabled.get() == that.enabled.get()
+                && port.get().equals(that.port.get())
+                && server.get()  == that.server.get()
+                && suspend.get()  == that.suspend.get();
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(enabled, port, server, suspend);
+    public Property<Boolean> getEnabled() {
+        return enabled;
     }
 
-    public void applyTo(JavaDebugOptions options) {
-        DefaultJavaDebugOptions defaultOptions = (DefaultJavaDebugOptions) options;
-        defaultOptions.setEnabled(isEnabled());
-        defaultOptions.setServer(isServer());
-        defaultOptions.setSuspend(isSuspend());
-        defaultOptions.setPort(getPort());
+    @Override
+    public Property<Integer> getPort() {
+        return port;
+    }
+
+    @Override
+    public Property<Boolean> getServer() {
+        return server;
+    }
+
+    @Override
+    public Property<Boolean> getSuspend() {
+        return suspend;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecAction.java
@@ -27,8 +27,8 @@ import java.util.concurrent.Executor;
  * Use {@link ExecActionFactory} or {@link DslExecActionFactory} instead.
  */
 public class DefaultJavaExecAction extends JavaExecHandleBuilder implements JavaExecAction {
-    public DefaultJavaExecAction(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Executor executor, BuildCancellationToken buildCancellationToken) {
-        super(fileResolver, fileCollectionFactory, executor, buildCancellationToken);
+    public DefaultJavaExecAction(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Executor executor, BuildCancellationToken buildCancellationToken, JavaForkOptionsFactory javaForkOptionsFactory) {
+        super(fileResolver, fileCollectionFactory, executor, buildCancellationToken, javaForkOptionsFactory);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -17,6 +17,8 @@
 package org.gradle.process.internal;
 
 import com.google.common.collect.Maps;
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.UnionFileCollection;
@@ -37,6 +39,7 @@ import static org.gradle.process.internal.util.MergeOptionsUtil.containsAll;
 import static org.gradle.process.internal.util.MergeOptionsUtil.getHeapSizeMb;
 import static org.gradle.process.internal.util.MergeOptionsUtil.mergeHeapSize;
 import static org.gradle.process.internal.util.MergeOptionsUtil.normalized;
+import static org.gradle.util.ConfigureUtil.configureUsing;
 
 public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements JavaForkOptionsInternal {
     private final PathToFileResolver resolver;
@@ -213,8 +216,15 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     }
 
     @Override
-    public void setDebugOptions(JavaDebugOptions debugOptions) {
-        options.setDebugOptions(debugOptions);
+    public void debugOptions(Closure closure) {
+        debugOptions(configureUsing(closure));
+    }
+
+    @Override
+    public void debugOptions(Action<JavaDebugOptions> action) {
+        JavaDebugOptions o = options.getDebugOptions();
+        action.execute(o);
+        options.setDebugOptions(o);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
 
 import java.util.ArrayList;
@@ -207,13 +208,13 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
         options.setDebug(enabled);
     }
 
-    public int getPort() {
-        return options.getDebugPort();
+    public JavaDebugOptions getDebugOptions() {
+        return options.getDebugOptions();
     }
 
     @Override
-    public void setDebugOptions(int port) {
-        options.setDebugPort(port);
+    public void setDebugOptions(JavaDebugOptions debugOptions) {
+        options.setDebugOptions(debugOptions);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -207,6 +207,15 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
         options.setDebug(enabled);
     }
 
+    public int getPort() {
+        return options.getDebugPort();
+    }
+
+    @Override
+    public void setDebugOptions(int port) {
+        options.setDebugPort(port);
+    }
+
     @Override
     public JavaForkOptions copyTo(JavaForkOptions target) {
         super.copyTo(target);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -16,46 +16,37 @@
 
 package org.gradle.process.internal;
 
-import com.google.common.collect.Maps;
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.UnionFileCollection;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import static org.gradle.process.internal.util.MergeOptionsUtil.canBeMerged;
 import static org.gradle.process.internal.util.MergeOptionsUtil.containsAll;
 import static org.gradle.process.internal.util.MergeOptionsUtil.getHeapSizeMb;
-import static org.gradle.process.internal.util.MergeOptionsUtil.mergeHeapSize;
 import static org.gradle.process.internal.util.MergeOptionsUtil.normalized;
-import static org.gradle.util.ConfigureUtil.configureUsing;
 
 public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements JavaForkOptionsInternal {
-    private final PathToFileResolver resolver;
     private final JvmOptions options;
-    private final FileCollectionFactory fileCollectionFactory;
     private List<CommandLineArgumentProvider> jvmArgumentProviders;
 
-    public DefaultJavaForkOptions(PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory) {
-        this(resolver, fileCollectionFactory, Jvm.current());
+    @Inject
+    public DefaultJavaForkOptions(PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, JavaDebugOptions debugOptions) {
+        this(resolver, fileCollectionFactory, Jvm.current(), debugOptions);
     }
 
-    public DefaultJavaForkOptions(PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, Jvm jvm) {
+    private DefaultJavaForkOptions(PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, Jvm jvm, JavaDebugOptions debugOptions) {
         super(resolver);
-        this.resolver = resolver;
-        options = new JvmOptions(fileCollectionFactory);
-        this.fileCollectionFactory = fileCollectionFactory;
+        options = new JvmOptions(fileCollectionFactory, debugOptions);
         setExecutable(jvm.getJavaExecutable());
     }
 
@@ -216,15 +207,8 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     }
 
     @Override
-    public void debugOptions(Closure closure) {
-        debugOptions(configureUsing(closure));
-    }
-
-    @Override
     public void debugOptions(Action<JavaDebugOptions> action) {
-        JavaDebugOptions o = options.getDebugOptions();
-        action.execute(o);
-        options.setDebugOptions(o);
+        action.execute(options.getDebugOptions());
     }
 
     @Override
@@ -237,54 +221,6 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
             }
         }
         return this;
-    }
-
-    @Override
-    public JavaForkOptionsInternal mergeWith(JavaForkOptions options) {
-        if (hasJvmArgumentProviders(this) || hasJvmArgumentProviders(options)) {
-            throw new UnsupportedOperationException("Cannot merge options with jvmArgumentProviders.");
-        }
-        JavaForkOptionsInternal mergedOptions = new DefaultJavaForkOptions(resolver, fileCollectionFactory);
-
-        if (!canBeMerged(getExecutable(), options.getExecutable())) {
-            throw new IllegalArgumentException("Cannot merge a fork options object with a different executable (this: " + getExecutable() + ", other: " + options.getExecutable() + ").");
-        } else {
-            mergedOptions.setExecutable(getExecutable() != null ? getExecutable() : options.getExecutable());
-        }
-
-        if (!canBeMerged(getWorkingDir(), options.getWorkingDir())) {
-            throw new IllegalArgumentException("Cannot merge a fork options object with a different working directory (this: " + getWorkingDir() + ", other: " + options.getWorkingDir() + ").");
-        } else {
-            mergedOptions.setWorkingDir(getWorkingDir() != null ? getWorkingDir() : options.getWorkingDir());
-        }
-
-        if (!canBeMerged(getDefaultCharacterEncoding(), options.getDefaultCharacterEncoding())) {
-            throw new IllegalArgumentException("Cannot merge a fork options object with a different default character encoding (this: " + getDefaultCharacterEncoding() + ", other: " + options.getDefaultCharacterEncoding() + ").");
-        } else {
-            mergedOptions.setDefaultCharacterEncoding(getDefaultCharacterEncoding() != null ? getDefaultCharacterEncoding() : options.getDefaultCharacterEncoding());
-        }
-
-        mergedOptions.setDebug(getDebug() || options.getDebug());
-        mergedOptions.setEnableAssertions(getEnableAssertions() || options.getEnableAssertions());
-
-        mergedOptions.setMinHeapSize(mergeHeapSize(getMinHeapSize(), options.getMinHeapSize()));
-        mergedOptions.setMaxHeapSize(mergeHeapSize(getMaxHeapSize(), options.getMaxHeapSize()));
-
-        Set<String> mergedJvmArgs = normalized(getJvmArgs());
-        mergedJvmArgs.addAll(normalized(options.getJvmArgs()));
-        mergedOptions.setJvmArgs(mergedJvmArgs);
-
-        Map<String, Object> mergedEnvironment = Maps.newHashMap(getEnvironment());
-        mergedEnvironment.putAll(options.getEnvironment());
-        mergedOptions.setEnvironment(mergedEnvironment);
-
-        Map<String, Object> mergedSystemProperties = Maps.newHashMap(getSystemProperties());
-        mergedSystemProperties.putAll(options.getSystemProperties());
-        mergedOptions.setSystemProperties(mergedSystemProperties);
-
-        mergedOptions.setBootstrapClasspath(new UnionFileCollection(getBootstrapClasspath(), options.getBootstrapClasspath()));
-
-        return mergedOptions;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
@@ -26,6 +26,7 @@ public interface ExecActionFactory {
     /**
      * Creates a {@link JavaExecAction} that is not decorated. Use this when the action is not made visible to the DSL.
      * If you need to make the action visible to the DSL, use {@link DslExecActionFactory#newDecoratedJavaExecAction()} instead.
+     * @return
      */
     JavaExecAction newJavaExecAction();
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecActionFactory.java
@@ -26,7 +26,6 @@ public interface ExecActionFactory {
     /**
      * Creates a {@link JavaExecAction} that is not decorated. Use this when the action is not made visible to the DSL.
      * If you need to make the action visible to the DSL, use {@link DslExecActionFactory#newDecoratedJavaExecAction()} instead.
-     * @return
      */
     JavaExecAction newJavaExecAction();
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecFactory.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal;
 import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -29,10 +30,10 @@ public interface ExecFactory extends ExecActionFactory, ExecHandleFactory, JavaE
     /**
      * Creates a new factory for the given context.
      */
-    ExecFactory forContext(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator);
+    ExecFactory forContext(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, ObjectFactory objectFactory);
 
     /**
      * Creates a new factory for the given context.
      */
-    ExecFactory forContext(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, BuildCancellationToken buildCancellationToken);
+    ExecFactory forContext(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, BuildCancellationToken buildCancellationToken, ObjectFactory objectFactory);
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -16,6 +16,8 @@
 package org.gradle.process.internal;
 
 import com.google.common.collect.Iterables;
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -35,6 +37,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+
+import static org.gradle.util.ConfigureUtil.*;
 
 /**
  * Use {@link JavaExecHandleFactory} instead.
@@ -200,8 +204,19 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     }
 
     @Override
-    public void setDebugOptions(JavaDebugOptions debugOptions) {
-        javaOptions.setDebugOptions(debugOptions);
+    public JavaDebugOptions getDebugOptions() {
+        return javaOptions.getDebugOptions();
+    }
+
+    @Override
+    public void debugOptions(Closure closure) {
+        debugOptions(configureUsing(closure));
+    }
+
+    @Override
+    public void debugOptions(Action<JavaDebugOptions> action) {
+        
+        javaOptions.debugOptions(action);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -199,6 +199,11 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     }
 
     @Override
+    public void setDebugOptions(int port) {
+        javaOptions.setDebugOptions(port);
+    }
+
+    @Override
     public String getMain() {
         return mainClass;
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.CollectionUtils;
@@ -199,8 +200,8 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     }
 
     @Override
-    public void setDebugOptions(int port) {
-        javaOptions.setDebugOptions(port);
+    public void setDebugOptions(JavaDebugOptions debugOptions) {
+        javaOptions.setDebugOptions(debugOptions);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -16,7 +16,6 @@
 package org.gradle.process.internal;
 
 import com.google.common.collect.Iterables;
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -38,8 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
-import static org.gradle.util.ConfigureUtil.*;
-
 /**
  * Use {@link JavaExecHandleFactory} instead.
  */
@@ -51,10 +48,10 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     private final JavaForkOptions javaOptions;
     private final List<CommandLineArgumentProvider> argumentProviders = new ArrayList<CommandLineArgumentProvider>();
 
-    public JavaExecHandleBuilder(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Executor executor, BuildCancellationToken buildCancellationToken) {
+    public JavaExecHandleBuilder(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Executor executor, BuildCancellationToken buildCancellationToken, JavaForkOptionsFactory javaForkOptionsFactory) {
         super(fileResolver, executor, buildCancellationToken);
         this.fileCollectionFactory = fileCollectionFactory;
-        javaOptions = new DefaultJavaForkOptions(fileResolver, fileCollectionFactory);
+        this.javaOptions = javaForkOptionsFactory.newJavaForkOptions();
         executable(javaOptions.getExecutable());
     }
 
@@ -209,13 +206,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     }
 
     @Override
-    public void debugOptions(Closure closure) {
-        debugOptions(configureUsing(closure));
-    }
-
-    @Override
     public void debugOptions(Action<JavaDebugOptions> action) {
-        
         javaOptions.debugOptions(action);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
@@ -19,13 +19,6 @@ package org.gradle.process.internal;
 import org.gradle.process.JavaForkOptions;
 
 public interface JavaForkOptionsInternal extends JavaForkOptions {
-    /**
-     * Merges these options with the given options.
-     *
-     * @param options The target options.
-     * @return A new {@link JavaForkOptionsInternal} with the merged values.
-     */
-    JavaForkOptionsInternal mergeWith(JavaForkOptions options);
 
     /**
      * Returns true if the given options are compatible with this set of options.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.CommandLineArgumentProvider
-import org.gradle.process.JavaDebugOptions
 import org.gradle.process.JavaForkOptions
 import org.gradle.process.internal.DefaultJavaForkOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -340,7 +339,9 @@ class DefaultJavaForkOptionsTest extends Specification {
 
     def "can set debug options"() {
         when:
-        options.setDebugOptions(new JavaDebugOptions(2233, false, false)) // TODO add more tests
+        options.debugOptions {
+            port = 2233
+        }
 
         then:
         options.debugOptions.port == 2233

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.CommandLineArgumentProvider
+import org.gradle.process.JavaDebugOptions
 import org.gradle.process.JavaForkOptions
 import org.gradle.process.internal.DefaultJavaForkOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -58,7 +59,6 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.bootstrapClasspath.files.isEmpty()
         !options.enableAssertions
         !options.debug
-        !options.port
         options.allJvmArgs == [fileEncodingProperty(), *localeProperties()]
     }
 
@@ -340,10 +340,10 @@ class DefaultJavaForkOptionsTest extends Specification {
 
     def "can set debug options"() {
         when:
-        options.setDebugOptions(2233)
+        options.setDebugOptions(new JavaDebugOptions(2233, false, false)) // TODO add more tests
 
         then:
-        options.port == 2233
+        options.debugOptions.port == 2233
     }
 
     def "can set bootstrapClasspath"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -58,6 +58,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.bootstrapClasspath.files.isEmpty()
         !options.enableAssertions
         !options.debug
+        !options.port
         options.allJvmArgs == [fileEncodingProperty(), *localeProperties()]
     }
 
@@ -335,6 +336,14 @@ class DefaultJavaForkOptionsTest extends Specification {
         then:
         options.debug
         options.jvmArgs == []
+    }
+
+    def "can set debug options"() {
+        when:
+        options.setDebugOptions(2233)
+
+        then:
+        options.port == 2233
     }
 
     def "can set bootstrapClasspath"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.api.internal.tasks.util
 
 import com.google.common.collect.ImmutableSet
-import org.gradle.api.Action
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.jvm.Jvm

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -276,67 +276,6 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']
     }
 
-    def "debug is enabled when set using jvmArgs"() {
-        when:
-        options.jvmArgs('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005')
-
-        then:
-        options.debug
-        options.jvmArgs == []
-
-        when:
-        options.allJvmArgs = []
-
-        then:
-        !options.debug
-
-        when:
-        options.debug = false
-        options.jvmArgs = ['-Xdebug']
-
-        then:
-        !options.debug
-        options.jvmArgs == ['-Xdebug']
-
-        when:
-        options.jvmArgs = ['-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
-
-        then:
-        !options.debug
-        options.jvmArgs == ['-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
-
-        when:
-        options.jvmArgs '-Xdebug'
-
-        then:
-        options.debug
-        options.jvmArgs == []
-
-        when:
-        options.debug = false
-        options.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=other']
-
-        then:
-        !options.debug
-        options.jvmArgs == ['-Xdebug', '-Xrunjdwp:transport=other']
-
-        when:
-        options.debug = false
-        options.allJvmArgs = ['-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005', '-Xdebug']
-
-        then:
-        options.debug
-        options.jvmArgs == []
-
-        when:
-        options.debug = false
-        options.allJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']
-
-        then:
-        options.debug
-        options.jvmArgs == []
-    }
-
     def "can set debug options"() {
         when:
         options.debugOptions {
@@ -418,7 +357,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         1 * target.setMaxHeapSize('1g')
         1 * target.setBootstrapClasspath(options.bootstrapClasspath)
         1 * target.setEnableAssertions(false)
-        1 * target.setDebug(false)
+        1 * target.debugOptions(_) // TODO
 
         then:
         1 * target.jvmArgs(['argFromProvider'])

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -18,11 +18,14 @@
 package org.gradle.api.internal.tasks.util
 
 import com.google.common.collect.ImmutableSet
+import org.gradle.api.Action
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.CommandLineArgumentProvider
+import org.gradle.process.JavaDebugOptions
 import org.gradle.process.JavaForkOptions
+import org.gradle.process.internal.DefaultJavaDebugOptions
 import org.gradle.process.internal.DefaultJavaForkOptions
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.UsesNativeServices
@@ -357,7 +360,11 @@ class DefaultJavaForkOptionsTest extends Specification {
         1 * target.setMaxHeapSize('1g')
         1 * target.setBootstrapClasspath(options.bootstrapClasspath)
         1 * target.setEnableAssertions(false)
-        1 * target.debugOptions(_) // TODO
+        1 * target.debugOptions({ action ->
+            JavaDebugOptions debugOptions = new DefaultJavaDebugOptions()
+            action.execute(debugOptions)
+            !debugOptions.enabled
+        })
 
         then:
         1 * target.jvmArgs(['argFromProvider'])

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
@@ -33,7 +33,7 @@ class DefaultExecActionFactoryTest extends ConcurrentSpec {
     def resolver = TestFiles.resolver(tmpDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     def instantiator = TestUtil.instantiatorFactory()
-    def factory = DefaultExecActionFactory.of(resolver, fileCollectionFactory, executorFactory).forContext(resolver, fileCollectionFactory, instantiator.decorateLenient())
+    def factory = DefaultExecActionFactory.of(resolver, fileCollectionFactory, executorFactory).forContext(resolver, fileCollectionFactory, instantiator.decorateLenient(), null)
 
     def javaexec() {
         File testFile = tmpDir.file("someFile")

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
@@ -33,7 +33,7 @@ class DefaultExecActionFactoryTest extends ConcurrentSpec {
     def resolver = TestFiles.resolver(tmpDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     def instantiator = TestUtil.instantiatorFactory()
-    def factory = DefaultExecActionFactory.of(resolver, fileCollectionFactory, executorFactory).forContext(resolver, fileCollectionFactory, instantiator.decorateLenient(), null)
+    def factory = DefaultExecActionFactory.of(resolver, fileCollectionFactory, executorFactory).forContext(resolver, fileCollectionFactory, instantiator.decorateLenient(), TestUtil.objectFactory())
 
     def javaexec() {
         File testFile = tmpDir.file("someFile")

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -30,7 +30,7 @@ import java.util.concurrent.Executor
 import static java.util.Arrays.asList
 
 class JavaExecHandleBuilderTest extends Specification {
-    JavaExecHandleBuilder builder = new JavaExecHandleBuilder(TestFiles.resolver(), TestFiles.fileCollectionFactory(), Mock(Executor), new DefaultBuildCancellationToken())
+    JavaExecHandleBuilder builder = new JavaExecHandleBuilder(TestFiles.resolver(), TestFiles.fileCollectionFactory(), Mock(Executor), new DefaultBuildCancellationToken(), TestFiles.execFactory())
 
     FileCollectionFactory fileCollectionFactory = new DefaultFileCollectionFactory()
 

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.process.internal
 
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.process.JavaDebugOptions
 import org.gradle.process.JavaForkOptions
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -272,7 +271,9 @@ class JvmOptionsTest extends Specification {
 
         when:
         opts.debug = true
-        opts.debugOptions = new JavaDebugOptions(port, server, suspend)
+        opts.debugOptions.port = port
+        opts.debugOptions.server = server
+        opts.debugOptions.suspend = suspend
 
         then:
         opts.allJvmArgs.findAll { it.contains 'jdwp' } == [expected]

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -95,6 +95,24 @@ class JvmOptionsTest extends Specification {
         opts.debug == false
     }
 
+    def "debug port can be set via allJvmArgs"() {
+        setup:
+        def opts = createOpts()
+
+        when:
+        opts.allJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=localhost:4456']
+
+        then:
+        opts.debug
+        opts.debugPort == 4456
+
+        when:
+        opts.allJvmArgs = []
+
+        then:
+        opts.debug == false
+    }
+
     def "managed jvm args includes heap settings"() {
         expect:
         parse("-Xms1G -XX:-PrintClassHistogram -Xmx2G -Dfoo.encoding=blah").managedJvmArgs == ["-Xms1G", "-Xmx2G", "-Dfile.encoding=${defaultCharset}", *localePropertyStrings()]

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -80,65 +80,6 @@ class JvmOptionsTest extends Specification {
         parse("-Xms1G -Dfile.encoding=UTF-8 -Dfoo.encoding=blah -Dfile.encoding=UTF-16").allJvmArgs == ["-Dfoo.encoding=blah", "-Xms1G", "-Dfile.encoding=UTF-16", *localePropertyStrings()]
     }
 
-    def "debug option can be set via allJvmArgs"() {
-        setup:
-        def opts = createOpts()
-
-        when:
-        opts.allJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']
-        then:
-        opts.debug
-
-        when:
-        opts.allJvmArgs = []
-        then:
-        !opts.debug
-    }
-
-    def "debug port can be set via allJvmArgs"() {
-        setup:
-        def opts = createOpts()
-
-        when:
-        opts.allJvmArgs = ['-Xdebug']
-
-        then:
-        !opts.debug
-
-        when:
-        opts.allJvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=n,suspend=y,address=8989']
-
-        then:
-        opts.debug
-        opts.debugOptions.port == 8989
-        !opts.debugOptions.server
-        opts.debugOptions.suspend
-
-        when:
-        opts.allJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=localhost:4456']
-
-        then:
-        opts.debug
-        !opts.debugOptions.suspend
-        !opts.debugOptions.server
-        opts.debugOptions.port == 4456
-
-        when:
-        opts.allJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:4457']
-
-        then:
-        opts.debug
-        opts.debugOptions.suspend
-        opts.debugOptions.server
-        opts.debugOptions.port == 4457
-
-        when:
-        opts.allJvmArgs = []
-
-        then:
-        !opts.debug
-    }
-
     def "managed jvm args includes heap settings"() {
         expect:
         parse("-Xms1G -XX:-PrintClassHistogram -Xmx2G -Dfoo.encoding=blah").managedJvmArgs == ["-Xms1G", "-Xmx2G", "-Dfile.encoding=${defaultCharset}", *localePropertyStrings()]

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -142,6 +142,7 @@ class JvmOptionsTest extends Specification {
         1 * target.systemProperties({
             it == new TreeMap(["file.encoding": "UTF-16"] + localeProperties())
         })
+        1 * target.getDebugOptions() >> new DefaultJavaDebugOptions()
     }
 
     @Unroll
@@ -212,9 +213,9 @@ class JvmOptionsTest extends Specification {
 
         when:
         opts.debug = true
-        opts.debugOptions.port = port
-        opts.debugOptions.server = server
-        opts.debugOptions.suspend = suspend
+        opts.debugOptions.port.set(port)
+        opts.debugOptions.server.set(server)
+        opts.debugOptions.suspend.set(suspend)
 
         then:
         opts.allJvmArgs.findAll { it.contains 'jdwp' } == [expected]

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -145,7 +145,7 @@ public class TestFiles {
     }
 
     public static ExecFactory execFactory(File baseDir) {
-        return execFactory().forContext(resolver(baseDir), fileCollectionFactory(baseDir), TestUtil.instantiatorFactory().inject());
+        return execFactory().forContext(resolver(baseDir), fileCollectionFactory(baseDir), TestUtil.instantiatorFactory().inject(), TestUtil.objectFactory());
     }
 
     public static ExecActionFactory execActionFactory() {

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -134,7 +134,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         def toolingApiJar = contentsDir.file("lib/gradle-tooling-api-${baseVersion}.jar")
         toolingApiJar.assertIsFile()
-        assert toolingApiJar.length() < 366 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
+        assert toolingApiJar.length() < 367 * 1024 // tooling api jar is the small plain tooling api jar version and not the fat jar.
 
         // Plugins
         assertIsGradleJar(contentsDir.file("lib/plugins/gradle-dependency-management-${baseVersion}.jar"))

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -182,6 +182,30 @@ Gradle can now detect that it is running in an interactive terminal on Linux aar
 
 Thanks to [Amey](https://github.com/ameyp) for adding this support to [native-platform](https://github.com/adammurdoch/native-platform/).
 
+## Debug support for forked Java processes
+
+Gradle has now a new DSL element to configure debugging for Java processes.  
+ 
+```groovy
+project.javaexec {
+
+  debugOptions {
+     enabled = true
+     port = 4455
+     server = true
+     suspend = true
+   }
+}
+```
+
+This configuration appends the following JVM argument to the process: `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=4455` 
+ 
+The `debugOptions` configuration is available for `project.javaExec` and for tasks using the `JavaExec` type, including the `test` task.
+ 
+## Debug tests via the Tooling API
+ 
+In addition to the new DSL element above, the Tooling API is capable of launching tests in debug mode. Clients can  invoke `TestLauncher.debugTestsOn(port)` to launch a test in debug mode. This feature will be used in the upcoming Buildship release.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/userguide/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/java_testing.adoc
@@ -472,6 +472,19 @@ On the few occasions that you want to debug your code while the tests are runnin
 
 When debugging for tests is enabled, Gradle will start the test process suspended and listening on port 5005.
 
+You can also enable debugging in the DSL, where you can also configure other properties:
+
+    test {
+        debugOptions {
+            enabled = true
+            port = 4455
+            server = true
+            suspend = true
+        }
+    }
+
+With this configuration the test JVM will behave just like when passing the `--debug-jvm` argument but it will listen on port 4455.
+
 [[sec:java_test_fixtures]]
 == Using test fixtures
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -123,6 +123,11 @@ configurations.all {
 }
 ```
 
+=== Disabled debug argument parsing in JavaExec
+
+Gradle 5.6 introduced a new DSL element (`JavaForkOptions.debugOptions(Action<JavaDebugOptions>)`) to configure debug properties for forked Java processes. Due to this change, Gradle no longer parses debug-related JVM arguments. Consequently, `JavaForkOptions.getDebu()` no longer returns `true` if the `-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005` or the `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005` argument is specified to the process.
+
+
 See <<managing_transitive_dependencies.adoc#sec:capabilities, the capabilities section of the documentation>> for more options.
 
 [[changes_5.5]]

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JDWPUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JDWPUtil.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures.jvm
 
 import org.gradle.util.ports.DefaultPortDetector
+import org.gradle.util.ports.FixedAvailablePortAllocator
 import org.junit.Assume
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -33,7 +34,7 @@ class JDWPUtil implements TestRule {
     def connectionArgs
 
     JDWPUtil() {
-        this(findFreePort())
+        this(FixedAvailablePortAllocator.instance.assignPort())
     }
 
     JDWPUtil(Integer port) {
@@ -44,16 +45,6 @@ class JDWPUtil implements TestRule {
     JDWPUtil(String host, Integer port) {
         this.host = host
         this.port = port
-    }
-
-    static int findFreePort() {
-        new ServerSocket(0).withCloseable { socket ->
-            try {
-                return socket.getLocalPort()
-            } catch (IOException e) {
-                throw new RuntimeException("Cannot find free port", e)
-            }
-        }
     }
 
     @Override
@@ -117,5 +108,7 @@ class JDWPUtil implements TestRule {
                 }
             }
         }
+
+        FixedAvailablePortAllocator.instance.releasePort(port)
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JDWPUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JDWPUtil.groovy
@@ -64,14 +64,14 @@ class JDWPUtil implements TestRule {
 
     def connect() {
         if (vm == null) {
-        def vmm = Class.forName("com.sun.jdi.Bootstrap").virtualMachineManager()
-        def connection = vmm.attachingConnectors().find { "dt_socket".equalsIgnoreCase(it.transport().name()) }
-        def connectionArgs = connection.defaultArguments()
-        connectionArgs.get("port").setValue(port as String)
-        connectionArgs.get("hostname").setValue(host)
-        this.vm = connection.attach(connectionArgs)
-    }
-    vm
+            def vmm = Class.forName("com.sun.jdi.Bootstrap").virtualMachineManager()
+            def connection = vmm.attachingConnectors().find { "dt_socket".equalsIgnoreCase(it.transport().name()) }
+            def connectionArgs = connection.defaultArguments()
+            connectionArgs.get("port").setValue(port as String)
+            connectionArgs.get("hostname").setValue(host)
+            this.vm = connection.attach(connectionArgs)
+        }
+        vm
 }
 
     def listen() {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/CommandLineIntegrationSpec.groovy
@@ -18,7 +18,7 @@ package org.gradle.launcher
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.launcher.debug.JDWPUtil
+import org.gradle.integtests.fixtures.jvm.JDWPUtil
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.junit.Rule
 import spock.lang.IgnoreIf

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
@@ -19,10 +19,13 @@ package org.gradle.tooling.internal.provider;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.StartParameterInternal;
+import org.gradle.tooling.events.test.internal.DefaultDebugOptions;
 import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
+import org.gradle.tooling.internal.protocol.test.InternalDebugOptions;
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 import org.gradle.tooling.internal.provider.test.ProviderInternalJvmTestRequest;
 import org.gradle.tooling.internal.provider.test.ProviderInternalTestExecutionRequest;
+import org.gradle.tooling.model.UnsupportedMethodException;
 import org.gradle.util.CollectionUtils;
 
 import java.util.Collection;
@@ -35,13 +38,15 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
     private final Set<InternalTestDescriptor> testDescriptors;
     private final Set<String> classNames;
     private final Set<InternalJvmTestRequest> internalJvmTestRequests;
+    private final InternalDebugOptions debugOptions;
 
-    private TestExecutionRequestAction(BuildClientSubscriptions clientSubscriptions, StartParameterInternal startParameter, Set<InternalTestDescriptor> testDescriptors, Set<String> providerClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests) {
+    private TestExecutionRequestAction(BuildClientSubscriptions clientSubscriptions, StartParameterInternal startParameter, Set<InternalTestDescriptor> testDescriptors, Set<String> providerClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions) {
         super(clientSubscriptions);
         this.startParameter = startParameter;
         this.testDescriptors = testDescriptors;
         this.classNames = providerClassNames;
         this.internalJvmTestRequests = internalJvmTestRequests;
+        this.debugOptions = debugOptions;
     }
 
     // Unpacks the request to serialize across to the daemon and creates instance of
@@ -53,7 +58,18 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
         return new TestExecutionRequestAction(clientSubscriptions, startParameter,
                                                 ImmutableSet.copyOf(testExecutionRequest.getTestExecutionDescriptors()),
                                                 ImmutableSet.copyOf(testClassNames),
-                                                providerInternalJvmTestRequests);
+                                                providerInternalJvmTestRequests,
+                                                getDebugOptions(testExecutionRequest));
+    }
+
+    // TODO (donat) how can we handle this properly in the TAPI protocol?
+    private static InternalDebugOptions getDebugOptions(ProviderInternalTestExecutionRequest testExecutionRequest) {
+        try {
+        return testExecutionRequest.getDebugOptions();
+        } catch (UnsupportedMethodException e) {
+        // default value for older Gradle clients
+            return new DefaultDebugOptions();
+        }
     }
 
     private static List<InternalJvmTestRequest> toProviderInternalJvmTestRequest(Collection<InternalJvmTestRequest> internalJvmTestRequests, Collection<String> testClassNames) {
@@ -90,5 +106,9 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
 
     public Collection<InternalTestDescriptor> getTestExecutionDescriptors() {
         return testDescriptors;
+    }
+
+    public InternalDebugOptions getDebugOptions() {
+        return debugOptions;
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
@@ -62,12 +62,11 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
                                                 getDebugOptions(testExecutionRequest));
     }
 
-    // TODO (donat) how can we handle this properly in the TAPI protocol?
     private static InternalDebugOptions getDebugOptions(ProviderInternalTestExecutionRequest testExecutionRequest) {
         try {
-        return testExecutionRequest.getDebugOptions();
+            return testExecutionRequest.getDebugOptions();
         } catch (UnsupportedMethodException e) {
-        // default value for older Gradle clients
+            // default value for older Gradle clients
             return new DefaultDebugOptions();
         }
     }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.serialize.SerializerSpec
 import org.gradle.launcher.cli.action.BuildActionSerializer
 import org.gradle.launcher.cli.action.ExecuteBuildAction
 import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.events.test.internal.DefaultDebugOptions
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions
 import org.gradle.tooling.internal.provider.BuildModelAction
 import org.gradle.tooling.internal.provider.ClientProvidedBuildAction
@@ -58,7 +59,7 @@ class BuildActionSerializerTest extends SerializerSpec {
         where:
         action << [
             new ClientProvidedBuildAction(new StartParameterInternal(), new SerializedPayload(null, []), true, new BuildClientSubscriptions(EnumSet.allOf(OperationType))),
-            new TestExecutionRequestAction(new BuildClientSubscriptions(EnumSet.allOf(OperationType)), new StartParameterInternal(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet()),
+            new TestExecutionRequestAction(new BuildClientSubscriptions(EnumSet.allOf(OperationType)), new StartParameterInternal(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), new DefaultDebugOptions()),
             new BuildModelAction(new StartParameterInternal(), "model", false, new BuildClientSubscriptions(EnumSet.allOf(OperationType)))
         ]
     }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
@@ -137,18 +137,4 @@ class PropertiesToDaemonParametersConverterTest extends Specification {
         true    | true
         false   | false
     }
-
-    def "enable debug mode from JVM args when default debug argument is used"() {
-        when:
-        converter.convert([
-            (DaemonBuildOptions.JvmArgsOption.GRADLE_PROPERTY)                 : "-Xmx256m $debugArgs".toString(),
-        ], params)
-
-        then:
-        params.debug
-
-        where:
-        debugArgs << ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005', '-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
-    }
-
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -92,6 +92,26 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         succeeds('run')
     }
 
+    def "If custom debug argument is passed to the build then debug options is ignored"() {
+        setup:
+        sampleProject"""    
+            debugOptions {
+                enabled = true
+                server = false
+                suspend = false
+            }
+            
+            jvmArgs "-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=$jdwpClient.port"
+        """
+
+        jdwpClient.listen()
+
+        expect:
+        succeeds('run')
+        output.contains "Debug configuration ignored in favor of the supplied JVM arguments: [-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=$jdwpClient.port]"
+    }
+
+
     private void sampleProject(String runConfig) {
         file('src/main/java/Driver.java')
         file("src/main/java/Driver.java").text = mainClass("""

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.jvm.JDWPUtil
+import org.junit.Rule
+
+class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
+
+    @Rule
+    JDWPUtil jdwpClient = new JDWPUtil()
+
+    def "Debug is disabled by default"() {
+        setup:
+        sampleProject"""
+            debugOptions {
+            }
+        """
+
+        expect:
+        succeeds('run')
+    }
+
+    def "Deebug mode can be disabled"() {
+        setup:
+        sampleProject"""
+            debugOptions {
+                enabled = false
+            }
+        """
+
+        expect:
+        succeeds('run')
+    }
+
+    def "Debug session fails without debugger"() {
+        setup:
+        sampleProject"""
+            debugOptions {
+                enabled = true
+            }
+        """
+
+        expect:
+        def failure = fails('run')
+        failure.assertHasErrorOutput('ERROR: transport error 202: connect failed: Connection refused')
+    }
+
+    def "Can debug Java exec"() {
+        setup:
+        sampleProject"""    
+            debugOptions {
+                enabled = true
+                server = false
+                suspend = false
+                port = $jdwpClient.port
+            }
+        """
+        jdwpClient.listen()
+
+        expect:
+        succeeds('run')
+    }
+
+    def "Debug options overrides debug property"() {
+        setup:
+        sampleProject"""    
+            debug = true
+        
+            debugOptions {
+                enabled = false
+            }
+        """
+
+        expect:
+        succeeds('run')
+    }
+
+    private void sampleProject(String runConfig) {
+        file('src/main/java/Driver.java')
+        file("src/main/java/Driver.java").text = mainClass("""
+            try {
+                FileWriter out = new FileWriter("out.txt");
+                for (String arg: args) {
+                    out.write(arg);
+                    out.write("\\n");
+                }
+                out.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        """)
+
+
+        buildFile.text = """
+            apply plugin: "java"
+
+            task run(type: JavaExec) {
+                classpath = project.layout.files(compileJava)
+                main "driver.Driver"
+                args "1"
+                
+                $runConfig
+            }
+        """
+    }
+
+    private static String mainClass(String body) {
+        """
+            package driver;
+
+            import java.io.*;
+            import java.lang.System;
+
+            public class Driver {
+                public static void main(String[] args) {
+                ${body}
+                }
+            }
+        """
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -16,13 +16,11 @@
 
 package org.gradle.api.tasks
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.jvm.JDWPUtil
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.junit.Rule
-import spock.lang.IgnoreIf
+import spock.lang.Ignore
 
 class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
@@ -79,7 +77,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    @IgnoreIf({ OperatingSystem.current().isWindows() })
+    @Ignore
     def "can debug Java exec with socket attach type debugger (server = true)"(String taskName) {
         setup:
         sampleProject"""    

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -66,7 +66,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        def failure = fails(taskName)
+        def failure = executer.withTasks(taskName).withStackTraceChecksDisabled().runWithFailure()
         failure.assertHasErrorOutput('ERROR: transport error 202: connect failed: Connection refused')
 
         where:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -19,8 +19,10 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.jvm.JDWPUtil
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.junit.Rule
+import spock.lang.IgnoreIf
 
 class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
@@ -92,6 +94,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
+    @IgnoreIf({ OperatingSystem.current().isWindows() })
     def "Can debug Java exec with socket attach type debugger (server = true)"(String taskName) {
         setup:
         sampleProject"""    

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -43,21 +43,6 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    def "debug mode can be disabled"(String taskName) {
-        setup:
-        sampleProject"""
-            debugOptions {
-                enabled = false
-            }
-        """
-
-        expect:
-        succeeds(taskName)
-
-        where:
-        taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
-    }
-
     def "debug session fails without debugger"(String taskName) {
         setup:
         sampleProject"""

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -29,7 +29,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     JDWPUtil debugClient = new JDWPUtil()
 
-    def "Debug is disabled by default"(String taskName) {
+    def "debug is disabled by default"(String taskName) {
         setup:
         sampleProject"""
             debugOptions {
@@ -43,7 +43,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    def "Debug mode can be disabled"(String taskName) {
+    def "debug mode can be disabled"(String taskName) {
         setup:
         sampleProject"""
             debugOptions {
@@ -58,7 +58,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    def "Debug session fails without debugger"(String taskName) {
+    def "debug session fails without debugger"(String taskName) {
         setup:
         sampleProject"""
             debugOptions {
@@ -75,7 +75,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    def "Can debug Java exec with socket listen type debugger (server = false)"(String taskName) {
+    def "can debug Java exec with socket listen type debugger (server = false)"(String taskName) {
         setup:
         sampleProject"""    
             debugOptions {
@@ -95,7 +95,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @IgnoreIf({ OperatingSystem.current().isWindows() })
-    def "Can debug Java exec with socket attach type debugger (server = true)"(String taskName) {
+    def "can debug Java exec with socket attach type debugger (server = true)"(String taskName) {
         setup:
         sampleProject"""    
             debugOptions {
@@ -122,7 +122,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    def "Debug options overrides debug property"(String taskName) {
+    def "cebug options overrides debug property"(String taskName) {
         setup:
         sampleProject"""    
             debug = true
@@ -140,7 +140,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    def "If custom debug argument is passed to the build then debug options is ignored"(String taskName) {
+    def "if custom debug argument is passed to the build then debug options is ignored"(String taskName) {
         setup:
         sampleProject"""    
             debugOptions {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -105,7 +105,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
         taskName << ['runJavaExec', 'runProjectJavaExec', 'test']
     }
 
-    def "cebug options overrides debug property"(String taskName) {
+    def "debug options overrides debug property"(String taskName) {
         setup:
         sampleProject"""    
             debug = true

--- a/subprojects/process-services/src/main/java/org/gradle/process/ProcessForkOptions.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/ProcessForkOptions.java
@@ -39,7 +39,7 @@ public interface ProcessForkOptions {
 
     /**
      * Sets the name of the executable to use.
-     *
+     *P
      * @param executable The executable. Must not be null.
      */
     void setExecutable(Object executable);

--- a/subprojects/process-services/src/main/java/org/gradle/process/ProcessForkOptions.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/ProcessForkOptions.java
@@ -39,7 +39,7 @@ public interface ProcessForkOptions {
 
     /**
      * Sets the name of the executable to use.
-     *P
+     *
      * @param executable The executable. Must not be null.
      */
     void setExecutable(Object executable);

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -454,12 +454,28 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         forkOptions.setDebug(enabled);
     }
 
+
     /**
      * {@inheritDoc}
      */
     @Override
-    public void setDebugOptions(JavaDebugOptions debugOptions) {
-        forkOptions.setDebugOptions(debugOptions);
+    public JavaDebugOptions getDebugOptions() {
+        return forkOptions.getDebugOptions();
+    }
+
+
+    @Override
+    public void debugOptions(Closure closure) {
+        debugOptions(ConfigureUtil.<JavaDebugOptions>configureUsing(closure)); // TODO why doesn't it work with static import®
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param action
+     */
+    @Override
+    public void debugOptions(Action<JavaDebugOptions> action) {
+        forkOptions.debugOptions(action);
         // run all tests on the same JVM
         setForkEvery(null);
         setMaxParallelForks(1);

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -454,6 +454,14 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDebugOptions(int port) {
+        forkOptions.setDebugOptions(port);
+    }
+
+    /**
      * Enables fail fast behavior causing the task to fail on the first failed test.
      */
     @Option(option = "fail-fast", description = "Stops test execution after the first failed test.")

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -65,6 +65,7 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.ProcessForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
@@ -457,8 +458,11 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      * {@inheritDoc}
      */
     @Override
-    public void setDebugOptions(int port) {
-        forkOptions.setDebugOptions(port);
+    public void setDebugOptions(JavaDebugOptions debugOptions) {
+        forkOptions.setDebugOptions(debugOptions);
+        // run all tests on the same JVM
+        setForkEvery(null);
+        setMaxParallelForks(1);
     }
 
     /**

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -476,9 +476,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     @Override
     public void debugOptions(Action<JavaDebugOptions> action) {
         forkOptions.debugOptions(action);
-        // run all tests on the same JVM
-        setForkEvery(null);
-        setMaxParallelForks(1);
     }
 
     /**

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1005,7 +1005,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      */
     @Internal
     public long getForkEvery() {
-        return forkEvery;
+        return getDebug() ? 0 : forkEvery;
     }
 
     /**

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -463,12 +463,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         return forkOptions.getDebugOptions();
     }
 
-
-    @Override
-    public void debugOptions(Closure closure) {
-        debugOptions(ConfigureUtil.<JavaDebugOptions>configureUsing(closure));
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -466,7 +466,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
 
     @Override
     public void debugOptions(Closure closure) {
-        debugOptions(ConfigureUtil.<JavaDebugOptions>configureUsing(closure)); // TODO why doesn't it work with static import®
+        debugOptions(ConfigureUtil.<JavaDebugOptions>configureUsing(closure));
     }
 
     /**

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -471,7 +471,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
 
     /**
      * {@inheritDoc}
-     * @param action
      */
     @Override
     public void debugOptions(Action<JavaDebugOptions> action) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
@@ -27,6 +28,7 @@ import org.gradle.api.tasks.testing.TestFilter;
 import org.gradle.execution.BuildConfigurationAction;
 import org.gradle.execution.BuildExecutionContext;
 import org.gradle.process.JavaDebugOptions;
+import org.gradle.process.internal.DefaultJavaDebugOptions;
 import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction;
@@ -62,7 +64,15 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
             InternalDebugOptions debugOptions = testExecutionRequest.getDebugOptions();
             if (debugOptions.isDebugMode()) {
                 task.setDebug(true);
-                task.setDebugOptions(new JavaDebugOptions(debugOptions.getPort(), false, false));
+                task.debugOptions(new Action<JavaDebugOptions>() {
+                    @Override
+                    public void execute(JavaDebugOptions javaDebugOptions) {
+                        DefaultJavaDebugOptions options = (DefaultJavaDebugOptions) javaDebugOptions;
+                        options.setPort(debugOptions.getPort());
+                        options.setServer(false);
+                        options.setSuspend(false);
+                    }
+                });
             }
         }
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.testing.TestExecutionException;
 import org.gradle.api.tasks.testing.TestFilter;
 import org.gradle.execution.BuildConfigurationAction;
 import org.gradle.execution.BuildExecutionContext;
+import org.gradle.process.JavaDebugOptions;
 import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction;
@@ -61,10 +62,7 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
             InternalDebugOptions debugOptions = testExecutionRequest.getDebugOptions();
             if (debugOptions.isDebugMode()) {
                 task.setDebug(true);
-                task.setDebugOptions(debugOptions.getPort());
-                // run all tests on the same JVM
-                task.setForkEvery(null);
-                task.setMaxParallelForks(1);
+                task.setDebugOptions(new JavaDebugOptions(debugOptions.getPort(), false, false));
             }
         }
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -30,6 +30,7 @@ import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction;
 import org.gradle.tooling.internal.provider.events.DefaultTestDescriptor;
+import org.gradle.tooling.internal.protocol.test.InternalDebugOptions;
 
 import java.util.*;
 
@@ -57,6 +58,14 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
             task.setIgnoreFailures(true);
             task.getFilter().setFailOnNoMatchingTests(false);
             task.getOutputs().upToDateWhen(Specs.SATISFIES_NONE);
+            InternalDebugOptions debugOptions = testExecutionRequest.getDebugOptions();
+            if (debugOptions.isDebugMode()) {
+                task.setDebug(true);
+                task.setDebugOptions(debugOptions.getPort());
+                // run all tests on the same JVM
+                task.setForkEvery(null);
+                task.setMaxParallelForks(1);
+            }
         }
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -63,14 +63,14 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
             task.getOutputs().upToDateWhen(Specs.SATISFIES_NONE);
             InternalDebugOptions debugOptions = testExecutionRequest.getDebugOptions();
             if (debugOptions.isDebugMode()) {
-                task.setDebug(true);
                 task.debugOptions(new Action<JavaDebugOptions>() {
                     @Override
                     public void execute(JavaDebugOptions javaDebugOptions) {
                         DefaultJavaDebugOptions options = (DefaultJavaDebugOptions) javaDebugOptions;
-                        options.setPort(debugOptions.getPort());
-                        options.setServer(false);
-                        options.setSuspend(false);
+                        options.getEnabled().set(true);
+                        options.getPort().set(debugOptions.getPort());
+                        options.getServer().set(false);
+                        options.getSuspend().set(false);
                     }
                 });
             }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestFilter
 import org.gradle.execution.BuildExecutionContext
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
+import org.gradle.tooling.internal.protocol.test.InternalDebugOptions
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest
 import org.gradle.tooling.internal.provider.TestExecutionRequestAction
 import org.gradle.tooling.internal.provider.events.DefaultTestDescriptor
@@ -47,6 +48,7 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
     BuildExecutionContext buildContext
     TaskExecutionGraphInternal taskGraph
     TestExecutionRequestAction testExecutionRequest
+    InternalDebugOptions debugOptions
 
     def setup() {
         outputsInternal = Mock()
@@ -58,6 +60,10 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
         testExecutionRequest = Mock()
         testTask = Mock()
         testFilter = Mock()
+
+        debugOptions = Mock()
+        debugOptions.isDebugMode() >> false
+        testExecutionRequest.getDebugOptions() >> debugOptions
 
         setupProject()
         setupTestTask()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
@@ -31,10 +31,7 @@ import spock.lang.Timeout
 @ToolingApiVersion(">=5.6")
 @TargetGradleVersion(">=5.6")
 @Timeout(60)
-class TestLauncherDebuggingCrossVersionTest extends ToolingApiSpecification {
-
-    // TODO extract common elements to setup()
-    // TODO use async api to connect to VirtualMachine
+class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
 
     def setup() {
         buildFile << """
@@ -65,7 +62,7 @@ class TestLauncherDebuggingCrossVersionTest extends ToolingApiSpecification {
         withConnection { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses("example.MyTest")
-                .withDebugOptions(findFreePort())
+                .debugTests(findFreePort())
                 .run()
         }
 
@@ -81,27 +78,7 @@ class TestLauncherDebuggingCrossVersionTest extends ToolingApiSpecification {
         withConnection { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses("example.MyTest")
-                .withDebugOptions(port)
-                .run()
-        }
-
-        then:
-        true // test successfully executed with debugger attached
-
-        cleanup:
-        connector.stopListening(arguments)
-    }
-
-    def "Overwrites configuration from --debug-jvm parameter"() {
-        setup:
-        def (connector, port, arguments) = startSocketListenDebugSession()
-
-        when:
-        withConnection { connection ->
-            connection.newTestLauncher()
-                .withJvmTestClasses("example.MyTest")
-                .withDebugOptions(port)
-                .addJvmArguments("--debug-jvm")
+                .debugTests(port)
                 .run()
         }
 
@@ -126,7 +103,7 @@ class TestLauncherDebuggingCrossVersionTest extends ToolingApiSpecification {
         withConnection { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses("example.MyTest", "example.SecondTest")
-                .withDebugOptions(port)
+                .debugTests(port)
                 .run()
         }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
@@ -62,7 +62,7 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
         withConnection { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses("example.MyTest")
-                .debugTests(JDWPUtil.findFreePort())
+                .debugTestsOn(JDWPUtil.findFreePort())
                 .run()
         }
 
@@ -78,7 +78,7 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
         withConnection { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses("example.MyTest")
-                .debugTests(jdwpClient.port)
+                .debugTestsOn(jdwpClient.port)
                 .run()
         }
 
@@ -100,7 +100,7 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
         withConnection { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses("example.MyTest", "example.SecondTest")
-                .debugTests(jdwpClient.port)
+                .debugTestsOn(jdwpClient.port)
                 .run()
         }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
@@ -21,9 +21,9 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.BuildException
+import org.gradle.util.ports.FixedAvailablePortAllocator
 import org.junit.Rule
 import spock.lang.Timeout
-
 
 @ToolingApiVersion(">=5.6")
 @TargetGradleVersion(">=5.6")
@@ -58,16 +58,22 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
     }
 
     def "build fails if debugger is not ready"() {
+        setup:
+        def port = FixedAvailablePortAllocator.instance.assignPort()
+
         when:
         withConnection { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses("example.MyTest")
-                .debugTestsOn(JDWPUtil.findFreePort())
+                .debugTestsOn(port)
                 .run()
         }
 
         then:
         thrown(BuildException)
+
+        cleanup:
+        FixedAvailablePortAllocator.instance.releasePort(port)
     }
 
     def "can launch tests in debug mode"() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
@@ -107,4 +107,7 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
         then:
         true // test successfully executed with debugger attached
     }
+
+    def "Overwrites debug options"() {}
+
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
@@ -91,7 +91,7 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
         true // test successfully executed with debugger attached
     }
 
-    def "Forks only one JVM to debug"() {
+    def "forks only one JVM to debug"() {
         setup:
         buildFile << """
              tasks.withType(Test) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebugTestsCrossVersionTest.groovy
@@ -77,7 +77,6 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
     }
 
     def "can launch tests in debug mode"() {
-        setup:
         jdwpClient.listen()
 
         when:
@@ -113,7 +112,4 @@ class TestLauncherDebugTestsCrossVersionTest extends ToolingApiSpecification {
         then:
         true // test successfully executed with debugger attached
     }
-
-    def "Overwrites debug options"() {}
-
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebuggingCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TestLauncherDebuggingCrossVersionTest.groovy
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r56
+
+import com.sun.jdi.Bootstrap
+import com.sun.jdi.VirtualMachine
+import com.sun.jdi.connect.Connector
+import com.sun.jdi.connect.ListeningConnector
+import com.sun.jdi.connect.TransportTimeoutException
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.BuildException
+import spock.lang.Timeout
+
+
+@ToolingApiVersion(">=5.6")
+@TargetGradleVersion(">=5.6")
+@Timeout(60)
+class TestLauncherDebuggingCrossVersionTest extends ToolingApiSpecification {
+
+    // TODO extract common elements to setup()
+    // TODO use async api to connect to VirtualMachine
+
+    def setup() {
+        buildFile << """
+            plugins { id 'java-library' }
+            ${mavenCentralRepository()}
+            dependencies { testCompile 'junit:junit:4.12' }
+        """
+        file('src/test/java/example/MyTest.java').text = """
+            package example;
+            public class MyTest {
+                @org.junit.Test public void foo() throws Exception {
+                     org.junit.Assert.assertEquals(1, 1);
+                }
+            }
+        """
+        file('src/test/java/example/SecondTest.java').text = """
+            package example;
+            public class SecondTest {
+                @org.junit.Test public void bar() throws Exception {
+                     org.junit.Assert.assertEquals(1, 1);
+                }
+            }
+        """
+    }
+
+    def "build fails if debugger is not ready"() {
+        when:
+        withConnection { connection ->
+            connection.newTestLauncher()
+                .withJvmTestClasses("example.MyTest")
+                .withDebugOptions(findFreePort())
+                .run()
+        }
+
+        then:
+        thrown(BuildException)
+    }
+
+    def "build fails if port is not available"() {
+        // TODO implement test build fails if port is not available
+    }
+
+    def "can launch tests in debug mode"() {
+        when:
+        int port = findFreePort()
+        ListeningConnector connector = newConnector()
+        Map<String, Connector.Argument> arguments = newConnectorArguments(connector, port)
+        connector.startListening(arguments)
+        VirtualMachine vm
+        Thread.start {
+            while (!vm) {
+                try {
+                    vm = connector.accept(arguments)
+                } catch (TransportTimeoutException e) {
+                }
+            }
+        }
+
+        withConnection { connection ->
+            connection.newTestLauncher()
+                .withJvmTestClasses("example.MyTest")
+                .withDebugOptions(port)
+                .run()
+        }
+
+        then:
+        vm
+
+        cleanup:
+        connector.stopListening(arguments)
+    }
+
+    def "Overwrites configuration from --debug-jvm parameter"() {
+        setup:
+        int port = findFreePort()
+        ListeningConnector connector = newConnector()
+        Map<String, Connector.Argument> arguments = newConnectorArguments(connector, port)
+        connector.startListening(arguments)
+        VirtualMachine vm
+        Thread.start {
+            while (!vm) {
+                try {
+                    vm = connector.accept(arguments)
+                } catch (TransportTimeoutException e) {
+                }
+            }
+        }
+
+        when:
+        withConnection { connection ->
+            connection.newTestLauncher()
+                .withJvmTestClasses("example.MyTest")
+                .withDebugOptions(port)
+                .addJvmArguments("--debug-jvm")
+                .run()
+        }
+
+        then:
+        vm
+    }
+
+    def "Forks only one JVM to debug"() {
+        setup:
+        buildFile << """
+             tasks.withType(Test) {
+                  forkEvery = 1
+                  maxParallelForks = 2
+            }
+        """
+
+        int port = findFreePort()
+        ListeningConnector connector = newConnector()
+        Map<String, Connector.Argument> arguments = newConnectorArguments(connector, port)
+        connector.startListening(arguments)
+        VirtualMachine vm
+        Thread.start {
+            while (!vm) {
+                try {
+                    vm = connector.accept(arguments)
+                } catch (TransportTimeoutException e) {
+                }
+            }
+        }
+
+        when:
+        withConnection { connection ->
+            connection.newTestLauncher()
+                .withJvmTestClasses("example.MyTest", "example.SecondTest")
+                .withDebugOptions(port)
+                .run()
+        }
+
+        then:
+        vm
+    }
+
+    int findFreePort() {
+        new ServerSocket(0).withCloseable { socket ->
+            try {
+                return socket.getLocalPort()
+            } catch (IOException e) {
+                throw new RuntimeException("Cannot find free port", e)
+            }
+        }
+    }
+
+    ListeningConnector newConnector() {
+        Bootstrap.virtualMachineManager().listeningConnectors().find { it.name() == "com.sun.jdi.SocketListen" }
+    }
+
+    Map<String, Connector.Argument> newConnectorArguments(ListeningConnector connector, int port) {
+        Map<String, Connector.Argument> acceptArguments = connector.defaultArguments()
+
+        Connector.Argument param = acceptArguments.get("port")
+        param.setValue(String.valueOf(port))
+        Connector.Argument timeout = acceptArguments.get("timeout")
+        timeout.setValue("3000") // 3 seconds
+        acceptArguments
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -84,15 +84,24 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
     TestLauncher withJvmTestMethods(String testClass, Iterable<String> methods);
 
     /**
-     * Runs the tests in debug mode.
+     * Configures test JVM to run in debug mode.
+     * <p>
+     * When called, the forked test JVM is launched with the following argument:
+     * <pre>-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=localhost:&lt;port&gt;</pre>
+     * This means the test JVM expects a debugger at the specified port that uses a
+     * <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/jpda/conninv.html#Connectors">socket listening connector</a>.
+     * If the debugger is not present then the test execution will fail.
+     * <p>
+     * Invoking this method adjusts the test task to launch only one JVM. More specifically, the parallel execution
+     * gets disabled and the {@code forkEvery} property is set to 0.
      *
-     * @param port the target port where to wait for the debugger
+     * @param port the target port where the test JVM expects the debugger
      * @return this
      *
      * @since 5.6
      */
     @Incubating
-    TestLauncher withDebugOptions(int port);
+    TestLauncher debugTests(int port);
 
     /**
      * Executes the tests, blocking until complete.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling;
 
+import org.gradle.api.Incubating;
 import org.gradle.tooling.events.test.TestOperationDescriptor;
 
 /**
@@ -81,6 +82,17 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      * @since 2.7
      */
     TestLauncher withJvmTestMethods(String testClass, Iterable<String> methods);
+
+    /**
+     * Runs the tests in debug mode.
+     *
+     * @param port the target port where to wait for the debugger
+     * @return this
+     *
+     * @since 5.6
+     */
+    @Incubating
+    TestLauncher withDebugOptions(int port);
 
     /**
      * Executes the tests, blocking until complete.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -89,7 +89,7 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      * When called, the forked test JVM is launched with the following argument:
      * <pre>-agentlib:jdwp=transport=dt_socket,server=n,suspend=n,address=localhost:&lt;port&gt;</pre>
      * This means the test JVM expects a debugger at the specified port that uses a
-     * <a href="https://docs.oracle.com/javase/1.5.0/docs/guide/jpda/conninv.html#Connectors">socket listening connector</a>.
+     * <a href="https://docs.oracle.com/javase/6/docs/technotes/guides/jpda/conninv.html#Connectors">socket listening connector</a>.
      * If the debugger is not present then the test execution will fail.
      * <p>
      * Invoking this method adjusts the test task to launch only one JVM. More specifically, the parallel execution

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -101,7 +101,7 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      * @since 5.6
      */
     @Incubating
-    TestLauncher debugTests(int port);
+    TestLauncher debugTestsOn(int port);
 
     /**
      * Executes the tests, blocking until complete.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/internal/DefaultDebugOptions.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/test/internal/DefaultDebugOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,27 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.provider.test;
+package org.gradle.tooling.events.test.internal;
 
-import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
 import org.gradle.tooling.internal.protocol.test.InternalDebugOptions;
-import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 
-import java.util.Collection;
+import java.io.Serializable;
 
-/**
- * @since 2.7-rc-1
- */
-public interface ProviderInternalTestExecutionRequest {
-    Collection<InternalTestDescriptor> getTestExecutionDescriptors();
-    Collection<String> getTestClassNames();
-    Collection<InternalJvmTestRequest> getInternalJvmTestRequests(Collection<InternalJvmTestRequest> defaults);
-    InternalDebugOptions getDebugOptions();
+public class DefaultDebugOptions implements InternalDebugOptions, Serializable {
+
+    private int port = -1;
+
+    @Override
+    public int getPort() {
+        return this.port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public boolean isDebugMode() {
+        return port > 0;
+    }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -22,6 +22,7 @@ import org.gradle.tooling.ResultHandler;
 import org.gradle.tooling.TestExecutionException;
 import org.gradle.tooling.TestLauncher;
 import org.gradle.tooling.events.test.TestOperationDescriptor;
+import org.gradle.tooling.events.test.internal.DefaultDebugOptions;
 import org.gradle.tooling.internal.consumer.async.AsyncConsumerActionExecutor;
 import org.gradle.tooling.internal.consumer.connection.ConsumerAction;
 import org.gradle.tooling.internal.consumer.connection.ConsumerConnection;
@@ -37,6 +38,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     private final Set<TestOperationDescriptor> operationDescriptors = new LinkedHashSet<TestOperationDescriptor>();
     private final Set<String> testClassNames = new LinkedHashSet<String>();
     private final Set<InternalJvmTestRequest> internalJvmTestRequests = new LinkedHashSet<InternalJvmTestRequest>();
+    private final DefaultDebugOptions debugOptions = new DefaultDebugOptions();
 
     public DefaultTestLauncher(AsyncConsumerActionExecutor connection, ConnectionParameters parameters) {
         super(parameters);
@@ -101,6 +103,12 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     }
 
     @Override
+    public TestLauncher withDebugOptions(int port) {
+        this.debugOptions.setPort(port);
+        return this;
+    }
+
+    @Override
     public void run() {
         BlockingResultHandler<Void> handler = new BlockingResultHandler<Void>(Void.class);
         run(handler);
@@ -113,7 +121,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
             throw new TestExecutionException("No test declared for execution.");
         }
         final ConsumerOperationParameters operationParameters = getConsumerOperationParameters();
-        final TestExecutionRequest testExecutionRequest = new TestExecutionRequest(operationDescriptors, ImmutableList.copyOf(testClassNames), ImmutableSet.copyOf(internalJvmTestRequests));
+        final TestExecutionRequest testExecutionRequest = new TestExecutionRequest(operationDescriptors, ImmutableList.copyOf(testClassNames), ImmutableSet.copyOf(internalJvmTestRequests), debugOptions);
         connection.run(new ConsumerAction<Void>() {
             @Override
             public ConsumerOperationParameters getParameters() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -103,7 +103,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     }
 
     @Override
-    public TestLauncher withDebugOptions(int port) {
+    public TestLauncher debugTests(int port) {
         this.debugOptions.setPort(port);
         return this;
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -103,7 +103,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     }
 
     @Override
-    public TestLauncher debugTests(int port) {
+    public TestLauncher debugTestsOn(int port) {
         this.debugOptions.setPort(port);
         return this;
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/TestExecutionRequest.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/TestExecutionRequest.java
@@ -21,6 +21,7 @@ import org.gradle.tooling.events.OperationDescriptor;
 import org.gradle.tooling.events.internal.OperationDescriptorWrapper;
 import org.gradle.tooling.events.test.TestOperationDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
+import org.gradle.tooling.internal.protocol.test.InternalDebugOptions;
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 import org.gradle.tooling.internal.protocol.test.InternalTestExecutionRequest;
 import org.gradle.util.CollectionUtils;
@@ -32,11 +33,17 @@ public class TestExecutionRequest implements InternalTestExecutionRequest {
     private final Collection<InternalTestDescriptor> testDescriptors;
     private final Collection<String> testClassNames;
     private final Collection<InternalJvmTestRequest> internalJvmTestRequests;
+    private final InternalDebugOptions debugOptions;
 
-    public TestExecutionRequest(Iterable<TestOperationDescriptor> operationDescriptors, Collection<String> testClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests) {
+    public TestExecutionRequest(Iterable<TestOperationDescriptor> operationDescriptors, Collection<String> testClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions) {
         this.testDescriptors = adaptDescriptors(operationDescriptors);
         this.testClassNames = testClassNames;
         this.internalJvmTestRequests = internalJvmTestRequests;
+        this.debugOptions = debugOptions;
+    }
+
+    public InternalDebugOptions getDebugOptions() {
+        return debugOptions;
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/test/InternalDebugOptions.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/test/InternalDebugOptions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.protocol.test;
+
+/**
+ * Preferences for test debugging.
+ *
+ * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
+ *
+ * @since 5.6
+ */
+public interface InternalDebugOptions {
+    boolean isDebugMode();
+    int getPort();
+}


### PR DESCRIPTION
Here is the second round on adding debug support to the `TestLauncher` interface.
There are 2 remaining TODOs in this PR. The first one is one missing cross-version test; I'm working on it. The second is whether there's a better way to handle backward compatibility than the `try-catch` block in `TestExecutionRequestAction`.