### PR TITLE
Add (non-) abi change santa tracker performance tests

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/AbstractJavaSourceFileMutator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/mutator/AbstractJavaSourceFileMutator.groovy
@@ -31,7 +31,7 @@ abstract class AbstractJavaSourceFileMutator extends AbstractFileChangeMutator {
         int insertPos = text.indexOf("}", lastOpeningPos)
         boolean isClassClosing = insertPos == text.lastIndexOf("}")
         if (insertPos < 0 || isClassClosing) {
-            throw new IllegalArgumentException("Cannot parse source file $sourceFile to apply changes")
+            throw new IllegalArgumentException("Cannot parse source file $sourceFilePath to apply changes")
         }
         applyChangeAt(text, insertPos)
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -19,18 +19,34 @@ package org.gradle.performance.regression.android
 import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 import org.gradle.performance.fixture.BuildExperimentListenerAdapter
+import org.gradle.performance.fixture.CrossVersionPerformanceTestRunner
+import org.gradle.performance.mutator.ApplyAbiChangeToJavaSourceFileMutator
+import org.gradle.performance.mutator.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.util.GFileUtils
 import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest {
+    private static final SANTA_TRACKER = new AndroidTestProject(
+        templateName: 'santaTrackerAndroidBuild',
+        memory: '1g',
+        taskForChange: ':santa-tracker:assembleDebug',
+        fileToChange: 'tracker/src/main/java/com/google/android/apps/santatracker/tracker/ui/BottomSheetBehavior.java'
+    )
+    private static final LARGE_ANDROID_BUILD = new AndroidTestProject(
+        templateName: 'largeAndroidBuild',
+        memory: '5g',
+    )
+    private static final K9_ANDROID = new AndroidTestProject(
+        templateName: 'k9AndroidBuild',
+        memory: '1g',
+    )
 
     @Unroll
     def "#tasks on #testProject"() {
         given:
-        runner.testProject = testProject
+        testProject.configure(runner)
         runner.tasksToRun = tasks.split(' ')
-        runner.gradleOpts = ["-Xms$memory", "-Xmx$memory"]
         runner.args = parallel ? ['-Dorg.gradle.parallel=true'] : []
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
@@ -44,23 +60,22 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject         | memory | parallel | warmUpRuns | runs | tasks
-        'k9AndroidBuild'           | '1g' | false | null | null | 'help'
-        'k9AndroidBuild'           | '1g' | false | null | null | 'assembleDebug'
-//        'k9AndroidBuild'    | '1g'   | false    | null       | null | 'clean k9mail:assembleDebug'
-        'largeAndroidBuild'        | '5g' | true  | null | null | 'help'
-        'largeAndroidBuild'        | '5g' | true  | null | null | 'assembleDebug'
-        'largeAndroidBuild'        | '5g' | true  | 2    | 8    | 'clean phthalic:assembleDebug'
-        'santaTrackerAndroidBuild' | '1g' | true  | null | null | 'assembleDebug'
+        testProject         | parallel | warmUpRuns | runs | tasks
+        K9_ANDROID          | false    | null       | null | 'help'
+        K9_ANDROID          | false    | null       | null | 'assembleDebug'
+//        K9_ANDROID    | false    | null       | null | 'clean k9mail:assembleDebug'
+        LARGE_ANDROID_BUILD | true     | null       | null | 'help'
+        LARGE_ANDROID_BUILD | true     | null       | null | 'assembleDebug'
+        LARGE_ANDROID_BUILD | true     | 2          | 8    | 'clean phthalic:assembleDebug'
+        SANTA_TRACKER       | true     | null       | null | 'assembleDebug'
     }
 
     @Category(PerformanceExperiment)
     @Unroll
     def "clean #tasks on #testProject with clean transforms cache"() {
         given:
-        runner.testProject = testProject
+        testProject.configure(runner)
         runner.tasksToRun = tasks.split(' ')
-        runner.gradleOpts = ["-Xms$memory", "-Xmx$memory"]
         runner.args = ['-Dorg.gradle.parallel=true']
         runner.warmUpRuns = warmUpRuns
         runner.cleanTasks = ["clean"]
@@ -76,10 +91,50 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject                | memory | warmUpRuns | runs | tasks
-        'largeAndroidBuild'        | '5g'   | 2          | 8    | 'phthalic:assembleDebug'
-        'largeAndroidBuild'        | '5g'   | 2          | 8    | 'assembleDebug'
-        'santaTrackerAndroidBuild' | '1g'   | null       | null | 'assembleDebug'
+        testProject         | warmUpRuns | runs | tasks
+        LARGE_ANDROID_BUILD | 2          | 8    | 'phthalic:assembleDebug'
+        LARGE_ANDROID_BUILD | 2          | 8    | 'assembleDebug'
+        SANTA_TRACKER       | null       | null | 'assembleDebug'
+    }
+
+    @Unroll
+    def "abi change on #testProject"() {
+        given:
+        testProject.configure(runner)
+        runner.tasksToRun = [testProject.taskForChange]
+        runner.args = ['-Dorg.gradle.parallel=true']
+        runner.minimumVersion = "5.4"
+        runner.targetVersions = ["5.6-20190702000118+0000"]
+        runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.fileToChange))
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        where:
+        testProject << [SANTA_TRACKER]
+    }
+
+    @Unroll
+    def "non-abi change on #testProject"() {
+        given:
+        testProject.configure(runner)
+        runner.tasksToRun = [testProject.taskForChange]
+        runner.args = ['-Dorg.gradle.parallel=true']
+        runner.minimumVersion = "5.4"
+        runner.targetVersions = ["5.6-20190702000118+0000"]
+        runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.fileToChange))
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        where:
+        testProject << [SANTA_TRACKER]
     }
 
     private static BuildExperimentListenerAdapter cleanTransformsCacheBeforeInvocation() {
@@ -98,6 +153,23 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
                     }
                 }
             }
+        }
+    }
+
+    static class AndroidTestProject {
+        String templateName
+        String memory
+        String taskForChange
+        String fileToChange
+
+        void configure(CrossVersionPerformanceTestRunner runner) {
+            runner.testProject = templateName
+            runner.gradleOpts = ["-Xms$memory", "-Xmx$memory"]
+        }
+
+        @Override
+        String toString() {
+            templateName
         }
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -31,7 +31,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
         templateName: 'santaTrackerAndroidBuild',
         memory: '1g',
         taskForChange: ':santa-tracker:assembleDebug',
-        fileToChange: 'tracker/src/main/java/com/google/android/apps/santatracker/tracker/ui/BottomSheetBehavior.java'
+        fileToChange: 'snowballrun/src/main/java/com/google/android/apps/santatracker/doodles/snowballrun/BackgroundActor.java'
     )
     private static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild',

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -30,8 +30,6 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
     private static final SANTA_TRACKER = new AndroidTestProject(
         templateName: 'santaTrackerAndroidBuild',
         memory: '1g',
-        taskForChange: ':santa-tracker:assembleDebug',
-        fileToChange: 'snowballrun/src/main/java/com/google/android/apps/santatracker/doodles/snowballrun/BackgroundActor.java'
     )
     private static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild',
@@ -41,6 +39,8 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
         templateName: 'k9AndroidBuild',
         memory: '1g',
     )
+    private static final String SANTA_TRACKER_ASSEMBLE_DEBUG = ':santa-tracker:assembleDebug'
+    private static final String SANTA_TRACKER_JAVA_FILE_TO_CHANGE = 'snowballrun/src/main/java/com/google/android/apps/santatracker/doodles/snowballrun/BackgroundActor.java'
 
     @Unroll
     def "#tasks on #testProject"() {
@@ -101,11 +101,11 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
     def "abi change on #testProject"() {
         given:
         testProject.configure(runner)
-        runner.tasksToRun = [testProject.taskForChange]
+        runner.tasksToRun = [SANTA_TRACKER_ASSEMBLE_DEBUG]
         runner.args = ['-Dorg.gradle.parallel=true']
         runner.minimumVersion = "5.4"
         runner.targetVersions = ["5.6-20190702000118+0000"]
-        runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.fileToChange))
+        runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(SANTA_TRACKER_JAVA_FILE_TO_CHANGE))
 
         when:
         def result = runner.run()
@@ -121,11 +121,11 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
     def "non-abi change on #testProject"() {
         given:
         testProject.configure(runner)
-        runner.tasksToRun = [testProject.taskForChange]
+        runner.tasksToRun = [SANTA_TRACKER_ASSEMBLE_DEBUG]
         runner.args = ['-Dorg.gradle.parallel=true']
         runner.minimumVersion = "5.4"
         runner.targetVersions = ["5.6-20190702000118+0000"]
-        runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.fileToChange))
+        runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(SANTA_TRACKER_JAVA_FILE_TO_CHANGE))
 
         when:
         def result = runner.run()
@@ -159,8 +159,6 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
     static class AndroidTestProject {
         String templateName
         String memory
-        String taskForChange
-        String fileToChange
 
         void configure(CrossVersionPerformanceTestRunner runner) {
             runner.testProject = templateName

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -355,7 +355,7 @@ tasks.register("largeAndroidBuild", RemoteProject) {
 
 tasks.register("santaTrackerAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
-    branch = 'agp-3.5.0'
+    branch = 'agp-3.6.0'
     doLast {
         new File(outputDirectory, 'santa-tracker/google-services.json').text = """
 {


### PR DESCRIPTION
Some test to see how fast we are when doing a single file change required for deploying an app to the device via apply changes.

Fixes https://github.com/gradle/gradle-private/issues/2394