### PR TITLE
Add option to package classes directory to a jar on the compile classpath

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -71,6 +71,12 @@ One benefit of managing plugin versions in this way is that the `pluginManagemen
 
 See [plugin version management](userguide/plugins.html#sec:plugin_version_management) for more details.
 
+## Performance fix for using the Java library plugin in very large projects on Windows
+
+Very large multi-projects can suffer from a significant performance decrease in Java compilation when switching from the `java` to the `java-library` plugin.
+This is caused by the large amount of class files on the classpath, which is only an issue on Windows systems.
+You can now tell the `java-library` plugin to [prefer jars over class folders on the compile classpath](userguide/java_library_plugin.html#sec:java_library_known_issues_windows_performance) by setting the `org.gradle.java.compile-classpath-packaging` system property to `true`.
+
 ## Improvements for plugin authors
 
 ### Task dependencies are honored for `@Input` properties of type `Provider`

--- a/subprojects/docs/src/docs/userguide/java_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_library_plugin.adoc
@@ -249,3 +249,11 @@ include::sample[dir="java-library/with-groovy/kotlin",files="a/build.gradle.kts[
 === Increased memory usage for consumers
 
 When a project uses the Java Library plugin, consumers will use the output classes directory of this project directly on their compile classpath, instead of the jar file if the project uses the Java plugin. An indirect consequence is that up-to-date checking will require more memory, because Gradle will snapshot individual class files instead of a single jar. This may lead to increased memory consumption for large projects.
+
+[[sec:java_library_known_issues_windows_performance]]
+=== Significant build performance drop on Windows for huge multi-projects
+
+Another side effect of the snapshotting of individual class files, only affecting Windows systems, is that the performance can significantly drop when processing a very large amount of class files on the compile classpath.
+This only concerns very large multi-projects where a lot of classes are present on the classpath by using many `api` or (deprecated) `compile` dependencies.
+To mitigate this, you can set the `org.gradle.java.compile-classpath-packaging` system property to `true` to change the behavior of the Java Library plugin to use jars instead of class folders for everything on the compile classpath.
+Note, since this has other performance impacts and potentially side effects, by triggering all jar tasks at compile time, it is only recommended to activate this if you suffer from the described performance issue on Windows.

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.experiment.java
 
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.results.BaselineVersion
@@ -32,6 +33,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
     def "java-library vs java on #testProject"() {
         def javaLibraryRuns = "java-library-plugin"
         def javaRuns = "java-plugin"
+        def compileClasspathPackaging = OperatingSystem.current().windows
 
         given:
         runner.testGroup = "java plugins"
@@ -39,7 +41,7 @@ class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest
             warmUpCount = warmUpRuns
             invocationCount = runs
             projectName(testProject.projectName).displayName(javaLibraryRuns).invocation {
-                tasksToRun("clean", "classes").args("-PcompileConfiguration").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
+                tasksToRun("clean", "classes").args("-PcompileConfiguration", "-Dorg.gradle.java.compile-classpath-packaging=$compileClasspathPackaging").gradleOpts("-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}")
             }
         }
         runner.baseline {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
@@ -35,9 +35,14 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
 
     @Issue("https://github.com/gradle/gradle/issues/7398")
     @Unroll
-    def "selects #expected output when #consumerPlugin plugin adds a project dependency to #consumerConf and producer has java-library=#groovyWithJavaLib"(
-            String consumerPlugin, String consumerConf, boolean groovyWithJavaLib, String expected) {
+    def "selects #expected output when #consumerPlugin plugin adds a project dependency to #consumerConf and producer has java-library=#groovyWithJavaLib with compile-classpath-packaging=#compileClasspathPackaging"(
+            String consumerPlugin, String consumerConf, boolean groovyWithJavaLib, boolean compileClasspathPackaging, String expected) {
         given:
+        if (compileClasspathPackaging) {
+            propertiesFile << """
+                systemProp.org.gradle.java.compile-classpath-packaging=true
+            """.trim()
+        }
         multiProjectBuild('issue7398', ['groovyLib', 'javaLib']) {
             file('groovyLib').with {
                 file('src/main/groovy/GroovyClass.groovy') << "public class GroovyClass {}"
@@ -97,17 +102,29 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
         }
 
         where:
-        consumerPlugin | consumerConf     | groovyWithJavaLib | expected
-        'java-library' | 'api'            | true              | "classes"
-        'java-library' | 'api'            | false             | "jar"
-        'java-library' | 'compile'        | true              | "classes"
-        'java-library' | 'compile'        | false             | "jar"
-        'java-library' | 'implementation' | true              | "classes"
-        'java-library' | 'implementation' | false             | "jar"
+        consumerPlugin | consumerConf     | groovyWithJavaLib | compileClasspathPackaging | expected
+        'java-library' | 'api'            | true              | false                     | "classes"
+        'java-library' | 'api'            | false             | false                     | "jar"
+        'java-library' | 'compile'        | true              | false                     | "classes"
+        'java-library' | 'compile'        | false             | false                     | "jar"
+        'java-library' | 'implementation' | true              | false                     | "classes"
+        'java-library' | 'implementation' | false             | false                     | "jar"
 
-        'java'         | 'compile'        | true              | "classes"
-        'java'         | 'compile'        | false             | "jar"
-        'java'         | 'implementation' | true              | "classes"
-        'java'         | 'implementation' | false             | "jar"
+        'java'         | 'compile'        | true              | false                     | "classes"
+        'java'         | 'compile'        | false             | false                     | "jar"
+        'java'         | 'implementation' | true              | false                     | "classes"
+        'java'         | 'implementation' | false             | false                     | "jar"
+
+        'java-library' | 'api'            | true              | true                      | "jar"
+        'java-library' | 'api'            | false             | true                      | "jar"
+        'java-library' | 'compile'        | true              | true                      | "jar"
+        'java-library' | 'compile'        | false             | true                      | "jar"
+        'java-library' | 'implementation' | true              | true                      | "jar"
+        'java-library' | 'implementation' | false             | true                      | "jar"
+
+        'java'         | 'compile'        | true              | true                      | "jar"
+        'java'         | 'compile'        | false             | true                      | "jar"
+        'java'         | 'implementation' | true              | true                      | "jar"
+        'java'         | 'implementation' | false             | true                      | "jar"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -25,7 +25,18 @@ import java.util.jar.JarOutputStream
 
 class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
-    def "project can declare an API dependency"() {
+    private toggleCompileClasspathPackaging(boolean activate) {
+        if (activate) {
+            propertiesFile << """
+                systemProp.org.gradle.java.compile-classpath-packaging=true
+            """.trim()
+        }
+    }
+
+    @Unroll
+    def "project can declare an API dependency [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         given:
         subproject('a') {
             'build.gradle'('''
@@ -61,7 +72,12 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
     def "uses the default configuration when producer is not a library"() {
@@ -147,7 +163,9 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    def "uses the API of a library when compiling a custom source set against it"() {
+    def "uses the API of a library when compiling a custom source set against it [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         given:
         subproject('a') {
             'build.gradle'("""
@@ -188,7 +206,12 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
     @Unroll
@@ -234,7 +257,10 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         configuration << ['testCompile', 'testImplementation']
     }
 
-    def "recompiles consumer if API dependency of producer changed"() {
+    @Unroll
+    def "recompiles consumer if API dependency of producer changed [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         publishSharedV1()
         publishSharedV11()
 
@@ -286,7 +312,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':a:compileJava', ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
 
         when:
         file('b/build.gradle').text = file('b/build.gradle').text.replace(/api 'org.gradle.test:shared:1.0'/, '''
@@ -297,10 +323,18 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         then:
         succeeds ':a:compileJava', 'a:compileJava'
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
-    def "doesn't recompile consumer if implementation dependency of producer changed"() {
+    @Unroll
+    def "doesn't recompile consumer if implementation dependency of producer changed [compileClasspathPackaging=#compileClasspathPackaging]"() {
+        toggleCompileClasspathPackaging(compileClasspathPackaging)
+
         publishSharedV1()
         publishSharedV11()
 
@@ -348,7 +382,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':a:compileJava', ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
 
         when:
         file('b/build.gradle').text = file('b/build.gradle').text.replace(/implementation 'org.gradle.test:shared:1.0'/, '''
@@ -359,8 +393,13 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         then:
         succeeds 'a:compileJava'
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        packagingTasks(compileClasspathPackaging)
         skipped ':a:compileJava'
+
+        where:
+        compileClasspathPackaging | _
+        false                     | _
+        true                      | _
     }
 
     @Unroll
@@ -401,6 +440,15 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
         scenario              | token       | expectedDirName     | executed           | notExec
         'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
         'resources directory' | 'RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
+    }
+
+    private void packagingTasks(boolean expectExecuted) {
+        def tasks = [':b:processResources', ':b:classes', ':b:jar']
+        if (expectExecuted) {
+            executed(*tasks)
+        } else {
+            notExecuted(*tasks)
+        }
     }
 
     private void subproject(String name, @DelegatesTo(value=FileTreeBuilder, strategy = Closure.DELEGATE_FIRST) Closure<Void> config) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
@@ -22,6 +22,11 @@ class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaTestFixturesInt
         'java-library'
     }
 
+    @Override
+    List getSkippedJars(boolean compileClasspathPackaging) {
+        compileClasspathPackaging ? [] : [':jar', ':testFixturesJar']
+    }
+
     def "can consume test fixtures of subproject written in Groovy"() {
         settingsFile << """
             include 'sub'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
@@ -21,4 +21,10 @@ class JavaTestFixturesIntegrationTest extends AbstractJavaTestFixturesIntegratio
     String getPluginName() {
         'java'
     }
+
+    @Override
+    List getSkippedJars(boolean compileClasspathPackaging) {
+        compileClasspathPackaging ? [] : [':testFixturesJar']
+    }
+
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -77,6 +77,16 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     public static final String DOCUMENTATION_GROUP = "documentation";
 
     /**
+     * Set this property to use JARs build from subprojects, instead of the classes folder from these project, on the compile classpath.
+     * The main use case for this is to mitigate performance issues on very large multi-projects building on Windows.
+     * Setting this property will cause the 'jar' task of all subprojects in the dependency tree to always run during compilation.
+     *
+     * @since 5.6
+     */
+    @Incubating
+    public static final String COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY = "org.gradle.java.compile-classpath-packaging";
+
+    /**
      * A list of known artifact types which are known to prevent from
      * publication.
      *
@@ -90,10 +100,12 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     );
 
     private final ObjectFactory objectFactory;
+    private final boolean javaClasspathPackaging;
 
     @Inject
     public JavaBasePlugin(ObjectFactory objectFactory) {
         this.objectFactory = objectFactory;
+        this.javaClasspathPackaging = Boolean.getBoolean(COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY);
     }
 
     @Override
@@ -279,7 +291,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSetName + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
         compileClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
-        compileClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
+        compileClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, javaClasspathPackaging? LibraryElements.JAR : LibraryElements.CLASSES));
         compileClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         ((ConfigurationInternal)compileClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 


### PR DESCRIPTION
_Copied from #9700_

A solution for #6784.

### How it works

Turn on using the `jar`, built by the _jar task_, instead of the class folder on the compile classpath by setting the following system property:

`org.gradle.java.compile-classpath-packaging=true`

### Measurements 
Results for measuring the [huge project](https://github.com/gradle/gradle/blob/5b7a84089e44e9eee446ee7401ff7f6fb4a44fda/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/JavaTestProject.groovy#L38-L41) on Windows:

**Without compile-classpath-packaging** 

```
    Measuring Gradle tasks: clean classes
    Speed java-library-plugin: Results were inconclusive with 95% confidence.
    Difference: 22.622 s slower (22622 ms), 9.79%
      java-library-plugin median: 4.23 m min: 4.164 m, max: 4.266 m, se: 2.516 s}
      > [4.266 m, 4.23 m, 4.164 m]
      java-plugin median: 3.853 m min: 3.837 m, max: 3.866 m, se: 710.32 ms}
      > [3.837 m, 3.866 m, 3.853 m]
```

**With compile-classpath-packaging** 
```
    Measuring Gradle tasks: clean classes
    Speed java-library-plugin: Results were inconclusive with 95% confidence.
    Difference: 10.114 s faster (10114 ms), -4.37%
      java-library-plugin median: 3.688 m min: 3.671 m, max: 3.72 m, se: 1.22 s}
      > [3.688 m, 3.671 m, 3.72 m]
      java-plugin median: 3.856 m min: 3.839 m, max: 3.86 m, se: 544.53 ms}
      > [3.839 m, 3.86 m, 3.856 m]
```