### PR TITLE
Capture the array type when isolating an array

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
@@ -128,14 +128,14 @@ public class DefaultValueSnapshotter implements ValueSnapshotter, IsolatableFact
         if (value.getClass().isArray()) {
             int length = Array.getLength(value);
             if (length == 0) {
-                return visitor.emptyArray();
+                return visitor.emptyArray(value.getClass().getComponentType());
             }
             ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(length);
             for (int i = 0; i < length; i++) {
                 Object element = Array.get(value, i);
                 builder.add(processValue(element, visitor));
             }
-            return visitor.array(builder.build());
+            return visitor.array(builder.build(), value.getClass().getComponentType());
         }
         if (value instanceof Attribute) {
             return visitor.attributeValue((Attribute<?>) value);
@@ -199,9 +199,9 @@ public class DefaultValueSnapshotter implements ValueSnapshotter, IsolatableFact
 
         T fromIsolatable(Isolatable<?> value);
 
-        T emptyArray();
+        T emptyArray(Class<?> arrayType);
 
-        T array(ImmutableList<T> elements);
+        T array(ImmutableList<T> elements, Class<?> arrayType);
 
         T emptyList();
 
@@ -292,12 +292,12 @@ public class DefaultValueSnapshotter implements ValueSnapshotter, IsolatableFact
         }
 
         @Override
-        public ValueSnapshot emptyArray() {
+        public ValueSnapshot emptyArray(Class<?> arrayType) {
             return ArrayValueSnapshot.EMPTY;
         }
 
         @Override
-        public ValueSnapshot array(ImmutableList<ValueSnapshot> elements) {
+        public ValueSnapshot array(ImmutableList<ValueSnapshot> elements, Class<?> arrayType) {
             return new ArrayValueSnapshot(elements);
         }
 
@@ -402,13 +402,13 @@ public class DefaultValueSnapshotter implements ValueSnapshotter, IsolatableFact
         }
 
         @Override
-        public Isolatable<?> emptyArray() {
-            return IsolatedArray.EMPTY;
+        public Isolatable<?> emptyArray(Class<?> arrayType) {
+            return IsolatedArray.empty(arrayType);
         }
 
         @Override
-        public Isolatable<?> array(ImmutableList<Isolatable<?>> elements) {
-            return new IsolatedArray(elements);
+        public Isolatable<?> array(ImmutableList<Isolatable<?>> elements, Class<?> arrayType) {
+            return new IsolatedArray(elements, arrayType);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedArray.java
@@ -21,12 +21,15 @@ import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.Array;
 
 public class IsolatedArray extends AbstractArraySnapshot<Isolatable<?>> implements Isolatable<Object[]> {
-    public static final IsolatedArray EMPTY = new IsolatedArray(ImmutableList.of());
+    public static final IsolatedArray EMPTY = empty(Object.class);
+    private final Class<?> arrayType;
 
-    public IsolatedArray(ImmutableList<Isolatable<?>> elements) {
+    public IsolatedArray(ImmutableList<Isolatable<?>> elements, Class<?> arrayType) {
         super(elements);
+        this.arrayType = arrayType;
     }
 
     @Override
@@ -43,7 +46,7 @@ public class IsolatedArray extends AbstractArraySnapshot<Isolatable<?>> implemen
 
     @Override
     public Object[] isolate() {
-        Object[] toReturn = new Object[elements.size()];
+        Object[] toReturn = (Object[]) Array.newInstance(arrayType, elements.size());
         for (int i = 0; i < elements.size(); i++) {
             Isolatable<?> element = elements.get(i);
             toReturn[i] = element.isolate();
@@ -55,5 +58,13 @@ public class IsolatedArray extends AbstractArraySnapshot<Isolatable<?>> implemen
     @Override
     public <S> S coerce(Class<S> type) {
         return null;
+    }
+
+    public Class<?> getArrayType() {
+        return arrayType;
+    }
+
+    public static IsolatedArray empty(Class<?> arrayType) {
+        return new IsolatedArray(ImmutableList.of(), arrayType);
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -266,6 +266,7 @@ class DefaultValueSnapshotterTest extends Specification {
         isolated1 instanceof IsolatedArray
         def copy1 = isolated1.isolate()
         copy1 == [] as String[]
+        copy1.class == String[].class
         !copy1.is(original1)
 
         def original2 = ["123"] as String[]
@@ -273,6 +274,7 @@ class DefaultValueSnapshotterTest extends Specification {
         isolated2 instanceof IsolatedArray
         def copy2 = isolated2.isolate()
         copy2 == ["123"] as String[]
+        copy2.class == String[].class
         !copy2.is(original2)
     }
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -118,6 +118,28 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         isolationMode << ISOLATION_MODES
     }
 
+    def "can provide array parameters with isolation mode #isolationMode"() {
+        buildFile << """
+            ext.testObject = ["foo", "bar"] as String[]
+
+            ${parameterRunnableWithType('String[]', 'println param.join(",")') }
+
+            task runWork(type: ParameterTask) {
+                isolationMode = ${isolationMode}
+                params = [testObject]
+            } 
+        """
+
+        when:
+        succeeds("runWork")
+
+        then:
+        outputContains("foo,bar")
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
     def "can provide list property parameters with isolation mode #isolationMode"() {
         buildFile << """
             ext.testObject = objects.listProperty(String)

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
@@ -475,14 +475,16 @@ public class IsolatableSerializerRegistry extends DefaultSerializerRegistry {
         @Override
         public void write(Encoder encoder, IsolatedArray value) throws Exception {
             encoder.writeByte(ISOLATED_ARRAY);
+            encoder.writeString(value.getArrayType().getName());
             writeIsolatableSequence(encoder, value.getElements());
         }
 
         @Override
         public IsolatedArray read(Decoder decoder) throws Exception {
             ImmutableList.Builder<Isolatable<?>> builder = ImmutableList.builder();
+            Class<?> arrayType = fromClassName(decoder.readString());
             readIsolatableSequence(decoder, builder);
-            return new IsolatedArray(builder.build());
+            return new IsolatedArray(builder.build(), arrayType);
         }
 
         @Override

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
@@ -278,6 +278,9 @@ class IsolatableSerializerRegistryTest extends Specification {
 
         then:
         newIsolatables[0].isolate() == array
+
+        and:
+        newIsolatables[0].isolate().class == String[].class
     }
 
     def "can serialize/deserialize isolated List"() {


### PR DESCRIPTION
When we construct an `Object[]` coming out of `isolate()` we lose the ability to use the object type to select a constructor when instantiating a `Runnable` with the worker API.  This captures the array types so that we can construct a properly typed array when we isolate the parameter.