### PR TITLE
Full recompilation with annotation processor

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -284,10 +284,14 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         return WorkResults.didWork(true);
     }
 
-    private boolean shouldProcessAnnotations(GroovyJavaJointCompileSpec spec) {
-        return spec.getGroovyCompileOptions().isJavaAnnotationProcessing()
-            && !spec.getAnnotationProcessorPath().isEmpty()
+    public static boolean annotationProcessingConfigured(GroovyJavaJointCompileSpec spec) {
+        return !spec.getAnnotationProcessorPath().isEmpty()
             && !spec.getCompileOptions().getCompilerArgs().contains("-proc:none");
+    }
+
+    private static boolean shouldProcessAnnotations(GroovyJavaJointCompileSpec spec) {
+        return spec.getGroovyCompileOptions().isJavaAnnotationProcessing()
+            && annotationProcessingConfigured(spec);
     }
 
     private void applyConfigurationScript(File configScript, CompilerConfiguration configuration) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -284,14 +284,8 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         return WorkResults.didWork(true);
     }
 
-    public static boolean annotationProcessingConfigured(GroovyJavaJointCompileSpec spec) {
-        return !spec.getAnnotationProcessorPath().isEmpty()
-            && !spec.getCompileOptions().getCompilerArgs().contains("-proc:none");
-    }
-
     private static boolean shouldProcessAnnotations(GroovyJavaJointCompileSpec spec) {
-        return spec.getGroovyCompileOptions().isJavaAnnotationProcessing()
-            && annotationProcessingConfigured(spec);
+        return spec.getGroovyCompileOptions().isJavaAnnotationProcessing() && spec.annotationProcessingConfigured();
     }
 
     private void applyConfigurationScript(File configScript, CompilerConfiguration configuration) {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -79,7 +79,6 @@ import java.util.concurrent.Callable;
 import java.util.stream.StreamSupport;
 
 import static org.gradle.api.internal.FeaturePreviews.Feature.GROOVY_COMPILATION_AVOIDANCE;
-import static org.gradle.api.internal.tasks.compile.ApiGroovyCompiler.annotationProcessingConfigured;
 import static org.gradle.api.internal.tasks.compile.SourceClassesMappingFileAccessor.readSourceClassesMappingFile;
 import static org.gradle.api.internal.tasks.compile.SourceClassesMappingFileAccessor.writeSourceClassesMappingFile;
 
@@ -275,10 +274,11 @@ public class GroovyCompile extends AbstractCompile {
         if (getOptions().isIncremental() && spec.getSourceRoots().isEmpty()) {
             DeprecationLogger.nagUserOfDeprecatedBehaviour("Unable to infer source roots. Incremental Groovy compilation requires the source roots and has been disabled. Change the configuration of your sources or disable incremental Groovy compilation.");
         }
-        if (getOptions().isIncremental() && annotationProcessingConfigured(spec)) {
-            DeprecationLogger.nagUserOfDeprecatedBehaviour("Annotation processing is not supported when incremental Groovy compilation is enabled.");
+        if (getOptions().isIncremental() && spec.annotationProcessingConfigured()) {
+            DeprecationLogger.nagUserOfDeprecated("Incremental Groovy compilation has been disabled since Java annotation processors are configured. Enabling incremental compilation and configuring Java annotation processors for Groovy compilation",
+                "Disable incremental Groovy compilation or remove the Java annotation processor configuration.");
         }
-        return getOptions().isIncremental() && !spec.getSourceRoots().isEmpty() && !annotationProcessingConfigured(spec);
+        return getOptions().isIncremental() && !spec.getSourceRoots().isEmpty() && !spec.annotationProcessingConfigured();
     }
 
     private DefaultGroovyJavaJointCompileSpec createSpec() {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -275,7 +275,8 @@ public class GroovyCompile extends AbstractCompile {
             DeprecationLogger.nagUserOfDeprecatedBehaviour("Unable to infer source roots. Incremental Groovy compilation requires the source roots and has been disabled. Change the configuration of your sources or disable incremental Groovy compilation.");
         }
         if (getOptions().isIncremental() && spec.annotationProcessingConfigured()) {
-            DeprecationLogger.nagUserOfDeprecated("Incremental Groovy compilation has been disabled since Java annotation processors are configured. Enabling incremental compilation and configuring Java annotation processors for Groovy compilation",
+            DeprecationLogger.nagUserOfDeprecated(
+                "Incremental Groovy compilation has been disabled since Java annotation processors are configured. Enabling incremental compilation and configuring Java annotation processors for Groovy compilation",
                 "Disable incremental Groovy compilation or remove the Java annotation processor configuration.");
         }
         return getOptions().isIncremental() && !spec.getSourceRoots().isEmpty() && !spec.annotationProcessingConfigured();

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -79,6 +79,7 @@ import java.util.concurrent.Callable;
 import java.util.stream.StreamSupport;
 
 import static org.gradle.api.internal.FeaturePreviews.Feature.GROOVY_COMPILATION_AVOIDANCE;
+import static org.gradle.api.internal.tasks.compile.ApiGroovyCompiler.annotationProcessingConfigured;
 import static org.gradle.api.internal.tasks.compile.SourceClassesMappingFileAccessor.readSourceClassesMappingFile;
 import static org.gradle.api.internal.tasks.compile.SourceClassesMappingFileAccessor.writeSourceClassesMappingFile;
 
@@ -274,7 +275,10 @@ public class GroovyCompile extends AbstractCompile {
         if (getOptions().isIncremental() && spec.getSourceRoots().isEmpty()) {
             DeprecationLogger.nagUserOfDeprecatedBehaviour("Unable to infer source roots. Incremental Groovy compilation requires the source roots and has been disabled. Change the configuration of your sources or disable incremental Groovy compilation.");
         }
-        return getOptions().isIncremental() && !spec.getSourceRoots().isEmpty();
+        if (getOptions().isIncremental() && annotationProcessingConfigured(spec)) {
+            DeprecationLogger.nagUserOfDeprecatedBehaviour("Annotation processing is not supported when incremental Groovy compilation is enabled.");
+        }
+        return getOptions().isIncremental() && !spec.getSourceRoots().isEmpty() && !annotationProcessingConfigured(spec);
     }
 
     private DefaultGroovyJavaJointCompileSpec createSpec() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
@@ -44,4 +44,8 @@ public interface JavaCompileSpec extends JvmLanguageCompileSpec {
     Set<String> getClasses();
 
     List<File> getModulePath();
+
+    default boolean annotationProcessingConfigured() {
+        return !getAnnotationProcessorPath().isEmpty() && !getCompileOptions().getCompilerArgs().contains("-proc:none");
+    }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -77,7 +77,6 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         groovyClassFile('Groovy.class').exists()
         groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
         groovyClassFile('Groovy$$Generated.class').exists()
-        outputDoesNotContain('Annotation processing is not supported when incremental Groovy compilation is enabled.')
     }
 
     def "disableIncrementalCompilationWithAnnotationProcessor"() {
@@ -99,21 +98,10 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
         groovyClassFile('Groovy$$Generated.class').exists()
         outputContains(
-            ['Incremental Groovy compilation has been disabled since Java annotation processors are configured.',
-             ' Enabling incremental compilation and configuring Java annotation processors for Groovy compilation has been deprecated.',
-             ' This is scheduled to be removed in Gradle 6.0.',
-             ' Disable incremental Groovy compilation or remove the Java annotation processor configuration.'].join(''))
-
-        when:
-        writeAnnotationProcessingBuild(
-            "", // no Java
-            "$annotationText class Groovy { int i }"
-        )
-
-        then:
-        executer.expectDeprecationWarning()
-        succeeds("compileGroovy")
-        outputContains('Incremental Groovy compilation has been disabled since Java annotation processors are configured')
+            'Incremental Groovy compilation has been disabled since Java annotation processors are configured.' +
+                ' Enabling incremental compilation and configuring Java annotation processors for Groovy compilation has been deprecated.' +
+                ' This is scheduled to be removed in Gradle 6.0.' +
+                ' Disable incremental Groovy compilation or remove the Java annotation processor configuration.')
     }
 
     def "compileBadCodeWithAnnotationProcessor"() {
@@ -701,10 +689,10 @@ ${compilerConfiguration()}
         """
 
         if (java) {
-            file("src/main/groovy/Java.java").text = java
+            file("src/main/groovy/Java.java") << java
         }
         if (groovy) {
-            file("src/main/groovy/Groovy.groovy").text = groovy
+            file("src/main/groovy/Groovy.groovy") << groovy
         }
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -27,6 +27,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.fixture.GroovyCoverage
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import org.junit.Assume
 import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -61,9 +62,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "compileWithAnnotationProcessor"() {
-        if (versionLowerThan("1.7")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("1.7"))
 
         when:
         writeAnnotationProcessingBuild(
@@ -82,9 +81,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "disableIncrementalCompilationWithAnnotationProcessor"() {
-        if (versionLowerThan("1.7")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("1.7"))
 
         when:
         writeAnnotationProcessingBuild(
@@ -101,7 +98,11 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         groovyClassFile('Groovy.class').exists()
         groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
         groovyClassFile('Groovy$$Generated.class').exists()
-        outputContains('Annotation processing is not supported when incremental Groovy compilation is enabled.')
+        outputContains(
+            ['Incremental Groovy compilation has been disabled since Java annotation processors are configured.',
+             ' Enabling incremental compilation and configuring Java annotation processors for Groovy compilation has been deprecated.',
+             ' This is scheduled to be removed in Gradle 6.0.',
+             ' Disable incremental Groovy compilation or remove the Java annotation processor configuration.'].join(''))
 
         when:
         writeAnnotationProcessingBuild(
@@ -112,13 +113,11 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         then:
         executer.expectDeprecationWarning()
         succeeds("compileGroovy")
-        outputContains('Annotation processing is not supported when incremental Groovy compilation is enabled.')
+        outputContains('Incremental Groovy compilation has been disabled since Java annotation processors are configured')
     }
 
     def "compileBadCodeWithAnnotationProcessor"() {
-        if (versionLowerThan("1.7")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("1.7"))
 
         when:
         writeAnnotationProcessingBuild(
@@ -209,9 +208,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "jointCompileWithAnnotationProcessor"() {
-        if (versionLowerThan("1.7")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("1.7"))
 
         when:
         writeAnnotationProcessingBuild(
@@ -250,9 +247,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "jointCompileBadCodeWithAnnotationProcessor"() {
-        if (versionLowerThan("1.7")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("1.7"))
 
         when:
         writeAnnotationProcessingBuild(
@@ -338,9 +333,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "groovyToolClassesAreNotVisible"() {
-        if (versionLowerThan("2.0")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("2.0"))
 
         groovyDependency = "org.codehaus.groovy:groovy:$version"
 
@@ -384,9 +377,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "configurationScriptNotSupported"() {
-        if (!versionLowerThan("2.1")) {
-            return
-        }
+        Assume.assumeTrue(versionLowerThan("2.1"))
 
         expect:
         fails("compileGroovy")
@@ -394,9 +385,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "useConfigurationScript"() {
-        if (versionLowerThan("2.1")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("2.1"))
 
         expect:
         fails("compileGroovy")
@@ -404,18 +393,15 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     }
 
     def "failsBecauseOfMissingConfigFile"() {
-        if (versionLowerThan("2.1")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("2.1"))
+
         expect:
         fails("compileGroovy")
         failure.assertHasCause("File '${file('groovycompilerconfig.groovy')}' specified for property 'groovyOptions.configurationScript' does not exist.")
     }
 
     def "failsBecauseOfInvalidConfigFile"() {
-        if (versionLowerThan("2.1")) {
-            return
-        }
+        Assume.assumeFalse(versionLowerThan("2.1"))
         expect:
         fails("compileGroovy")
         failure.assertHasCause("Could not execute Groovy compiler configuration script: ${file('groovycompilerconfig.groovy')}")


### PR DESCRIPTION
### Context

This fixes #9871 

We don't want to support annotation processing with incremental Groovy compilation because there're too many complicated corner cases - we simply disable Groovy incremental compilation if any Java annotation processors detected.