### PR TITLE
Merge build types running only unit tests

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -7,15 +7,21 @@ import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
-    uuid = testCoverage.asConfigurationId(model, subProject)
+class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProjects: List<String> = listOf(), stage: Stage, buildTypeName: String = "") : BaseGradleBuildType(model, stage = stage, init = {
+    val coverageName = if (subProjects.size > 1)  buildTypeName else subProjects.joinToString("")
+    uuid = testCoverage.asConfigurationId(model, coverageName)
     id = AbsoluteId(uuid)
-    name = testCoverage.asName() + if (!subProject.isEmpty()) " ($subProject)" else ""
-    val testTask = if (!subProject.isEmpty()) {
-        subProject + ":"
-    } else {
-        ""
-    } + testCoverage.testType.name + "Test"
+    name = testCoverage.asName() + if (coverageName.isEmpty()) "" else " ($coverageName)"
+    description = "${testCoverage.asName()} for ${when (subProjects.size) {
+        0 -> "all projects "
+        1 -> "project ${subProjects.joinToString("")}"
+        else -> "projects ${subProjects.joinToString(", ")}"
+    }}"
+    val testTaskName = "${testCoverage.testType.name}Test"
+    val testTasks = if (subProjects.isEmpty())
+        testTaskName
+    else
+        subProjects.map { "$it:$testTaskName" }.joinToString(" ")
     val quickTest = testCoverage.testType == TestType.quick
     val buildScanTags = listOf("FunctionalTest")
     val buildScanValues = mapOf(
@@ -23,7 +29,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
             "coverageJvmVendor" to testCoverage.vendor.name,
             "coverageJvmVersion" to testCoverage.testJvmVersion.name
     )
-    applyTestDefaults(model, this, testTask, notQuick = !quickTest, os = testCoverage.os,
+    applyTestDefaults(model, this, testTasks, notQuick = !quickTest, os = testCoverage.os,
             extraParameters = (
                     listOf(""""-PtestJavaHome=%${testCoverage.os}.${testCoverage.testJvmVersion}.${testCoverage.vendor}.64bit%"""")
                             + buildScanTags.map { buildScanTag(it) }

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -123,6 +123,9 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
                     if (subProject.containsSlowTests && stage.omitsSlowProjects) {
                         return@forEach
                     }
+                    if (subProject.hasOnlyUnitTests()) {
+                        return@forEach
+                    }
                     if (subProject.unitTests && testCoverage.testType.unitTests) {
                         dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProject.name))) { snapshot {} }
                     } else if (subProject.functionalTests && testCoverage.testType.functionalTests) {
@@ -130,6 +133,9 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
                     } else if (subProject.crossVersionTests && testCoverage.testType.crossVersionTests) {
                         dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProject.name))) { snapshot {} }
                     }
+                }
+                if (testCoverage.testType.unitTests && model.subProjects.any { it.hasOnlyUnitTests() }) {
+                    dependency(AbsoluteId(testCoverage.asConfigurationId(model, FunctionalTestProject.allUnitTestsBuildTypeName))) { snapshot {} }
                 }
             } else {
                 dependency(AbsoluteId(testCoverage.asConfigurationId(model))) {

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -16,7 +16,7 @@ import model.TestType
 import model.Trigger
 import projects.FunctionalTestProject
 
-class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean, rootProjectUuid: String) : BaseGradleBuildType(model, init = {
+class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean) : BaseGradleBuildType(model, init = {
     uuid = stageTriggerUuid(model, stage)
     id = stageTriggerId(model, stage)
     name = stage.stageName.stageName + " (Trigger)"
@@ -117,13 +117,9 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
             val isSplitIntoBuckets = testCoverage.testType != TestType.soak
             if (isSplitIntoBuckets) {
                 model.subProjects.forEach { subProject ->
-                    if (shouldBeSkipped(subProject, testCoverage)) {
-                        return@forEach
-                    }
-                    if (subProject.containsSlowTests && stage.omitsSlowProjects) {
-                        return@forEach
-                    }
-                    if (subProject.hasOnlyUnitTests()) {
+                    if (shouldBeSkipped(subProject, testCoverage)
+                        || stage.shouldOmitSlowProject(subProject)
+                        || !subProject.hasSeparateTestBuild(testCoverage.testType)) {
                         return@forEach
                     }
                     if (subProject.unitTests && testCoverage.testType.unitTests) {
@@ -134,7 +130,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
                         dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProject.name))) { snapshot {} }
                     }
                 }
-                if (testCoverage.testType.unitTests && model.subProjects.any { it.hasOnlyUnitTests() }) {
+                if (model.subProjects.any { it.includeInMergedTestBuild(testCoverage.testType) }) {
                     dependency(AbsoluteId(testCoverage.asConfigurationId(model, FunctionalTestProject.allUnitTestsBuildTypeName))) { snapshot {} }
                 }
             } else {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -203,6 +203,8 @@ data class GradleSubproject(val name: String, val unitTests: Boolean = true, val
     }
 
     fun hasTestsOf(type: TestType) = (unitTests && type.unitTests) || (functionalTests && type.functionalTests) || (crossVersionTests && type.crossVersionTests)
+
+    fun hasOnlyUnitTests() = unitTests && !functionalTests && !crossVersionTests
 }
 
 interface StageName {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -205,6 +205,10 @@ data class GradleSubproject(val name: String, val unitTests: Boolean = true, val
     fun hasTestsOf(type: TestType) = (unitTests && type.unitTests) || (functionalTests && type.functionalTests) || (crossVersionTests && type.crossVersionTests)
 
     fun hasOnlyUnitTests() = unitTests && !functionalTests && !crossVersionTests
+
+    fun hasSeparateTestBuild(type: TestType) = hasTestsOf(type) && !hasOnlyUnitTests()
+
+    fun includeInMergedTestBuild(type: TestType) = hasTestsOf(type) && hasOnlyUnitTests()
 }
 
 interface StageName {
@@ -218,6 +222,8 @@ interface StageName {
 
 data class Stage(val stageName: StageName, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never, val functionalTestsDependOnSpecificBuilds: Boolean = false, val runsIndependent: Boolean = false, val omitsSlowProjects : Boolean = false, val dependsOnSanityCheck: Boolean = false) {
     val id = stageName.id
+
+    fun shouldOmitSlowProject(project: GradleSubproject) = project.containsSlowTests && omitsSlowProjects
 }
 
 data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val testJvmVersion: JvmVersion, val vendor: JvmVendor = JvmVendor.oracle, val buildJvmVersion: JvmVersion = JvmVersion.java11) {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -22,13 +22,21 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
             return@forEach
         }
 
-        if (subProject.hasTestsOf(testConfig.testType)) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+        if (subProject.hasTestsOf(testConfig.testType) && !subProject.hasOnlyUnitTests()) {
+            buildType(FunctionalTest(model, testConfig, listOf(subProject.name), stage))
         }
     }
+
+    if (testConfig.testType.unitTests && model.subProjects.any { it.hasOnlyUnitTests() }) {
+        val projectsWithOnlyUnitTests = model.subProjects.filter { it.hasOnlyUnitTests() }.map { it.name }
+        buildType(FunctionalTest(model, testConfig, projectsWithOnlyUnitTests, stage, allUnitTestsBuildTypeName))
+    }
+
 }){
     companion object {
-        val missingTestCoverage = mutableListOf<TestCoverage>()
+        const val allUnitTestsBuildTypeName = "AllUnitTests"
+
+        val missingTestCoverage = mutableSetOf<TestCoverage>()
 
         private fun addMissingTestCoverage(coverage: TestCoverage) {
             this.missingTestCoverage.add(coverage)

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -28,6 +28,7 @@ class RootProject(model: CIBuildModel) : Project({
 
     var prevStage: Stage? = null
     var deferredAlreadyDeclared = false
+    FunctionalTestProject.missingTestCoverage.clear()
     model.stages.forEach { stage ->
         val containsDeferredTests = !stage.omitsSlowProjects && !deferredAlreadyDeclared
         deferredAlreadyDeclared = deferredAlreadyDeclared || containsDeferredTests

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -32,7 +32,7 @@ class RootProject(model: CIBuildModel) : Project({
     model.stages.forEach { stage ->
         val containsDeferredTests = !stage.omitsSlowProjects && !deferredAlreadyDeclared
         deferredAlreadyDeclared = deferredAlreadyDeclared || containsDeferredTests
-        buildType(StagePasses(model, stage,  prevStage, containsDeferredTests, uuid))
+        buildType(StagePasses(model, stage,  prevStage, containsDeferredTests))
         subProject(StageProject(model, stage, containsDeferredTests, uuid))
         prevStage = stage
     }

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -70,7 +70,7 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
                             subProject.hasTestsOf(testConfig.testType)
                         }
                         .forEach { testConfig ->
-                            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+                            buildType(FunctionalTest(model, testConfig, listOf(subProject.name), stage))
                         }
                 }
         }

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -5,6 +5,7 @@ import common.NoBuildCache
 import common.Os
 import configurations.shouldBeSkipped
 import jetbrains.buildServer.configs.kotlin.v2018_2.Project
+import jetbrains.buildServer.configs.kotlin.v2018_2.buildSteps.GradleBuildStep
 import model.CIBuildModel
 import model.GradleSubproject
 import model.SpecificBuild
@@ -71,7 +72,9 @@ class CIConfigIntegrationTests {
                         if (shouldBeSkipped(subProject, testCoverage)) {
                             return@forEach
                         }
-                        if (subProject.unitTests && testCoverage.testType.unitTests) {
+                        if (subProject.hasOnlyUnitTests()) {
+                            return@forEach
+                        } else if(subProject.unitTests && testCoverage.testType.unitTests) {
                             functionalTestCount++
                         } else if (subProject.functionalTests && testCoverage.testType.functionalTests) {
                             functionalTestCount++
@@ -79,13 +82,16 @@ class CIConfigIntegrationTests {
                             functionalTestCount++
                         }
                     }
+                    if (testCoverage.testType.unitTests) {
+                        functionalTestCount++ // All unit tests build type
+                    }
                     if (testCoverage.testType == TestType.soak) {
                         functionalTestCount++
                     }
                 }
 
                 // hacky way to consider deferred tests
-                val deferredTestCount = if (stage.stageName == StageNames.READY_FOR_NIGHTLY) 10 else 0
+                val deferredTestCount = if (stage.stageName == StageNames.READY_FOR_NIGHTLY) 4 else 0
                 assertEquals(
                stage.specificBuilds.size + functionalTestCount + stage.performanceTests.size + (if (prevStage != null) 1 else 0) + deferredTestCount,
                        it.dependencies.items.size, stage.stageName.stageName)
@@ -203,6 +209,28 @@ class CIConfigIntegrationTests {
         assertFalse(projectFoldersWithUnitTests.isEmpty())
         projectFoldersWithUnitTests.forEach {
             assertTrue(projectsWithUnitTests.map { it.asDirectoryName() }.contains(it.name), "Contains unit tests: $it")
+        }
+    }
+
+    @Test
+    fun allSubprojectsWithOnlyUnitTestsAreInASingleProject() {
+        val model = CIBuildModel()
+        val unitTestBuildTypes = RootProject(model).subProjects
+            .flatMap { it.subProjects }
+            .flatMap { it.buildTypes.filter { it.name.contains("AllUnitTests") } }
+        val unitTestProjects = model.subProjects.filter { it.hasOnlyUnitTests() }
+
+        assertTrue(unitTestBuildTypes.isNotEmpty())
+        unitTestBuildTypes.forEach {
+            val gradleSteps = it.steps.items.filterIsInstance<GradleBuildStep>()
+            assertTrue(gradleSteps.isNotEmpty())
+            gradleSteps.forEach { step ->
+                unitTestProjects.forEach { project ->
+                    if (step.name !in listOf("VERIFY_TEST_FILES_CLEANUP", "KILL_PROCESSES_STARTED_BY_GRADLE", "KILL_PROCESSES_STARTED_BY_GRADLE_RERUN")) {
+                        assertTrue(step.tasks!!.contains(project.name), "Step $step")
+                    }
+                }
+            }
         }
     }
 

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -74,7 +74,7 @@ class CIConfigIntegrationTests {
                         }
                         if (subProject.hasOnlyUnitTests()) {
                             return@forEach
-                        } else if(subProject.unitTests && testCoverage.testType.unitTests) {
+                        } else if (subProject.unitTests && testCoverage.testType.unitTests) {
                             functionalTestCount++
                         } else if (subProject.functionalTests && testCoverage.testType.functionalTests) {
                             functionalTestCount++


### PR DESCRIPTION
So we don't have so many small build types. The unit tests should run
very fast anyway.