### PR TITLE
Full recompilation on Groovy-Java joint compilation

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -75,15 +75,11 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
 
     private static abstract class IncrementalCompilationCustomizer extends CompilationCustomizer {
         static IncrementalCompilationCustomizer fromSpec(GroovyJavaJointCompileSpec spec, File[] sortedSourceFiles) {
-            if (spec.getCompilationMappingFile() != null && !isJavaGroovyJointCompilation(sortedSourceFiles)) {
+            if (spec.getCompilationMappingFile() != null) {
                 return new TrackingClassGenerationCompilationCustomizer(new CompilationSourceDirs(spec.getSourceRoots()), spec.getCompilationMappingFile());
             } else {
                 return new NoOpCompilationCustomizer();
             }
-        }
-
-        private static boolean isJavaGroovyJointCompilation(File[] sourceFiles) {
-            return Stream.of(sourceFiles).anyMatch(file -> hasExtension(file, ".java"));
         }
 
         public IncrementalCompilationCustomizer() {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -61,7 +61,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.gradle.api.internal.tasks.compile.SourceClassesMappingFileAccessor.writeSourceClassesMappingFile;
 import static org.gradle.internal.FileUtils.hasExtension;
@@ -74,7 +73,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
     }
 
     private static abstract class IncrementalCompilationCustomizer extends CompilationCustomizer {
-        static IncrementalCompilationCustomizer fromSpec(GroovyJavaJointCompileSpec spec, File[] sortedSourceFiles) {
+        static IncrementalCompilationCustomizer fromSpec(GroovyJavaJointCompileSpec spec) {
             if (spec.getCompilationMappingFile() != null) {
                 return new TrackingClassGenerationCompilationCustomizer(new CompilationSourceDirs(spec.getSourceRoots()), spec.getCompilationMappingFile());
             } else {
@@ -164,9 +163,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         configuration.setTargetDirectory(spec.getDestinationDir());
         canonicalizeValues(spec.getGroovyCompileOptions().getOptimizationOptions());
 
-        File[] sortedSourceFiles = getSortedSourceFiles(spec);
-
-        IncrementalCompilationCustomizer customizer = IncrementalCompilationCustomizer.fromSpec(spec, sortedSourceFiles);
+        IncrementalCompilationCustomizer customizer = IncrementalCompilationCustomizer.fromSpec(spec);
         customizer.addToConfiguration(configuration);
 
         if (spec.getGroovyCompileOptions().getConfigurationScript() != null) {
@@ -227,7 +224,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
             // to the sources won't cause any issues.
             unit.addSources(new File[]{new File("ForceStubGeneration.java")});
         }
-        unit.addSources(sortedSourceFiles);
+        unit.addSources(getSortedSourceFiles(spec));
 
         unit.setCompilerFactory(new JavaCompilerFactory() {
             @Override

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractSourceIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractSourceIncrementalCompilationIntegrationTest.groovy
@@ -17,36 +17,13 @@
 package org.gradle.java.compile.incremental
 
 
-import org.gradle.integtests.fixtures.CompilationOutputsFixture
 import org.gradle.integtests.fixtures.CompiledLanguage
 import spock.lang.Issue
 import spock.lang.Unroll
 
 abstract class AbstractSourceIncrementalCompilationIntegrationTest extends AbstractJavaGroovyIncrementalCompilationSupport {
-    CompilationOutputsFixture outputs
-
-    def setup() {
-        outputs = new CompilationOutputsFixture(file("build/classes"))
-
-        buildFile << """
-            apply plugin: '${language.name}'
-        """
-    }
 
     abstract void recompiledWithFailure(String expectedFailure, String... recompiledClasses)
-
-    File source(String... classBodies) {
-        File out
-        for (String body : classBodies) {
-            def className = (body =~ /(?s).*?(?:class|interface|enum) (\w+) .*/)[0][1]
-            assert className: "unable to find class name"
-            def f = file("src/main/${language.name}/${className}.${language.name}")
-            f.createFile()
-            f.text = body
-            out = f
-        }
-        out
-    }
 
     def "detects deletion of an isolated source class with an inner class"() {
         def a = source """class A {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovyJavaJointIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovyJavaJointIncrementalCompilationIntegrationTest.groovy
@@ -61,15 +61,15 @@ class GroovyJavaJointIncrementalCompilationIntegrationTest extends AbstractJavaG
         upToDateOrMessage(secondBuildMessage)
 
         where:
-        scenario                                     | initialSet            | firstChange                   | firstBuildMessage                                        | secondChange                  | secondBuildMessage
-        'Add Java files to Groovy file set'          | ['G']                 | ['G', 'J']                    | 'changes to non-Groovy files'                            | ['G', 'J']                    | 'UP-TO-DATE'
-        'Add Groovy files to Java file set'          | ['J']                 | ['G', 'J']                    | 'unable to get source-classes mapping'                   | ['G', 'J.changed']            | 'changes to non-Groovy files'
-        'Change Java files in joint compilation'     | ['G', 'J']            | ['G', 'J.changed']            | 'changes to non-Groovy files'                            | ['G', 'J.changed']            | 'UP-TO-DATE'
-        'Change Groovy files which Java  depends on' | ['G', 'J_G']          | ['G.changed', 'J_G']          | 'unable to find source file of class J_G'                | ['G.changed', 'J_G']          | 'UP-TO-DATE'
-        'Remove Java files in joint compilation'     | ['G', 'J']            | ['G']                         | 'changes to non-Groovy files'                            | ['G', 'G_G']                  | 'Incremental compilation of '
-        'Remove Groovy fiels in joint compilation'   | ['G', 'J']            | ['J']                         | 'UP-TO-DATE'/*None of the classes needs to be compiled*/ | ['J', 'G']                    | 'unable to get source-classes mapping'
-        'Add Groovy files to joint file set'         | ['G', 'J']            | ['G', 'J', 'G_G']             | 'Incremental compilation of'                             | ['G', 'J', 'G_G']             | 'UP-TO-DATE'
-        'Change root Groovy files '                  | ['G', 'G_G', 'J_G_G'] | ['G.changed', 'G_G', 'J_G_G'] | 'unable to find source file of class J_G_G'              | ['G.changed', 'G_G', 'J_G_G'] | 'UP-TO-DATE'
+        scenario                                    | initialSet            | firstChange                   | firstBuildMessage                                        | secondChange                  | secondBuildMessage
+        'Add Java files to Groovy file set'         | ['G']                 | ['G', 'J']                    | 'changes to non-Groovy files'                            | ['G', 'J']                    | 'UP-TO-DATE'
+        'Add Groovy files to Java file set'         | ['J']                 | ['G', 'J']                    | 'unable to get source-classes mapping'                   | ['G', 'J.changed']            | 'changes to non-Groovy files'
+        'Change Java files in joint compilation'    | ['G', 'J']            | ['G', 'J.changed']            | 'changes to non-Groovy files'                            | ['G', 'J.changed']            | 'UP-TO-DATE'
+        'Change Groovy files which Java depends on' | ['G', 'J_G']          | ['G.changed', 'J_G']          | 'unable to find source file of class J_G'                | ['G.changed', 'J_G']          | 'UP-TO-DATE'
+        'Remove Java files in joint compilation'    | ['G', 'J']            | ['G']                         | 'changes to non-Groovy files'                            | ['G', 'G_G']                  | 'Incremental compilation of '
+        'Remove Groovy files in joint compilation'  | ['G', 'J']            | ['J']                         | 'UP-TO-DATE'/*None of the classes needs to be compiled*/ | ['J', 'G']                    | 'unable to get source-classes mapping'
+        'Add Groovy files to joint file set'        | ['G', 'J']            | ['G', 'J', 'G_G']             | 'Incremental compilation of'                             | ['G', 'J', 'G_G']             | 'UP-TO-DATE'
+        'Change root Groovy files '                 | ['G', 'G_G', 'J_G_G'] | ['G.changed', 'G_G', 'J_G_G'] | 'unable to find source file of class J_G_G'              | ['G.changed', 'G_G', 'J_G_G'] | 'UP-TO-DATE'
     }
 
     void applyFileSet(List<String> fileSet) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovyJavaJointIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovyJavaJointIncrementalCompilationIntegrationTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.compile.incremental
+
+import org.gradle.integtests.fixtures.CompiledLanguage
+import spock.lang.Unroll
+
+class GroovyJavaJointIncrementalCompilationIntegrationTest extends AbstractJavaGroovyIncrementalCompilationSupport {
+    CompiledLanguage language = CompiledLanguage.GROOVY
+
+    def setup() {
+        configureGroovyIncrementalCompilation()
+    }
+
+    static Map sources = [
+        'G.groovy': 'class G {}',
+        'G.groovy.changed': 'class G { int i }',
+        'J.java': 'class J { }',
+        'J.java.changed': 'class J { int i; }',
+        'J2.java': 'class J2 {}',
+        'G2.groovy': 'class G2 {}'
+    ]
+
+    void applyFileSet(List<String> fileSet) {
+        file('src/main/groovy').forceDeleteDir()
+        fileSet.each {
+            file("src/main/groovy/${it.replace('.changed', '')}").text = sources[it]
+        }
+    }
+
+    @Unroll
+    def 'full compilation with Groovy-Java joint compilation'() {
+        given:
+        applyFileSet(initialSet)
+
+        when:
+        run "compileGroovy"
+        applyFileSet(firstChange)
+
+        then:
+        run "compileGroovy", "--info"
+        executedAndNotSkipped(":compileGroovy")
+        outputContains(firstRecompilationReason)
+
+        when:
+        applyFileSet(secondChange)
+        run "compileGroovy", "--info"
+
+        then:
+        if (secondRecompilationReason == 'UP-TO-DATE') {
+            skipped(":compileGroovy")
+        } else {
+            executedAndNotSkipped(":compileGroovy")
+        }
+        outputContains(secondRecompilationReason)
+
+        where:
+        initialSet             | firstChange                         | firstRecompilationReason                 | secondChange                        | secondRecompilationReason
+        ['G.groovy']           | ['G.groovy', 'J.java']              | 'Groovy-Java joint compilation detected' | ['G.groovy', 'J.java']              | 'UP-TO-DATE'
+        ['J.java']             | ['G.groovy', 'J.java']              | 'no source class mapping file found'     | ['G.groovy', 'J.java.changed']      | 'no source class mapping file found'
+        ['G.groovy', 'J.java'] | ['G.groovy', 'J.java.changed']      | 'no source class mapping file found'     | ['G.groovy', 'J.java.changed']      | 'UP-TO-DATE'
+        ['G.groovy', 'J.java'] | ['G.groovy.changed', 'J.java']      | 'no source class mapping file found'     | ['G.groovy.changed', 'J.java']      | 'UP-TO-DATE'
+        ['G.groovy', 'J.java'] | ['G.groovy']                        | 'no source class mapping file found'     | ['G.groovy', 'G2.groovy']           | 'Incremental compilation of '
+        ['G.groovy', 'J.java'] | ['J.java']                          | 'no source class mapping file found'     | ['J.java', 'J2.java']               | 'no source class mapping file found'
+        ['G.groovy', 'J.java'] | ['G.groovy', 'J.java', 'J2.java']   | 'no source class mapping file found'     | ['G.groovy', 'G2.groovy']           | 'no source class mapping file found'
+        ['G.groovy', 'J.java'] | ['G.groovy', 'J.java', 'G2.groovy'] | 'no source class mapping file found'     | ['G.groovy', 'J.java', 'G2.groovy'] | 'UP-TO-DATE'
+    }
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovyJavaJointIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovyJavaJointIncrementalCompilationIntegrationTest.groovy
@@ -26,7 +26,7 @@ class GroovyJavaJointIncrementalCompilationIntegrationTest extends AbstractJavaG
         configureGroovyIncrementalCompilation()
     }
 
-    static Map sources = [
+    private static final Map SOURCES = [
         'G': 'class G { }',
         'G.changed': 'class G { int i }',
         'J': 'class J { }',
@@ -39,22 +39,6 @@ class GroovyJavaJointIncrementalCompilationIntegrationTest extends AbstractJavaG
         'G_G': 'class G_G extends G { }',
         'J_G_G': 'class J_G_G extends G_G { }',
     ]
-
-    void applyFileSet(List<String> fileSet) {
-        file('src/main/groovy').forceDeleteDir()
-        fileSet.each {
-            file("src/main/groovy/${it.replace('.changed', '') + (it.startsWith('J') ? '.java' : '.groovy')}").text = sources[it]
-        }
-    }
-
-    void upToDateOrMessage(String message) {
-        if (message == 'UP-TO-DATE') {
-            skipped(":compileGroovy")
-        } else {
-            executedAndNotSkipped(":compileGroovy")
-        }
-        outputContains(message)
-    }
 
     @Unroll
     def 'Groovy-Java joint compilation on #scenario'() {
@@ -86,5 +70,21 @@ class GroovyJavaJointIncrementalCompilationIntegrationTest extends AbstractJavaG
         'Remove Groovy fiels in joint compilation'   | ['G', 'J']            | ['J']                         | 'UP-TO-DATE'/*None of the classes needs to be compiled*/ | ['J', 'G']                    | 'unable to get source-classes mapping'
         'Add Groovy files to joint file set'         | ['G', 'J']            | ['G', 'J', 'G_G']             | 'Incremental compilation of'                             | ['G', 'J', 'G_G']             | 'UP-TO-DATE'
         'Change root Groovy files '                  | ['G', 'G_G', 'J_G_G'] | ['G.changed', 'G_G', 'J_G_G'] | 'unable to find source file of class J_G_G'              | ['G.changed', 'G_G', 'J_G_G'] | 'UP-TO-DATE'
+    }
+
+    void applyFileSet(List<String> fileSet) {
+        file('src/main/groovy').forceDeleteDir()
+        fileSet.each {
+            file("src/main/groovy/${it.replace('.changed', '') + (it.startsWith('J') ? '.java' : '.groovy')}").text = SOURCES[it]
+        }
+    }
+
+    void upToDateOrMessage(String message) {
+        if (message == 'UP-TO-DATE') {
+            skipped(":compileGroovy")
+        } else {
+            executedAndNotSkipped(":compileGroovy")
+        }
+        outputContains(message)
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovySourceIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/GroovySourceIncrementalCompilationIntegrationTest.groovy
@@ -53,7 +53,7 @@ class GroovySourceIncrementalCompilationIntegrationTest extends AbstractSourceIn
         run language.compileTaskName, '-i'
 
         then:
-        outputContains('no source class mapping file found')
+        outputContains('unable to get source-classes mapping relationship')
     }
 
     def 'only recompile affected classes when multiple class in one groovy file'() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
+import org.gradle.internal.FileUtils;
 import org.gradle.work.FileChange;
 import org.gradle.work.InputChanges;
 
@@ -110,6 +111,11 @@ public class GroovyRecompilationSpecProvider extends AbstractRecompilationSpecPr
             }
 
             File changedFile = fileChange.getFile();
+            if (FileUtils.hasExtension(changedFile, ".java")) {
+                spec.setFullRebuildCause("Groovy-Java joint compilation detected", changedFile);
+                return;
+            }
+
             String relativeFilePath = fileChange.getNormalizedPath();
 
             Collection<String> changedClasses = sourceFileClassNameConverter.getClassNames(relativeFilePath);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
@@ -56,7 +56,7 @@ public class GroovyRecompilationSpecProvider extends AbstractRecompilationSpecPr
     public RecompilationSpec provideRecompilationSpec(CurrentCompilation current, PreviousCompilation previous) {
         RecompilationSpec spec = new RecompilationSpec();
         if (sourceFileClassNameConverter.isEmpty()) {
-            spec.setFullRebuildCause("no source class mapping file found", null);
+            spec.setFullRebuildCause("unable to get source-classes mapping relationship from last compilation", null);
             return spec;
         }
 
@@ -111,8 +111,8 @@ public class GroovyRecompilationSpecProvider extends AbstractRecompilationSpecPr
             }
 
             File changedFile = fileChange.getFile();
-            if (FileUtils.hasExtension(changedFile, ".java")) {
-                spec.setFullRebuildCause("Groovy-Java joint compilation detected", changedFile);
+            if (!FileUtils.hasExtension(changedFile, ".groovy")) {
+                spec.setFullRebuildCause("changes to non-Groovy files are not supported by incremental compilation", changedFile);
                 return;
             }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.compile.incremental.recomp;
 
 import org.gradle.api.file.FileTree;
+import org.gradle.api.file.FileType;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.tasks.util.PatternSet;
@@ -111,7 +112,7 @@ public class GroovyRecompilationSpecProvider extends AbstractRecompilationSpecPr
             }
 
             File changedFile = fileChange.getFile();
-            if (!FileUtils.hasExtension(changedFile, ".groovy")) {
+            if (fileChange.getFileType() != FileType.DIRECTORY && !FileUtils.hasExtension(changedFile, ".groovy")) {
                 spec.setFullRebuildCause("changes to non-Groovy files are not supported by incremental compilation", changedFile);
                 return;
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/GroovyRecompilationSpecProvider.java
@@ -132,7 +132,7 @@ public class GroovyRecompilationSpecProvider extends AbstractRecompilationSpecPr
             if (relativeSourceFile.isPresent()) {
                 spec.getRelativeSourcePathsToCompile().add(relativeSourceFile.get());
             } else {
-                spec.setFullRebuildCause("Can't find source file of class " + className, null);
+                spec.setFullRebuildCause("unable to find source file of class " + className, null);
             }
         }
     }


### PR DESCRIPTION
# Context

Currently, incremental Groovy compilation only works for files compiled by the Groovy compiler. Java files are compiled by the Java compiler.
This PR disables incremental compiler if Java files found because this might cause incorrectness.