### PR TITLE
Rebaseline `configure largeJavaMultiProject` performance test

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -31,7 +31,7 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['help']
-        runner.targetVersions = ["5.5-20190515115345+0000"]
+        runner.targetVersions = ["5.6-20190627000039+0000"]
 
         when:
         def result = runner.run()


### PR DESCRIPTION
As a 2-3% regression has been going on for some time now.

Signed-off-by: Rodrigo B. de Oliveira <rodrigo@gradle.com>
