### PR TITLE
Support overlapping Ivy patterns

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionLister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionLister.java
@@ -27,13 +27,16 @@ import org.gradle.internal.resource.ResourceExceptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class ResourceVersionLister implements VersionLister {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceVersionLister.class);
@@ -42,7 +45,7 @@ public class ResourceVersionLister implements VersionLister {
 
     private final ExternalResourceRepository repository;
     private final String fileSeparator = "/";
-    private final Set<ExternalResourceName> visitedDirectories = new HashSet<ExternalResourceName>();
+    private final Map<ExternalResourceName, List<String>> directoriesToList = new HashMap<>();
 
     public ResourceVersionLister(ExternalResourceRepository repository) {
         this.repository = repository;
@@ -51,57 +54,75 @@ public class ResourceVersionLister implements VersionLister {
     @Override
     public void listVersions(ModuleIdentifier module, IvyArtifactName artifact, List<ResourcePattern> patterns, BuildableModuleVersionListingResolveResult result) {
         List<String> collector = Lists.newArrayList();
+        Map<ResourcePattern, ExternalResourceName> versionListPatterns = patterns.stream().collect(Collectors.toMap(pattern -> pattern, pattern -> pattern.toVersionListPattern(module, artifact)));
         for (ResourcePattern pattern : patterns) {
-            visit(pattern, artifact, module, collector, result);
+            visit(pattern, versionListPatterns, collector, result);
         }
         if (!collector.isEmpty()) {
             result.listed(collector);
         }
     }
 
-    private void visit(ResourcePattern pattern, IvyArtifactName artifact, ModuleIdentifier module, List<String> collector, BuildableModuleVersionListingResolveResult result) {
-        ExternalResourceName versionListPattern = pattern.toVersionListPattern(module, artifact);
+    private void visit(ResourcePattern pattern, Map<ResourcePattern, ExternalResourceName> versionListPatterns, List<String> collector, BuildableModuleVersionListingResolveResult result) {
+        ExternalResourceName versionListPattern = versionListPatterns.get(pattern);
         LOGGER.debug("Listing all in {}", versionListPattern);
         try {
-            List<String> versionStrings = listRevisionToken(versionListPattern, result);
-            for (String versionString : versionStrings) {
-                collector.add(versionString);
-            }
+            collector.addAll(listRevisionToken(versionListPattern, result, versionListPatterns));
         } catch (Exception e) {
             throw ResourceExceptions.failure(versionListPattern.getUri(), String.format("Could not list versions using %s.", pattern), e);
         }
     }
 
     // lists all the values a revision token listed by a given url lister
-    private List<String> listRevisionToken(ExternalResourceName versionListPattern, BuildableModuleVersionListingResolveResult result) {
+    private List<String> listRevisionToken(ExternalResourceName versionListPattern, BuildableModuleVersionListingResolveResult result, Map<ResourcePattern, ExternalResourceName> versionListPatterns) {
         String pattern = versionListPattern.getPath();
         if (!pattern.contains(REVISION_TOKEN)) {
             LOGGER.debug("revision token not defined in pattern {}.", pattern);
             return Collections.emptyList();
         }
         String prefix = pattern.substring(0, pattern.indexOf(REVISION_TOKEN));
+        List<String> listedVersions;
         if (revisionMatchesDirectoryName(pattern)) {
             ExternalResourceName parent = versionListPattern.getRoot().resolve(prefix);
-            return listAll(parent, result);
+            listedVersions = listAll(parent, result);
         } else {
             int parentFolderSlashIndex = prefix.lastIndexOf(fileSeparator);
             String revisionParentFolder = parentFolderSlashIndex == -1 ? "" : prefix.substring(0, parentFolderSlashIndex + 1);
             ExternalResourceName parent = versionListPattern.getRoot().resolve(revisionParentFolder);
             LOGGER.debug("using {} to list all in {} ", repository, revisionParentFolder);
-            if (!visitedDirectories.add(parent)) {
-                return Collections.emptyList();
-            }
             result.attempted(parent);
-            List<String> all = repository.resource(parent).list();
+            List<String> all = listWithCache(parent);
             if (all == null) {
                 return Collections.emptyList();
             }
             LOGGER.debug("found {} urls", all.size());
             Pattern regexPattern = createRegexPattern(pattern, parentFolderSlashIndex);
-            List<String> ret = filterMatchedValues(all, regexPattern);
-            LOGGER.debug("{} matched {}", ret.size(), pattern);
-            return ret;
+            listedVersions = filterMatchedValues(all, regexPattern);
+            LOGGER.debug("{} matched {}", listedVersions.size(), pattern);
         }
+        if (versionListPatterns.size() > 1) {
+            // Verify that none of the listed "versions" do match another pattern
+            return filterOutMatchesWithOverlappingPatterns(listedVersions, versionListPattern, versionListPatterns.values());
+        }
+        return listedVersions;
+    }
+
+    private List<String> filterOutMatchesWithOverlappingPatterns(List<String> listedVersions, ExternalResourceName currentVersionListPattern, Collection<ExternalResourceName> versionListPatterns) {
+        List<String> remaining = Lists.newArrayList(listedVersions);
+        for (ExternalResourceName otherVersionListPattern : versionListPatterns) {
+            if (otherVersionListPattern != currentVersionListPattern) {
+                String patternPath = otherVersionListPattern.getPath();
+                Pattern regexPattern = toControlRegexPattern(patternPath);
+                List<String> matching = listedVersions.stream()
+                    .filter(version -> regexPattern.matcher(currentVersionListPattern.getPath().replace(REVISION_TOKEN, version)).matches())
+                    .collect(Collectors.toList());
+                if (!matching.isEmpty()) {
+                    LOGGER.debug("Filtered out {} from results for overlapping match with {}", matching, otherVersionListPattern);
+                    remaining.removeAll(matching);
+                }
+            }
+        }
+        return remaining;
     }
 
     private List<String> filterMatchedValues(List<String> all, final Pattern p) {
@@ -125,8 +146,16 @@ public class ResourceVersionLister implements VersionLister {
             namePattern = pattern.substring(prefixLastSlashIndex + 1);
         }
         namePattern = namePattern.replaceAll("\\.", "\\\\.");
-
         String acceptNamePattern = namePattern.replaceAll("\\[revision\\]", "(.+)");
+        return Pattern.compile(acceptNamePattern);
+    }
+
+    private Pattern toControlRegexPattern(String pattern) {
+        pattern = pattern.replaceAll("\\.", "\\\\.");
+
+        // Creates a control regexp pattern where extra revision tokens _must_ have the same value as the original one
+        String acceptNamePattern = pattern.replaceFirst("\\[revision\\]", "(.+)")
+            .replaceAll("\\[revision\\]", "\1");
         return Pattern.compile(acceptNamePattern);
     }
 
@@ -144,17 +173,25 @@ public class ResourceVersionLister implements VersionLister {
         return true;
     }
 
-    private List<String> listAll(ExternalResourceName parent, BuildableModuleVersionListingResolveResult result)  {
-        if (!visitedDirectories.add(parent)) {
-            return Collections.emptyList();
-        }
+    private List<String> listAll(ExternalResourceName parent, BuildableModuleVersionListingResolveResult result) {
         LOGGER.debug("using {} to list all in {}", repository, parent);
         result.attempted(parent.toString());
-        List<String> paths = repository.resource(parent).list();
+        List<String> paths = listWithCache(parent);
         if (paths == null) {
             return Collections.emptyList();
         }
         LOGGER.debug("found {} resources", paths.size());
         return paths;
+    }
+
+    @Nullable
+    private List<String> listWithCache(ExternalResourceName parent) {
+        if (directoriesToList.containsKey(parent)) {
+            return directoriesToList.get(parent);
+        } else {
+            List<String> result = repository.resource(parent).list();
+            directoriesToList.put(parent, result);
+            return result;
+        }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionListerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionListerTest.groovy
@@ -35,7 +35,7 @@ class ResourceVersionListerTest extends Specification {
     def artifact = new DefaultIvyArtifactName("proj1", "jar", "jar")
     def result = new DefaultBuildableModuleVersionListingResolveResult()
 
-    def ResourceVersionLister lister;
+    ResourceVersionLister lister;
 
     def setup() {
         lister = new ResourceVersionLister(repo)
@@ -142,6 +142,24 @@ class ResourceVersionListerTest extends Specification {
         1 * resource1.list() >> ["1.2", "1.3"]
         1 * repo.resource(new ExternalResourceName("/org.acme/")) >> resource2
         1 * resource2.list() >> ["1.3", "1.4"]
+        0 * _
+    }
+
+    def 'overlapping patterns filter out parts matching more than one pattern'() {
+        def resource1 = Mock(ExternalResource)
+
+        when:
+        def pattern1 = pattern("/[organisation]/[module]/[revision]/ivy-[revision].xml")
+        def pattern2 = pattern("/[organisation]/[module]/ivy-[revision].xml")
+        lister.listVersions(module, artifact, [pattern1, pattern2], result)
+        def versions = result.versions
+
+        then:
+        versions == ['1.0.0', '1.5.0', '2.0.0'] as Set
+
+        and:
+        1 * repo.resource(new ExternalResourceName('/org.acme/proj1/')) >> resource1
+        1 * resource1.list() >> ['1.0.0', '1.5.0', 'ivy-2.0.0.xml']
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionListerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionListerTest.groovy
@@ -163,6 +163,24 @@ class ResourceVersionListerTest extends Specification {
         0 * _
     }
 
+    def 'exact duplicates do not filter out all results'() {
+        def resource1 = Mock(ExternalResource)
+
+        when:
+        def pattern1 = pattern("/[organisation]/[module]/ivy-[revision].xml")
+        def pattern2 = pattern("/[organisation]/[module]/ivy-[revision].xml")
+        lister.listVersions(module, artifact, [pattern1, pattern2], result)
+        def versions = result.versions
+
+        then:
+        versions == ['1.0.0', '2.0.0'] as Set
+
+        and:
+        1 * repo.resource(new ExternalResourceName('/org.acme/proj1/')) >> resource1
+        1 * resource1.list() >> ['ivy-1.0.0.xml', 'ivy-2.0.0.xml']
+        0 * _
+    }
+
     def "ignores duplicate patterns"() {
         def resource = Mock(ExternalResource)
 


### PR DESCRIPTION
* Previously, only a single pattern could access a given location. We
now cache the listing results and return them for all patterns needing
it.
* When multiple patterns co-exist, we filter out results from a given
pattern that happen to match another one.