### PR TITLE
De-incubate artifact transforms

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -491,7 +491,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @see TransformAction
      * @since 5.3
      */
-    @Incubating
     <T extends TransformParameters> void registerTransform(Class<? extends TransformAction<T>> actionType, Action<? super TransformSpec<T>> registrationAction);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ArtifactTransformException.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ArtifactTransformException.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts.transform;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.exceptions.Contextual;
@@ -33,7 +32,6 @@ import java.io.File;
 @Contextual
 public class ArtifactTransformException extends GradleException {
 
-    @Deprecated
     public ArtifactTransformException(File input, AttributeContainer expectedAttributes, @SuppressWarnings("unused") Class<? extends ArtifactTransform> transform, Throwable cause) {
         this(input, expectedAttributes, cause);
     }
@@ -43,7 +41,6 @@ public class ArtifactTransformException extends GradleException {
      *
      * @since 5.1
      */
-    @Incubating
     public ArtifactTransformException(File file, AttributeContainer expectedAttributes, Throwable cause) {
         super(String.format("Failed to transform file '%s' to match attributes %s",
             file.getName(), expectedAttributes), cause);
@@ -54,7 +51,6 @@ public class ArtifactTransformException extends GradleException {
      *
      * @since 5.1
      */
-    @Incubating
     public ArtifactTransformException(ComponentArtifactIdentifier artifact, AttributeContainer expectedAttributes, Throwable cause) {
         super(String.format("Failed to transform artifact '%s' to match attributes %s",
             artifact, expectedAttributes), cause);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/CacheableTransform.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/CacheableTransform.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts.transform;
 
-import org.gradle.api.Incubating;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -54,7 +52,6 @@ import java.lang.annotation.Target;
  *
  * @since 5.3
  */
-@Incubating
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface CacheableTransform {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.transform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.InjectionPointQualifier;
@@ -53,7 +52,6 @@ import java.lang.annotation.Target;
  *
  * @since 5.3
  */
-@Incubating
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 @Documented

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifactDependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifactDependencies.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.transform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.reflect.InjectionPointQualifier;
 
@@ -59,7 +58,6 @@ import java.lang.annotation.Target;
  *
  * @since 5.3
  */
-@Incubating
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 @Documented

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts.transform;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 import javax.inject.Inject;
 
@@ -60,7 +59,6 @@ import javax.inject.Inject;
  * @param <T> Parameter type for the transform action. Should be {@link TransformParameters.None} if the action does not have parameters.
  * @since 5.3
  */
-@Incubating
 public interface TransformAction<T extends TransformParameters> {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformOutputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformOutputs.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.transform;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.io.File;
@@ -30,7 +29,6 @@ import java.io.File;
  *
  * @since 5.3
  */
-@Incubating
 @HasInternalProtocol
 public interface TransformOutputs {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformParameters.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts.transform;
 
-import org.gradle.api.Incubating;
-
 /**
  * Marker interface for parameter objects to {@link TransformAction}s.
  *
@@ -47,7 +45,6 @@ public interface TransformParameters {
      *
      * @since 5.3
      */
-    @Incubating
     final class None implements TransformParameters {
         private None() {}
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformParameters.java
@@ -39,7 +39,6 @@ import org.gradle.api.Incubating;
  *
  * @since 5.3
  */
-@Incubating
 public interface TransformParameters {
     /**
      * Used for {@link TransformAction}s without parameters.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts.transform;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 
 /**
@@ -27,7 +26,6 @@ import org.gradle.api.attributes.AttributeContainer;
  * @param <T> The transform specific parameter type.
  * @since 5.3
  */
-@Incubating
 public interface TransformSpec<T extends TransformParameters> {
     /**
      * Attributes that match the variant that is consumed.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -170,6 +170,10 @@ The following are the features that have been promoted in this Gradle release.
 ### Example promoted
 -->
 
+### Transforming dependency artifacts on resolution
+
+The API around [artifact transforms](userguide/dependency_management_attribute_based_matching.html#sec:abm_artifact_transforms) is not incubating any more.
+
 ## Fixed issues
 
 ## Known issues


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/9035

Changes to artifact transforms need to conform with our backwards compatibility guarantees, since they are used by the Android Gradle plugin 3.5 and later.