### PR TITLE
StaticVersionComparator: add snapshot to SPECIAL_MEANINGS so it's more important that other strings

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 class StaticVersionComparator implements Comparator<Version> {
     private static final Map<String, Integer> SPECIAL_MEANINGS =
-            ImmutableMap.of("dev", -2, "snapshot", -1,"rc", 1, "release", 2, "final", 3);
+            ImmutableMap.of("dev", -2, "snapshot", -1, "rc", 1, "release", 2, "final", 3);
 
     /**
      * Compares 2 versions. Algorithm is inspired by PHP version_compare one.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 class StaticVersionComparator implements Comparator<Version> {
     private static final Map<String, Integer> SPECIAL_MEANINGS =
-            ImmutableMap.of("dev", -2, "snapshot", -1, "rc", 1, "release", 2, "final", 3);
+            ImmutableMap.of("dev", -1, "snapshot", 1, "rc", 2, "release", 3, "final", 4);
 
     /**
      * Compares 2 versions. Algorithm is inspired by PHP version_compare one.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 class StaticVersionComparator implements Comparator<Version> {
     private static final Map<String, Integer> SPECIAL_MEANINGS =
-            ImmutableMap.of("dev", -1, "rc", 1, "release", 2, "final", 3);
+            ImmutableMap.of("dev", -2, "snapshot", -1,"rc", 1, "release", 2, "final", 3);
 
     /**
      * Compares 2 versions. Algorithm is inspired by PHP version_compare one.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -93,6 +93,27 @@ class DefaultVersionComparatorTest extends Specification {
         "a-b-c"     | "a.b"
     }
 
+    def "sorts numbers accordingly for pre-release versions"() {
+        expect:
+        compare(smaller, larger) < 0
+        compare(larger, smaller) > 0
+        compare(smaller, smaller) == 0
+        compare(larger, larger) == 0
+
+        where:
+        smaller                                | larger
+        "1.0.0-snapshot.1"                     | "1.0.0-snapshot.2"
+        "1.0.0-snapshot.20190107234512"        | "1.0.0-snapshot.20190107234513"
+        "1.0.0-snapshot.20190207234512"        | "1.0.0-snapshot.20190707234513"
+        "1.0.0-snapshot.20190207234512"        | "1.0.0-snapshot.20200101000000"
+        "1.0.0-dev.1"                          | "1.0.0-dev.2"
+        "1.0.0-dev.20190107234512"             | "1.0.0-dev.20190107234513"
+        "1.0.0-dev.20190207234512"             | "1.0.0-dev.20190707234513"
+        "1.0.0-dev.20190207234512"             | "1.0.0-dev.20200101000000"
+        "1.0.0-dev.20190207234512"             | "1.0.0-snapshot.20190207234512"
+        "1.0.0-snapshot.20190107234512+branch" | "1.0.0-snapshot.20190107234512+test" //TODO: ideally this should return either of two since + shouldn't be part of comparison because of semantic
+    }
+
     def "gives some special treatment to 'dev', 'snapshot', 'rc', 'release', and 'final' qualifiers"() {
         expect:
         compare(smaller, larger) < 0
@@ -133,12 +154,12 @@ class DefaultVersionComparatorTest extends Specification {
         compare(larger, larger) == 0
 
         where:
-        smaller        | larger
-        "1.0-dev"      | "1.0-a"
-        "1.0-a"        | "1.0-snapshot"
-        "1.0-a"        | "1.0-rc"
-        "1.0-a"        | "1.0-release"
-        "1.0-a"        | "1.0-final"
+        smaller   | larger
+        "1.0-dev" | "1.0-a"
+        "1.0-a"   | "1.0-snapshot"
+        "1.0-a"   | "1.0-rc"
+        "1.0-a"   | "1.0-release"
+        "1.0-a"   | "1.0-final"
     }
 
     def "compares identical versions equal"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -93,7 +93,7 @@ class DefaultVersionComparatorTest extends Specification {
         "a-b-c"     | "a.b"
     }
 
-    def "gives some special treatment to 'dev', 'rc', 'release', and 'final' qualifiers"() {
+    def "gives some special treatment to 'dev', 'snapshot', 'rc', 'release', and 'final' qualifiers"() {
         expect:
         compare(smaller, larger) < 0
         compare(larger, smaller) > 0
@@ -101,22 +101,27 @@ class DefaultVersionComparatorTest extends Specification {
         compare(larger, larger) == 0
 
         where:
-        smaller       | larger
-        "1.0-dev-1"   | "1.0"
-        "1.0-dev-1"   | "1.0-dev-2"
-        "1.0-rc-1"    | "1.0"
-        "1.0-rc-1"    | "1.0-rc-2"
-        "1.0-rc-1"    | "1.0-release"
-        "1.0-dev-1"   | "1.0-xx-1"
-        "1.0-xx-1"    | "1.0-rc-1"
-        "1.0-release" | "1.0"
-        "1.0-final"   | "1.0"
-        "1.0-dev-1"   | "1.0-rc-1"
-        "1.0-rc-1"    | "1.0-final"
-        "1.0-dev-1"   | "1.0-final"
-        "1.0-release" | "1.0-final"
-        "1.0.0.RC1"   | "1.0.0.RC2"
-        "1.0.0.RC2"   | "1.0.0.RELEASE"
+        smaller          | larger
+        "1.0-dev-1"      | "1.0"
+        "1.0-dev-1"      | "1.0-dev-2"
+        "1.0-dev-1"      | "1.0-snapshot-1"
+        "1.0-snapshot-1" | "1.0-rc-1"
+        "1.0-snapshot-1" | "1.0-release"
+        "1.0-snapshot-1" | "1.0-final"
+        "1.0-snapshot-1" | "1.0"
+        "1.0-rc-1"       | "1.0"
+        "1.0-rc-1"       | "1.0-rc-2"
+        "1.0-rc-1"       | "1.0-release"
+        "1.0-dev-1"      | "1.0-xx-1"
+        "1.0-xx-1"       | "1.0-rc-1"
+        "1.0-release"    | "1.0"
+        "1.0-final"      | "1.0"
+        "1.0-dev-1"      | "1.0-rc-1"
+        "1.0-rc-1"       | "1.0-final"
+        "1.0-dev-1"      | "1.0-final"
+        "1.0-release"    | "1.0-final"
+        "1.0.0.RC1"      | "1.0.0.RC2"
+        "1.0.0.RC2"      | "1.0.0.RELEASE"
     }
 
     def "compares special qualifiers against non-special strings"() {
@@ -132,11 +137,6 @@ class DefaultVersionComparatorTest extends Specification {
         "1.0-a"        | "1.0-rc"
         "1.0-a"        | "1.0-release"
         "1.0-a"        | "1.0-final"
-
-        "1.0-dev"      | "1.0-SNAPSHOT"
-        "1.0-SNAPSHOT" | "1.0-rc"
-        "1.0-SNAPSHOT" | "1.0-release"
-        "1.0-SNAPSHOT" | "1.0-final"
     }
 
     def "compares identical versions equal"() {
@@ -176,11 +176,11 @@ class DefaultVersionComparatorTest extends Specification {
         compare(larger, larger) == 0
 
         where:
-        smaller        | larger
-        "1.01"         | "1.2"
-        "1.1"          | "1.02"
-        "01.0"         | "2.0"
-        "1.0"          | "02.0"
+        smaller | larger
+        "1.01"  | "1.2"
+        "1.1"   | "1.02"
+        "01.0"  | "2.0"
+        "1.0"   | "02.0"
     }
 
     def "compares versions where earlier version parts differ only in leading zeros"() {
@@ -191,11 +191,11 @@ class DefaultVersionComparatorTest extends Specification {
         compare(larger, larger) == 0
 
         where:
-        smaller        | larger
-        "01.1"         | "1.2"
-        "1.1"          | "01.2"
-        "1.01.1"       | "1.1.2"
-        "1.1.1"        | "1.01.2"
+        smaller  | larger
+        "01.1"   | "1.2"
+        "1.1"    | "01.2"
+        "1.01.1" | "1.1.2"
+        "1.1.1"  | "1.01.2"
     }
 
     def "compares unrelated versions unequal"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -114,6 +114,7 @@ class DefaultVersionComparatorTest extends Specification {
         "1.0-rc-1"       | "1.0-release"
         "1.0-dev-1"      | "1.0-xx-1"
         "1.0-xx-1"       | "1.0-rc-1"
+        "1.0-xx-1"       | "1.0-snapshot-1"
         "1.0-release"    | "1.0"
         "1.0-final"      | "1.0"
         "1.0-dev-1"      | "1.0-rc-1"
@@ -134,6 +135,7 @@ class DefaultVersionComparatorTest extends Specification {
         where:
         smaller        | larger
         "1.0-dev"      | "1.0-a"
+        "1.0-a"        | "1.0-snapshot"
         "1.0-a"        | "1.0-rc"
         "1.0-a"        | "1.0-release"
         "1.0-a"        | "1.0-final"


### PR DESCRIPTION
### Context
did some digging https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java#L90

Given this:

```
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>test.roberto</groupId>
  <artifactId>dynamic-dependency-test-publishing</artifactId>
  <versioning>
    <release>0.0.2-apple.1</release>
    <versions>
      <version>0.0.2-rc.1</version>
      <version>0.0.2-zc.1</version>
      <version>0.0.2-apple.1</version>
    </versions>
    <lastUpdated>20190709223745</lastUpdated>
  </versioning>
</metadata>
```

you get all the versions, but `sortLatestFirst` does a trick. It sorts the versions with a `versionComparator` (https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java#L237)


This one in particular -> https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java

https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java#L77

https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java#L32

So at the end, no matter what you have… if there’s a `-dev` or `-rc`, it will take those as latest for `latest.release` or a range like `0.+`

Internally we are planinng to do versions like:

1.0.0-snapshot.{timestamp}
1.0.0-rc.1
1.0.0

Is it doable for you to add `snapshot` into that comparator? it seems like having

```
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>test.roberto</groupId>
  <artifactId>dynamic-dependency-test-publishing</artifactId>
  <versioning>
    <release>0.0.2-zc.1</release>
    <versions>
      <version>0.0.2-snapshot.1</version>
      <version>0.0.2-zc.1</version>
    </versions>
    <lastUpdated>20190709223745</lastUpdated>
  </versioning>
</metadata>
```

would pick up the latest release from maven metadata and don’t pick snapshot on this case.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
