### PR TITLE
Copy should succeed if it has named pipe in output that wasn't produces by the task

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -26,6 +26,7 @@ Include only their name, impactful features should be called out separately belo
 [Dominik Giger](https://github.com/gigerdo),
 [Stephan Windmüller](https://github.com/stovocor),
 [Zemian Deng](https://github.com/zemian),
+[Robin Verduijn](https://github.com/robinverduijn),
 and [Christian Fränkel](https://github.com/fraenkelc).
 
 ## Upgrade Instructions

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -498,6 +498,19 @@ public class TestFile extends File {
         NativeServices.getInstance().get(FileSystem.class)
             .createSymbolicLink(this, target);
         clearCanonCaches();
+        return this;
+    }
+
+    public TestFile createNamedPipe() {
+        try {
+            Process mkfifo = new ProcessBuilder("mkfifo", getAbsolutePath())
+                .redirectErrorStream(true)
+                .start();
+            assert mkfifo.waitFor() == 0; // assert the exit value signals success
+            return this;
+        } catch (IOException | InterruptedException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private void clearCanonCaches() {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -490,12 +490,13 @@ public class TestFile extends File {
         return hashingStream.hash().toString();
     }
 
-    public void createLink(File target) {
-        createLink(target.getAbsolutePath());
+    public TestFile createLink(String target) {
+        return createLink(new File(target));
     }
 
-    public void createLink(String target) {
-        NativeServices.getInstance().get(FileSystem.class).createSymbolicLink(this, new File(target));
+    public TestFile createLink(File target) {
+        NativeServices.getInstance().get(FileSystem.class)
+            .createSymbolicLink(this, target);
         clearCanonCaches();
     }
 

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
@@ -165,7 +165,7 @@ class DirectorySnapshotterTest extends Specification {
         rootDir.file('unreadableDirectory').createDir().makeUnreadable()
 
         when:
-        def snapshot = directorySnapshotter.snapshot(rootDir.absolutePath, directoryWalkerPredicate(new PatternSet()), new AtomicBoolean(false))
+        def snapshot = directorySnapshotter.snapshot(rootDir.absolutePath, null, new AtomicBoolean(false))
 
         then:
         assert snapshot instanceof DirectorySnapshot
@@ -187,7 +187,7 @@ class DirectorySnapshotterTest extends Specification {
         def pipe = rootDir.file("testPipe").createNamedPipe()
 
         when:
-        def snapshot = directorySnapshotter.snapshot(rootDir.absolutePath, directoryWalkerPredicate(new PatternSet()), new AtomicBoolean(false))
+        def snapshot = directorySnapshotter.snapshot(rootDir.absolutePath, null, new AtomicBoolean(false))
         then:
         assert snapshot instanceof DirectorySnapshot
         snapshot.children.collectEntries { [it.name, it.class] } == [

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
@@ -191,7 +191,7 @@ class DirectorySnapshotterTest extends Specification {
         then:
         assert snapshot instanceof DirectorySnapshot
         snapshot.children.collectEntries { [it.name, it.class] } == [
-            testPipe: MissingFileSnapshot,
+            testPipe: MissingFileSnapshot
         ]
 
         cleanup:


### PR DESCRIPTION
Fixes #2552

Follow-up of https://github.com/gradle/gradle/pull/9878 and https://github.com/gradle/gradle/pull/2691

#9878 already fixed named pipes, this PR adds tests for it and recognizes the author, since he contributed test cases (cc: @robinverduijn)