### PR TITLE
Implement typed parameter API for workers

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -81,6 +81,14 @@ public abstract class ClassLoaderUtils {
         return CLASS_DEFINER.defineDecoratorClass(decoratedClass, targetClassLoader, className, clazzBytes);
     }
 
+    public static Class<?> classFromContextLoader(String className) {
+        try {
+            return Thread.currentThread().getContextClassLoader().loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
     /**
      * Define a class into a class loader.
      *

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -94,7 +94,6 @@ import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceLocator;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.state.ManagedFactoryRegistry;
 import org.gradle.model.internal.inspect.MethodModelRuleExtractor;
 import org.gradle.model.internal.inspect.MethodModelRuleExtractors;
 import org.gradle.model.internal.inspect.ModelRuleExtractor;
@@ -237,8 +236,8 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         return new StringInterner();
     }
 
-    InstantiatorFactory createInstantiatorFactory(CrossBuildInMemoryCacheFactory cacheFactory, List<InjectAnnotationHandler> annotationHandlers, ManagedFactoryRegistry managedFactoryRegistry) {
-        return new DefaultInstantiatorFactory(cacheFactory, annotationHandlers, managedFactoryRegistry);
+    InstantiatorFactory createInstantiatorFactory(CrossBuildInMemoryCacheFactory cacheFactory, List<InjectAnnotationHandler> annotationHandlers) {
+        return new DefaultInstantiatorFactory(cacheFactory, annotationHandlers);
     }
 
     GradleUserHomeScopeServiceRegistry createGradleUserHomeScopeServiceRegistry(ServiceRegistry globalServices) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -27,6 +27,7 @@ import org.gradle.initialization.DefaultLegacyTypesSupport;
 import org.gradle.initialization.LegacyTypesSupport;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
@@ -72,8 +73,9 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
         return new NamedObjectInstantiator(cacheFactory);
     }
     
-    ManagedFactoryRegistry createManagedFactoryRegistry(NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver) {
+    ManagedFactoryRegistry createManagedFactoryRegistry(NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, InstantiatorFactory instantiatorFactory) {
         return new DefaultManagedFactoryRegistry().withFactories(
+                instantiatorFactory.getManagedFactory(),
                 new ConfigurableFileCollectionManagedFactory(fileResolver),
                 new RegularFileManagedFactory(),
                 new RegularFilePropertyManagedFactory(fileResolver),

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -29,7 +29,6 @@ import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.remote.internal.hub.StreamFailureHandler;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 
 import java.io.Serializable;
@@ -57,7 +56,7 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
         try {
             ServiceRegistry parentServices = workerProcessContext.getServiceRegistry();
             if (instantiatorFactory == null) {
-                instantiatorFactory = new DefaultInstantiatorFactory(new DefaultCrossBuildInMemoryCacheFactory(new DefaultListenerManager()), Collections.emptyList(), new DefaultManagedFactoryRegistry());
+                instantiatorFactory = new DefaultInstantiatorFactory(new DefaultCrossBuildInMemoryCacheFactory(new DefaultListenerManager()), Collections.emptyList());
             }
             DefaultServiceRegistry serviceRegistry = new DefaultServiceRegistry("worker-action-services", parentServices);
             // Make the argument serializers available so work implementations can register their own serializers

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -62,8 +62,7 @@ class TestUtil {
         if (instantiatorFactory == null) {
             NativeServicesTestFixture.initialize()
             def annotationHandlers = ProjectBuilderImpl.getGlobalServices().getAll(InjectAnnotationHandler.class)
-            def managedFactoryRegistry = ProjectBuilderImpl.getGlobalServices().get(ManagedFactoryRegistry.class)
-            instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), annotationHandlers, managedFactoryRegistry)
+            instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), annotationHandlers)
         }
         return instantiatorFactory
     }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -76,6 +76,14 @@
             "acceptation": "False positive on Kotlin upgrade to 1.3.41, baseline is effectively null returning",
             "changes": [
                 "From non-null returning to null returning breaking change"
+             ]
+        },
+        {
+            "type": "org.gradle.workers.WorkerConfiguration",
+            "member": "Class org.gradle.workers.WorkerConfiguration",
+            "acceptation": "Common functionality moved to an incubating class",
+            "changes": [
+                "org.gradle.workers.BaseWorkerSpec"
             ]
         }
     ]

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -39,7 +39,6 @@ import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerFactory;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -31,7 +31,6 @@ import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
-import java.io.Serializable;
 
 public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> {
     private final Class<? extends Compiler<JavaCompileSpec>> compilerClass;

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -66,7 +66,7 @@ class DefaultJavaCompilerFactoryTest extends Specification {
         compiler instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate instanceof NormalizingJavaCompiler
         compiler.delegate.delegate instanceof DaemonJavaCompiler
-        compiler.delegate.delegate.delegateClass == JdkJavaCompiler.class
+        compiler.delegate.delegate.compilerClass == JdkJavaCompiler.class
     }
 
     def "creates in-process compiler when ForkingJavaCompileSpec is provided and joint compilation"() {

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -59,7 +59,8 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
     public WorkResult execute(T spec) {
         DaemonForkOptions daemonForkOptions = toDaemonForkOptions(spec);
         Worker worker = workerFactory.getWorker(daemonForkOptions);
-        DefaultWorkResult result = worker.execute(actionExecutionSpecFactory.newIsolatedSpec("compiler daemon", CompilerCallable.class, new Object[] {delegateClass.getName(), delegateParameters, spec}, daemonForkOptions.getClassLoaderStructure()));
+
+        DefaultWorkResult result = worker.execute(actionExecutionSpecFactory.newAdapterIsolatedSpec("compiler daemon", CompilerCallable.class, new Object[] {delegateClass.getName(), delegateParameters, spec}, daemonForkOptions.getClassLoaderStructure()));
         if (result.isSuccess()) {
             return result;
         } else {

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.BaseForkOptions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -107,13 +108,7 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
 
         @Override
         public void execute() {
-            Class<? extends Compiler<?>> compilerClass;
-            try {
-                compilerClass = Cast.uncheckedCast(Thread.currentThread().getContextClassLoader().loadClass(getParameters().getCompilerClassName()));
-            } catch (ClassNotFoundException e) {
-                throw UncheckedException.throwAsUncheckedException(e);
-            }
-
+            Class<? extends Compiler<?>> compilerClass = Cast.uncheckedCast(ClassLoaderUtils.classFromContextLoader(getParameters().getCompilerClassName()));
             Compiler<?> compiler = instantiator.newInstance(compilerClass, getParameters().getCompilerInstanceParameters());
             setWorkResult(compiler.execute(Cast.uncheckedCast(getParameters().getCompileSpec())));
         }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -53,7 +53,6 @@ import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
-import java.io.Serializable;
 
 public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends AbstractDaemonCompiler<T> {
     private final Class<? extends Compiler<T>> compilerClass;

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -53,21 +53,31 @@ import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
+import java.io.Serializable;
 
 public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends AbstractDaemonCompiler<T> {
+    private final Class<? extends Compiler<T>> compilerClass;
+    private final Object[] compilerConstructorArguments;
     private final Iterable<File> zincClasspath;
     private final JavaForkOptionsFactory forkOptionsFactory;
     private final File daemonWorkingDir;
     private final ClassPathRegistry classPathRegistry;
     private final ClassLoaderRegistry classLoaderRegistry;
 
-    public DaemonScalaCompiler(File daemonWorkingDir, Class<? extends Compiler<T>> delegateClass, Object[] delegateParameters, WorkerDaemonFactory workerDaemonFactory, Iterable<File> zincClasspath, JavaForkOptionsFactory forkOptionsFactory, ClassPathRegistry classPathRegistry, ClassLoaderRegistry classLoaderRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory) {
-        super(delegateClass, delegateParameters, workerDaemonFactory, actionExecutionSpecFactory);
+    public DaemonScalaCompiler(File daemonWorkingDir, Class<? extends Compiler<T>> compilerClass, Object[] compilerConstructorArguments, WorkerDaemonFactory workerDaemonFactory, Iterable<File> zincClasspath, JavaForkOptionsFactory forkOptionsFactory, ClassPathRegistry classPathRegistry, ClassLoaderRegistry classLoaderRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory) {
+        super(workerDaemonFactory, actionExecutionSpecFactory);
+        this.compilerClass = compilerClass;
+        this.compilerConstructorArguments = compilerConstructorArguments;
         this.zincClasspath = zincClasspath;
         this.forkOptionsFactory = forkOptionsFactory;
         this.daemonWorkingDir = daemonWorkingDir;
         this.classPathRegistry = classPathRegistry;
         this.classLoaderRegistry = classLoaderRegistry;
+    }
+
+    @Override
+    protected CompilerParameters getCompilerParameters(T spec) {
+        return new ScalaCompilerParameters<T>(compilerClass.getName(), compilerConstructorArguments, spec);
     }
 
     @Override
@@ -100,6 +110,20 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
         gradleApiAndScalaSpec.allowPackage("com.google");
 
         return gradleApiAndScalaSpec;
+    }
+
+    public static class ScalaCompilerParameters<T extends ScalaJavaJointCompileSpec> extends CompilerParameters {
+        private final T compileSpec;
+
+        public ScalaCompilerParameters(String compilerClassName, Object[] compilerInstanceParameters, T compileSpec) {
+            super(compilerClassName, compilerInstanceParameters);
+            this.compileSpec = compileSpec;
+        }
+
+        @Override
+        public T getCompileSpec() {
+            return compileSpec;
+        }
     }
 }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiatorFactory.java
@@ -18,6 +18,7 @@ package org.gradle.internal.instantiation;
 
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceLookup;
+import org.gradle.internal.state.ManagedFactory;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -113,4 +114,9 @@ public interface InstantiatorFactory {
      * @param services The registry of services to make available to instances.
      */
     Instantiator injectAndDecorateLenient(ServiceLookup services);
+
+    /**
+     * Returns a managed factory to use when isolating managed objects created using this factory.
+     */
+    ManagedFactory getManagedFactory();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/DefaultManagedFactoryRegistry.java
@@ -50,8 +50,7 @@ public class DefaultManagedFactoryRegistry implements ManagedFactoryRegistry {
         return factory;
     }
 
-    @Override
-    public void register(ManagedFactory factory) {
+    private void register(ManagedFactory factory) {
         ManagedFactory existing = managedFactoryCache.getIfPresent(factory.getId());
         if (existing != null) {
             throw new IllegalArgumentException("A managed factory with type " + existing.getClass().getSimpleName() + " (id: " + existing.getId() + ") has already been registered.");

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/ManagedFactoryRegistry.java
@@ -20,10 +20,5 @@ public interface ManagedFactoryRegistry {
     /**
      * Looks up a {@link ManagedFactory} that can provide the given type.
      */
-    <T> ManagedFactory lookup(int id);
-
-    /**
-     * Registers a new factory
-     */
-    void register(ManagedFactory factory);
+    ManagedFactory lookup(int id);
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.instantiation
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.state.DefaultManagedFactoryRegistry
 import org.gradle.internal.state.Managed
+import org.gradle.internal.state.ManagedFactory
 import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -27,28 +28,14 @@ import spock.lang.Shared
 import spock.lang.Unroll
 
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.*
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.AbstractBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Bean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.BeanWithAbstractProperty
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceDirectoryPropertyBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceFileCollectionBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceFilePropertyBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceListPropertyBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceMapPropertyBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfacePrimitiveBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfacePropertyBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceSetPropertyBean
-import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.InterfaceWithDefaultMethods
-
 
 class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec {
     @ClassRule
     @Shared
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    final ManagedFactoryRegistry managedFactoryRegistry = new DefaultManagedFactoryRegistry()
-    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), managedFactoryRegistry)
+    ManagedFactory generatorFactory = TestUtil.instantiatorFactory().managedFactory
+    final ManagedFactoryRegistry managedFactoryRegistry = new DefaultManagedFactoryRegistry().withFactories(generatorFactory)
+    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), generatorFactory.id)
 
     def canConstructInstanceOfAbstractClassWithAbstractPropertyGetterAndSetter() {
         def bean = create(BeanWithAbstractProperty)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.internal.IConventionAware
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.BiAction
-import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.internal.util.BiFunction
 import org.gradle.util.ConfigureUtil
 import spock.lang.Issue
@@ -32,7 +31,7 @@ import spock.lang.Issue
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Bean
 
 class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), 0)
 
     def "can attach nested extensions to object"() {
         given:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
-import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
 
 import javax.inject.Inject
@@ -39,7 +38,7 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.NonG
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.PrivateInjectBean
 
 class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), 0)
 
     def "can inject service using @Inject on a getter method with dummy method body"() {
         given:
@@ -230,7 +229,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         def services = defaultServices()
         _ * services.get(Number, CustomInject) >> 12
 
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), 0)
 
         when:
         def obj = create(generator, BeanWithCustomServices, services)
@@ -246,7 +245,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         def services = defaultServices()
         _ * services.get(Number, CustomInject) >> 12
 
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), 0)
 
         when:
         def obj = create(generator, AbstractBeanWithCustomServices, services)
@@ -258,7 +257,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot use multiple inject annotations on getter"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), 0)
 
         when:
         create(generator, MultipleInjectAnnotations)
@@ -327,7 +326,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom annotation that is known but not enabled to getter method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory(), 0)
 
         when:
         create(generator, BeanWithCustomServices)
@@ -338,7 +337,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom annotation that is known but not enabled to static method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [], new TestCrossBuildInMemoryCacheFactory(), 0)
 
         when:
         create(generator, StaticCustomInjectBean)
@@ -349,7 +348,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom inject annotation to methods of ExtensionAware"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), 0)
 
         when:
         generator.generate(ExtensibleBeanWithCustomInject)
@@ -360,7 +359,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
     }
 
     def "cannot attach custom inject annotation to static method"() {
-        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+        def generator = AsmBackedClassGenerator.decorateAndInject([new CustomAnnotationHandler()], [CustomInject], new TestCrossBuildInMemoryCacheFactory(), 0)
 
         when:
         generator.generate(StaticCustomInjectBean)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectUndecoratedTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.internal.IConventionAware
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.ServiceLookup
-import org.gradle.internal.state.ManagedFactoryRegistry
 
 import javax.inject.Inject
 
@@ -31,7 +30,7 @@ import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.Abst
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.BeanWithServiceGetters
 
 class AsmBackedClassGeneratorInjectUndecoratedTest extends AbstractClassGeneratorSpec {
-    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+    final ClassGenerator generator = AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), 0)
 
     def "returns original class when class is not abstract and no service getter methods present"() {
         expect:
@@ -84,8 +83,8 @@ class AsmBackedClassGeneratorInjectUndecoratedTest extends AbstractClassGenerato
         services.get(Number) >> 12
 
         expect:
-        def decorated = create(AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry)), BeanWithServiceGetters)
-        def undecorated = create(AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry)), BeanWithServiceGetters)
+        def decorated = create(AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), 0), BeanWithServiceGetters)
+        def undecorated = create(AsmBackedClassGenerator.injectOnly([], [], new TestCrossBuildInMemoryCacheFactory(),0), BeanWithServiceGetters)
         decorated.class != undecorated.class
         decorated instanceof ExtensionAware
         !(undecorated instanceof ExtensionAware)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
@@ -53,7 +53,6 @@ import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.util.TestUtil;
 import org.junit.Rule;
@@ -102,7 +101,7 @@ import static org.junit.Assert.fail;
 public class AsmBackedClassGeneratorTest {
     @Rule
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
-    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject(Collections.emptyList(), Collections.emptyList(), new TestCrossBuildInMemoryCacheFactory(), new DefaultManagedFactoryRegistry());
+    final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject(Collections.emptyList(), Collections.emptyList(), new TestCrossBuildInMemoryCacheFactory(), 0);
 
     private <T> T newInstance(Class<T> clazz, Object... args) throws Exception {
         DefaultServiceRegistry services = new DefaultServiceRegistry();

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiatorFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiatorFactoryTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.internal.instantiation
 
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
-import org.gradle.internal.state.ManagedFactoryRegistry
 import spock.lang.Specification
 
 import javax.inject.Inject
@@ -27,7 +26,7 @@ import java.lang.annotation.RetentionPolicy
 
 
 class DefaultInstantiatorFactoryTest extends Specification {
-    def instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), [handler(Annotation1), handler(Annotation2)], Mock(ManagedFactoryRegistry))
+    def instantiatorFactory = new DefaultInstantiatorFactory(new TestCrossBuildInMemoryCacheFactory(), [handler(Annotation1), handler(Annotation2)])
 
     def "creates scheme with requested annotations"() {
         expect:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DependencyInjectionUsingClassGeneratorBackedInstantiatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DependencyInjectionUsingClassGeneratorBackedInstantiatorTest.groovy
@@ -19,14 +19,13 @@ import org.gradle.cache.internal.CrossBuildInMemoryCache
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceLookup
-import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import javax.inject.Inject
 
 class DependencyInjectionUsingClassGeneratorBackedInstantiatorTest extends Specification {
-    final ClassGenerator classGenerator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), Mock(ManagedFactoryRegistry))
+    final ClassGenerator classGenerator = AsmBackedClassGenerator.decorateAndInject([], [], new TestCrossBuildInMemoryCacheFactory(), 0)
     final CrossBuildInMemoryCache cache = new TestCrossBuildInMemoryCacheFactory().newCache()
     final ServiceLookup services = new DefaultServiceRegistry()
     final DependencyInjectingInstantiator instantiator = new DependencyInjectingInstantiator(new Jsr330ConstructorSelector(classGenerator, cache), services)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/state/DefaultManagedFactoryRegistryTest.groovy
@@ -30,23 +30,6 @@ class DefaultManagedFactoryRegistryTest extends Specification {
         registry.lookup(fooFactory.id) == fooFactory
     }
 
-    def "returns a registered factory for a managed type"() {
-        def buzzFactory = factory(Buzz)
-        def barFactory = factory(Bar)
-
-        when:
-        registry.withFactories(buzzFactory)
-
-        then:
-        registry.lookup(barFactory.id) == null
-
-        when:
-        registry.register(barFactory)
-
-        then:
-        registry.lookup(barFactory.id) == barFactory
-    }
-
     def "returns null for unknown type"() {
         def fooFactory = factory(Foo)
         def barFactory = factory(Bar)
@@ -92,10 +75,9 @@ class DefaultManagedFactoryRegistryTest extends Specification {
     def "throws exception when a factory with the same id is registered twice"() {
         def fooFactory1 = factory(Foo)
         def fooFactory2 = factory(Foo)
-        registry.withFactories(fooFactory1)
 
         when:
-        registry.register(fooFactory2)
+        registry.withFactories(fooFactory1, fooFactory2)
 
         then:
         def e = thrown(IllegalArgumentException)

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
@@ -37,7 +37,6 @@ import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
-import java.io.Serializable;
 
 public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemonCompiler<T> {
     private final Class<? extends Compiler<T>> compilerClass;

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/toolchain/DaemonPlayCompiler.java
@@ -37,21 +37,31 @@ import org.gradle.workers.internal.KeepAliveMode;
 import org.gradle.workers.internal.WorkerDaemonFactory;
 
 import java.io.File;
+import java.io.Serializable;
 
 public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemonCompiler<T> {
+    private final Class<? extends Compiler<T>> compilerClass;
+    private final Object[] compilerConstructorArguments;
     private final Iterable<File> compilerClasspath;
     private final JavaForkOptionsFactory forkOptionsFactory;
     private final ClassPathRegistry classPathRegistry;
     private final ClassLoaderRegistry classLoaderRegistry;
     private final File daemonWorkingDir;
 
-    public DaemonPlayCompiler(File daemonWorkingDir, Class<? extends Compiler<T>> compiler, Object[] compilerParameters, WorkerDaemonFactory workerDaemonFactory, Iterable<File> compilerClasspath, JavaForkOptionsFactory forkOptionsFactory, ClassPathRegistry classPathRegistry, ClassLoaderRegistry classLoaderRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory) {
-        super(compiler, compilerParameters, workerDaemonFactory, actionExecutionSpecFactory);
+    public DaemonPlayCompiler(File daemonWorkingDir, Class<? extends Compiler<T>> compilerClass, Object[] compilerConstructorArguments, WorkerDaemonFactory workerDaemonFactory, Iterable<File> compilerClasspath, JavaForkOptionsFactory forkOptionsFactory, ClassPathRegistry classPathRegistry, ClassLoaderRegistry classLoaderRegistry, ActionExecutionSpecFactory actionExecutionSpecFactory) {
+        super(workerDaemonFactory, actionExecutionSpecFactory);
+        this.compilerClass = compilerClass;
+        this.compilerConstructorArguments = compilerConstructorArguments;
         this.compilerClasspath = compilerClasspath;
         this.forkOptionsFactory = forkOptionsFactory;
         this.daemonWorkingDir = daemonWorkingDir;
         this.classPathRegistry = classPathRegistry;
         this.classLoaderRegistry = classLoaderRegistry;
+    }
+
+    @Override
+    protected CompilerParameters getCompilerParameters(T spec) {
+        return new PlayCompilerParameters<T>(compilerClass.getName(), compilerConstructorArguments, spec);
     }
 
     @Override
@@ -86,5 +96,19 @@ public class DaemonPlayCompiler<T extends PlayCompileSpec> extends AbstractDaemo
         gradleApiAndPlaySpec.allowPackage("org.apache.commons.lang");
 
         return gradleApiAndPlaySpec;
+    }
+
+    public static class PlayCompilerParameters<T extends PlayCompileSpec> extends CompilerParameters {
+        private final T compileSpec;
+
+        public PlayCompilerParameters(String compilerClassName, Object[] compilerInstanceParameters, T compileSpec) {
+            super(compilerClassName, compilerInstanceParameters);
+            this.compileSpec = compileSpec;
+        }
+
+        @Override
+        public T getCompileSpec() {
+            return compileSpec;
+        }
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/WorkItemProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/WorkItemProgressEventCrossVersionSpec.groovy
@@ -25,7 +25,6 @@ import org.gradle.tooling.BuildException
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.work.WorkItemOperationDescriptor
-import org.gradle.workers.fixtures.WorkerExecutorFixture
 
 @ToolingApiVersion('>=5.1')
 @TargetGradleVersion('>=5.1')

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/WorkItemProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/WorkItemProgressEventCrossVersionSpec.groovy
@@ -34,7 +34,7 @@ class WorkItemProgressEventCrossVersionSpec extends ToolingApiSpecification {
 
     void setup() {
         fixture.prepareTaskTypeUsingWorker()
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 displayName = "Test Work"
@@ -91,7 +91,7 @@ class WorkItemProgressEventCrossVersionSpec extends ToolingApiSpecification {
     def "includes failure in progress event"() {
         given:
         buildFile << """
-            ${fixture.getRunnableThatFails(IllegalStateException, "something went horribly wrong")}
+            ${fixture.getWorkerExecutionThatFails(IllegalStateException, "something went horribly wrong")}
             runInWorker {
                 displayName = null
                 runnableClass = RunnableThatFails

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
@@ -28,7 +28,7 @@ abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegration
         fixture.prepareTaskTypeUsingWorker()
     }
 
-    void assertRunnableExecuted(String taskName) {
+    void assertWorkerExecuted(String taskName) {
         fixture.list.each {
             outputFileDir.file(taskName).file(it).assertExists()
         }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -133,7 +133,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
 
             task runInDaemon(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = ${workerExecutionThatVerifiesOptions}.class
+                workerExecutionClass = ${workerExecutionThatVerifiesOptions.name}.class
                 additionalForkOptions = { options ->
                     options.with {
                         minHeapSize = "128m"
@@ -141,7 +141,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
                         systemProperty("foo", "bar")
                         jvmArgs("-Dbar=baz")
                         bootstrapClasspath = fileTree(new File(Jvm.current().jre.homeDir, "lib")).include("*.jar")
-                        bootstrapClasspath(new File("${normaliseFileSeparators(systemSpecificAbsolutePath('foo'))}"))
+                        bootstrapClasspath(new File("${normaliseFileSeparators(systemSpecificAbsolutePath(testDirectory.file("foo").absolutePath))}"))
                         defaultCharacterEncoding = "UTF-8"
                         enableAssertions = true
                         environment "foo", "bar"

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import org.gradle.workers.fixtures.WorkerExecutorFixture
 import org.junit.Assume
 
 import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
@@ -30,18 +31,57 @@ import static org.hamcrest.CoreMatchers.notNullValue
 
 @IntegrationTestTimeout(180)
 class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
+    WorkerExecutorFixture.ExecutionClass workerExecutionThatPrintsWorkingDirectory
+    WorkerExecutorFixture.ExecutionClass workerExecutionThatVerifiesOptions
+
+    def setup() {
+        workerExecutionThatPrintsWorkingDirectory = fixture.getWorkerExecutionThatCreatesFiles("WorkingDirExecution")
+        workerExecutionThatPrintsWorkingDirectory.with {
+            constructorAction = """
+                Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        println "Shutdown working dir: " + System.getProperty("user.dir")
+                    }
+                }));
+            """
+            action += """
+                println "Execution working dir: " + System.getProperty("user.dir")
+            """
+        }
+
+        workerExecutionThatVerifiesOptions = fixture.getWorkerExecutionThatCreatesFiles("OptionVerifyingWorkerExecution")
+        workerExecutionThatVerifiesOptions.with {
+            imports += [
+                    "java.util.regex.Pattern",
+                    "java.lang.management.ManagementFactory",
+                    "java.lang.management.RuntimeMXBean"
+            ]
+            action += """
+                RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+                List<String> arguments = runtimeMxBean.getInputArguments();
+                assert arguments.contains("-Dfoo=bar");
+                assert arguments.contains("-Dbar=baz");
+                assert arguments.contains("-Xmx128m");
+                assert arguments.contains("-Xms128m");
+                assert arguments.contains("-Dfile.encoding=UTF-8");
+                assert arguments.contains("-ea");
+    
+                assert runtimeMxBean.getBootClassPath().replaceAll(Pattern.quote(File.separator),'/').endsWith("/foo");
+    
+                assert System.getenv("foo").equals("bar")
+            """
+        }
+    }
 
     def "uses the worker home directory as working directory for worker execution"() {
         def workerHomeDir = executer.gradleUserHomeDir.file("workers").getAbsolutePath()
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
+        workerExecutionThatPrintsWorkingDirectory.writeToBuildFile()
         buildFile << """
-            import org.gradle.workers.IsolationMode
-
-            $runnableThatPrintsWorkingDirectory
-
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = WorkingDirRunnable.class
+                workerExecutionClass = ${workerExecutionThatPrintsWorkingDirectory.name}.class
             }
         """
 
@@ -65,15 +105,12 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
     }
 
     def "setting the working directory of a worker is not supported"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
+        workerExecutionThatPrintsWorkingDirectory.writeToBuildFile()
         buildFile << """
-            import org.gradle.workers.IsolationMode
-
-            $runnableThatPrintsWorkingDirectory
-
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = WorkingDirRunnable.class
+                workerExecutionClass = ${workerExecutionThatPrintsWorkingDirectory.name}.class
                 additionalForkOptions = { it.workingDir = project.file("unsupported") }
             }
         """
@@ -88,17 +125,15 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
     @Requires(TestPrecondition.JDK_ORACLE)
     def "interesting worker daemon fork options are honored"() {
         Assume.assumeThat(Jvm.current().jre, notNullValue())
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
+        workerExecutionThatVerifiesOptions.writeToBuildFile()
         outputFileDir.createDir()
-
         buildFile << """
             import org.gradle.internal.jvm.Jvm
 
-            $optionVerifyingRunnable
-
             task runInDaemon(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = OptionVerifyingRunnable.class
+                runnableClass = ${workerExecutionThatVerifiesOptions}.class
                 additionalForkOptions = { options ->
                     options.with {
                         minHeapSize = "128m"
@@ -119,23 +154,23 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         succeeds("runInDaemon")
 
         then:
-        assertRunnableExecuted("runInDaemon")
+        assertWorkerExecuted("runInDaemon")
     }
 
     def "worker daemons honor different executable specified in fork options"() {
         def differentJvm = AvailableJavaHomes.differentJdkWithValidJre
         Assume.assumeNotNull(differentJvm)
         def differentJavacExecutablePath = normaliseFileSeparators(differentJvm.getJavaExecutable().absolutePath)
+        def workerExecution = getWorkerExecutionThatVerifiesExecutable(differentJvm)
 
         fixture.withJava7CompatibleClasses()
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
+        workerExecution.writeToBuildFile()
 
         buildFile << """
-            ${getExecutableVerifyingRunnable(differentJvm)}
-
             task runInDaemon(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = ExecutableVerifyingRunnable.class
+                workerExecutionClass = ${workerExecution.name}.class
                 additionalForkOptions = { options ->
                     options.executable = new File('${differentJavacExecutablePath}')
                 }
@@ -146,90 +181,15 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         succeeds("runInDaemon")
 
         then:
-        assertRunnableExecuted("runInDaemon")
+        assertWorkerExecuted("runInDaemon")
     }
 
-    def getRunnableThatPrintsWorkingDirectory() {
-        return """
-            class WorkingDirRunnable extends TestRunnable {
-                @Inject
-                public WorkingDirRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-                        @Override
-                        public void run() {
-                            printWorkingDirectory("Shutdown")
-                        }
-                    }));
-                }
-                
-                public void run() {
-                    super.run()
-                    printWorkingDirectory("Execution")
-                }
-                
-                void printWorkingDirectory(String phase) {
-                    println phase + " working dir: " + System.getProperty("user.dir")
-                }
-            }
+    WorkerExecutorFixture.ExecutionClass getWorkerExecutionThatVerifiesExecutable(Jvm differentJvm) {
+        def workerClass = fixture.getWorkerExecutionThatCreatesFiles("ExecutableVerifyingWorkerExecution")
+        workerClass.imports.add("java.net.URL")
+        workerClass.action += """
+            assert new File('${normaliseFileSeparators(differentJvm.jre.homeDir.absolutePath)}').canonicalPath.equals(new File(System.getProperty("java.home")).canonicalPath);
         """
-    }
-
-    String getOptionVerifyingRunnable() {
-        return """
-            import java.io.File;
-            import java.util.regex.Pattern;
-            import java.util.List;
-            import org.gradle.other.Foo;
-            import java.lang.management.ManagementFactory;
-            import java.lang.management.RuntimeMXBean;
-            import javax.inject.Inject;
-
-            public class OptionVerifyingRunnable extends TestRunnable {
-                @Inject
-                public OptionVerifyingRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                }
-
-                public void run() {
-                    RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
-                    List<String> arguments = runtimeMxBean.getInputArguments();
-                    assert arguments.contains("-Dfoo=bar");
-                    assert arguments.contains("-Dbar=baz");
-                    assert arguments.contains("-Xmx128m");
-                    assert arguments.contains("-Xms128m");
-                    assert arguments.contains("-Dfile.encoding=UTF-8");
-                    assert arguments.contains("-ea");
-
-                    assert runtimeMxBean.getBootClassPath().replaceAll(Pattern.quote(File.separator),'/').endsWith("/foo");
-
-                    assert System.getenv("foo").equals("bar")
-
-                    super.run();
-                }
-            }
-        """
-    }
-
-    String getExecutableVerifyingRunnable(Jvm differentJvm) {
-        return """
-            import java.io.File;
-            import java.util.List;
-            import org.gradle.other.Foo;
-            import java.net.URL;
-
-            public class ExecutableVerifyingRunnable extends TestRunnable {
-                @Inject
-                public ExecutableVerifyingRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                }
-
-                public void run() {
-                    assert new File('${normaliseFileSeparators(differentJvm.jre.homeDir.absolutePath)}').canonicalPath.equals(new File(System.getProperty("java.home")).canonicalPath);
-
-                    super.run();
-                }
-            }
-        """
+        return workerClass
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -21,13 +21,14 @@ import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import org.gradle.workers.fixtures.WorkerExecutorFixture
 
 @IntegrationTestTimeout(180)
 class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationSpec {
     String logSnapshot = ""
 
     def "worker daemons are reused across builds"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
         buildFile << """
             import org.gradle.workers.internal.WorkerDaemonFactory
             
@@ -56,7 +57,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons can be restarted when daemon is stopped"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -81,7 +82,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are stopped when daemon is stopped"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -104,7 +105,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are stopped and not reused when log level is changed"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -134,7 +135,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are not reused when classpath changes"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -170,9 +171,8 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are not reused when they fail unexpectedly"() {
+        workerExecutorThatCanFailUnexpectedly.writeToBuildFile()
         buildFile << """
-            $runnableThatCanFailUnexpectedly
-
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
             }
@@ -200,7 +200,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "only compiler daemons are stopped with the build session"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
         file('src/main/java').createDir()
         file('src/main/java/Test.java') << "public class Test {}"
         buildFile << """
@@ -234,7 +234,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
 
     @Requires(TestPrecondition.UNIX)
     def "worker daemons exit when the parent build daemon is killed"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -274,38 +274,13 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
         return daemons.daemon.log - logSnapshot
     }
 
-    String getRunnableThatCanFailUnexpectedly() {
-        return """
-            import java.io.File;
-            import java.util.List;
-            import org.gradle.other.Foo;
-            import org.gradle.test.FileHelper;
-            import java.util.UUID;
-            import javax.inject.Inject;
-
-            public class TestRunnable implements Runnable {
-                private final List<String> files;
-                protected final File outputDir;
-                private final Foo foo;
-                private static final String id = UUID.randomUUID().toString();
-
-                @Inject
-                public TestRunnable(List<String> files, File outputDir, Foo foo) {
-                    this.files = files;
-                    this.outputDir = outputDir;
-                    this.foo = foo;
-                }
-
-                public void run() {
-                    for (String name : files) {
-                        File outputFile = new File(outputDir, name);
-                        FileHelper.write(id, outputFile);
-                    }
-                    if (files.contains("poisonPill")) {
-                        System.exit(127);
-                    }
-                }
+    WorkerExecutorFixture.ExecutionClass getWorkerExecutorThatCanFailUnexpectedly() {
+        def executionClass = fixture.workerExecutionThatCreatesFiles
+        executionClass.action += """
+            if (getParameters().getFiles().contains("poisonPill")) {
+                System.exit(127);
             }
         """
+        return executionClass
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -572,24 +572,6 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     @Ignore
-    def "null parameters can be provided"() {
-        fixture.withRunnableClassInBuildScript()
-
-        buildFile << """
-            task runInWorkerWithNullParameter(type: WorkerTask) {
-                foo = null
-                isolationMode = IsolationMode.NONE
-            } 
-        """
-
-        when:
-        succeeds "runInWorkerWithNullParameter"
-
-        then:
-        assertRunnableExecuted("runInWorkerWithNullParameter")
-    }
-
-    @Ignore
     @Issue("https://github.com/gradle/gradle/issues/8628")
     def "can find resources in the classpath via the context classloader using #isolationMode"() {
         fixture.withRunnableClassInBuildSrc()

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -263,7 +263,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                                         forkOptions.maxHeapSize = "64m"
                                     }
                                     config.forkOptions(additionalForkOptions)
-                                    config.classpath(additionalClasspath)
+                                    config.classpath.from(additionalClasspath)
                                     config.parameters {
                                         files = list.collect { it as String }
                                         outputDir = new File(outputFileDirPath)

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -19,9 +19,11 @@ package org.gradle.workers.internal
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.gradle.workers.IsolationMode
+
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -36,8 +38,8 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
-    def "can create and use a worker runnable defined in buildSrc in #isolationMode"() {
-        fixture.withRunnableClassInBuildSrc()
+    def "can create and use a worker execution defined in buildSrc in #isolationMode"() {
+        fixture.withWorkerExecutionClassInBuildSrc()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
@@ -49,13 +51,14 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         when:
-        buildFile << """
+        file('buildSrc/src/main/java/AnotherFoo.java') << """
             class AnotherFoo extends org.gradle.other.Foo {
             }
-            
+        """
+        buildFile << """
             runInWorker {
                 foo = new AnotherFoo()
             }
@@ -63,14 +66,14 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         where:
         isolationMode << ISOLATION_MODES
     }
 
-    def "can create and use a worker runnable defined in build script in #isolationMode"() {
-        fixture.withRunnableClassInBuildScript()
+    def "can create and use a worker execution defined in build script in #isolationMode"() {
+        fixture.withWorkerExecutionClassInBuildScript()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
@@ -82,13 +85,14 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         when:
-        buildFile << """
+        file('buildSrc/src/main/java/AnotherFoo.java') << """
             class AnotherFoo extends org.gradle.other.Foo {
             }
-            
+        """
+        buildFile << """
             runInWorker {
                 foo = new AnotherFoo()
             }
@@ -96,20 +100,20 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         where:
         isolationMode << ISOLATION_MODES
     }
 
-    def "can create and use a worker runnable defined in an external jar in #isolationMode"() {
-        def runnableJarName = "runnable.jar"
-        withRunnableClassInExternalJar(file(runnableJarName))
+    def "can create and use a worker execution defined in an external jar in #isolationMode"() {
+        def workerExecutionJarName = "workerExecution.jar"
+        withWorkerExecutionClassInExternalJar(file(workerExecutionJarName))
 
         buildFile << """
             buildscript {
                 dependencies {
-                    classpath files("$runnableJarName")
+                    classpath files("$workerExecutionJarName")
                 }
             }
 
@@ -122,13 +126,10 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         when:
         buildFile << """
-            class AnotherFoo extends org.gradle.other.Foo {
-            }
-            
             runInWorker {
                 foo = new AnotherFoo()
             }
@@ -136,7 +137,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         where:
         isolationMode << ISOLATION_MODES
@@ -144,7 +145,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "re-uses an existing idle worker daemon"() {
         executer.withWorkerDaemonsExpirationDisabled()
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
 
         buildFile << """
             task runInDaemon(type: WorkerTask) {
@@ -165,7 +166,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "starts a new worker daemon when existing worker daemons are incompatible"() {
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
 
         buildFile << """
             task runInDaemon(type: WorkerTask)
@@ -192,18 +193,18 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         blockingServer.start()
         blockingServer.expectConcurrent("runInDaemon", "startNewDaemon")
 
-        fixture.withRunnableClassInBuildSrc()
-        withBlockingRunnableClassInBuildSrc("http://localhost:${blockingServer.port}")
+        fixture.withWorkerExecutionClassInBuildSrc()
+        fixture.withBlockingWorkerExecutionClassInBuildSrc("http://localhost:${blockingServer.port}")
 
         buildFile << """
             task runInDaemon(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = BlockingRunnable.class
+                workerExecutionClass = BlockingWorkerExecution.class
             }
 
             task startNewDaemon(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = BlockingRunnable.class
+                workerExecutionClass = BlockingWorkerExecution.class
             }
 
             task runAllDaemons {
@@ -219,10 +220,9 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         assertDifferentDaemonsWereUsed("runInDaemon", "startNewDaemon")
     }
 
-    def "re-uses an existing compatible worker daemon when a different runnable is executed"() {
+    def "re-uses an existing compatible worker daemon when a different worker execution is executed"() {
         executer.withWorkerDaemonsExpirationDisabled()
-        fixture.withRunnableClassInBuildSrc()
-        withAlternateRunnableClassInBuildSrc()
+        fixture.withAlternateWorkerExecutionClassInBuildSrc()
 
         buildFile << """
             task runInDaemon(type: WorkerTask) {
@@ -231,7 +231,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
             task reuseDaemon(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                runnableClass = AlternateRunnable.class
+                workerExecutionClass = AlternateWorkerExecution.class
                 dependsOn runInDaemon
             }
         """
@@ -245,7 +245,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "throws if worker used from a thread with no current build operation in #isolationMode"() {
         given:
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
 
         and:
         buildFile << """
@@ -257,14 +257,18 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                         @Override
                         public void run() {
                             try {
-                                workerExecutor.submit(runnableClass) { config ->
+                                workerExecutor.execute(workerExecutionClass) { config ->
                                     config.isolationMode = $isolationMode
                                     if (isolationMode == IsolationMode.PROCESS) {
                                         forkOptions.maxHeapSize = "64m"
                                     }
                                     config.forkOptions(additionalForkOptions)
                                     config.classpath(additionalClasspath)
-                                    config.params = [ list.collect { it as String }, new File(outputFileDirPath), foo ]
+                                    config.parameters {
+                                        files = list.collect { it as String }
+                                        outputDir = new File(outputFileDirPath)
+                                        foo = owner.foo
+                                    }
                                 }.get()
                             } catch(Exception ex) {
                                 thrown = ex
@@ -294,7 +298,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "can set a custom display name for work items in #isolationMode"() {
         given:
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
@@ -309,7 +313,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         def operation = buildOperations.only(ExecuteWorkItemBuildOperationType)
         operation.displayName == "Test Work"
         with (operation.details) {
-            className == "org.gradle.test.TestRunnable"
+            className == "org.gradle.test.TestWorkerExecution"
             displayName == "Test Work"
         }
 
@@ -319,13 +323,12 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "includes failures in build operation in #isolationMode"() {
         given:
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
+        fixture.workerExecutionThatFails.writeToBuildFile()
         buildFile << """
-            ${fixture.runnableThatFails}
-
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
-                runnableClass = RunnableThatFails.class
+                workerExecutionClass = WorkerExecutionThatFails.class
             }
         """
 
@@ -334,15 +337,15 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
         then:
         def operation = buildOperations.only(ExecuteWorkItemBuildOperationType)
-        operation.displayName == "RunnableThatFails"
-        operation.failure == "java.lang.RuntimeException: Failure from runnable"
+        operation.displayName == "WorkerExecutionThatFails"
+        operation.failure == "java.lang.RuntimeException: Failure from worker execution"
 
         where:
         isolationMode << ISOLATION_MODES
     }
 
     def "can use a parameter that references classes in other packages in #isolationMode"() {
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
         withParameterClassReferencingClassInAnotherPackage()
 
         buildFile << """
@@ -358,55 +361,27 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         isolationMode << ISOLATION_MODES
     }
 
-    def "can set isolation mode using fork mode"() {
-        executer.withWorkerDaemonsExpirationDisabled()
-        fixture.withRunnableClassInBuildScript()
-
-        buildFile << """
-            task runInWorker(type: WorkerTask) {
-                def daemonCount = 0
-                forkMode = ForkMode.ALWAYS
-                
-                doFirst {
-                    daemonCount = services.get(org.gradle.workers.internal.WorkerDaemonClientsManager.class).allClients.size()
-                }
-                
-                doLast {
-                    assert services.get(org.gradle.workers.internal.WorkerDaemonClientsManager.class).allClients.size() > daemonCount
-                }
-            }
-        """
-
-        expect:
-        succeeds("runInWorker")
-    }
-
     def "classloader is not isolated when using IsolationMode.NONE"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
 
         buildFile << """
             class MutableItem {
                 static String value = "foo"
             }
             
-            class MutatingRunnable extends TestRunnable {
-                final String value
-                
+            abstract class MutatingWorkerExecution extends TestWorkerExecution {
                 @Inject
-                public MutatingRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                    this.value = files[0]
-                }
+                public MutatingWorkerExecution() { }
                 
-                public void run() {
-                    MutableItem.value = value
+                public void execute() {
+                    MutableItem.value = getParameters().files[0]
                 }
             }
             
             task mutateValue(type: WorkerTask) {
                 list = [ "bar" ]
                 isolationMode = IsolationMode.NONE
-                runnableClass = MutatingRunnable.class
+                workerExecutionClass = MutatingWorkerExecution.class
             } 
             
             task verifyNotIsolated {
@@ -422,31 +397,26 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "user classes are isolated when using IsolationMode.CLASSLOADER"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
 
         buildFile << """
             class MutableItem {
                 static String value = "foo"
             }
             
-            class MutatingRunnable extends TestRunnable {
-                final String value
-                
+            abstract class MutatingWorkerExecution extends TestWorkerExecution {
                 @Inject
-                public MutatingRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                    this.value = files[0]
-                }
+                public MutatingWorkerExecution() { }
                 
-                public void run() {
-                    MutableItem.value = value
+                public void execute() {
+                    MutableItem.value = getParameters().files[0]
                 }
             }
             
             task mutateValue(type: WorkerTask) {
                 list = [ "bar" ]
                 isolationMode = IsolationMode.CLASSLOADER
-                runnableClass = MutatingRunnable.class
+                workerExecutionClass = MutatingWorkerExecution.class
             } 
             
             task verifyIsolated {
@@ -462,7 +432,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "user classpath is isolated when using #isolationMode"() {
-        fixture.withRunnableClassInBuildScript()
+        fixture.withWorkerExecutionClassInBuildScript()
 
         buildFile << """
             import java.util.jar.Manifest 
@@ -479,13 +449,11 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                 customGuava "com.google.guava:guava:23.1-jre"
             }
             
-            class GuavaVersionRunnable extends TestRunnable {
+            abstract class GuavaVersionWorkerExecution extends TestWorkerExecution {
                 @Inject
-                public GuavaVersionRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo)
-                }
+                public GuavaVersionWorkerExecution() { }
                 
-                public void run() {
+                public void execute() {
                     Enumeration<URL> resources = this.getClass().getClassLoader()
                             .getResources("META-INF/MANIFEST.MF")
                     while (resources.hasMoreElements()) {
@@ -507,7 +475,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             
             task checkGuavaVersion(type: WorkerTask) {
                 isolationMode = IsolationMode.${isolationMode}
-                runnableClass = GuavaVersionRunnable.class
+                workerExecutionClass = GuavaVersionWorkerExecution.class
                 additionalClasspath = configurations.customGuava
             } 
         """
@@ -523,17 +491,15 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "classloader is minimal when using #isolationMode"() {
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
 
         buildFile << """         
-            class SneakyRunnable extends TestRunnable {            
+            abstract class SneakyWorkerExecution extends TestWorkerExecution {            
                 @Inject
-                public SneakyRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                }
+                public SneakyWorkerExecution() { }
                 
-                public void run() {
-                    super.run()
+                public void execute() {
+                    super.execute()
                     // These classes were chosen to be relatively stable and would be unusual to see in a worker. 
                     def gradleApiClasses = [
                         "${com.google.common.collect.Lists.canonicalName}",
@@ -544,7 +510,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                     }
                 }
                 
-                private boolean reachable(String classname) {
+                boolean reachable(String classname) {
                     try {
                         Class.forName(classname)
                         // bad! the class was leaked into the worker classpath
@@ -558,36 +524,34 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.$isolationMode
-                runnableClass = SneakyRunnable
+                workerExecutionClass = SneakyWorkerExecution
             } 
         """
 
         when:
         succeeds("runInWorker", "-i")
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         where:
         isolationMode << [IsolationMode.CLASSLOADER, IsolationMode.PROCESS]
     }
 
-    @Ignore
+    @Requires(TestPrecondition.NOT_WINDOWS)
     @Issue("https://github.com/gradle/gradle/issues/8628")
     def "can find resources in the classpath via the context classloader using #isolationMode"() {
-        fixture.withRunnableClassInBuildSrc()
+        fixture.withWorkerExecutionClassInBuildSrc()
 
         file('foo.txt').text = "foo!"
         buildFile << """
             apply plugin: "base"
 
-            class ResourceRunnable extends TestRunnable {
+            abstract class ResourceWorkerExecution extends TestWorkerExecution {
                 @Inject
-                public ResourceRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                }
+                public ResourceWorkerExecution() { }
 
-                public void run() {
-                    super.run()
+                public void execute() {
+                    super.execute()
                     def resource = Thread.currentThread().getContextClassLoader().getResource("foo.txt")
                     assert resource != null && resource.getPath().endsWith('build/libs/foo.jar!/foo.txt')
                     println resource
@@ -601,7 +565,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.${isolationMode}
-                runnableClass = ResourceRunnable
+                workerExecutionClass = ResourceWorkerExecution
                 additionalClasspath = tasks.jarFoo.outputs.files
                 dependsOn jarFoo
             } 
@@ -611,7 +575,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        assertRunnableExecuted("runInWorker")
+        assertWorkerExecuted("runInWorker")
 
         where:
         isolationMode << [IsolationMode.CLASSLOADER, IsolationMode.PROCESS]
@@ -639,86 +603,24 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         """
     }
 
-    String getBlockingRunnableThatCreatesFiles(String url) {
-        return """
-            import java.io.File;
-            import java.util.List;
-            import org.gradle.other.Foo;
-            import java.net.URL;
-            import javax.inject.Inject;
-
-            public class BlockingRunnable extends TestRunnable {
-                @Inject
-                public BlockingRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                }
-
-                public void run() {
-                    super.run();
-                    try {
-                        new URL("$url/" + outputDir.getName()).openConnection().getHeaderField("RESPONSE");
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-        """
-    }
-
-    String getAlternateRunnable() {
-        return """
-            import java.io.File;
-            import java.util.List;
-            import org.gradle.other.Foo;
-            import java.net.URL;
-            import javax.inject.Inject;
-
-            public class AlternateRunnable extends TestRunnable {
-                @Inject
-                public AlternateRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                }
-            }
-        """
-    }
-
-    void withBlockingRunnableClassInBuildSrc(String url) {
-        file("buildSrc/src/main/java/org/gradle/test/BlockingRunnable.java") << """
-            package org.gradle.test;
-
-            ${getBlockingRunnableThatCreatesFiles(url)}
-        """
-
-        fixture.addImportToBuildScript("org.gradle.test.BlockingRunnable")
-    }
-
-    void withAlternateRunnableClassInBuildSrc() {
-        file("buildSrc/src/main/java/org/gradle/test/AlternateRunnable.java") << """
-            package org.gradle.test;
-
-            ${fixture.alternateRunnable}
-        """
-
-        fixture.addImportToBuildScript("org.gradle.test.AlternateRunnable")
-    }
-
-    void withRunnableClassInExternalJar(File runnableJar) {
+    void withWorkerExecutionClassInExternalJar(File workerExecutionJar) {
         file("buildSrc").deleteDir()
 
         def builder = artifactBuilder()
-        builder.sourceFile("org/gradle/test/TestRunnable.java") << """
-            package org.gradle.test;
+        fixture.workerExecutionThatCreatesFiles.writeToFile builder.sourceFile("org/gradle/test/TestWorkerExecution.java")
+        fixture.testParameterType.writeToFile builder.sourceFile("org/gradle/test/TestParameters.java")
 
-            $fixture.runnableThatCreatesFiles
-        """
         builder.sourceFile("org/gradle/other/Foo.java") << """
             $fixture.parameterClass
+        """
+        builder.sourceFile('AnotherFoo.java') << """
+            class AnotherFoo extends org.gradle.other.Foo { }
         """
         builder.sourceFile("org/gradle/test/FileHelper.java") << """
             $fixture.fileHelperClass
         """
-        builder.buildJar(runnableJar)
+        builder.buildJar(workerExecutionJar)
 
-        fixture.addImportToBuildScript("org.gradle.test.TestRunnable")
+        fixture.addImportToBuildScript("org.gradle.test.TestWorkerExecution")
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
@@ -44,7 +44,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
             text = foo
             array = [foo, bar, baz]
             list = [foo, bar, baz]
-         """.stripIndent().strip()
+         """.stripIndent().trim()
 
         where:
         isolationMode << ISOLATION_MODES
@@ -86,7 +86,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
             text = foo
             array = [foo, bar, baz]
             list = [foo, bar, baz]
-         """.stripIndent().strip()
+         """.stripIndent().trim()
 
         where:
         forkMode          | operator
@@ -108,7 +108,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                 arrayOfThings = ["foo", "bar", "baz"]
                 listOfThings = ["foo", "bar", "baz"]
             }
-        """.stripIndent()
+        """
 
         when:
         fails("runInWorker")
@@ -186,5 +186,4 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
             }
         """
     }
-
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
+
+class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
+    @Unroll
+    def "can submit an item of work with the legacy API using isolation mode #isolationMode"() {
+        buildFile << """
+            ${legacyWorkerTypeAndTask}
+
+            task runWork(type: WorkerTask) {
+                text = "foo"
+                arrayOfThings = ["foo", "bar", "baz"]
+                listOfThings = ["foo", "bar", "baz"]
+
+                isolationMode = ${isolationMode}
+            }
+        """
+
+        when:
+        succeeds("runWork")
+
+        then:
+        result.groupedOutput.task(":runWork").output.contains """
+            text = foo
+            array = [foo, bar, baz]
+            list = [foo, bar, baz]
+         """.stripIndent().strip()
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
+    @Unroll
+    def "can control forking via forkMode with the legacy API using fork mode #isolationMode"() {
+        executer.withWorkerDaemonsExpirationDisabled()
+
+        buildFile << """
+            ${legacyWorkerTypeAndTask}
+
+            task runWork(type: WorkerTask) {
+                def daemonCount = 0
+
+                text = "foo"
+                arrayOfThings = ["foo", "bar", "baz"]
+                listOfThings = ["foo", "bar", "baz"]
+                
+                workerConfiguration = {
+                    forkMode = ${forkMode}
+                }
+
+                doFirst {
+                    daemonCount = services.get(org.gradle.workers.internal.WorkerDaemonClientsManager.class).allClients.size()
+                }
+                
+                doLast {
+                    assert services.get(org.gradle.workers.internal.WorkerDaemonClientsManager.class).allClients.size() ${operator} daemonCount
+                }
+            }
+        """
+
+        when:
+        succeeds("runWork")
+
+        then:
+        result.groupedOutput.task(":runWork").output.contains """
+            text = foo
+            array = [foo, bar, baz]
+            list = [foo, bar, baz]
+         """.stripIndent().strip()
+
+        where:
+        forkMode          | operator
+        "ForkMode.NEVER"  | "=="
+        "ForkMode.ALWAYS" | ">"
+    }
+
+    String getLegacyWorkerTypeAndTask() {
+        return """
+            import javax.inject.Inject
+
+            class TestRunnable implements Runnable {
+                final String text
+                final String[] arrayOfThings
+                final ListProperty<String> listOfThings
+                
+                @Inject
+                TestRunnable(String text, String[] arrayOfThings, ListProperty<String> listOfThings) {
+                    this.text = text
+                    this.arrayOfThings = arrayOfThings
+                    this.listOfThings = listOfThings
+                }
+                
+                void run() {
+                    println "text = " + text
+                    println "array = " + arrayOfThings
+                    println "list = " + listOfThings.get()
+                }
+            }
+            
+            class WorkerTask extends DefaultTask {
+                WorkerExecutor workerExecutor
+                String text
+                String[] arrayOfThings
+                ListProperty<String> listOfThings
+                IsolationMode isolationMode = IsolationMode.AUTO
+                Closure workerConfiguration
+                
+                @Inject
+                WorkerTask(WorkerExecutor workerExecutor) {
+                    this.workerExecutor = workerExecutor
+                    this.listOfThings = project.objects.listProperty(String)
+                }
+                
+                @TaskAction
+                void doWork() {
+                    workerExecutor.submit(TestRunnable.class) { config ->
+                        config.isolationMode = this.isolationMode
+                        config.params = [text, arrayOfThings, listOfThings]
+                        if (workerConfiguration != null) {
+                            workerConfiguration.delegate = config
+                            workerConfiguration(config)
+                        }
+                    }
+                }    
+            }
+        """
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -119,9 +119,9 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast {
-                    submitWorkItem("workItem0", ${parallelWorkerExecution.name}.class) { it.classpath([ new File("foo") ]) }
-                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class) { it.classpath([ new File("bar") ]) }
-                    submitWorkItem("workItem2", ${parallelWorkerExecution.name}.class) { it.classpath([ new File("baz") ]) }
+                    submitWorkItem("workItem0", ${parallelWorkerExecution.name}.class) { it.classpath.from([ new File("foo") ]) }
+                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class) { it.classpath.from([ new File("bar") ]) }
+                    submitWorkItem("workItem2", ${parallelWorkerExecution.name}.class) { it.classpath.from([ new File("baz") ]) }
                 }
             }
         """
@@ -904,7 +904,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                             config.forkOptions.maxHeapSize = "64m"
                         }
                         config.forkOptions(additionalForkOptions)
-                        config.classpath(additionalClasspath)
+                        config.classpath.from(additionalClasspath)
                         config.parameters {
                             itemName = item.toString() 
                         }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -20,6 +20,7 @@ package org.gradle.workers.internal
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.workers.fixtures.WorkerExecutorFixture
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
@@ -31,11 +32,50 @@ import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Rule
     BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
+    WorkerExecutorFixture.ParameterClass parallelParameterType
+    WorkerExecutorFixture.ExecutionClass parallelWorkerExecution
+    WorkerExecutorFixture.ExecutionClass failingWorkerExecution
+    WorkerExecutorFixture.ExecutionClass alternateParallelWorkerExecution
 
     def setup() {
         blockingHttpServer.start()
-        withParallelRunnableInBuildScript()
-        withAlternateRunnableInBuildScript()
+
+        parallelParameterType = fixture.parameterClass("ParallelParameter", "org.gradle.test").withFields([
+                "itemName": "String"
+        ])
+
+        parallelWorkerExecution = fixture.executionClass("ParallelWorkerExecution", "org.gradle.test", parallelParameterType)
+        parallelWorkerExecution.with {
+            imports += ["java.net.URI", "org.gradle.test.FileHelper"]
+            extraFields = "private static final String id = UUID.randomUUID().toString()"
+            action = """
+                System.out.println("Running \${parameters.itemName}...")
+                new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${parameters.itemName}", null, null).toURL().text
+                File outputDir = new File("${fixture.outputFileDirPath}")
+                File outputFile = new File(outputDir, parameters.itemName)
+                FileHelper.write(id, outputFile)
+            """
+        }
+
+        failingWorkerExecution = fixture.executionClass("FailingWorkerExecution", "org.gradle.test", parallelParameterType)
+        failingWorkerExecution.with {
+            action = """
+                throw new RuntimeException("Failure from \${parameters.itemName}");
+            """
+        }
+
+        alternateParallelWorkerExecution = fixture.executionClass("AlternateParallelWorkerExecution", "org.gradle.test", parallelParameterType)
+        alternateParallelWorkerExecution.with {
+            imports += ["java.net.URI", "org.gradle.test.FileHelper"]
+            extraFields = "private static final String id = UUID.randomUUID().toString()"
+            action = """
+                System.out.println("Running alternate_\${parameters.itemName}...")
+                new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/alternate_\${parameters.itemName}", null, null).toURL().text
+            """
+        }
+
+        parallelWorkerExecution.writeToBuildFile()
+        alternateParallelWorkerExecution.writeToBuildFile()
         withMultipleActionTaskTypeInBuildScript()
     }
 
@@ -79,9 +119,9 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast {
-                    submitWorkItem("workItem0", TestParallelRunnable) { it.classpath([ new File("foo") ]) }
-                    submitWorkItem("workItem1", TestParallelRunnable) { it.classpath([ new File("bar") ]) }
-                    submitWorkItem("workItem2", TestParallelRunnable) { it.classpath([ new File("baz") ]) }
+                    submitWorkItem("workItem0", ${parallelWorkerExecution.name}.class) { it.classpath([ new File("foo") ]) }
+                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class) { it.classpath([ new File("bar") ]) }
+                    submitWorkItem("workItem2", ${parallelWorkerExecution.name}.class) { it.classpath([ new File("baz") ]) }
                 }
             }
         """
@@ -102,9 +142,9 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast {
-                    submitWorkItem("workItem0", AlternateParallelRunnable.class)
-                    submitWorkItem("workItem1", TestParallelRunnable.class)
-                    submitWorkItem("workItem2", AlternateParallelRunnable.class)
+                    submitWorkItem("workItem0", ${alternateParallelWorkerExecution.name}.class)
+                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class)
+                    submitWorkItem("workItem2", ${alternateParallelWorkerExecution.name}.class)
                 }
             }
         """
@@ -144,13 +184,13 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "a second task action does not start if work submitted in #isolationMode by a previous task action fails"() {
+        failingWorkerExecution.writeToBuildFile()
+
         given:
         buildFile << """
-            $runnableThatFails
-
             task parallelWorkTask(type: MultipleWorkItemTask) {
-                doLast { submitWorkItem("taskAction1", runnableClass) { isolationMode = $isolationMode } }
-                doLast { submitWorkItem("taskAction2", RunnableThatFails.class) }
+                doLast { submitWorkItem("taskAction1", ${parallelWorkerExecution.name}.class) { isolationMode = $isolationMode } }
+                doLast { submitWorkItem("taskAction2", ${failingWorkerExecution.name}.class) }
                 doLast { submitWorkItem("taskAction3") }
             }
         """
@@ -161,7 +201,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         fails("parallelWorkTask")
 
         and:
-        failureHasCause("A failure occurred while executing RunnableThatFails")
+        failureHasCause("A failure occurred while executing ${failingWorkerExecution.name}")
         failureHasCause("Failure from taskAction2")
 
         where:
@@ -170,15 +210,15 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "all other submitted work executes when a work item fails in #isolationMode"() {
+        failingWorkerExecution.writeToBuildFile()
+
         given:
         buildFile << """
-            $runnableThatFails
-
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 doLast { 
-                    submitWorkItem("workItem1", runnableClass) { isolationMode = IsolationMode.PROCESS } 
-                    submitWorkItem("workItem2", RunnableThatFails.class) { isolationMode = $isolationMode }
-                    submitWorkItem("workItem3", runnableClass) { isolationMode = IsolationMode.CLASSLOADER } 
+                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class) { isolationMode = IsolationMode.PROCESS } 
+                    submitWorkItem("workItem2", ${failingWorkerExecution.name}.class) { isolationMode = $isolationMode }
+                    submitWorkItem("workItem3", ${parallelWorkerExecution.name}.class) { isolationMode = IsolationMode.CLASSLOADER } 
                 }
             }
         """
@@ -189,7 +229,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         fails("parallelWorkTask")
 
         and:
-        failureHasCause("A failure occurred while executing RunnableThatFails")
+        failureHasCause("A failure occurred while executing ${failingWorkerExecution.name}")
         failureHasCause("Failure from workItem2")
 
         where:
@@ -198,17 +238,17 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "all errors are reported when submitting failing work in #isolationModeDescription"() {
+        failingWorkerExecution.writeToBuildFile()
+
         given:
         buildFile << """
-            $runnableThatFails
-
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 doLast { 
-                    submitWorkItem("workItem1", RunnableThatFails.class) { config ->
+                    submitWorkItem("workItem1", ${failingWorkerExecution.name}.class) { config ->
                         config.isolationMode = $isolationMode1
                         config.displayName = "work item 1"
                     }
-                    submitWorkItem("workItem2", RunnableThatFails.class) { config ->
+                    submitWorkItem("workItem2", ${failingWorkerExecution.name}.class) { config ->
                         config.isolationMode = $isolationMode2
                         config.displayName = "work item 2"
                     }
@@ -242,14 +282,14 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "both errors in work items in #isolationMode and errors in the task action are reported"() {
+        failingWorkerExecution.writeToBuildFile()
+
         given:
         buildFile << """
-            $runnableThatFails
-
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast { 
-                    submitWorkItem("workItem1", RunnableThatFails.class) { config ->
+                    submitWorkItem("workItem1", ${failingWorkerExecution.name}.class) { config ->
                         config.displayName = "work item 1"
                     }
                     throw new RuntimeException("Failure from task action")
@@ -277,19 +317,19 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "user can take responsibility for failing work items in #isolationMode"() {
+        failingWorkerExecution.writeToBuildFile()
+
         given:
         buildFile << """
             import java.util.concurrent.ExecutionException
             import org.gradle.workers.WorkerExecutionException
-
-            $runnableThatFails
 
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast { 
                     submitWorkItem("workItem1", runnableClass)
 
-                    submitWorkItem("workItem2", RunnableThatFails.class) { config ->
+                    submitWorkItem("workItem2", ${failingWorkerExecution.name}.class) { config ->
                         config.displayName = "work item 2"
                     }
 
@@ -774,30 +814,26 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
     }
 
     def "cannot mutate worker parameters when using IsolationMode.NONE"() {
+        def verifyingParameterType = fixture.parameterClass("VerifyingParameter", "org.gradle.test").withFields([
+                "itemName": "String",
+                "list": "List<String>"
+        ])
+        def verifyingWorkerExecution = fixture.executionClass("VerifyingWorkerExecution", "org.gradle.test", verifyingParameterType)
+        verifyingWorkerExecution.imports += ["java.net.URI"]
+        verifyingWorkerExecution.action = """
+            assert parameters.list.size() == 1
+            new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${parameters.itemName}", null, null).toURL().text
+            assert parameters.list.size() == 1
+        """
+        verifyingWorkerExecution.writeToBuildFile()
+
         given:
         buildFile << """
             List<String> mutableList = ["foo"]
             
-            class VerifyingRunnable implements Runnable {
-                final String itemName
-                final List<String> list
-
-                @Inject
-                public VerifyingRunnable(String itemName, List<String> list) {
-                    this.itemName = itemName
-                    this.list = list
-                }
-
-                public void run() {
-                    assert list.size() == 1
-                    new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${itemName}", null, null).toURL().text
-                    assert list.size() == 1
-                }
-            }
-            
             class VerifyingRunnableTask extends DefaultTask {
-                String itemName
-                List<String> list
+                String item
+                List<String> testList
                 
                 @Inject
                 WorkerExecutor getWorkerExecutor() {
@@ -806,16 +842,19 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 
                 @TaskAction
                 void executeRunnable() {
-                    workerExecutor.submit(VerifyingRunnable.class) { config ->
-                        config.isolationMode = IsolationMode.NONE
-                        config.params = [ itemName.toString(), list ]
+                    workerExecutor.execute(${verifyingWorkerExecution.name}.class) { 
+                        isolationMode = IsolationMode.NONE
+                        parameters {
+                            itemName = item.toString()
+                            list = testList
+                        }
                     }
                 }
             }
             
             task firstTask(type: VerifyingRunnableTask) {
-                itemName = "task1"
-                list = mutableList
+                item = "task1"
+                testList = mutableList
             }
             
             task secondTask(type: MultipleWorkItemTask) {
@@ -834,65 +873,6 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         succeeds("firstTask", "secondTask")
     }
 
-    def getParallelRunnable() {
-        return """
-            import java.net.URI
-            import javax.inject.Inject
-            import org.gradle.test.FileHelper
-
-            public class TestParallelRunnable implements Runnable {
-                final String itemName
-                private static final String id = UUID.randomUUID().toString()
-
-                @Inject
-                public TestParallelRunnable(String itemName) {
-                    this.itemName = itemName
-                }
-                
-                public void run() {
-                    System.out.println("Running \${itemName}...")
-                    new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${itemName}", null, null).toURL().text
-                    File outputDir = new File("${fixture.outputFileDirPath}")
-                    File outputFile = new File(outputDir, itemName)
-                    FileHelper.write(id, outputFile)
-                }
-            }
-        """
-    }
-
-    def withParallelRunnableInBuildScript() {
-        buildFile << """
-            $parallelRunnable
-        """
-    }
-
-    def getAlternateParallelRunnable() {
-        return """
-            import java.net.URI
-            import javax.inject.Inject
-
-            public class AlternateParallelRunnable implements Runnable {
-                final String itemName 
-
-                @Inject
-                public AlternateParallelRunnable(String itemName) {
-                    this.itemName = itemName
-                }
-                
-                public void run() {
-                    System.out.println("Running alternate_\${itemName}...")
-                    new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/alternate_\${itemName}", null, null).toURL().text
-                }
-            }
-        """
-    }
-
-    def withAlternateRunnableInBuildScript() {
-        buildFile << """
-            $alternateParallelRunnable
-        """
-    }
-
     String getMultipleActionTaskType() {
         return """
             import javax.inject.Inject
@@ -901,7 +881,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             class MultipleWorkItemTask extends DefaultTask {
                 def isolationMode = IsolationMode.NONE
                 def additionalForkOptions = {}
-                def runnableClass = TestParallelRunnable.class
+                def runnableClass = ${parallelWorkerExecution.name}.class
                 def additionalClasspath = project.layout.files()
 
                 @Inject
@@ -918,14 +898,16 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 }
                 
                 def submitWorkItem(item, actionClass, configClosure) {
-                    return workerExecutor.submit(actionClass) { config ->
+                    return workerExecutor.execute(actionClass) { config ->
                         config.isolationMode = this.isolationMode
                         if (config.isolationMode == IsolationMode.PROCESS) {
                             config.forkOptions.maxHeapSize = "64m"
                         }
                         config.forkOptions(additionalForkOptions)
                         config.classpath(additionalClasspath)
-                        config.params = [ item.toString() ]
+                        config.parameters {
+                            itemName = item.toString() 
+                        }
                         configClosure.call(config)
                     }
                 }
@@ -936,25 +918,6 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
     def withMultipleActionTaskTypeInBuildScript() {
         buildFile << """
             $multipleActionTaskType
-        """
-    }
-
-    String getRunnableThatFails() {
-        return """
-            import javax.inject.Inject
-            
-            public class RunnableThatFails implements Runnable {
-                private final String itemName
-                
-                @Inject
-                public RunnableThatFails(String itemName) { 
-                    this.itemName = itemName
-                }
-
-                public void run() {
-                    throw new RuntimeException("Failure from \${itemName}");
-                }
-            }
         """
     }
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -358,23 +358,6 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         isolationMode << ISOLATION_MODES
     }
 
-    String parameterRunnableWithType(String type, String action) {
-        return """
-            class ParameterRunnable implements Runnable {
-                private ${type} param
-
-                @Inject
-                ParameterRunnable(${type} param) {
-                    this.param = param
-                }
-
-                void run() {
-                    ${action}
-                }
-            }
-        """
-    }
-
     String parameterWorkerExecution(String type, String action) {
         return """
             interface TestParameters extends WorkerParameters {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -59,12 +59,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             interface Foo extends Named { }
             ext.testObject = objects.named(Foo.class, "bar")
 
-            ${parameterWorkerExecution('Named', 'println parameters.foo.name')}
+            ${parameterWorkerExecution('Named', 'println parameters.testParam.name', true)}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam = testObject
                 }
             } 
         """
@@ -81,15 +81,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ext.testObject = objects.property(String)
-            testObject.set("bar")
-
-            ${parameterWorkerExecution('Property', 'println parameters.foo.get()')}
+            ${parameterWorkerExecution('Property<String>', 'println parameters.testParam.get()')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam.set("bar")
                 }
             } 
         """
@@ -106,15 +103,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide file collection parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ext.testObject = objects.fileCollection()
-            testObject.from("bar")
-
-            ${parameterWorkerExecution('FileCollection', 'parameters.foo.files.each { println it.name }')}
+            ${parameterWorkerExecution('ConfigurableFileCollection', 'parameters.testParam.files.each { println it.name }')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam.from("bar")
                 }
             } 
         """
@@ -175,16 +169,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide list property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ext.testObject = objects.listProperty(String)
-            testObject.add("foo")
-            testObject.add("bar")
-
-            ${parameterWorkerExecution('ListProperty', 'println parameters.foo.get().join(",")') }
+            ${parameterWorkerExecution('ListProperty<String>', 'println parameters.testParam.get().join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam.add("foo")
+                    testParam.add("bar")
                 }
             } 
         """
@@ -201,16 +192,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide set property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ext.testObject = objects.setProperty(String)
-            testObject.add("foo")
-            testObject.add("bar")
-
-            ${parameterWorkerExecution('SetProperty', 'println parameters.foo.get().join(",")') }
+            ${parameterWorkerExecution('SetProperty<String>', 'println parameters.testParam.get().join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam.add("foo")
+                    testParam.add("bar")
                 }
             } 
         """
@@ -227,16 +215,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide map property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ext.testObject = objects.mapProperty(String, String)
-            testObject.put("foo", "bar")
-            testObject.put("bar", "baz")
-
-            ${parameterWorkerExecution('MapProperty', 'println parameters.foo.get().collect { it.key + ":" + it.value }.join(",")') }
+            ${parameterWorkerExecution('MapProperty<String, String>', 'println parameters.testParam.get().collect { it.key + ":" + it.value }.join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam.put("foo", "bar")
+                    testParam.put("bar", "baz")
                 }
             } 
         """
@@ -253,15 +238,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide file property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ext.testObject = objects.fileProperty()
-            testObject.set(new File("bar"))
-
-            ${parameterWorkerExecution('RegularFileProperty', 'println parameters.foo.get().getAsFile().name')}
+            ${parameterWorkerExecution('RegularFileProperty', 'println parameters.testParam.get().getAsFile().name')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam.set(new File("bar"))
                 }
             } 
         """
@@ -278,15 +260,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide directory property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ext.testObject = objects.directoryProperty()
-            testObject.set(new File("bar"))
-
-            ${parameterWorkerExecution('DirectoryProperty', 'println parameters.foo.get().getAsFile().name')}
+            ${parameterWorkerExecution('DirectoryProperty', 'println parameters.testParam.get().getAsFile().name')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam.set(new File("bar"))
                 }
             } 
         """
@@ -316,12 +295,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ext.testObject = getServices().get(InstantiatorFactory.class).inject().newInstance(SomeExtension)
             ext.testObject.value = "bar"
 
-            ${parameterWorkerExecution('SomeExtension', 'println parameters.foo.value') }
+            ${parameterWorkerExecution('SomeExtension', 'println parameters.testParam.value', true) }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = testObject
+                    testParam = testObject
                 }
             }
         """
@@ -338,12 +317,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide a null parameter with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('String', 'println "foo is " + parameters.foo')}
+            ${parameterWorkerExecution('String', 'println "testParam is " + parameters.testParam', true)}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
                 parameters {
-                    foo = null
+                    testParam = null
                 }
             } 
         """
@@ -352,17 +331,17 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         succeeds("runWork")
 
         then:
-        outputContains("foo is null")
+        outputContains("testParam is null")
 
         where:
         isolationMode << ISOLATION_MODES
     }
 
-    String parameterWorkerExecution(String type, String action) {
+    String parameterWorkerExecution(String type, String action, boolean requiresSetter = false) {
         return """
             interface TestParameters extends WorkerParameters {
-                ${type} getFoo();
-                void setFoo(${type} foo);
+                ${type} getTestParam();
+                ${-> requiresSetter ? "void setTestParam(${type} testParam);" : ''}
             }
             
             abstract class ParameterWorkerExecution implements WorkerExecution<TestParameters> {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -310,9 +310,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         outputContains("bar")
 
         where:
-        // TODO: this doesn't work yet for out-of-process workers because the managed factory
-        // for generated classes is not guaranteed to be available in the worker process yet.
-        isolationMode << (ISOLATION_MODES - "IsolationMode.PROCESS")
+        isolationMode << ISOLATION_MODES
     }
 
     String parameterRunnableWithType(String type, String action) {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -31,7 +31,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             class ParameterTask extends DefaultTask {
                 WorkerExecutor workerExecutor
                 IsolationMode isolationMode
-                Object[] params
+                Closure paramConfig
 
                 @Inject
                 ParameterTask(WorkerExecutor workerExecutor) {
@@ -40,10 +40,15 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
                 @TaskAction
                 void doWork() {
-                    workerExecutor.submit(ParameterRunnable.class) {
+                    workerExecutor.execute(ParameterWorkerExecution.class) { 
                         isolationMode = this.isolationMode
-                        params = this.params
+                        paramConfig.delegate = parameters
+                        parameters(paramConfig)
                     }
+                }
+                
+                void parameters(Closure closure) {
+                    paramConfig = closure
                 }
             }  
         """
@@ -54,11 +59,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             interface Foo extends Named { }
             ext.testObject = objects.named(Foo.class, "bar")
 
-            ${parameterRunnableWithType('Named', 'println param.name')}
+            ${parameterWorkerExecution('Named', 'println parameters.foo.name')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -77,11 +84,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ext.testObject = objects.property(String)
             testObject.set("bar")
 
-            ${parameterRunnableWithType('Property', 'println param.get()')}
+            ${parameterWorkerExecution('Property', 'println parameters.foo.get()')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -100,11 +109,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ext.testObject = objects.fileCollection()
             testObject.from("bar")
 
-            ${parameterRunnableWithType('FileCollection', 'param.files.each { println it.name }')}
+            ${parameterWorkerExecution('FileCollection', 'parameters.foo.files.each { println it.name }')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -168,11 +179,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             testObject.add("foo")
             testObject.add("bar")
 
-            ${parameterRunnableWithType('ListProperty', 'println param.get().join(",")') }
+            ${parameterWorkerExecution('ListProperty', 'println parameters.foo.get().join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -192,11 +205,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             testObject.add("foo")
             testObject.add("bar")
 
-            ${parameterRunnableWithType('SetProperty', 'println param.get().join(",")') }
+            ${parameterWorkerExecution('SetProperty', 'println parameters.foo.get().join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -216,11 +231,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             testObject.put("foo", "bar")
             testObject.put("bar", "baz")
 
-            ${parameterRunnableWithType('MapProperty', 'println param.get().collect { it.key + ":" + it.value }.join(",")') }
+            ${parameterWorkerExecution('MapProperty', 'println parameters.foo.get().collect { it.key + ":" + it.value }.join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -239,11 +256,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ext.testObject = objects.fileProperty()
             testObject.set(new File("bar"))
 
-            ${parameterRunnableWithType('RegularFileProperty', 'println param.get().getAsFile().name')}
+            ${parameterWorkerExecution('RegularFileProperty', 'println parameters.foo.get().getAsFile().name')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -262,11 +281,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ext.testObject = objects.directoryProperty()
             testObject.set(new File("bar"))
 
-            ${parameterRunnableWithType('DirectoryProperty', 'println param.get().getAsFile().name')}
+            ${parameterWorkerExecution('DirectoryProperty', 'println parameters.foo.get().getAsFile().name')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             } 
         """
 
@@ -295,11 +316,13 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ext.testObject = getServices().get(InstantiatorFactory.class).inject().newInstance(SomeExtension)
             ext.testObject.value = "bar"
 
-            ${parameterRunnableWithType('SomeExtension', 'println param.value') }
+            ${parameterWorkerExecution('SomeExtension', 'println parameters.foo.value') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
-                params = [testObject]
+                parameters {
+                    foo = testObject
+                }
             }
         """
 
@@ -308,6 +331,28 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputContains("bar")
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
+    def "can provide a null parameter with isolation mode #isolationMode"() {
+        buildFile << """
+            ${parameterWorkerExecution('String', 'println "foo is " + parameters.foo')}
+
+            task runWork(type: ParameterTask) {
+                isolationMode = ${isolationMode}
+                parameters {
+                    foo = null
+                }
+            } 
+        """
+
+        when:
+        succeeds("runWork")
+
+        then:
+        outputContains("foo is null")
 
         where:
         isolationMode << ISOLATION_MODES
@@ -329,4 +374,20 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             }
         """
     }
+
+    String parameterWorkerExecution(String type, String action) {
+        return """
+            interface TestParameters extends WorkerParameters {
+                ${type} getFoo();
+                void setFoo(${type} foo);
+            }
+            
+            abstract class ParameterWorkerExecution implements WorkerExecution<TestParameters> {
+                void execute() {
+                    ${action}
+                }
+            }
+        """
+    }
 }
+

--- a/subprojects/workers/src/main/java/org/gradle/workers/BaseWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/BaseWorkerSpec.java
@@ -21,9 +21,14 @@ import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
 import org.gradle.process.JavaForkOptions;
 
-import javax.annotation.Nullable;
 import java.io.File;
 
+/**
+ * Represents the common configuration of a worker.  Used when submitting an item of work
+ * to the {@link WorkerExecutor}.
+ *
+ * @since 5.6
+ */
 @Incubating
 public interface BaseWorkerSpec extends Describable {
     /**
@@ -85,10 +90,4 @@ public interface BaseWorkerSpec extends Describable {
      * @param displayName the name of this item of work
      */
     void setDisplayName(String displayName);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Nullable
-    String getDisplayName();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/BaseWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/BaseWorkerSpec.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers;
+
+import org.gradle.api.Action;
+import org.gradle.api.Describable;
+import org.gradle.api.Incubating;
+import org.gradle.process.JavaForkOptions;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+@Incubating
+public interface BaseWorkerSpec extends Describable {
+    /**
+     * Adds a set of files to the classpath associated with the worker.
+     *
+     * @param files - the files to add to the classpath
+     */
+    void classpath(Iterable<File> files);
+
+    /**
+     * Sets the classpath associated with the worker.
+     *
+     * @param files - the files to set the classpath to
+     */
+    void setClasspath(Iterable<File> files);
+
+    /**
+     * Gets the classpath associated with the worker.
+     *
+     * @return the classpath associated with the worker
+     */
+    Iterable<File> getClasspath();
+
+    /**
+     * Gets the isolation mode for this worker, see {@link IsolationMode}.
+     *
+     * @return the isolation mode for this worker, see {@link IsolationMode}, defaults to {@link IsolationMode#AUTO}
+     *
+     * @since 4.0
+     */
+    IsolationMode getIsolationMode();
+
+    /**
+     * Sets the isolation mode for this worker, see {@link IsolationMode}.
+     *
+     * @param isolationMode the forking mode for this worker, see {@link IsolationMode}
+     *
+     * @since 4.0
+     */
+    void setIsolationMode(IsolationMode isolationMode);
+
+    /**
+     * Executes the provided action against the {@link JavaForkOptions} object associated with this builder.
+     *
+     * @param forkOptionsAction - An action to configure the {@link JavaForkOptions} for this builder
+     */
+    void forkOptions(Action<? super JavaForkOptions> forkOptionsAction);
+
+    /**
+     * Returns the {@link JavaForkOptions} object associated with this builder.
+     *
+     * @return the {@link JavaForkOptions} of this builder
+     */
+    JavaForkOptions getForkOptions();
+
+    /**
+     * Sets the name to use when displaying this item of work.
+     *
+     * @param displayName the name of this item of work
+     */
+    void setDisplayName(String displayName);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Nullable
+    String getDisplayName();
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/BaseWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/BaseWorkerSpec.java
@@ -21,8 +21,6 @@ import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
 import org.gradle.process.JavaForkOptions;
 
-import java.io.File;
-
 /**
  * Represents the common configuration of a worker.  Used when submitting an item of work
  * to the {@link WorkerExecutor}.
@@ -31,27 +29,6 @@ import java.io.File;
  */
 @Incubating
 public interface BaseWorkerSpec extends Describable {
-    /**
-     * Adds a set of files to the classpath associated with the worker.
-     *
-     * @param files - the files to add to the classpath
-     */
-    void classpath(Iterable<File> files);
-
-    /**
-     * Sets the classpath associated with the worker.
-     *
-     * @param files - the files to set the classpath to
-     */
-    void setClasspath(Iterable<File> files);
-
-    /**
-     * Gets the classpath associated with the worker.
-     *
-     * @return the classpath associated with the worker
-     */
-    Iterable<File> getClasspath();
-
     /**
      * Gets the isolation mode for this worker, see {@link IsolationMode}.
      *

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
@@ -47,6 +47,7 @@ public interface WorkerConfiguration extends ActionConfiguration, BaseWorkerSpec
      *
      * @return the forking mode for this worker, see {@link ForkMode}, defaults to {@link ForkMode#AUTO}
      */
+    @Deprecated
     ForkMode getForkMode();
 
     /**
@@ -54,6 +55,7 @@ public interface WorkerConfiguration extends ActionConfiguration, BaseWorkerSpec
      *
      * @param forkMode the forking mode for this worker, see {@link ForkMode}
      */
+    @Deprecated
     void setForkMode(ForkMode forkMode);
 
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
@@ -16,13 +16,7 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
-import org.gradle.api.Describable;
-import org.gradle.process.JavaForkOptions;
-
-import javax.annotation.Nullable;
-import java.io.File;
 
 /**
  * Represents the configuration of a worker.  Used when submitting an item of work
@@ -46,45 +40,7 @@ import java.io.File;
  *
  * @since 3.5
  */
-public interface WorkerConfiguration extends Describable, ActionConfiguration {
-    /**
-     * Adds a set of files to the classpath associated with the worker.
-     *
-     * @param files - the files to add to the classpath
-     */
-    void classpath(Iterable<File> files);
-
-    /**
-     * Sets the classpath associated with the worker.
-     *
-     * @param files - the files to set the classpath to
-     */
-    void setClasspath(Iterable<File> files);
-
-    /**
-     * Gets the classpath associated with the worker.
-     *
-     * @return the classpath associated with the worker
-     */
-    Iterable<File> getClasspath();
-
-    /**
-     * Gets the isolation mode for this worker, see {@link IsolationMode}.
-     *
-     * @return the isolation mode for this worker, see {@link IsolationMode}, defaults to {@link IsolationMode#AUTO}
-     *
-     * @since 4.0
-     */
-    IsolationMode getIsolationMode();
-
-    /**
-     * Sets the isolation mode for this worker, see {@link IsolationMode}.
-     *
-     * @param isolationMode the forking mode for this worker, see {@link IsolationMode}
-     *
-     * @since 4.0
-     */
-    void setIsolationMode(IsolationMode isolationMode);
+public interface WorkerConfiguration extends ActionConfiguration, BaseWorkerSpec {
 
     /**
      * Gets the forking mode for this worker, see {@link ForkMode}.
@@ -100,31 +56,4 @@ public interface WorkerConfiguration extends Describable, ActionConfiguration {
      */
     void setForkMode(ForkMode forkMode);
 
-    /**
-     * Executes the provided action against the {@link JavaForkOptions} object associated with this builder.
-     *
-     * @param forkOptionsAction - An action to configure the {@link JavaForkOptions} for this builder
-     */
-    void forkOptions(Action<? super JavaForkOptions> forkOptionsAction);
-
-    /**
-     * Returns the {@link JavaForkOptions} object associated with this builder.
-     *
-     * @return the {@link JavaForkOptions} of this builder
-     */
-    JavaForkOptions getForkOptions();
-
-    /**
-     * Sets the name to use when displaying this item of work.
-     *
-     * @param displayName the name of this item of work
-     */
-    void setDisplayName(String displayName);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Nullable
-    @Override
-    String getDisplayName();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
@@ -18,6 +18,8 @@ package org.gradle.workers;
 
 import org.gradle.api.ActionConfiguration;
 
+import java.io.File;
+
 /**
  * Represents the configuration of a worker.  Used when submitting an item of work
  * to the {@link WorkerExecutor}.
@@ -41,6 +43,26 @@ import org.gradle.api.ActionConfiguration;
  * @since 3.5
  */
 public interface WorkerConfiguration extends ActionConfiguration, BaseWorkerSpec {
+    /**
+     * Adds a set of files to the classpath associated with the worker.
+     *
+     * @param files - the files to add to the classpath
+     */
+    void classpath(Iterable<File> files);
+
+    /**
+     * Sets the classpath associated with the worker.
+     *
+     * @param files - the files to set the classpath to
+     */
+    void setClasspath(Iterable<File> files);
+
+    /**
+     * Gets the classpath associated with the worker.
+     *
+     * @return the classpath associated with the worker
+     */
+    Iterable<File> getClasspath();
 
     /**
      * Gets the forking mode for this worker, see {@link ForkMode}.

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecution.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecution.java
@@ -20,10 +20,52 @@ import org.gradle.api.Incubating;
 
 import javax.inject.Inject;
 
+/**
+ * Represents the implementation of a unit of work to be used when submitting work to the
+ * {@link WorkerExecutor}.
+ *
+ * <p>
+ *     A worker execution implementation is an abstract class implementing the {@link #execute()} method.
+ *     A minimal implementation may look like this:
+ * </p>
+ *
+ * <pre class='autoTested'>
+ * import org.gradle.workers.WorkerParameters;
+ *
+ * public abstract class MyExecution implements WorkerExecution&lt;WorkerParameters.None&gt; {
+ *     private final String greeting;
+ *
+ *     {@literal @}Inject
+ *     public MyExecution() {
+ *         this.greeting = "hello";
+ *     }
+ *
+ *     {@literal @}Override
+ *     public void execute() {
+ *         System.out.println(greeting);
+ *     }
+ * }
+ * </pre>
+ *
+ * Implementations of WorkerExecution are subject to the following constraints:
+ * <ul>
+ *     <li>Do not implement {@link #getParameters()} in your class, the method will be implemented by Gradle.</li>
+ *     <li>Constructors must be annotated with {@link Inject}.</li>
+ * </ul>
+ *
+ * @param <T> Parameter type for the worker execution. Should be {@link WorkerParameters.None} if the execution does not have parameters.
+ * @since 5.6
+ **/
 @Incubating
 public interface WorkerExecution<T extends WorkerParameters> {
+    /**
+     * The parameters associated with a concrete work item.
+     */
     @Inject
     T getParameters();
 
+    /**
+     * The work to perform when this work item executes.
+     */
     void execute();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecution.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.workers;
 
-import org.gradle.api.Describable;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.api.Incubating;
 
-import java.io.Serializable;
+import javax.inject.Inject;
 
-public interface ActionExecutionSpec<T extends WorkerParameters> extends Serializable, Describable {
-    Class<? extends WorkerExecution<T>> getImplementationClass();
-
-    @Override
-    String getDisplayName();
-
+@Incubating
+public interface WorkerExecution<T extends WorkerParameters> {
+    @Inject
     T getParameters();
 
-    ClassLoaderStructure getClassLoaderStructure();
+    void execute();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
@@ -56,6 +56,7 @@ public interface WorkerExecutor {
      * in the {@link WorkerConfiguration}.  If no idle daemons are available, a new daemon will be started.  Any errors
      * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
      */
+    @Deprecated
     void submit(Class<? extends Runnable> actionClass, Action<? super WorkerConfiguration> configAction);
 
     /**

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
@@ -66,6 +66,8 @@ public interface WorkerExecutor {
      * Work configured with {@link IsolationMode#PROCESS} will execute in an idle daemon that meets the requirements set
      * in the {@link WorkerSpec}.  If no idle daemons are available, a new daemon will be started.  Any errors
      * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
+     *
+     * @since 5.6
      */
     @Incubating
     <T extends WorkerParameters> void execute(Class<? extends WorkerExecution<T>> workerExecutionClass, Action<? super WorkerSpec<T>> configAction);

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
@@ -17,6 +17,7 @@
 package org.gradle.workers;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 
 /**
  * Allows work to be submitted for asynchronous execution.  This api allows for safe, concurrent execution of work items and enables:
@@ -56,6 +57,18 @@ public interface WorkerExecutor {
      * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
      */
     void submit(Class<? extends Runnable> actionClass, Action<? super WorkerConfiguration> configAction);
+
+    /**
+     * Submits a piece of work to be executed asynchronously.
+     *
+     * Execution of the work may begin immediately.
+     *
+     * Work configured with {@link IsolationMode#PROCESS} will execute in an idle daemon that meets the requirements set
+     * in the {@link WorkerSpec}.  If no idle daemons are available, a new daemon will be started.  Any errors
+     * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
+     */
+    @Incubating
+    <T extends WorkerParameters> void execute(Class<? extends WorkerExecution<T>> workerExecutionClass, Action<? super WorkerSpec<T>> configAction);
 
     /**
      * Blocks until all work associated with the current build operation is complete.  Note that when using this method inside

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.workers;
 
-import org.gradle.api.Describable;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.api.Incubating;
 
-import java.io.Serializable;
-
-public interface ActionExecutionSpec<T extends WorkerParameters> extends Serializable, Describable {
-    Class<? extends WorkerExecution<T>> getImplementationClass();
-
-    @Override
-    String getDisplayName();
-
-    T getParameters();
-
-    ClassLoaderStructure getClassLoaderStructure();
+@Incubating
+public interface WorkerParameters {
+    @Incubating
+    final class None implements WorkerParameters {
+        private None() {}
+    }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
@@ -18,8 +18,32 @@ package org.gradle.workers;
 
 import org.gradle.api.Incubating;
 
+/**
+ * Marker interface for parameter objects to {@link WorkerExecution}s.
+ *
+ * <p>
+ *     Parameter types should be interfaces, only declaring getters for {@link org.gradle.api.provider.Property}-like objects.
+ *     Example:
+ * </p>
+ * <pre class='autoTested'>
+ * public interface MyParameters extends WorkerParameters {
+ *     String getStringParameter();
+ *     void setStringParameters(String stringParameter);
+ *     ConfigurableFileCollection getFiles();
+ * }
+ * </pre>
+ *
+ * @since 5.6
+ */
 @Incubating
 public interface WorkerParameters {
+    /**
+     * Used for worker executions without parameters.
+     *
+     * <p>When {@link None} is used as parameters, calling {@link WorkerExecution#getParameters()} throws an exception.</p>
+     *
+     * @since 5.6
+     */
     @Incubating
     final class None implements WorkerParameters {
         private None() {}

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
@@ -48,4 +48,6 @@ public interface WorkerParameters {
     final class None implements WorkerParameters {
         private None() {}
     }
+
+    WorkerParameters.None NONE = new WorkerParameters.None();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
@@ -19,9 +19,42 @@ package org.gradle.workers;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 
+/**
+ * Represents the configuration of a worker.  Used when submitting an item of work
+ * to the {@link WorkerExecutor}.
+ *
+ * <pre>
+ *      workerExecutor.submit(MyWorkerExecution.class) { WorkerSpec spec -&gt;
+ *          spec.isolationMode = IsolationMode.PROCESS
+ *
+ *          forkOptions { JavaForkOptions options -&gt;
+ *              options.maxHeapSize = "512m"
+ *              options.systemProperty 'some.prop', 'value'
+ *              options.jvmArgs "-server"
+ *          }
+ *
+ *          classpath configurations.fooLibrary
+ *
+ *          // parameters are specific to the WorkerExecution class
+ *          spec.parameters {
+ *              foo = "bar"
+ *              files.from("some/file")
+ *          }
+ *      }
+ * </pre>
+ *
+ * @param <T> Parameter type for the worker execution. Should be {@link WorkerParameters.None} if the execution does not have parameters.
+ * @since 5.6
+ **/
 @Incubating
 public interface WorkerSpec<T extends WorkerParameters> extends BaseWorkerSpec {
+    /**
+     * Returns the parameters object to be used with this item of work.
+     */
     T getParameters();
 
+    /**
+     * Configures the parameters object for this item of work.
+     */
     void parameters(Action<T> action);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.workers.internal;
+package org.gradle.workers;
 
-import org.gradle.api.Describable;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 
-import java.io.Serializable;
-
-public interface ActionExecutionSpec<T extends WorkerParameters> extends Serializable, Describable {
-    Class<? extends WorkerExecution<T>> getImplementationClass();
-
-    @Override
-    String getDisplayName();
-
+@Incubating
+public interface WorkerSpec<T extends WorkerParameters> extends BaseWorkerSpec {
     T getParameters();
 
-    ClassLoaderStructure getClassLoaderStructure();
+    void parameters(Action<T> action);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
@@ -18,6 +18,7 @@ package org.gradle.workers;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.ConfigurableFileCollection;
 
 /**
  * Represents the configuration of a worker.  Used when submitting an item of work
@@ -48,6 +49,13 @@ import org.gradle.api.Incubating;
  **/
 @Incubating
 public interface WorkerSpec<T extends WorkerParameters> extends BaseWorkerSpec {
+    /**
+     * Gets the classpath associated with the worker.
+     *
+     * @return the classpath associated with the worker
+     */
+    ConfigurableFileCollection getClasspath();
+
     /**
      * Returns the parameters object to be used with this item of work.
      */

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
@@ -51,9 +51,18 @@ public abstract class AbstractWorker implements BuildOperationAwareWorker {
             public BuildOperationDescriptor.Builder description() {
                 return BuildOperationDescriptor.displayName(spec.getDisplayName())
                     .parent(parentBuildOperation)
-                    .details(new Details(spec.getImplementationClass().getName(), spec.getDisplayName()));
+                    .details(new Details(getImplementationClassName(spec), spec.getDisplayName()));
             }
         });
+    }
+
+    private static String getImplementationClassName(ActionExecutionSpec spec) {
+        if (spec.getImplementationClass() == AdapterWorkerExecution.class) {
+            AdapterWorkerParameters parameters = (AdapterWorkerParameters) spec.getParameters();
+            return parameters.getImplementationClassName();
+        } else {
+            return spec.getImplementationClass().getName();
+        }
     }
 
     interface Work {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
@@ -16,9 +16,13 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.workers.WorkerExecution;
+import org.gradle.workers.WorkerParameters;
+
 public interface ActionExecutionSpecFactory {
-    TransportableActionExecutionSpec newTransportableSpec(String displayName, Class<?> implementationClass, Object[] params, ClassLoaderStructure classLoaderStructure);
-    TransportableActionExecutionSpec newTransportableSpec(ActionExecutionSpec spec);
-    IsolatedParametersActionExecutionSpec newIsolatedSpec(String displayName, Class<?> implementationClass, Object[] params, ClassLoaderStructure classLoaderStructure);
-    SimpleActionExecutionSpec newSimpleSpec(ActionExecutionSpec spec);
+    <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(String displayName, Class<? extends WorkerExecution<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure);
+    <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec);
+    <T extends WorkerParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkerExecution<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure);
+    <T extends WorkerParameters> SimpleActionExecutionSpec<T> newSimpleSpec(ActionExecutionSpec<T> spec);
+    IsolatedParametersActionExecutionSpec<?> newAdapterIsolatedSpec(String displayName, Class<?> implementationClass, Object[] params, ClassLoaderStructure classLoaderStructure);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
@@ -20,9 +20,7 @@ import org.gradle.workers.WorkerExecution;
 import org.gradle.workers.WorkerParameters;
 
 public interface ActionExecutionSpecFactory {
-    <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(String displayName, Class<? extends WorkerExecution<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure);
     <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec);
     <T extends WorkerParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkerExecution<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure);
     <T extends WorkerParameters> SimpleActionExecutionSpec<T> newSimpleSpec(ActionExecutionSpec<T> spec);
-    IsolatedParametersActionExecutionSpec<?> newAdapterIsolatedSpec(String displayName, Class<?> implementationClass, Object[] params, ClassLoaderStructure classLoaderStructure);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerExecution.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerExecution.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.workers.WorkerExecution;
+
+import javax.inject.Inject;
+import java.util.concurrent.Callable;
+
+import static org.gradle.internal.classloader.ClassLoaderUtils.classFromContextLoader;
+
+public abstract class AdapterWorkerExecution implements WorkerExecution<AdapterWorkerParameters>, ProvidesWorkResult {
+    private final Instantiator instantiator;
+    private DefaultWorkResult workResult;
+
+    @Inject
+    public AdapterWorkerExecution(Instantiator instantiator) {
+        this.instantiator = instantiator;
+    }
+
+    @Override
+    public void execute() {
+        AdapterWorkerParameters parameters = getParameters();
+        String implementationClassName = parameters.getImplementationClassName();
+        Class<?> actionClass = classFromContextLoader(implementationClassName);
+
+        Object action = instantiator.newInstance(actionClass, parameters.getParams());
+        if (action instanceof Runnable) {
+            ((Runnable) action).run();
+            workResult = DefaultWorkResult.SUCCESS;
+        } else if (action instanceof Callable) {
+            Object result;
+            try {
+                result = ((Callable) action).call();
+                if (result instanceof DefaultWorkResult) {
+                    workResult = (DefaultWorkResult) result;
+                } else if (result instanceof WorkResult) {
+                    workResult = new DefaultWorkResult(((WorkResult) result).getDidWork(), null);
+                } else {
+                    throw new IllegalArgumentException("Worker actions must return a WorkResult.");
+                }
+            } catch (Exception e) {
+                workResult = new DefaultWorkResult(true, e);
+            }
+        } else {
+            throw new IllegalArgumentException("Worker actions must either implement Runnable or Callable<WorkResult>.");
+        }
+    }
+
+    @Override
+    public DefaultWorkResult getWorkResult() {
+        return workResult;
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerExecution.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerExecution.java
@@ -25,6 +25,11 @@ import java.util.concurrent.Callable;
 
 import static org.gradle.internal.classloader.ClassLoaderUtils.classFromContextLoader;
 
+/**
+ * This is used to bridge between the "old" worker api with untyped parameters and the typed
+ * parameter api.  It allows us to maintain backwards compatibility at the api layer, but use
+ * only typed parameters under the covers.  This can be removed once the old api is retired.
+ */
 public abstract class AdapterWorkerExecution implements WorkerExecution<AdapterWorkerParameters>, ProvidesWorkResult {
     private final Instantiator instantiator;
     private DefaultWorkResult workResult;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,11 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.api.Describable;
-import org.gradle.workers.WorkerExecution;
 import org.gradle.workers.WorkerParameters;
 
-import java.io.Serializable;
-
-public interface ActionExecutionSpec<T extends WorkerParameters> extends Serializable, Describable {
-    Class<? extends WorkerExecution<T>> getImplementationClass();
-
-    @Override
-    String getDisplayName();
-
-    T getParameters();
-
-    ClassLoaderStructure getClassLoaderStructure();
+public interface AdapterWorkerParameters extends WorkerParameters {
+    void setImplementationClassName(String implementationClassName);
+    String getImplementationClassName();
+    void setParams(Object[] params);
+    Object[] getParams();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkerParameters.java
@@ -18,6 +18,11 @@ package org.gradle.workers.internal;
 
 import org.gradle.workers.WorkerParameters;
 
+/**
+ * This is used to bridge between the "old" worker api with untyped parameters and the typed
+ * parameter api.  It allows us to maintain backwards compatibility at the api layer, but use
+ * only typed parameters under the covers.  This can be removed once the old api is retired.
+ */
 public interface AdapterWorkerParameters extends WorkerParameters {
     void setImplementationClassName(String implementationClassName);
     String getImplementationClassName();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
@@ -41,11 +41,6 @@ public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFac
     }
 
     @Override
-    public <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(String displayName, Class<? extends WorkerExecution<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure) {
-        return new TransportableActionExecutionSpec<T>(displayName, implementationClass.getName(), serialize(isolatableFactory.isolate(params)), classLoaderStructure);
-    }
-
-    @Override
     public <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec) {
         if (spec instanceof IsolatedParametersActionExecutionSpec) {
             IsolatedParametersActionExecutionSpec isolatedSpec = (IsolatedParametersActionExecutionSpec) spec;
@@ -75,14 +70,6 @@ public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFac
         } else {
             throw new IllegalArgumentException("Can't create a SimpleActionExecutionSpec from spec with type: " + spec.getClass().getSimpleName());
         }
-    }
-
-    @Override
-    public IsolatedParametersActionExecutionSpec<?> newAdapterIsolatedSpec(String displayName, Class<?> implementationClass, Object[] params, ClassLoaderStructure classLoaderStructure) {
-        AdapterWorkerParameters workerParameters = instantiatorFactory.inject().newInstance(AdapterWorkerParameters.class);
-        workerParameters.setImplementationClassName(implementationClass.getName());
-        workerParameters.setParams(params);
-        return newIsolatedSpec(displayName, AdapterWorkerExecution.class, workerParameters, classLoaderStructure);
     }
 
     Class<?> fromClassName(String className) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultBaseWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultBaseWorkerSpec.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.gradle.api.Action;
+import org.gradle.process.JavaForkOptions;
+import org.gradle.process.internal.JavaForkOptionsFactory;
+import org.gradle.util.GUtil;
+import org.gradle.workers.BaseWorkerSpec;
+import org.gradle.workers.IsolationMode;
+
+import java.io.File;
+import java.util.List;
+
+public class DefaultBaseWorkerSpec implements BaseWorkerSpec {
+    protected final JavaForkOptions forkOptions;
+    protected IsolationMode isolationMode = IsolationMode.AUTO;
+    private List<File> classpath = Lists.newArrayList();
+    private String displayName;
+
+    public DefaultBaseWorkerSpec(JavaForkOptionsFactory forkOptionsFactory) {
+        this.forkOptions = forkOptionsFactory.newJavaForkOptions();
+        getForkOptions().setEnvironment(Maps.<String, Object>newHashMap());
+    }
+
+    @Override
+    public Iterable<File> getClasspath() {
+        return classpath;
+    }
+
+    @Override
+    public void setClasspath(Iterable<File> classpath) {
+        this.classpath = Lists.newArrayList(classpath);
+    }
+
+    @Override
+    public IsolationMode getIsolationMode() {
+        return isolationMode;
+    }
+
+    @Override
+    public void setIsolationMode(IsolationMode isolationMode) {
+        this.isolationMode = isolationMode == null ? IsolationMode.AUTO : isolationMode;
+    }
+
+    @Override
+    public JavaForkOptions getForkOptions() {
+        return forkOptions;
+    }
+
+    @Override
+    public void classpath(Iterable<File> files) {
+        GUtil.addToCollection(classpath, files);
+    }
+
+    @Override
+    public void forkOptions(Action<? super JavaForkOptions> forkOptionsAction) {
+        forkOptionsAction.execute(forkOptions);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultBaseWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultBaseWorkerSpec.java
@@ -16,37 +16,21 @@
 
 package org.gradle.workers.internal;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
-import org.gradle.util.GUtil;
 import org.gradle.workers.BaseWorkerSpec;
 import org.gradle.workers.IsolationMode;
-
-import java.io.File;
-import java.util.List;
 
 public class DefaultBaseWorkerSpec implements BaseWorkerSpec {
     protected final JavaForkOptions forkOptions;
     protected IsolationMode isolationMode = IsolationMode.AUTO;
-    private List<File> classpath = Lists.newArrayList();
     private String displayName;
 
     public DefaultBaseWorkerSpec(JavaForkOptionsFactory forkOptionsFactory) {
         this.forkOptions = forkOptionsFactory.newJavaForkOptions();
         getForkOptions().setEnvironment(Maps.<String, Object>newHashMap());
-    }
-
-    @Override
-    public Iterable<File> getClasspath() {
-        return classpath;
-    }
-
-    @Override
-    public void setClasspath(Iterable<File> classpath) {
-        this.classpath = Lists.newArrayList(classpath);
     }
 
     @Override
@@ -62,11 +46,6 @@ public class DefaultBaseWorkerSpec implements BaseWorkerSpec {
     @Override
     public JavaForkOptions getForkOptions() {
         return forkOptions;
-    }
-
-    @Override
-    public void classpath(Iterable<File> files) {
-        GUtil.addToCollection(classpath, files);
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkResult.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkResult.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 public class DefaultWorkResult implements WorkResult, Serializable {
+    public static DefaultWorkResult SUCCESS = new DefaultWorkResult(true, null);
+
     private final boolean didWork;
     private final Throwable exception;
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkResult.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkResult.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 
 public class DefaultWorkResult implements WorkResult, Serializable {
-    public static DefaultWorkResult SUCCESS = new DefaultWorkResult(true, null);
+    public static final DefaultWorkResult SUCCESS = new DefaultWorkResult(true, null);
 
     private final boolean didWork;
     private final Throwable exception;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
@@ -16,54 +16,38 @@
 
 package org.gradle.workers.internal;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import org.gradle.api.Action;
+import org.gradle.api.ActionConfiguration;
 import org.gradle.api.internal.DefaultActionConfiguration;
-import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
-import org.gradle.util.GUtil;
 import org.gradle.workers.ForkMode;
 import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerConfiguration;
 
-import java.io.File;
-import java.util.List;
-
-public class DefaultWorkerConfiguration extends DefaultActionConfiguration implements WorkerConfiguration {
-    private final JavaForkOptions forkOptions;
-    private IsolationMode isolationMode = IsolationMode.AUTO;
-    private List<File> classpath = Lists.newArrayList();
-    private String displayName;
+public class DefaultWorkerConfiguration extends DefaultBaseWorkerSpec implements WorkerConfiguration {
+    private final ActionConfiguration actionConfiguration = new DefaultActionConfiguration();
 
     public DefaultWorkerConfiguration(JavaForkOptionsFactory forkOptionsFactory) {
-        this.forkOptions = forkOptionsFactory.newJavaForkOptions();
-        forkOptions.setEnvironment(Maps.<String, Object>newHashMap());
+        super(forkOptionsFactory);
     }
 
     @Override
-    public Iterable<File> getClasspath() {
-        return classpath;
+    public void params(Object... params) {
+        actionConfiguration.params(params);
     }
 
     @Override
-    public void setClasspath(Iterable<File> classpath) {
-        this.classpath = Lists.newArrayList(classpath);
+    public void setParams(Object... params) {
+        actionConfiguration.setParams(params);
     }
 
     @Override
-    public IsolationMode getIsolationMode() {
-        return isolationMode;
-    }
-
-    @Override
-    public void setIsolationMode(IsolationMode isolationMode) {
-        this.isolationMode = isolationMode == null ? IsolationMode.AUTO : isolationMode;
+    public Object[] getParams() {
+        return actionConfiguration.getParams();
     }
 
     @Override
     public ForkMode getForkMode() {
-        switch (isolationMode) {
+        switch (getIsolationMode()) {
             case AUTO:
                 return ForkMode.AUTO;
             case NONE:
@@ -91,28 +75,4 @@ public class DefaultWorkerConfiguration extends DefaultActionConfiguration imple
         }
     }
 
-    @Override
-    public JavaForkOptions getForkOptions() {
-        return forkOptions;
-    }
-
-    @Override
-    public void classpath(Iterable<File> files) {
-        GUtil.addToCollection(classpath, files);
-    }
-
-    @Override
-    public void forkOptions(Action<? super JavaForkOptions> forkOptionsAction) {
-        forkOptionsAction.execute(forkOptions);
-    }
-
-    @Override
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    @Override
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
@@ -16,18 +16,39 @@
 
 package org.gradle.workers.internal;
 
+import com.google.common.collect.Lists;
 import org.gradle.api.ActionConfiguration;
 import org.gradle.api.internal.DefaultActionConfiguration;
 import org.gradle.process.internal.JavaForkOptionsFactory;
+import org.gradle.util.GUtil;
 import org.gradle.workers.ForkMode;
 import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerConfiguration;
 
+import java.io.File;
+import java.util.List;
+
 public class DefaultWorkerConfiguration extends DefaultBaseWorkerSpec implements WorkerConfiguration {
     private final ActionConfiguration actionConfiguration = new DefaultActionConfiguration();
+    private List<File> classpath = Lists.newArrayList();
 
     public DefaultWorkerConfiguration(JavaForkOptionsFactory forkOptionsFactory) {
         super(forkOptionsFactory);
+    }
+
+    @Override
+    public Iterable<File> getClasspath() {
+        return classpath;
+    }
+
+    @Override
+    public void setClasspath(Iterable<File> classpath) {
+        this.classpath = Lists.newArrayList(classpath);
+    }
+
+    @Override
+    public void classpath(Iterable<File> files) {
+        GUtil.addToCollection(classpath, files);
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -116,10 +116,10 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         if (parameterType == WorkerParameters.class) {
             throw new IllegalArgumentException(String.format("Could not create worker parameters: must use a sub-type of %s as parameter type. Use %s for executions without parameters.", ModelType.of(WorkerParameters.class).getDisplayName(), ModelType.of(WorkerParameters.None.class).getDisplayName()));
         }
-        T parameters = instantiator.newInstance(parameterType);
+        T parameters = (parameterType == WorkerParameters.None.class) ? null : instantiator.newInstance(parameterType);
         WorkerSpec<T> workerSpec = new DefaultWorkerSpec<T>(forkOptionsFactory, parameters);
-        File workingDirectory = workerDirectoryProvider.getWorkingDirectory();
         File defaultWorkingDir = workerSpec.getForkOptions().getWorkingDir();
+        File workingDirectory = workerDirectoryProvider.getWorkingDirectory();
         configAction.execute(workerSpec);
         String description = getWorkerDisplayName(workerSpec, workerExecutionClass);
 
@@ -295,7 +295,9 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         List<Class<?>> classes = Lists.newArrayList();
         classes.add(actionClass);
         for (Object param : params) {
-            classes.add(param.getClass());
+            if (param != null) {
+                classes.add(param.getClass());
+            }
         }
         return classes.toArray(new Class[0]);
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -24,7 +24,6 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.reflect.Instantiator;
@@ -72,7 +71,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     private final ActionExecutionSpecFactory actionExecutionSpecFactory;
     private final Instantiator instantiator;
 
-    public DefaultWorkerExecutor(WorkerFactory daemonWorkerFactory, WorkerFactory isolatedClassloaderWorkerFactory, WorkerFactory noIsolationWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory workerExecutionQueueFactory, ClassLoaderStructureProvider classLoaderStructureProvider, ActionExecutionSpecFactory actionExecutionSpecFactory, InstantiatorFactory instantiatorFactory) {
+    public DefaultWorkerExecutor(WorkerFactory daemonWorkerFactory, WorkerFactory isolatedClassloaderWorkerFactory, WorkerFactory noIsolationWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory workerExecutionQueueFactory, ClassLoaderStructureProvider classLoaderStructureProvider, ActionExecutionSpecFactory actionExecutionSpecFactory, Instantiator instantiator) {
         this.daemonWorkerFactory = daemonWorkerFactory;
         this.isolatedClassloaderWorkerFactory = isolatedClassloaderWorkerFactory;
         this.noIsolationWorkerFactory = noIsolationWorkerFactory;
@@ -84,7 +83,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         this.workerDirectoryProvider = workerDirectoryProvider;
         this.classLoaderStructureProvider = classLoaderStructureProvider;
         this.actionExecutionSpecFactory = actionExecutionSpecFactory;
-        this.instantiator = instantiatorFactory.inject();
+        this.instantiator = instantiator;
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
@@ -16,22 +16,14 @@
 
 package org.gradle.workers.internal;
 
-import com.google.common.reflect.TypeToken;
 import org.gradle.internal.Cast;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.DefaultServiceRegistry;
-import org.gradle.internal.service.ServiceLookup;
-import org.gradle.internal.service.ServiceLookupException;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.service.UnknownServiceException;
 import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 
 public class DefaultWorkerServer implements WorkerProtocol {
     private final ServiceRegistry parent;
@@ -64,35 +56,5 @@ public class DefaultWorkerServer implements WorkerProtocol {
     @Override
     public String toString() {
         return "DefaultWorkerServer{}";
-    }
-
-    private static class ParameterServiceLookup implements ServiceLookup {
-        private final ServiceLookup delegate;
-        private final WorkerParameters parameters;
-
-        public ParameterServiceLookup(ServiceLookup delegate, WorkerParameters parameters) {
-            this.delegate = delegate;
-            this.parameters = parameters;
-        }
-
-        @Nullable
-        @Override
-        public Object find(Type serviceType) throws ServiceLookupException {
-            TypeToken<?> serviceTypeToken = TypeToken.of(serviceType);
-            if (serviceTypeToken.isSupertypeOf(parameters.getClass())) {
-                return parameters;
-            }
-            return delegate.find(serviceType);
-        }
-
-        @Override
-        public Object get(Type serviceType) throws UnknownServiceException, ServiceLookupException {
-            return find(serviceType);
-        }
-
-        @Override
-        public Object get(Type serviceType, Class<? extends Annotation> annotatedWith) throws UnknownServiceException, ServiceLookupException {
-            return delegate.get(serviceType, annotatedWith);
-        }
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
@@ -39,7 +39,9 @@ public class DefaultWorkerServer implements WorkerProtocol {
             Class<? extends WorkerExecution> implementationClass = Cast.uncheckedCast(spec.getImplementationClass());
             DefaultServiceRegistry serviceRegistry = new DefaultServiceRegistry(parent);
             Instantiator instantiator = parent.get(InstantiatorFactory.class).inject(serviceRegistry);
-            serviceRegistry.add(spec.getParameters().getClass(), Cast.uncheckedCast(spec.getParameters()));
+            if (spec.getParameters() != null) {
+                serviceRegistry.add(spec.getParameters().getClass(), Cast.uncheckedCast(spec.getParameters()));
+            }
             serviceRegistry.add(Instantiator.class, instantiator);
             WorkerExecution execution = instantiator.newInstance(implementationClass);
             execution.execute();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,26 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.api.Describable;
-import org.gradle.workers.WorkerExecution;
+import org.gradle.api.Action;
+import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkerSpec;
 
-import java.io.Serializable;
+public class DefaultWorkerSpec<T extends WorkerParameters> extends DefaultBaseWorkerSpec implements WorkerSpec<T> {
+    private final T parameters;
 
-public interface ActionExecutionSpec<T extends WorkerParameters> extends Serializable, Describable {
-    Class<? extends WorkerExecution<T>> getImplementationClass();
+    public DefaultWorkerSpec(JavaForkOptionsFactory forkOptionsFactory, T parameters) {
+        super(forkOptionsFactory);
+        this.parameters = parameters;
+    }
 
     @Override
-    String getDisplayName();
+    public T getParameters() {
+        return parameters;
+    }
 
-    T getParameters();
-
-    ClassLoaderStructure getClassLoaderStructure();
+    @Override
+    public void parameters(Action<T> action) {
+        action.execute(parameters);
+    }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerSpec.java
@@ -21,9 +21,12 @@ import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.workers.WorkerParameters;
 import org.gradle.workers.WorkerSpec;
 
+import javax.inject.Inject;
+
 public class DefaultWorkerSpec<T extends WorkerParameters> extends DefaultBaseWorkerSpec implements WorkerSpec<T> {
     private final T parameters;
 
+    @Inject
     public DefaultWorkerSpec(JavaForkOptionsFactory forkOptionsFactory, T parameters) {
         super(forkOptionsFactory);
         this.parameters = parameters;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
@@ -55,6 +55,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.gradle.internal.classloader.ClassLoaderUtils.*;
+
 public class IsolatableSerializerRegistry extends DefaultSerializerRegistry {
     private static final byte STRING_VALUE = (byte) 0;
     private static final byte BOOLEAN_VALUE = (byte) 1;
@@ -185,7 +187,7 @@ public class IsolatableSerializerRegistry extends DefaultSerializerRegistry {
     }
 
     private Class<?> fromClassName(String className) throws Exception {
-        return Thread.currentThread().getContextClassLoader().loadClass(className);
+        return classFromContextLoader(className);
     }
 
     private class StringValueSnapshotSerializer implements IsolatableSerializer<StringValueSnapshot> {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
@@ -16,15 +16,17 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.internal.snapshot.impl.IsolatedArray;
+import org.gradle.internal.isolation.Isolatable;
+import org.gradle.workers.WorkerExecution;
+import org.gradle.workers.WorkerParameters;
 
-public class IsolatedParametersActionExecutionSpec implements ActionExecutionSpec {
+public class IsolatedParametersActionExecutionSpec<T extends WorkerParameters> implements ActionExecutionSpec<T> {
     private final String displayName;
-    private final Class<?> implementationClass;
-    private final IsolatedArray isolatedParams;
+    private final Class<? extends WorkerExecution<T>> implementationClass;
+    private final Isolatable<T> isolatedParams;
     private final ClassLoaderStructure classLoaderStructure;
 
-    public IsolatedParametersActionExecutionSpec(Class<?> implementationClass, String displayName, IsolatedArray isolatedParams, ClassLoaderStructure classLoaderStructure) {
+    public IsolatedParametersActionExecutionSpec(Class<? extends WorkerExecution<T>> implementationClass, String displayName, Isolatable<T> isolatedParams, ClassLoaderStructure classLoaderStructure) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
         this.isolatedParams = isolatedParams;
@@ -32,7 +34,7 @@ public class IsolatedParametersActionExecutionSpec implements ActionExecutionSpe
     }
 
     @Override
-    public Class<?> getImplementationClass() {
+    public Class<? extends WorkerExecution<T>> getImplementationClass() {
         return implementationClass;
     }
 
@@ -42,7 +44,7 @@ public class IsolatedParametersActionExecutionSpec implements ActionExecutionSpe
     }
 
     @Override
-    public Object[] getParams() {
+    public T getParameters() {
         return isolatedParams.isolate();
     }
 
@@ -51,7 +53,7 @@ public class IsolatedParametersActionExecutionSpec implements ActionExecutionSpe
         return classLoaderStructure;
     }
 
-    public IsolatedArray getIsolatedParams() {
+    public Isolatable<T> getIsolatedParams() {
         return isolatedParams;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ProvidesWorkResult.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ProvidesWorkResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,6 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.api.Describable;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
-
-import java.io.Serializable;
-
-public interface ActionExecutionSpec<T extends WorkerParameters> extends Serializable, Describable {
-    Class<? extends WorkerExecution<T>> getImplementationClass();
-
-    @Override
-    String getDisplayName();
-
-    T getParameters();
-
-    ClassLoaderStructure getClassLoaderStructure();
+public interface ProvidesWorkResult {
+    DefaultWorkResult getWorkResult();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
@@ -16,13 +16,16 @@
 
 package org.gradle.workers.internal;
 
-public class SimpleActionExecutionSpec implements ActionExecutionSpec {
-    private final Class<?> implementationClass;
+import org.gradle.workers.WorkerExecution;
+import org.gradle.workers.WorkerParameters;
+
+public class SimpleActionExecutionSpec<T extends WorkerParameters> implements ActionExecutionSpec<T> {
+    private final Class<? extends WorkerExecution<T>> implementationClass;
     private final String displayName;
-    private final Object[] params;
+    private final T params;
     private final ClassLoaderStructure classLoaderStructure;
 
-    public SimpleActionExecutionSpec(Class<?> implementationClass, String displayName, Object[] params, ClassLoaderStructure classLoaderStructure) {
+    public SimpleActionExecutionSpec(Class<? extends WorkerExecution<T>> implementationClass, String displayName, T params, ClassLoaderStructure classLoaderStructure) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
         this.params = params;
@@ -30,7 +33,7 @@ public class SimpleActionExecutionSpec implements ActionExecutionSpec {
     }
 
     @Override
-    public Class<?> getImplementationClass() {
+    public Class<? extends WorkerExecution<T>> getImplementationClass() {
         return implementationClass;
     }
 
@@ -40,7 +43,7 @@ public class SimpleActionExecutionSpec implements ActionExecutionSpec {
     }
 
     @Override
-    public Object[] getParams() {
+    public T getParameters() {
         return params;
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
@@ -16,7 +16,10 @@
 
 package org.gradle.workers.internal;
 
-public class TransportableActionExecutionSpec implements ActionExecutionSpec {
+import org.gradle.workers.WorkerExecution;
+import org.gradle.workers.WorkerParameters;
+
+public class TransportableActionExecutionSpec<T extends WorkerParameters> implements ActionExecutionSpec<T> {
     private final String displayName;
     private final String implementationClassName;
     private final byte[] serializedParameters;
@@ -35,7 +38,7 @@ public class TransportableActionExecutionSpec implements ActionExecutionSpec {
     }
 
     @Override
-    public Class<?> getImplementationClass() {
+    public Class<? extends WorkerExecution<T>> getImplementationClass() {
         throw new UnsupportedOperationException();
     }
 
@@ -45,7 +48,7 @@ public class TransportableActionExecutionSpec implements ActionExecutionSpec {
     }
 
     @Override
-    public Object[] getParams() {
+    public T getParameters() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonServer.java
@@ -18,6 +18,7 @@ package org.gradle.workers.internal;
 
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
@@ -79,8 +80,8 @@ public class WorkerDaemonServer implements WorkerProtocol {
             return new IsolatableSerializerRegistry(classLoaderHierarchyHasher, managedFactoryRegistry);
         }
 
-        ActionExecutionSpecFactory createActionExecutionSpecFactory(IsolatableFactory isolatableFactory, IsolatableSerializerRegistry serializerRegistry) {
-            return new DefaultActionExecutionSpecFactory(isolatableFactory, serializerRegistry);
+        ActionExecutionSpecFactory createActionExecutionSpecFactory(IsolatableFactory isolatableFactory, IsolatableSerializerRegistry serializerRegistry, InstantiatorFactory instantiatorFactory) {
+            return new DefaultActionExecutionSpecFactory(isolatableFactory, serializerRegistry, instantiatorFactory);
         }
 
         DefaultValueSnapshotter createValueSnapshotter(ClassLoaderHierarchyHasher classLoaderHierarchyHasher, ManagedFactoryRegistry managedFactoryRegistry) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -120,7 +120,7 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
                                             ServiceRegistry serviceRegistry,
                                             ActionExecutionSpecFactory actionExecutionSpecFactory) {
             NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, serviceRegistry);
-            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory);
+            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiatorFactory.inject(serviceRegistry));
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -101,8 +101,8 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
             return new IsolatableSerializerRegistry(classLoaderHierarchyHasher, managedFactoryRegistry);
         }
 
-        ActionExecutionSpecFactory createActionExecutionSpecFactory(IsolatableFactory isolatableFactory, IsolatableSerializerRegistry serializerRegistry) {
-            return new DefaultActionExecutionSpecFactory(isolatableFactory, serializerRegistry);
+        ActionExecutionSpecFactory createActionExecutionSpecFactory(IsolatableFactory isolatableFactory, IsolatableSerializerRegistry serializerRegistry, InstantiatorFactory instantiatorFactory) {
+            return new DefaultActionExecutionSpecFactory(isolatableFactory, serializerRegistry, instantiatorFactory);
         }
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -120,7 +120,7 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
                                             ServiceRegistry serviceRegistry,
                                             ActionExecutionSpecFactory actionExecutionSpecFactory) {
             NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, serviceRegistry);
-            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiatorFactory.injectAndDecorate(serviceRegistry));
+            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiatorFactory.injectAndDecorateLenient(serviceRegistry));
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -120,7 +120,7 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
                                             ServiceRegistry serviceRegistry,
                                             ActionExecutionSpecFactory actionExecutionSpecFactory) {
             NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, serviceRegistry);
-            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiatorFactory.inject(serviceRegistry));
+            DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiatorFactory.injectAndDecorate(serviceRegistry));
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;
         }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.workers.internal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.Factory
 import org.gradle.internal.exceptions.DefaultMultiCauseException
-import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.work.AsyncWorkTracker
@@ -56,18 +55,16 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def executionQueue = Mock(ConditionalExecutionQueue)
     def classLoaderStructureProvider = Mock(ClassLoaderStructureProvider)
     def actionExecutionSpecFactory = Mock(ActionExecutionSpecFactory)
-    def instantiatorFactory = Mock(InstantiatorFactory)
     def instantiator = Mock(Instantiator)
     def parameters = Mock(AdapterWorkerParameters)
     DefaultWorkerExecutor workerExecutor
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        _ * instantiatorFactory.inject() >> instantiator
         _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
         _ * parameters.implementationClassName >> TestRunnable.class.getName()
         _ * parameters.params >> []
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiatorFactory)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -56,7 +56,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.workers.internal
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.model.ObjectFactory
 import org.gradle.internal.Factory
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -48,6 +49,9 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkerTracker = Mock(AsyncWorkTracker)
     def forkOptionsFactory = new TestForkOptionsFactory(TestFiles.execFactory())
+    def objectFactory = Stub(ObjectFactory) {
+        fileCollection() >> { TestFiles.fileCollectionFactory().configurableFiles() }
+    }
     def workerDirectoryProvider = Stub(WorkerDirectoryProvider) {
         getWorkingDirectory() >> { temporaryFolder.root }
     }
@@ -62,7 +66,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
         _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
-        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(args[1][0], args[1][1]) }
+        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(forkOptionsFactory, objectFactory, args[1][0]) }
         _ * parameters.implementationClassName >> TestRunnable.class.getName()
         _ * parameters.params >> []
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -62,6 +62,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
         _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
+        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(args[1][0], args[1][1]) }
         _ * parameters.implementationClassName >> TestRunnable.class.getName()
         _ * parameters.params >> []
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -59,7 +59,7 @@ class DefaultWorkerExecutorTest extends Specification {
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.workers.internal
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.classloader.VisitableURLClassLoader
-import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.work.AsyncWorkTracker
@@ -58,7 +57,6 @@ class DefaultWorkerExecutorTest extends Specification {
     def classLoaderStructureProvider = Mock(ClassLoaderStructureProvider)
     def worker = Mock(BuildOperationAwareWorker)
     def actionExecutionSpecFactory = Mock(ActionExecutionSpecFactory)
-    def instantiatorFactory = Mock(InstantiatorFactory)
     def instantiator = Mock(Instantiator)
     def parameters = Mock(AdapterWorkerParameters)
     ConditionalExecution task
@@ -66,9 +64,8 @@ class DefaultWorkerExecutorTest extends Specification {
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        _ * instantiatorFactory.inject() >> instantiator
         _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiatorFactory)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -134,7 +134,7 @@ class DefaultWorkerExecutorTest extends Specification {
     def "can add to classpath on executor"() {
         given:
         WorkerSpec configuration = new DefaultWorkerSpec<WorkerParameters.None>(forkOptionsFactory, objectFactory, null)
-        def foo = new File("/foo")
+        def foo = temporaryFolder.createFile("foo")
         configuration.classpath.from([foo])
 
         when:
@@ -224,7 +224,7 @@ class DefaultWorkerExecutorTest extends Specification {
         workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
             configuration.isolationMode = IsolationMode.NONE
             configuration.params = []
-            configuration.classpath([new File("/foo")])
+            configuration.classpath([temporaryFolder.createFile("foo")])
         }
 
         then:

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.workers.internal
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.model.ObjectFactory
 import org.gradle.internal.classloader.VisitableURLClassLoader
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
@@ -48,6 +49,9 @@ class DefaultWorkerExecutorTest extends Specification {
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def asyncWorkTracker = Mock(AsyncWorkTracker)
     def forkOptionsFactory = TestFiles.execFactory(temporaryFolder.testDirectory)
+    def objectFactory = Stub(ObjectFactory) {
+        fileCollection() >> { TestFiles.fileCollectionFactory().configurableFiles() }
+    }
     def workerDirectoryProvider = Stub(WorkerDirectoryProvider) {
         getWorkingDirectory() >> { temporaryFolder.testDirectory }
     }
@@ -65,7 +69,7 @@ class DefaultWorkerExecutorTest extends Specification {
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
         _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
-        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(args[1][0], args[1][1]) }
+        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(forkOptionsFactory, objectFactory, args[1][0]) }
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
@@ -103,7 +107,7 @@ class DefaultWorkerExecutorTest extends Specification {
     }
 
     def "can convert javaForkOptions to daemonForkOptions"() {
-        WorkerSpec configuration = new DefaultWorkerSpec<WorkerParameters.None>(forkOptionsFactory, null)
+        WorkerSpec configuration = new DefaultWorkerSpec<WorkerParameters.None>(forkOptionsFactory, objectFactory, null)
 
         given:
         configuration.forkOptions { options ->
@@ -129,9 +133,9 @@ class DefaultWorkerExecutorTest extends Specification {
 
     def "can add to classpath on executor"() {
         given:
-        WorkerSpec configuration = new DefaultWorkerSpec<WorkerParameters.None>(forkOptionsFactory, null)
+        WorkerSpec configuration = new DefaultWorkerSpec<WorkerParameters.None>(forkOptionsFactory, objectFactory, null)
         def foo = new File("/foo")
-        configuration.classpath([foo])
+        configuration.classpath.from([foo])
 
         when:
         DaemonForkOptions daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration)
@@ -220,7 +224,7 @@ class DefaultWorkerExecutorTest extends Specification {
         workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
             configuration.isolationMode = IsolationMode.NONE
             configuration.params = []
-            configuration.classpath([new File("foo")])
+            configuration.classpath([new File("/foo")])
         }
 
         then:

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -65,6 +65,7 @@ class DefaultWorkerExecutorTest extends Specification {
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
         _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
+        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(args[1][0], args[1][1]) }
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.workers.internal
 
 import org.gradle.api.logging.LogLevel
 import org.gradle.internal.operations.BuildOperationRef
+import org.gradle.workers.WorkerExecution
+import org.gradle.workers.WorkerParameters
 import spock.lang.Specification
 
 class WorkerDaemonClientTest extends Specification {
@@ -64,6 +66,11 @@ class WorkerDaemonClientTest extends Specification {
     }
 
     def spec() {
-        return new SimpleActionExecutionSpec(Runnable.class, "test", [] as Object[], null)
+        return new SimpleActionExecutionSpec(TestWorkerExecution, "test", null, null)
+    }
+
+    static abstract class TestWorkerExecution implements WorkerExecution<WorkerParameters.None> {
+        @Override
+        void execute() { }
     }
 }

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -88,7 +88,7 @@ class WorkerExecutorFixture {
                             forkOptions.maxHeapSize = "64m"
                         }
                         forkOptions(additionalForkOptions)
-                        classpath(additionalClasspath)
+                        classpath.from(additionalClasspath)
                         parameters {
                             files = list.collect { it as String }
                             outputDir = new File(outputFileDirPath)


### PR DESCRIPTION
This introduces a typed parameter API for workers following the pattern used by artifact transforms.  Among other things, this allows null parameters to be passed and fixes https://github.com/gradle/gradle/issues/2405.