### PR TITLE
Exclude @Inject in @since compatibility check

### DIFF
--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
@@ -22,9 +22,7 @@ import japicmp.model.JApiConstructor;
 import japicmp.model.JApiField;
 import japicmp.model.JApiHasAnnotations;
 import japicmp.model.JApiMethod;
-
 import me.champeau.gradle.japicmp.report.Violation;
-
 import org.gradle.binarycompatibility.metadata.KotlinMetadataQueries;
 
 import java.util.Map;
@@ -49,7 +47,7 @@ public class SinceAnnotationMissingRule extends AbstractGradleViolationRule {
     private boolean shouldSkipViolationCheckFor(JApiCompatibility member) {
         return !isClassFieldConstructorOrMethod(member) ||
             isDeprecated(member) ||
-            isInjectConstructor(member) ||
+            isInject(member) ||
             isOverrideMethod(member) ||
             isKotlinFileFacadeClass(member);
     }
@@ -58,8 +56,8 @@ public class SinceAnnotationMissingRule extends AbstractGradleViolationRule {
         return member instanceof JApiClass || member instanceof JApiField || member instanceof JApiConstructor || member instanceof JApiMethod;
     }
 
-    private boolean isInjectConstructor(JApiCompatibility member) {
-        return member instanceof JApiConstructor && isInject((JApiHasAnnotations) member);
+    private boolean isInject(JApiCompatibility member) {
+        return member instanceof JApiHasAnnotations && isInject((JApiHasAnnotations) member);
     }
 
     private boolean isOverrideMethod(JApiCompatibility member) {

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -2,12 +2,6 @@
     "acceptedApiChanges": [
         {
             "type": "org.gradle.api.publish.maven.tasks.AbstractPublishToMaven",
-            "member": "Method org.gradle.api.publish.maven.tasks.AbstractPublishToMaven.getMavenPublishers()",
-            "acceptation": "Injected Service",
-            "changes": []
-        },
-        {
-            "type": "org.gradle.api.publish.maven.tasks.AbstractPublishToMaven",
             "member": "Method org.gradle.api.publish.maven.tasks.AbstractPublishToMaven.getMavenRepositoryLocator()",
             "acceptation": "Replaced by factory service: MavenPublishers",
             "changes": [
@@ -37,18 +31,6 @@
             "changes": [
                 "Method has been removed"
             ]
-        },
-        {
-            "type": "org.gradle.api.publish.maven.tasks.AbstractPublishToMaven",
-            "member": "Method org.gradle.api.publish.maven.tasks.AbstractPublishToMaven.getDuplicatePublicationTracker()",
-            "acceptation": "Injected service",
-            "changes": []
-        },
-        {
-            "type": "org.gradle.api.publish.ivy.tasks.PublishToIvyRepository",
-            "member": "Method org.gradle.api.publish.ivy.tasks.PublishToIvyRepository.getDuplicatePublicationTracker()",
-            "acceptation": "Injected service",
-            "changes": []
         },
         {
             "type": "org.gradle.api.plugins.JavaLibraryPlugin",

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -61,12 +61,6 @@
             "changes": [
                 "Method has been removed"
             ]
-        },
-        {
-            "type": "org.gradle.api.tasks.compile.GroovyCompile",
-            "member": "Method org.gradle.api.tasks.compile.GroovyCompile.getFeaturePreviews()",
-            "acceptation": "Injected property",
-            "changes": []
         }
     ]
 }


### PR DESCRIPTION
# Context

Previously we only exclude `@Inject` getters in `@Incubating` compatibility check but not for `@Since` check. This PR fixes it then removes the unnecessary entries in `accepted-api-changes.json`. 
