### PR TITLE
Use asciidoc C++ macro to avoid documentation artifacts

### DIFF
--- a/subprojects/docs/src/docs/userguide/building_cpp_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/building_cpp_projects.adoc
@@ -13,36 +13,36 @@
 // limitations under the License.
 
 [[building_cpp_projects]]
-= Building C++ projects
+= Building {cpp} projects
 
 Gradle uses a convention-over-configuration approach to building native projects.
 If you are coming from another native build system, these concepts may be unfamiliar at first, but they serve a purpose to simplify build script authoring.
 
-We will look at C\++ projects in detail in this chapter, but most of the topics will apply to other supported native languages as well.
-If you don’t have much experience with building native projects with Gradle, take a look at the C++ tutorials for step-by-step instructions on how to build various types of basic C++ projects as well as some common use cases.
+We will look at {cpp} projects in detail in this chapter, but most of the topics will apply to other supported native languages as well.
+If you don’t have much experience with building native projects with Gradle, take a look at the {cpp} tutorials for step-by-step instructions on how to build various types of basic {cpp} projects as well as some common use cases.
 
-The C++ plugins covered in this chapter were https://blog.gradle.org/introducing-the-new-cpp-plugins[introduced in 2018] and we recommend users to use those plugins over <<native_software.adoc#native_binaries,the older Native plugins>> that you may find references to.
+The {cpp} plugins covered in this chapter were https://blog.gradle.org/introducing-the-new-cpp-plugins[introduced in 2018] and we recommend users to use those plugins over <<native_software.adoc#native_binaries,the older Native plugins>> that you may find references to.
 
 [[sec:cpp_introduction]]
 == Introduction
 
-The simplest build script for a C\++ project applies the C++ application plugin or the C++ library plugin and optionally sets the project version:
+The simplest build script for a {cpp} project applies the {cpp} application plugin or the {cpp} library plugin and optionally sets the project version:
 
-.Applying the C++ Plugin
+.Applying the {cpp} Plugin
 ====
 include::sample[dir="userguide/cpp/basic/groovy",files="build.gradle[tags=apply-cpp-plugin]"]
 include::sample[dir="userguide/cpp/basic/kotlin",files="build.gradle.kts[tags=apply-cpp-plugin]"]
 ====
 
-By applying either of the C++ plugins, you get a whole host of features:
+By applying either of the {cpp} plugins, you get a whole host of features:
 
- * `compileDebugCpp` and `compileReleaseCpp` tasks that compiles the C++ source files under _src/main/cpp_ for the well-known debug and release build types, respectively.
- * `linkDebug` and `linkRelease` tasks that link the compiled C++ object files into an executable for applications or shared library for libraries with shared linkage for the debug and release build types.
- * `createDebug` and `createRelease` tasks that assemble the compiled C++ object files into a static library for libraries with static linkage for the debug and release build types.
+ * `compileDebugCpp` and `compileReleaseCpp` tasks that compiles the {cpp} source files under _src/main/cpp_ for the well-known debug and release build types, respectively.
+ * `linkDebug` and `linkRelease` tasks that link the compiled {cpp} object files into an executable for applications or shared library for libraries with shared linkage for the debug and release build types.
+ * `createDebug` and `createRelease` tasks that assemble the compiled {cpp} object files into a static library for libraries with static linkage for the debug and release build types.
 
-For any non-trivial C++ project, you’ll probably have some file dependencies and additional configuration specific to _your_ project.
+For any non-trivial {cpp} project, you’ll probably have some file dependencies and additional configuration specific to _your_ project.
 
-The C++ plugins also integrates the above tasks into the standard <<base_plugin#sec:base_tasks,lifecycle tasks>>. The task that produces the development binary is attached to `assemble`.  By default, the development binary is the debug variant.
+The {cpp} plugins also integrates the above tasks into the standard <<base_plugin#sec:base_tasks,lifecycle tasks>>. The task that produces the development binary is attached to `assemble`.  By default, the development binary is the debug variant.
 
 The rest of the chapter explains the different ways to customize the build to your requirements when building libraries and applications.
 
@@ -65,34 +65,34 @@ You can find a list of them in the <<plugin_reference.adoc#native_languages,nati
 [[sec:cpp_source_sets]]
 == Declaring your source files
 
-Gradle’s C++ support uses a `ConfigurableFileCollection` directly from the link:{groovyDslPath}/org.gradle.language.cpp.CppApplication.html[application] or link:{groovyDslPath}/org.gradle.language.cpp.CppLibrary.html[library] script block to configure the set of sources to compile.
+Gradle’s {cpp} support uses a `ConfigurableFileCollection` directly from the link:{groovyDslPath}/org.gradle.language.cpp.CppApplication.html[application] or link:{groovyDslPath}/org.gradle.language.cpp.CppLibrary.html[library] script block to configure the set of sources to compile.
 
 Libraries make a distinction between private (implementation details) and public (exported to consumer) headers. 
 
 You can also configure sources for each binary build for those cases where sources are compiled only on certain target machines.
 
-.Sources and C++ compilation
+.Sources and {cpp} compilation
 image::cpp-sourcesets-compilation.png[]
 
-Test sources are configured on each test suite script block. See <<cpp_testing.adoc#,Testing C++ projects>> chapter.
+Test sources are configured on each test suite script block. See <<cpp_testing.adoc#,Testing {cpp} projects>> chapter.
 
 [[sec:cpp_dependency_management_overview]]
 == Managing your dependencies
 
 The vast majority of projects rely on other projects, so managing your project's dependencies is an important part of building any project.
-Dependency management is a big topic, so we will only focus on the basics for C++ projects here.
+Dependency management is a big topic, so we will only focus on the basics for {cpp} projects here.
 If you’d like to dive into the details, check out the <<introduction_dependency_management.adoc#introduction_dependency_management,introduction to dependency management>>.
 
 Gradle provides support for consuming pre-built binaries from Maven repositories published by Gradle footnote:[Unfortunately, Conan and Nuget repositories aren’t yet support as core features]. 
 
 We will cover how to add dependencies between projects within a multi-build project.
 
-Specifying dependencies for your C++ project requires two pieces of information:
+Specifying dependencies for your {cpp} project requires two pieces of information:
 
  * Identifying information for the dependency (project path, Maven GAV)
  * What it’s needed for, e.g. compilation, linking, runtime or all of the above.
 
-This information is specified in a `dependencies {}` block of the C++ `application` or `library` script block.
+This information is specified in a `dependencies {}` block of the {cpp} `application` or `library` script block.
 For example, to tell Gradle that your project requires library `common` to compile and link your production code, you can use the following fragment:
 
 .Declaring dependencies
@@ -117,9 +117,9 @@ As far as configurations go, the main ones of interest are:
 
 You can learn more about these and how they relate to one another in the native plugin reference chapter.
 
-Be aware that the <<cpp_library_plugin.adoc#,C++ Library Plugin>> creates an additional configuration - `api` - for dependencies that are required for compiling and linking both the module and any modules that depend on it.
+Be aware that the <<cpp_library_plugin.adoc#,{cpp} Library Plugin>> creates an additional configuration - `api` - for dependencies that are required for compiling and linking both the module and any modules that depend on it.
 
-We have only scratched the surface here, so we recommend that you read the dedicated dependency management chapters once you’re comfortable with the basics of building C++ projects with Gradle.
+We have only scratched the surface here, so we recommend that you read the dedicated dependency management chapters once you’re comfortable with the basics of building {cpp} projects with Gradle.
 
 Some common scenarios that require further reading include:
 
@@ -153,13 +153,13 @@ When you build a native binary, Gradle will attempt to locate a tool chain insta
 Gradle select the first tool chain that can build for the target operating system and architecture.
 In the future, Gradle will consider source and ABI compatibility when selecting a tool chain.
 
-Gradle has general support for the three major tool chains on major operating system: Clang footnote:[Installed with Xcode on macOS], GCC footnote:[Installed through Cygwin and MinGW for 32- and 64-bits architecture on Windows] and Visual C++ footnote:[Installed with Visual Studio 2010 to 2017] (Windows-only).
+Gradle has general support for the three major tool chains on major operating system: Clang footnote:[Installed with Xcode on macOS], GCC footnote:[Installed through Cygwin and MinGW for 32- and 64-bits architecture on Windows] and Visual {cpp} footnote:[Installed with Visual Studio 2010 to 2017] (Windows-only).
 GCC and Clang installed using Macports and Homebrew have been reported to work fine, but this isn’t tested continuously.
 
 ==== Windows
 
 To build on Windows, install a compatible version of Visual Studio[4].
-The C++ plugins will discover the Visual Studio installations and select the latest version.
+The {cpp} plugins will discover the Visual Studio installations and select the latest version.
 There is no need to mess around with environment variables or batch scripts.
 This works fine from a Cygwin shell or the Windows command-line.
 
@@ -169,15 +169,15 @@ Clang is currently not supported.
 ==== macOS
 
 To build on macOS, you should install Xcode.
-The C++ plugins will discover the Xcode installation using the system PATH.
+The {cpp} plugins will discover the Xcode installation using the system PATH.
 
-The C++ plugins also work with GCC and Clang installed with Macports or Homebrew footnote:[Macports and Homebrew installation of GCC and Clang is not officially supported].
+The {cpp} plugins also work with GCC and Clang installed with Macports or Homebrew footnote:[Macports and Homebrew installation of GCC and Clang is not officially supported].
 To use one of the Macports or Homebrew, you will need to add Macports/Homebrew to the system PATH.
 
 ==== Linux
 
 To build on Linux, install a compatible version of GCC or Clang.
-The C++ plugins will discover GCC or Clang using the system PATH.
+The {cpp} plugins will discover GCC or Clang using the system PATH.
 
 [[sec:custom_cpp_source_set_paths]]
 === Customizing file and directory locations
@@ -189,7 +189,7 @@ You do that via the `library` script block.
 Each component script block, as well as each binary, defines where it’s source code resides.
 You can override the convention values by using the following syntax:
 
-.Setting C++ source set
+.Setting {cpp} source set
 ====
 include::sample[dir="userguide/cpp/basic/groovy",files="build.gradle[tags=cpp-source-set]"]
 include::sample[dir="userguide/cpp/basic/kotlin",files="build.gradle.kts[tags=cpp-source-set]"]
@@ -206,7 +206,7 @@ Read the task reference for an up-to-date and comprehensive list of the options.
 
 For example, if you want to change the warning level generated by the compiler for all variants, you can use this configuration:
 
-.Setting C++ compiler options for all variants
+.Setting {cpp} compiler options for all variants
 ====
 include::sample[dir="userguide/cpp/basic/groovy",files="build.gradle[tags=cpp-compiler-options-all-variants]"]
 include::sample[dir="userguide/cpp/basic/kotlin",files="build.gradle.kts[tags=cpp-compiler-options-all-variants]"]
@@ -214,7 +214,7 @@ include::sample[dir="userguide/cpp/basic/kotlin",files="build.gradle.kts[tags=cp
 
 It’s also possible to find the instance for a specific variant through the `BinaryCollection` on the `application` or `library` script block:
 
-.Setting C++ compiler options per variant
+.Setting {cpp} compiler options per variant
 ====
 include::sample[dir="userguide/cpp/basic/groovy",files="build.gradle[tags=cpp-compiler-options-per-variants]"]
 include::sample[dir="userguide/cpp/basic/kotlin",files="build.gradle.kts[tags=cpp-compiler-options-per-variants]"]
@@ -223,7 +223,7 @@ include::sample[dir="userguide/cpp/basic/kotlin",files="build.gradle.kts[tags=cp
 [[sec:select_cpp_target_machines]]
 === Selecting target machines
 
-By default, Gradle will attempt to create a C++ binary variant for the host operating system and architecture.
+By default, Gradle will attempt to create a {cpp} binary variant for the host operating system and architecture.
 It is possible to override this by specifying the set of `TargetMachine` on the `application` or `library` script block:
 
 .Setting target machines
@@ -235,7 +235,7 @@ include::sample[dir="userguide/cpp/basic/kotlin",files="build.gradle.kts[tags=cp
 [[sec:cpp_packaging]]
 == Packaging and publishing
 
-How you package and potentially publish your C++ project varies greatly in the native world.
+How you package and potentially publish your {cpp} project varies greatly in the native world.
 Gradle comes with defaults, but custom packaging can be implemented without any issues.
 
  * Executable files are published directly to Maven repositories.
@@ -245,30 +245,30 @@ Gradle comes with defaults, but custom packaging can be implemented without any 
 [[sec:cleaning_cpp_build]]
 == Cleaning the build
 
-The C++ Application and Library Plugins add a `clean` task to you project by using the <<base_plugin,base plugin>>.
+The {cpp} Application and Library Plugins add a `clean` task to you project by using the <<base_plugin,base plugin>>.
 This task simply deletes everything in the `$buildDir` directory, hence why you should always put files generated by the build in there.
 The task is an instance of Delete and you can change what directory it deletes by setting its `dir` property.
 
 [[sec:building_cpp_libraries]]
-== Building C++ libraries
+== Building {cpp} libraries
 
-The unique aspect of library projects is that they are used (or "consumed") by other C++ projects.
+The unique aspect of library projects is that they are used (or "consumed") by other {cpp} projects.
 That means the dependency metadata published with the binaries and headers - in the form of a Gradle Metadata - is crucial.
 In particular, consumers of your library should be able to distinguish between two different types of dependencies: those that are only required to compile your library and those that are also required to compile the consumer.
 
-Gradle manages this distinction via the <<cpp_library_plugin.adoc#,C++ Library Plugin>>, which introduces an _api_ configuration in addition to the _implementation_ once covered in this chapter.
+Gradle manages this distinction via the <<cpp_library_plugin.adoc#,{cpp} Library Plugin>>, which introduces an _api_ configuration in addition to the _implementation_ once covered in this chapter.
 If the types from a dependency appear as unresolved symbols of the static library or within the public headers then that dependency is exposed via your library’s public API and should, therefore, be added to the _api_ configuration.
 Otherwise, the dependency is an internal implementation detail and should be added to _implementation_.
 
-If you’re unsure of the difference between an API and implementation dependency, the <<cpp_library_plugin.adoc#sec:cpp_library_api_vs_implementation,C\++ Library Plugin>> chapter has a detailed explanation.
-In addition, you can see a basic, practical example of building a C++ library in the corresponding link:{guidesUrl}/building-cpp-libraries[guide].
+If you’re unsure of the difference between an API and implementation dependency, the <<cpp_library_plugin.adoc#sec:cpp_library_api_vs_implementation,{cpp} Library Plugin>> chapter has a detailed explanation.
+In addition, you can see a basic, practical example of building a {cpp} library in the corresponding link:{guidesUrl}/building-cpp-libraries[guide].
 
 [[sec:building_cpp_applications]]
-== Building C++ applications
+== Building {cpp} applications
 
-See the <<cpp_application_plugin.adoc#,C++ Application Plugin>> chapter for more details, but here’s a quick summary of what you get:
+See the <<cpp_application_plugin.adoc#,{cpp} Application Plugin>> chapter for more details, but here’s a quick summary of what you get:
 
  * `install` create a directory containing everything needed to run it
  * Shell and Windows Batch scripts to start the application
 
-You can see a basic example of building a C++ application in the corresponding link:{guidesUrl}/building-cpp-applications[guide].
+You can see a basic example of building a {cpp} application in the corresponding link:{guidesUrl}/building-cpp-applications[guide].


### PR DESCRIPTION
<!--- The issue this PR addresses -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Seems like this change was lost at some point during all the change to C++ documentation.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fdocs%2Fuse-cpp-macro)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
