### PR TITLE
Display branch name in flakiness detection report

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -58,9 +58,6 @@ import java.util.zip.ZipInputStream
 @CompileStatic
 @CacheableTask
 class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
-    @Internal
-    String branchName
-
     @Input
     String buildTypeId
 

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -32,6 +32,9 @@ import org.openmbee.junit.model.JUnitTestSuite
 @CompileStatic
 abstract class ReportGenerationPerformanceTest extends PerformanceTest {
     @Internal
+    String branchName
+
+    @Internal
     String buildId
 
     @OutputDirectory
@@ -52,6 +55,7 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
                 spec.args(reportDir.path, resultsJson.path, getProject().getName())
                 spec.systemProperties(databaseParameters)
                 spec.systemProperty("org.gradle.performance.execution.channel", channel)
+                spec.systemProperty("org.gradle.performance.execution.branch", branchName)
                 spec.systemProperty("githubToken", project.findProperty("githubToken"))
                 spec.setClasspath(ReportGenerationPerformanceTest.this.getClasspath())
             }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzer.groovy
@@ -78,6 +78,7 @@ class DefaultPerformanceFlakinessAnalyzer implements PerformanceFlakinessAnalyze
 ${FROM_BOT_PREFIX}
 
 Coordinator url: https://builds.gradle.org/viewLog.html?buildId=${System.getenv("BUILD_ID")}
+Branch: ${System.getProperty('org.gradle.performance.execution.branch')}
 Worker url: ${scenario.webUrl}
 Agent: [${scenario.agentName}](${scenario.agentUrl})
 Details:

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzer.groovy
@@ -34,6 +34,7 @@ import static org.gradle.ci.github.GitHubIssuesClient.TEST_NAME_PREFIX
 
 @CompileStatic
 class DefaultPerformanceFlakinessAnalyzer implements PerformanceFlakinessAnalyzer {
+    static final String BRANCH_PROPERTY_NAME = "org.gradle.performance.execution.branch";
     static final String GITHUB_FIX_IT_LABEL = "fix-it"
     static final String GITHUB_IN_PERFORMANCE_LABEL = "in:performance"
     private final GitHubIssuesClient gitHubIssuesClient
@@ -78,7 +79,7 @@ class DefaultPerformanceFlakinessAnalyzer implements PerformanceFlakinessAnalyze
 ${FROM_BOT_PREFIX}
 
 Coordinator url: https://builds.gradle.org/viewLog.html?buildId=${System.getenv("BUILD_ID")}
-Branch: ${System.getProperty('org.gradle.performance.execution.branch')}
+Branch: ${System.getProperty(BRANCH_PROPERTY_NAME)}
 Worker url: ${scenario.webUrl}
 Agent: [${scenario.agentName}](${scenario.agentUrl})
 Details:

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzerTest.groovy
@@ -23,10 +23,12 @@ import org.kohsuke.github.GHIssue
 import org.kohsuke.github.GHIssueState
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.util.environment.RestoreSystemProperties
 
 import static org.gradle.ci.github.GitHubIssuesClient.CI_TRACKED_FLAKINESS_LABEL
 import static DefaultPerformanceFlakinessAnalyzer.GITHUB_FIX_IT_LABEL
 import static DefaultPerformanceFlakinessAnalyzer.GITHUB_IN_PERFORMANCE_LABEL
+import static org.gradle.performance.results.DefaultPerformanceFlakinessAnalyzer.*
 
 class DefaultPerformanceFlakinessAnalyzerTest extends Specification {
     GitHubIssuesClient issuesClient = Mock(GitHubIssuesClient)
@@ -47,8 +49,10 @@ class DefaultPerformanceFlakinessAnalyzerTest extends Specification {
         ]
     )
 
+    @RestoreSystemProperties
     def 'known flaky issue gets commented, reopened and labeled as fix-it'() {
         given:
+        System.setProperty(BRANCH_PROPERTY_NAME, 'my-branch')
         GHIssue issue = Mock(GHIssue)
         1 * flakyTestProvider.knownInvalidFailures >> [new FlakyTest(name: 'my.AwesomeClass.otherScenario'), new FlakyTest(name: 'my.AwesomeClass.myScenario', issue: issue)]
         1 * issue.state >> GHIssueState.CLOSED
@@ -64,6 +68,7 @@ class DefaultPerformanceFlakinessAnalyzerTest extends Specification {
 FROM-BOT
 
 Coordinator url: https://builds.gradle.org/viewLog.html?buildId=${System.getenv("BUILD_ID")}
+Branch: my-branch
 Worker url: myUrl
 Agent: [myAgent](myAgentUrl)
 Details:
@@ -97,6 +102,7 @@ MESSAGE: we're slower than
 FROM-BOT
 
 Coordinator url: https://builds.gradle.org/viewLog.html?buildId=${System.getenv("BUILD_ID")}
+Branch: ${System.getProperty('org.gradle.performance.execution.branch')}
 Worker url: myUrl
 Agent: [myAgent](myAgentUrl)
 Details:


### PR DESCRIPTION
This closes https://github.com/gradle/gradle-private/issues/2315

This PR displays branch name in flakiness detection report to avoid confusion.