### PR TITLE
Deprecate declaring incremental tasks with no outputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
@@ -16,9 +16,13 @@
 
 package org.gradle.api.internal.changedetection.state
 
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.work.InputChanges
 import spock.lang.Issue
+import spock.lang.Unroll
 
+@Unroll
 class TaskTypeUpToDateIntegrationTest extends AbstractIntegrationSpec {
 
     def "task is up-to-date after unrelated change to build script"() {
@@ -174,6 +178,33 @@ class TaskTypeUpToDateIntegrationTest extends AbstractIntegrationSpec {
         succeeds "copy"
 
         then: skipped(":copy")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/9723")
+    def "declaring a task action receiving #incrementalChangesType without declaring outputs is deprecated"() {
+        def input = file('input.txt').createFile()
+        buildFile << """
+            class IncrementalTask extends DefaultTask {
+                @InputFile File input
+             
+                @TaskAction execute(${incrementalChangesType} inputChanges) {
+                }
+            }   
+            
+            task noOutput(type: IncrementalTask) {
+                input = file('${input.name}')
+            }
+        """
+
+        when:
+        executer.expectDeprecationWarning()
+        run 'noOutput'
+        then:
+        outputContains("Using the incremental task API without declaring any outputs has been deprecated. This is scheduled to be removed in Gradle 6.0. Please declare output files for your task or use `task.upToDateWhen { true }`.")
+        noneSkipped()
+
+        where:
+        incrementalChangesType << [IncrementalTaskInputs, InputChanges]*.simpleName
     }
 
     private static String declareSimpleCopyTask(boolean modification = false) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskTypeUpToDateIntegrationTest.groovy
@@ -200,7 +200,7 @@ class TaskTypeUpToDateIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDeprecationWarning()
         run 'noOutput'
         then:
-        outputContains("Using the incremental task API without declaring any outputs has been deprecated. This is scheduled to be removed in Gradle 6.0. Please declare output files for your task or use `task.upToDateWhen { true }`.")
+        outputContains("Using the incremental task API without declaring any outputs has been deprecated. This is scheduled to be removed in Gradle 6.0. Please declare output files for your task or use `TaskOutputs.upToDateWhen()`.")
         noneSkipped()
 
         where:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractIncrementalTasksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractIncrementalTasksIntegrationTest.groovy
@@ -59,6 +59,10 @@ abstract class AbstractIncrementalTasksIntegrationTest extends AbstractIntegrati
         @InputDirectory
         abstract DirectoryProperty getInputDir()
 
+        @Optional
+        @OutputFile
+        abstract RegularFileProperty getOutputFile()
+
         @TaskAction
         $taskAction
 
@@ -211,10 +215,6 @@ abstract class AbstractIncrementalTasksIntegrationTest extends AbstractIntegrati
         inputDir = project.mkdir('inputs')
     }
 """
-        executer.beforeExecute {
-            expectDeprecationWarning()
-        }
-
         and:
         previousExecution()
 
@@ -266,9 +266,6 @@ abstract class AbstractIncrementalTasksIntegrationTest extends AbstractIntegrati
         inputDir = project.mkdir('inputs')
     }
 """
-        executer.beforeExecute {
-            expectDeprecationWarning()
-        }
 
         then:
         executesNonIncrementally()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractIncrementalTasksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractIncrementalTasksIntegrationTest.groovy
@@ -211,6 +211,10 @@ abstract class AbstractIncrementalTasksIntegrationTest extends AbstractIntegrati
         inputDir = project.mkdir('inputs')
     }
 """
+        executer.beforeExecute {
+            expectDeprecationWarning()
+        }
+
         and:
         previousExecution()
 
@@ -262,6 +266,9 @@ abstract class AbstractIncrementalTasksIntegrationTest extends AbstractIntegrati
         inputDir = project.mkdir('inputs')
     }
 """
+        executer.beforeExecute {
+            expectDeprecationWarning()
+        }
 
         then:
         executesNonIncrementally()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1256,6 +1256,9 @@ task generate(type: TransformerTask) {
         project.ext.inputDirs.split(',').each { inputs.dir(it) }
     }
 '''
+        executer.beforeExecute {
+            expectDeprecationWarning()
+        }
 
         when:
         args('-PinputDirs=inputDir1,inputDir2')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1254,7 +1254,7 @@ task generate(type: TransformerTask) {
     
     task myTask (type: MyTask){
         project.ext.inputDirs.split(',').each { inputs.dir(it) }
-        project.upToDateWhen { true }
+        outputs.upToDateWhen { true }
     }
 '''
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1254,11 +1254,9 @@ task generate(type: TransformerTask) {
     
     task myTask (type: MyTask){
         project.ext.inputDirs.split(',').each { inputs.dir(it) }
+        project.upToDateWhen { true }
     }
 '''
-        executer.beforeExecute {
-            expectDeprecationWarning()
-        }
 
         when:
         args('-PinputDirs=inputDir1,inputDir2')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -131,6 +131,10 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
                 @InputFile
                 abstract RegularFileProperty getNonIncrementalInput()
 
+                @Optional
+                @OutputFile
+                abstract RegularFileProperty getOutputFile()
+
                 @Override
                 void execute(InputChanges inputChanges) {
                     inputChanges.getFileChanges(nonIncrementalInput)
@@ -143,9 +147,6 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
             }
         """
         file("nonIncremental").text = "input"
-        executer.beforeExecute {
-            expectDeprecationWarning()
-        }
 
         expect:
         fails("withNonIncrementalInput")
@@ -160,6 +161,10 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
                 @InputFile
                 File nonIncrementalInput
 
+                @Optional
+                @OutputFile
+                abstract RegularFileProperty getOutputFile()
+
                 @Override
                 void execute(InputChanges changes) {
                     super.execute(changes)
@@ -173,9 +178,6 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
             }
         """
         file("nonIncremental").text = "input"
-        executer.beforeExecute {
-            expectDeprecationWarning()
-        }
         run("withNonIncrementalInput")
 
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -143,6 +143,9 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
             }
         """
         file("nonIncremental").text = "input"
+        executer.beforeExecute {
+            expectDeprecationWarning()
+        }
 
         expect:
         fails("withNonIncrementalInput")
@@ -170,6 +173,9 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
             }
         """
         file("nonIncremental").text = "input"
+        executer.beforeExecute {
+            expectDeprecationWarning()
+        }
         run("withNonIncrementalInput")
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskExecutionModeResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/changes/DefaultTaskExecutionModeResolver.java
@@ -43,7 +43,7 @@ public class DefaultTaskExecutionModeResolver implements TaskExecutionModeResolv
         if (!properties.hasDeclaredOutputs() && upToDateSpec.isEmpty()) {
             if (task.hasTaskActions()) {
                 if (requiresInputChanges(task)) {
-                    DeprecationLogger.nagUserOfDeprecated("Using the incremental task API without declaring any outputs", "Please declare output files for your task or use `task.upToDateWhen { true }`.");
+                    DeprecationLogger.nagUserOfDeprecated("Using the incremental task API without declaring any outputs", "Please declare output files for your task or use `TaskOutputs.upToDateWhen()`.");
                 } else {
                     return TaskExecutionMode.NO_OUTPUTS_WITH_ACTIONS;
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.project.taskfactory;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.reflect.Instantiator;
@@ -51,16 +50,6 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
 
     private <S extends Task> S process(S task) {
         TaskClassInfo taskClassInfo = taskClassInfoStore.getTaskClassInfo(task.getClass());
-
-        if (taskClassInfo.isIncremental()) {
-            // Add a dummy upToDateWhen spec: this will force TaskOutputs.hasOutputs() to be true.
-            task.getOutputs().upToDateWhen(new Spec<Task>() {
-                @Override
-                public boolean isSatisfiedBy(Task element) {
-                    return true;
-                }
-            });
-        }
 
         for (TaskActionFactory actionFactory : taskClassInfo.getTaskActionFactories()) {
             ((TaskInternal) task).prependParallelSafeAction(actionFactory.create(instantiator));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -76,7 +76,7 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
             }
         }
 
-        return new TaskClassInfo(incremental, taskActionFactoriesBuilder.build(), cacheable);
+        return new TaskClassInfo(taskActionFactoriesBuilder.build(), cacheable);
     }
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/TaskClassInfo.java
@@ -19,22 +19,16 @@ package org.gradle.api.internal.project.taskfactory;
 import com.google.common.collect.ImmutableList;
 
 public class TaskClassInfo {
-    private final boolean incremental;
     private final ImmutableList<TaskActionFactory> taskActionFactories;
     private final boolean cacheable;
 
-    public TaskClassInfo(boolean incremental, ImmutableList<TaskActionFactory> taskActionFactories, boolean cacheable) {
-        this.incremental = incremental;
+    public TaskClassInfo(ImmutableList<TaskActionFactory> taskActionFactories, boolean cacheable) {
         this.taskActionFactories = taskActionFactories;
         this.cacheable = cacheable;
     }
 
     public ImmutableList<TaskActionFactory> getTaskActionFactories() {
         return taskActionFactories;
-    }
-
-    public boolean isIncremental() {
-        return incremental;
     }
 
     public boolean isCacheable() {

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -55,7 +55,7 @@ This will become an error in Gradle 6.0.
 ==== Declaring an incremental task without outputs
 
 Declaring an <<custom_tasks.adoc#incremental_tasks,incremental task>> without declaring outputs is now deprecated.
-Declare file outputs or use `outputs.upToDateWhen { true }` instead.
+Declare file outputs or use link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#upToDateWhen-groovy.lang.Closure-[TaskOutputs.upToDateWhen()] instead.
 
 This will become an error in Gradle 6.0.
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -52,6 +52,13 @@ Creating `SignOperation` instances directly is now deprecated. Instead, the meth
 
 This will become an error in Gradle 6.0.
 
+==== Declaring an incremental task without outputs
+
+Declaring an <<custom_tasks.adoc#incremental_tasks,incremental task>> without declaring outputs is now deprecated.
+Declare file outputs or use `outputs.upToDateWhen { true }` instead.
+
+This will become an error in Gradle 6.0.
+
 === Potential breaking changes
 
 ==== Task dependencies are honored for task `@Input` properties whose value is a `Property`


### PR DESCRIPTION
#9723

An incremental task should always declare an output. Gradle
automatically declared an upToDate spec for incremental tasks to make
sure this is always the case.

Actually, the implementor of the task should add the spec if the task
does not declare any outputs. We expect nearly all incremental tasks
to already declare outputs.