### PR TITLE
Merge build types running only unit tests

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -7,15 +7,21 @@ import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
-    uuid = testCoverage.asConfigurationId(model, subProject)
+class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProjects: List<String> = listOf(), stage: Stage, buildTypeName: String = "") : BaseGradleBuildType(model, stage = stage, init = {
+    val coverageName = if (subProjects.size > 1)  buildTypeName else subProjects.joinToString("")
+    uuid = testCoverage.asConfigurationId(model, coverageName)
     id = AbsoluteId(uuid)
-    name = testCoverage.asName() + if (!subProject.isEmpty()) " ($subProject)" else ""
-    val testTask = if (!subProject.isEmpty()) {
-        subProject + ":"
-    } else {
-        ""
-    } + testCoverage.testType.name + "Test"
+    name = testCoverage.asName() + if (coverageName.isEmpty()) "" else " ($coverageName)"
+    description = "${testCoverage.asName()} for ${when (subProjects.size) {
+        0 -> "all projects "
+        1 -> "project ${subProjects.joinToString("")}"
+        else -> "projects ${subProjects.joinToString(", ")}"
+    }}"
+    val testTaskName = "${testCoverage.testType.name}Test"
+    val testTasks = if (subProjects.isEmpty())
+        testTaskName
+    else
+        subProjects.map { "$it:$testTaskName" }.joinToString(" ")
     val quickTest = testCoverage.testType == TestType.quick
     val buildScanTags = listOf("FunctionalTest")
     val buildScanValues = mapOf(
@@ -23,7 +29,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
             "coverageJvmVendor" to testCoverage.vendor.name,
             "coverageJvmVersion" to testCoverage.testJvmVersion.name
     )
-    applyTestDefaults(model, this, testTask, notQuick = !quickTest, os = testCoverage.os,
+    applyTestDefaults(model, this, testTasks, notQuick = !quickTest, os = testCoverage.os,
             extraParameters = (
                     listOf(""""-PtestJavaHome=%${testCoverage.os}.${testCoverage.testJvmVersion}.${testCoverage.vendor}.64bit%"""")
                             + buildScanTags.map { buildScanTag(it) }

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -16,7 +16,7 @@ import model.TestType
 import model.Trigger
 import projects.FunctionalTestProject
 
-class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean, rootProjectUuid: String) : BaseGradleBuildType(model, init = {
+class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean) : BaseGradleBuildType(model, init = {
     uuid = stageTriggerUuid(model, stage)
     id = stageTriggerId(model, stage)
     name = stage.stageName.stageName + " (Trigger)"
@@ -117,10 +117,9 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
             val isSplitIntoBuckets = testCoverage.testType != TestType.soak
             if (isSplitIntoBuckets) {
                 model.subProjects.forEach { subProject ->
-                    if (shouldBeSkipped(subProject, testCoverage)) {
-                        return@forEach
-                    }
-                    if (subProject.containsSlowTests && stage.omitsSlowProjects) {
+                    if (shouldBeSkipped(subProject, testCoverage)
+                        || stage.shouldOmitSlowProject(subProject)
+                        || !subProject.hasSeparateTestBuild(testCoverage.testType)) {
                         return@forEach
                     }
                     if (subProject.unitTests && testCoverage.testType.unitTests) {
@@ -130,6 +129,9 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
                     } else if (subProject.crossVersionTests && testCoverage.testType.crossVersionTests) {
                         dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProject.name))) { snapshot {} }
                     }
+                }
+                if (model.subProjects.any { it.includeInMergedTestBuild(testCoverage.testType) }) {
+                    dependency(AbsoluteId(testCoverage.asConfigurationId(model, FunctionalTestProject.allUnitTestsBuildTypeName))) { snapshot {} }
                 }
             } else {
                 dependency(AbsoluteId(testCoverage.asConfigurationId(model))) {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -205,6 +205,12 @@ data class GradleSubproject(val name: String, val unitTests: Boolean = true, val
     }
 
     fun hasTestsOf(type: TestType) = (unitTests && type.unitTests) || (functionalTests && type.functionalTests) || (crossVersionTests && type.crossVersionTests)
+
+    fun hasOnlyUnitTests() = unitTests && !functionalTests && !crossVersionTests
+
+    fun hasSeparateTestBuild(type: TestType) = hasTestsOf(type) && !hasOnlyUnitTests()
+
+    fun includeInMergedTestBuild(type: TestType) = hasTestsOf(type) && hasOnlyUnitTests()
 }
 
 interface StageName {
@@ -218,6 +224,8 @@ interface StageName {
 
 data class Stage(val stageName: StageName, val specificBuilds: List<SpecificBuild> = emptyList(), val performanceTests: List<PerformanceTestType> = emptyList(), val functionalTests: List<TestCoverage> = emptyList(), val trigger: Trigger = Trigger.never, val functionalTestsDependOnSpecificBuilds: Boolean = false, val runsIndependent: Boolean = false, val omitsSlowProjects : Boolean = false, val dependsOnSanityCheck: Boolean = false) {
     val id = stageName.id
+
+    fun shouldOmitSlowProject(project: GradleSubproject) = project.containsSlowTests && omitsSlowProjects
 }
 
 data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val testJvmVersion: JvmVersion, val vendor: JvmVendor = JvmVendor.oracle, val buildJvmVersion: JvmVersion = JvmVersion.java11) {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -17,18 +17,29 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
         if (shouldBeSkipped(subProject, testConfig)) {
             return@forEach
         }
-        if (subProject.containsSlowTests && stage.omitsSlowProjects) {
+        if (stage.shouldOmitSlowProject(subProject)) {
             addMissingTestCoverage(testConfig)
             return@forEach
         }
 
-        if (subProject.hasTestsOf(testConfig.testType)) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+        if (subProject.hasSeparateTestBuild(testConfig.testType)) {
+            buildType(FunctionalTest(model, testConfig, listOf(subProject.name), stage))
         }
     }
+
+    val projectNamesForMergedTestsBuild = model.subProjects
+        .filter { it.includeInMergedTestBuild(testConfig.testType) }
+        .map { it.name }
+
+    if (projectNamesForMergedTestsBuild.isNotEmpty()) {
+        buildType(FunctionalTest(model, testConfig, projectNamesForMergedTestsBuild, stage, allUnitTestsBuildTypeName))
+    }
+
 }){
     companion object {
-        val missingTestCoverage = mutableListOf<TestCoverage>()
+        const val allUnitTestsBuildTypeName = "AllUnitTests"
+
+        val missingTestCoverage = mutableSetOf<TestCoverage>()
 
         private fun addMissingTestCoverage(coverage: TestCoverage) {
             this.missingTestCoverage.add(coverage)

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -28,10 +28,11 @@ class RootProject(model: CIBuildModel) : Project({
 
     var prevStage: Stage? = null
     var deferredAlreadyDeclared = false
+    FunctionalTestProject.missingTestCoverage.clear()
     model.stages.forEach { stage ->
         val containsDeferredTests = !stage.omitsSlowProjects && !deferredAlreadyDeclared
         deferredAlreadyDeclared = deferredAlreadyDeclared || containsDeferredTests
-        buildType(StagePasses(model, stage,  prevStage, containsDeferredTests, uuid))
+        buildType(StagePasses(model, stage,  prevStage, containsDeferredTests))
         subProject(StageProject(model, stage, containsDeferredTests, uuid))
         prevStage = stage
     }

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -70,7 +70,7 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
                             subProject.hasTestsOf(testConfig.testType)
                         }
                         .forEach { testConfig ->
-                            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+                            buildType(FunctionalTest(model, testConfig, listOf(subProject.name), stage))
                         }
                 }
         }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -14,6 +14,10 @@ class BuildTypesPlugin : Plugin<Project> {
         extensions.add("buildTypes", buildTypes)
         buildTypes.all {
             register(this)
+            val activeBuildTypes = buildTypes.filter { it.active }
+            require(activeBuildTypes.size <= 1) {
+                "Only one build type can be active. Active build types: ${activeBuildTypes.joinToString(", ") { it.name }}"
+            }
         }
     }
 
@@ -31,16 +35,19 @@ class BuildTypesPlugin : Plugin<Project> {
         }
 
         val invokedTaskNames = gradle.startParameter.taskNames
-        buildType.findUsedTaskNameAndIndexIn(invokedTaskNames)?.let { (usedName, index) ->
+        val usedTaskNames = buildType.findUsedTaskNamesWithIndexIn(invokedTaskNames).reversed()
+        usedTaskNames.forEach { (_, usedName) ->
             require(usedName.isNotEmpty())
-            if (!isTaskHelpInvocation(invokedTaskNames, index)) {
-                buildType.active = true
-                buildType.onProjectProperties = { properties: ProjectProperties ->
-                    properties.forEach { (name, value) ->
-                        project.setOrCreateProperty(name, value)
-                    }
+            buildType.active = true
+            buildType.onProjectProperties = { properties: ProjectProperties ->
+                properties.forEach { (name, value) ->
+                    project.setOrCreateProperty(name, value)
                 }
-                afterEvaluate {
+            }
+        }
+        if (usedTaskNames.isNotEmpty()) {
+            afterEvaluate {
+                usedTaskNames.forEach { (index, usedName) ->
                     invokedTaskNames.removeAt(index)
 
                     val subproject = usedName.substringBeforeLast(":", "")
@@ -53,16 +60,12 @@ class BuildTypesPlugin : Plugin<Project> {
     }
 
     private
-    fun BuildType.findUsedTaskNameAndIndexIn(taskNames: List<String>): Pair<String, Int>? {
+    fun BuildType.findUsedTaskNamesWithIndexIn(taskNames: List<String>): List<IndexedValue<String>> {
         val candidates = arrayOf(name, abbreviation)
         val nameSuffix = ":$name"
         val abbreviationSuffix = ":$abbreviation"
-        return taskNames.indexOfFirst {
-            it in candidates || it.endsWith(nameSuffix) || it.endsWith(abbreviationSuffix)
-        }.takeIf {
-            it >= 0
-        }?.let {
-            taskNames[it] to it
+        return taskNames.withIndex().filter { (index, taskName) ->
+            (taskName in candidates || taskName.endsWith(nameSuffix) || taskName.endsWith(abbreviationSuffix)) && !isTaskHelpInvocation(taskNames, index)
         }
     }
 


### PR DESCRIPTION
So we don't have so many small build types. The unit tests should run
very fast anyway.

Another try for #9895, now supporting the invocation of built types on multiple subprojects.