### PR TITLE
Set JavaInstantExecutionPerformanceTest minimumVersion

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -47,6 +47,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionPerformanc
 
         given:
         runner.targetVersions = ["5.6-20190625073933+0000"]
+        runner.minimumVersion = "5.6-20190625073933+0000"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
         runner.args = ["-Dorg.gradle.unsafe.instant-execution"]


### PR DESCRIPTION
So that historical performance tests don't fail.