### PR TITLE
Protect instant execution against `StackOverflowError`

### DIFF
--- a/gradle/testDependencies.gradle
+++ b/gradle/testDependencies.gradle
@@ -33,4 +33,5 @@ testLibraries.cglib = 'cglib:cglib:3.2.6'
 testLibraries.sampleCheck = 'org.gradle:sample-check:0.6.1'
 testLibraries.littleproxy = 'org.gradle.org.littleshoot:littleproxy:1.1.3' // because("latest officially released version is incompatible with Guava >= 20")
 testLibraries.mockito_kotlin = 'com.nhaarman:mockito-kotlin:1.6.0'
+testLibraries.mockito_kotlin2 = 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
 testLibraries.jackson_kotlin = 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2'

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(futureKotlin("reflect"))
 
     testImplementation(testFixtures(project(":core")))
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0")
 
     integTestImplementation(project(":toolingApi"))
 

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(futureKotlin("reflect"))
 
     testImplementation(testFixtures(project(":core")))
-    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0")
+    testImplementation(testLibrary("mockito_kotlin2"))
 
     integTestImplementation(project(":toolingApi"))
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -22,11 +22,6 @@ import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterReposito
 
 class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
-    def setup() {
-        // TODO:kotlin-dsl
-        executer.noDeprecationChecks()
-    }
-
     def "build on Groovy build with JUnit tests"() {
 
         def instantExecution = newInstantExecutionFixture()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionGroovyIntegrationTest.groovy
@@ -21,6 +21,12 @@ import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterReposito
 
 
 class InstantExecutionGroovyIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+
+    def setup() {
+        // TODO:kotlin-dsl
+        executer.noDeprecationChecks()
+    }
+
     def "build on Groovy build with JUnit tests"() {
 
         def instantExecution = newInstantExecutionFixture()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
@@ -26,9 +26,6 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
 
     def setup() {
         instantExecution = newInstantExecutionFixture()
-
-        // TODO:kotlin-dsl
-        executer.noDeprecationChecks()
     }
 
     def "build on Java build with a single source file and no dependencies"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
@@ -26,6 +26,9 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
 
     def setup() {
         instantExecution = newInstantExecutionFixture()
+
+        // TODO:kotlin-dsl
+        executer.noDeprecationChecks()
     }
 
     def "build on Java build with a single source file and no dependencies"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -381,6 +381,10 @@ inline fun <T> T.withGradle(
 }
 
 
+/**
+ * [Starts][startCoroutine] the suspending [block], asserts it runs
+ * to completion and returns its result.
+ */
 internal
 fun <R> runToCompletion(block: suspend () -> R): R {
     var completion: Result<R>? = null

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
@@ -78,13 +78,11 @@ class InstantExecutionReport(
         try {
             block()
         } catch (e: Throwable) {
-            when (e.cause) {
-                is TooManyInstantExecutionProblemsException -> {
-                    return e
-                }
-                else -> {
-                    add(e)
-                }
+            when (e.cause ?: e) {
+                is TooManyInstantExecutionProblemsException -> return e
+                is StackOverflowError -> add(e)
+                is Error -> throw e
+                else -> add(e)
             }
         }
         return null

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/extensions/CastExtensions.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/extensions/CastExtensions.kt
@@ -20,5 +20,5 @@ import org.gradle.internal.Cast
 
 
 internal
-inline fun <reified T> Any.uncheckedCast(): T =
+fun <T> Any.uncheckedCast(): T =
     Cast.uncheckedNonnullCast(this)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -265,10 +265,10 @@ interface MutableIsolateContext {
 
 
 internal
-inline fun <T : MutableIsolateContext> T.withIsolate(owner: IsolateOwner, block: T.() -> Unit) {
+inline fun <T : MutableIsolateContext, R> T.withIsolate(owner: IsolateOwner, block: T.() -> R): R {
     enterIsolate(owner)
     try {
-        block()
+        return block()
     } finally {
         leaveIsolate()
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -35,7 +35,7 @@ interface Codec<T> {
 
     suspend fun WriteContext.encode(value: T)
 
-    fun ReadContext.decode(): T?
+    suspend fun ReadContext.decode(): T?
 }
 
 
@@ -66,7 +66,7 @@ interface ReadContext : IsolateContext, Decoder {
 
     fun getProject(path: String): ProjectInternal
 
-    fun read(): Any?
+    suspend fun read(): Any?
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -33,7 +33,7 @@ import kotlin.reflect.KClass
  */
 interface Codec<T> {
 
-    fun WriteContext.encode(value: T)
+    suspend fun WriteContext.encode(value: T)
 
     fun ReadContext.decode(): T?
 }
@@ -47,13 +47,13 @@ interface WriteContext : IsolateContext, Encoder {
 
     fun writeActionFor(value: Any?): Encoding?
 
-    fun write(value: Any?) {
+    suspend fun write(value: Any?) {
         writeActionFor(value)!!(value)
     }
 }
 
 
-typealias Encoding = WriteContext.(value: Any?) -> Unit
+typealias Encoding = suspend WriteContext.(value: Any?) -> Unit
 
 
 interface ReadContext : IsolateContext, Decoder {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -177,12 +177,46 @@ sealed class PropertyTrace {
         val trace: PropertyTrace
     ) : PropertyTrace()
 
-    override fun toString(): String = when (this) {
-        is Gradle -> "Gradle state"
-        is Property -> "$kind `$name` of $trace"
-        is Bean -> "`${type.name}` bean found in $trace"
-        is Task -> "task `$path` of type `${type.name}`"
-        is Unknown -> "unknown property"
+    override fun toString(): String =
+        StringBuilder().apply {
+            sequence.forEach {
+                appendStringOf(it)
+            }
+        }.toString()
+
+    private
+    fun StringBuilder.appendStringOf(trace: PropertyTrace) {
+        when (trace) {
+            is Gradle -> {
+                append("Gradle state")
+            }
+            is Property -> {
+                append(trace.kind)
+                append(" ")
+                quoted(trace.name)
+                append(" of ")
+            }
+            is Bean -> {
+                quoted(trace.type.name)
+                append(" bean found in ")
+            }
+            is Task -> {
+                append("task ")
+                quoted(trace.path)
+                append(" of type ")
+                quoted(trace.type.name)
+            }
+            is Unknown -> {
+                append("unknown property")
+            }
+        }
+    }
+
+    private
+    fun StringBuilder.quoted(s: String) {
+        append('`')
+        append(s)
+        append('`')
     }
 
     val sequence: Sequence<PropertyTrace>

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
@@ -129,9 +129,7 @@ fun <T : Any> reentrant(codec: Codec<T>): Codec<T> = object : Codec<T> {
                     encode(frame.value)
                 }
             }.startCoroutine(Continuation(coroutineContext) {
-                require(encodeStack.peek() === frame)
-                encodeStack.pop()
-                frame.k?.resumeWith(it) ?: it.getOrThrow()
+                encodeStack.pop().k?.resumeWith(it) ?: it.getOrThrow()
             })
         } while (encodeStack.isNotEmpty())
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -106,7 +106,7 @@ class DefaultReadContext(
         this.projectProvider = projectProvider
     }
 
-    override fun read(): Any? = decoding.run {
+    override suspend fun read(): Any? = decoding.run {
         decode()
     }
 
@@ -130,7 +130,7 @@ class DefaultReadContext(
 
 internal
 interface DecodingProvider {
-    fun ReadContext.decode(): Any?
+    suspend fun ReadContext.decode(): Any?
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -37,6 +37,7 @@ import org.gradle.instantexecution.serialization.withPropertyTrace
 import org.gradle.internal.reflect.JavaReflectionUtil
 import sun.reflect.ReflectionFactory
 import java.io.File
+import java.io.IOException
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.util.concurrent.Callable
@@ -76,7 +77,7 @@ class BeanPropertyReader(
     fun newBean(): Any =
         constructorForSerialization.newInstance()
 
-    fun ReadContext.readFieldsOf(bean: Any) {
+    suspend fun ReadContext.readFieldsOf(bean: Any) {
         readEachProperty(PropertyKind.Field) { fieldName, fieldValue ->
             val setter = setterByFieldName.getValue(fieldName)
             setter(bean, fieldValue)
@@ -154,7 +155,7 @@ class BeanPropertyReader(
 /**
  * Reads a sequence of properties written with [writingProperties].
  */
-fun ReadContext.readEachProperty(kind: PropertyKind, action: (String, Any?) -> Unit) {
+suspend fun ReadContext.readEachProperty(kind: PropertyKind, action: (String, Any?) -> Unit) {
     while (true) {
 
         val name = readString()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -169,7 +169,11 @@ suspend fun ReadContext.readEachProperty(kind: PropertyKind, action: (String, An
                     read().also {
                         logPropertyInfo("deserialize", it)
                     }
-                } catch (e: Throwable) {
+                } catch (passThrough: IOException) {
+                    throw passThrough
+                } catch (passThrough: GradleException) {
+                    throw passThrough
+                } catch (e: Exception) {
                     throw GradleException("Could not load the value of $trace.", e)
                 }
             action(name, value)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -45,7 +45,7 @@ class BeanPropertyWriter(
     /**
      * Serializes a bean by serializing the value of each of its fields.
      */
-    fun WriteContext.writeFieldsOf(bean: Any) {
+    suspend fun WriteContext.writeFieldsOf(bean: Any) {
         writingProperties {
             for (field in relevantFields) {
                 val fieldName = field.name
@@ -79,7 +79,7 @@ class BeanPropertyWriter(
  * Returns whether the given property could be written. A property can only be written when there's
  * a suitable [Codec] for its [value].
  */
-fun WriteContext.writeNextProperty(name: String, value: Any?, kind: PropertyKind): Boolean {
+suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: PropertyKind): Boolean {
     withPropertyTrace(kind, name) {
         val writeValue = writeActionFor(value)
         if (writeValue == null) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -40,7 +40,7 @@ class BeanPropertyWriter(
 ) {
 
     private
-    val relevantFields = relevantStateOf(beanType)
+    val relevantFields = relevantStateOf(beanType).toList()
 
     /**
      * Serializes a bean by serializing the value of each of its fields.

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
@@ -28,7 +28,7 @@ import org.gradle.instantexecution.serialization.WriteContext
 internal
 object ArtifactCollectionCodec : Codec<ArtifactCollection> {
 
-    override fun WriteContext.encode(value: ArtifactCollection) = Unit
+    override suspend fun WriteContext.encode(value: ArtifactCollection) = Unit
 
     override fun ReadContext.decode(): ArtifactCollection? =
         EmptyArtifactCollection(ImmutableFileCollection.of())

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ArtifactCollectionCodec.kt
@@ -30,7 +30,7 @@ object ArtifactCollectionCodec : Codec<ArtifactCollection> {
 
     override suspend fun WriteContext.encode(value: ArtifactCollection) = Unit
 
-    override fun ReadContext.decode(): ArtifactCollection? =
+    override suspend fun ReadContext.decode(): ArtifactCollection? =
         EmptyArtifactCollection(ImmutableFileCollection.of())
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
@@ -30,7 +30,7 @@ import org.gradle.instantexecution.serialization.writeClass
 internal
 class BeanCodec : Codec<Any> {
 
-    override fun WriteContext.encode(value: Any) {
+    override suspend fun WriteContext.encode(value: Any) {
         val id = isolate.identities.getId(value)
         if (id != null) {
             writeSmallInt(id)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
@@ -46,7 +46,7 @@ class BeanCodec : Codec<Any> {
         }
     }
 
-    override fun ReadContext.decode(): Any? {
+    override suspend fun ReadContext.decode(): Any? {
         val id = readSmallInt()
         val previousValue = isolate.identities.getInstance(id)
         if (previousValue != null) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BuildOperationListenersCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BuildOperationListenersCodec.kt
@@ -46,7 +46,7 @@ class BuildOperationListenersCodec {
         )
     }
 
-    fun MutableWriteContext.writeBuildOperationListeners(manager: BuildOperationListenerManager) {
+    suspend fun MutableWriteContext.writeBuildOperationListeners(manager: BuildOperationListenerManager) {
         writeCollection(manager.listeners) { listener ->
             write(listener)
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BuildOperationListenersCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BuildOperationListenersCodec.kt
@@ -52,7 +52,7 @@ class BuildOperationListenersCodec {
         }
     }
 
-    fun MutableReadContext.readBuildOperationListeners(): List<BuildOperationListener> =
+    suspend fun MutableReadContext.readBuildOperationListeners(): List<BuildOperationListener> =
         readList().uncheckedCast()
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClassCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClassCodec.kt
@@ -30,6 +30,6 @@ object ClassCodec : Codec<Class<*>> {
         writeClass(value)
     }
 
-    override fun ReadContext.decode(): Class<*>? =
+    override suspend fun ReadContext.decode(): Class<*>? =
         readClass()
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClassCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClassCodec.kt
@@ -26,7 +26,7 @@ import org.gradle.instantexecution.serialization.writeClass
 internal
 object ClassCodec : Codec<Class<*>> {
 
-    override fun WriteContext.encode(value: Class<*>) {
+    override suspend fun WriteContext.encode(value: Class<*>) {
         writeClass(value)
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -37,6 +37,7 @@ import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.SerializerCodec
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.ownerService
+import org.gradle.instantexecution.serialization.reentrant
 import org.gradle.instantexecution.serialization.unsupported
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -131,7 +132,7 @@ class Codecs(
         bind(ownerService<BuildOperationListenerManager>())
         bind(ownerService<BuildRequestMetaData>())
 
-        bind(BeanCodec())
+        bind(reentrant(BeanCodec()))
     }
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -157,8 +157,9 @@ class Codecs(
     fun computeEncoding(type: Class<*>): Encoding? =
         bindings.find { it.type.isAssignableFrom(type) }?.run {
             encoding { value ->
+                require(value != null)
                 writeByte(tag)
-                codec.run { encode(value!!) }
+                codec.run { encode(value) }
             }
         }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -132,6 +132,9 @@ class Codecs(
         bind(ownerService<BuildOperationListenerManager>())
         bind(ownerService<BuildRequestMetaData>())
 
+        // This protects the BeanCodec against StackOverflowErrors but
+        // we can still get them for the other codecs, for instance,
+        // with deeply nested Lists, deeply nested Maps, etc.
         bind(reentrant(BeanCodec()))
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -148,7 +148,7 @@ class Codecs(
         else -> encodings.computeIfAbsent(candidate.javaClass, ::computeEncoding)
     }
 
-    override fun ReadContext.decode(): Any? = when (val tag = readByte()) {
+    override suspend fun ReadContext.decode(): Any? = when (val tag = readByte()) {
         NULL_VALUE -> null
         else -> bindings[tag.toInt()].codec.run { decode() }
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
@@ -34,7 +34,7 @@ class ConfigurableFileCollectionCodec(
     override suspend fun WriteContext.encode(value: ConfigurableFileCollection) =
         fileSetSerializer.write(this, value.files)
 
-    override fun ReadContext.decode(): ConfigurableFileCollection =
+    override suspend fun ReadContext.decode(): ConfigurableFileCollection =
         fileCollectionFactory.configurableFiles().also {
             it.setFrom(fileSetSerializer.read(this))
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
@@ -31,7 +31,7 @@ class ConfigurableFileCollectionCodec(
     private val fileCollectionFactory: FileCollectionFactory
 ) : Codec<ConfigurableFileCollection> {
 
-    override fun WriteContext.encode(value: ConfigurableFileCollection) =
+    override suspend fun WriteContext.encode(value: ConfigurableFileCollection) =
         fileSetSerializer.write(this, value.files)
 
     override fun ReadContext.decode(): ConfigurableFileCollection =

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -37,7 +37,7 @@ class DefaultCopySpecCodec(
         write(allSourcePaths)
     }
 
-    override fun ReadContext.decode(): DefaultCopySpec {
+    override suspend fun ReadContext.decode(): DefaultCopySpec {
         @Suppress("unchecked_cast")
         val sourceFiles = read() as List<File>
         val copySpec = DefaultCopySpec(fileResolver, instantiator)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -31,7 +31,7 @@ class DefaultCopySpecCodec(
     private val instantiator: Instantiator
 ) : Codec<DefaultCopySpec> {
 
-    override fun WriteContext.encode(value: DefaultCopySpec) {
+    override suspend fun WriteContext.encode(value: DefaultCopySpec) {
         val allSourcePaths = ArrayList<File>()
         collectSourcePathsFrom(value, allSourcePaths)
         write(allSourcePaths)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DestinationRootCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DestinationRootCopySpecCodec.kt
@@ -30,7 +30,7 @@ class DestinationRootCopySpecCodec(
     private val fileResolver: FileResolver
 ) : Codec<DestinationRootCopySpec> {
 
-    override fun WriteContext.encode(value: DestinationRootCopySpec) {
+    override suspend fun WriteContext.encode(value: DestinationRootCopySpec) {
         write(value.destinationDir)
         write(value.delegate)
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DestinationRootCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DestinationRootCopySpecCodec.kt
@@ -35,7 +35,7 @@ class DestinationRootCopySpecCodec(
         write(value.delegate)
     }
 
-    override fun ReadContext.decode(): DestinationRootCopySpec {
+    override suspend fun ReadContext.decode(): DestinationRootCopySpec {
         val destDir = read() as? File
         val delegate = read() as CopySpecInternal
         val spec = DestinationRootCopySpec(fileResolver, delegate)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -38,7 +38,7 @@ class FileCollectionCodec(
     private val directoryFileTreeFactory: DirectoryFileTreeFactory
 ) : Codec<FileCollectionInternal> {
 
-    override fun WriteContext.encode(value: FileCollectionInternal) {
+    override suspend fun WriteContext.encode(value: FileCollectionInternal) {
         runCatching {
             val visitor = CollectingVisitor(directoryFileTreeFactory)
             value.visitLeafCollections(visitor)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -55,7 +55,7 @@ class FileCollectionCodec(
         }
     }
 
-    override fun ReadContext.decode(): FileCollectionInternal =
+    override suspend fun ReadContext.decode(): FileCollectionInternal =
         if (readBoolean()) fileCollectionFactory.fixed(fileSetSerializer.read(this))
         else fileCollectionFactory.create(ErrorFileSet(readString()))
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -40,7 +40,7 @@ class FileTreeCodec(
         fileSetSerializer.write(this, fileTreeRootsOf(value))
     }
 
-    override fun ReadContext.decode(): FileTreeInternal? =
+    override suspend fun ReadContext.decode(): FileTreeInternal? =
         DefaultCompositeFileTree(
             fileSetSerializer.read(this).map {
                 FileTreeAdapter(directoryFileTreeFactory.create(it))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -36,7 +36,7 @@ class FileTreeCodec(
     private val directoryFileTreeFactory: DirectoryFileTreeFactory
 ) : Codec<FileTreeInternal> {
 
-    override fun WriteContext.encode(value: FileTreeInternal) {
+    override suspend fun WriteContext.encode(value: FileTreeInternal) {
         fileSetSerializer.write(this, fileTreeRootsOf(value))
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ListenerBroadcastCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ListenerBroadcastCodec.kt
@@ -31,7 +31,7 @@ class ListenerBroadcastCodec(private val listenerManager: ListenerManager) : Cod
         writeClass(value.type)
     }
 
-    override fun ReadContext.decode(): AnonymousListenerBroadcast<*> {
+    override suspend fun ReadContext.decode(): AnonymousListenerBroadcast<*> {
         val type = readClass()
         return listenerManager.createAnonymousBroadcaster(type)
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ListenerBroadcastCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ListenerBroadcastCodec.kt
@@ -27,7 +27,7 @@ import org.gradle.internal.event.ListenerManager
 
 internal
 class ListenerBroadcastCodec(private val listenerManager: ListenerManager) : Codec<AnonymousListenerBroadcast<*>> {
-    override fun WriteContext.encode(value: AnonymousListenerBroadcast<*>) {
+    override suspend fun WriteContext.encode(value: AnonymousListenerBroadcast<*>) {
         writeClass(value.type)
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/LoggerCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/LoggerCodec.kt
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory
 internal
 object LoggerCodec : Codec<Logger> {
 
-    override fun WriteContext.encode(value: Logger) {
+    override suspend fun WriteContext.encode(value: Logger) {
         writeString(value.name)
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/LoggerCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/LoggerCodec.kt
@@ -31,6 +31,6 @@ object LoggerCodec : Codec<Logger> {
         writeString(value.name)
     }
 
-    override fun ReadContext.decode(): Logger? =
+    override suspend fun ReadContext.decode(): Logger? =
         LoggerFactory.getLogger(readString())
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCodec.kt
@@ -35,7 +35,7 @@ object MethodCodec : Codec<Method> {
         writeClassArray(value.parameterTypes)
     }
 
-    override fun ReadContext.decode(): Method? {
+    override suspend fun ReadContext.decode(): Method? {
         val declaringClass = readClass()
         val methodName = readString()
         val parameterTypes = readClassArray()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCodec.kt
@@ -29,7 +29,7 @@ import java.lang.reflect.Method
 internal
 object MethodCodec : Codec<Method> {
 
-    override fun WriteContext.encode(value: Method) {
+    override suspend fun WriteContext.encode(value: Method) {
         writeClass(value.declaringClass)
         writeString(value.name)
         writeClassArray(value.parameterTypes)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -57,12 +57,12 @@ import org.gradle.instantexecution.serialization.writeStrings
 internal
 class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
 
-    fun MutableWriteContext.writeTaskGraphOf(build: ClassicModeBuild, tasks: List<Task>) {
+    suspend fun MutableWriteContext.writeTaskGraphOf(build: ClassicModeBuild, tasks: List<Task>) {
         writeCollection(tasks) { task ->
             try {
-                projectStateRegistry.stateFor(task.project).withMutableState {
-                    writeTask(task, build.dependenciesOf(task))
-                }
+//                projectStateRegistry.stateFor(task.project).withMutableState {
+                writeTask(task, build.dependenciesOf(task))
+//                }
             } catch (e: Throwable) {
                 throw GradleException("Could not save state of $task.", e)
             }
@@ -92,7 +92,7 @@ class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
     }
 
     private
-    fun MutableWriteContext.writeTask(task: Task, dependencies: Set<Task>) {
+    suspend fun MutableWriteContext.writeTask(task: Task, dependencies: Set<Task>) {
         val taskType = GeneratedSubclasses.unpack(task.javaClass)
         writeClass(taskType)
         writeString(task.project.path)
@@ -143,75 +143,152 @@ inline fun <T> T.withTaskOf(
 
 
 private
-fun WriteContext.writeRegisteredPropertiesOf(
+sealed class RegisteredProperty {
+
+    data class InputFile(
+        val propertyName: String,
+        val optional: Boolean,
+        val skipWhenEmpty: Boolean,
+        val incremental: Boolean,
+        val fileNormalizer: Class<out FileNormalizer>?,
+        val propertyValue: PropertyValue,
+        val filePropertyType: InputFilePropertyType
+    ) : RegisteredProperty()
+
+    data class Input(
+        val propertyName: String,
+        val propertyValue: PropertyValue,
+        val optional: Boolean
+    ) : RegisteredProperty()
+
+    data class OutputFile(
+        val propertyName: String,
+        val optional: Boolean,
+        val value: PropertyValue,
+        val filePropertyType: OutputFilePropertyType
+    ) : RegisteredProperty()
+}
+
+
+private
+suspend fun WriteContext.writeRegisteredPropertiesOf(
     task: Task,
     propertyWriter: BeanPropertyWriter
 ) = propertyWriter.run {
 
-    fun writeProperty(propertyName: String, propertyValue: PropertyValue, kind: PropertyKind): Boolean {
+    suspend fun writeProperty(propertyName: String, propertyValue: PropertyValue, kind: PropertyKind): Boolean {
         val value = unpack(propertyValue.call()) ?: return false
         return writeNextProperty(propertyName, value, kind)
     }
 
-    fun writeInputProperty(propertyName: String, propertyValue: PropertyValue): Boolean =
+    suspend fun writeInputProperty(propertyName: String, propertyValue: PropertyValue): Boolean =
         writeProperty(propertyName, propertyValue, PropertyKind.InputProperty)
 
-    fun writeOutputProperty(propertyName: String, propertyValue: PropertyValue): Boolean =
+    suspend fun writeOutputProperty(propertyName: String, propertyValue: PropertyValue): Boolean =
         writeProperty(propertyName, propertyValue, PropertyKind.OutputProperty)
 
     writingProperties {
-        (task.inputs as TaskInputsInternal).visitRegisteredProperties(object : PropertyVisitor.Adapter() {
-
-            override fun visitInputFileProperty(
-                propertyName: String,
-                optional: Boolean,
-                skipWhenEmpty: Boolean,
-                incremental: Boolean,
-                fileNormalizer: Class<out FileNormalizer>?,
-                propertyValue: PropertyValue,
-                filePropertyType: InputFilePropertyType
-            ) {
-                if (!writeInputProperty(propertyName, propertyValue)) {
-                    return
+        val properties = collectRegisteredInputsOf(task)
+        properties.forEach { property ->
+            property.run {
+                when (this) {
+                    is RegisteredProperty.InputFile -> {
+                        if (writeInputProperty(propertyName, propertyValue)) {
+                            writeBoolean(optional)
+                            writeBoolean(true)
+                            writeEnum(filePropertyType)
+                            writeBoolean(skipWhenEmpty)
+                            writeClass(fileNormalizer!!)
+                        }
+                    }
+                    is RegisteredProperty.Input -> {
+                        if (writeInputProperty(propertyName, propertyValue)) {
+                            writeBoolean(optional)
+                            writeBoolean(false)
+                        }
+                    }
                 }
-                writeBoolean(optional)
-                writeBoolean(true)
-                writeEnum(filePropertyType)
-                writeBoolean(skipWhenEmpty)
-                writeClass(fileNormalizer!!)
             }
-
-            override fun visitInputProperty(
-                propertyName: String,
-                propertyValue: PropertyValue,
-                optional: Boolean
-            ) {
-                if (!writeInputProperty(propertyName, propertyValue)) {
-                    return
-                }
-                writeBoolean(optional)
-                writeBoolean(false)
-            }
-        })
+        }
     }
 
     writingProperties {
-        (task.outputs as TaskOutputsInternal).visitRegisteredProperties(object : PropertyVisitor.Adapter() {
-
-            override fun visitOutputFileProperty(
-                propertyName: String,
-                optional: Boolean,
-                value: PropertyValue,
-                filePropertyType: OutputFilePropertyType
-            ) {
-                if (!writeOutputProperty(propertyName, value)) {
-                    return
+        val properties = collectRegisteredOutputsOf(task)
+        properties.forEach {
+            it.run {
+                if (writeOutputProperty(propertyName, value)) {
+                    writeBoolean(optional)
+                    writeEnum(filePropertyType)
                 }
-                writeBoolean(optional)
-                writeEnum(filePropertyType)
             }
-        })
+        }
     }
+}
+
+
+private
+fun collectRegisteredOutputsOf(task: Task): MutableList<RegisteredProperty.OutputFile> {
+    val properties = mutableListOf<RegisteredProperty.OutputFile>()
+    (task.outputs as TaskOutputsInternal).visitRegisteredProperties(object : PropertyVisitor.Adapter() {
+
+        override fun visitOutputFileProperty(
+            propertyName: String,
+            optional: Boolean,
+            value: PropertyValue,
+            filePropertyType: OutputFilePropertyType
+        ) {
+            properties.add(
+                RegisteredProperty.OutputFile(propertyName, optional, value, filePropertyType)
+            )
+        }
+    })
+    return properties
+}
+
+
+private
+fun collectRegisteredInputsOf(task: Task): MutableList<RegisteredProperty> {
+    val properties = mutableListOf<RegisteredProperty>()
+
+    (task.inputs as TaskInputsInternal).visitRegisteredProperties(object : PropertyVisitor.Adapter() {
+
+        override fun visitInputFileProperty(
+            propertyName: String,
+            optional: Boolean,
+            skipWhenEmpty: Boolean,
+            incremental: Boolean,
+            fileNormalizer: Class<out FileNormalizer>?,
+            propertyValue: PropertyValue,
+            filePropertyType: InputFilePropertyType
+        ) {
+            properties.add(
+                RegisteredProperty.InputFile(
+                    propertyName,
+                    optional,
+                    skipWhenEmpty,
+                    incremental,
+                    fileNormalizer,
+                    propertyValue,
+                    filePropertyType
+                )
+            )
+        }
+
+        override fun visitInputProperty(
+            propertyName: String,
+            propertyValue: PropertyValue,
+            optional: Boolean
+        ) {
+            properties.add(
+                RegisteredProperty.Input(
+                    propertyName,
+                    propertyValue,
+                    optional
+                )
+            )
+        }
+    })
+    return properties
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -69,14 +69,14 @@ class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
         }
     }
 
-    fun MutableReadContext.readTaskGraph(): List<Task> {
+    suspend fun MutableReadContext.readTaskGraph(): List<Task> {
         val tasksWithDependencies = readTasksWithDependencies()
         wireTaskDependencies(tasksWithDependencies)
         return tasksWithDependencies.map { (task, _) -> task }
     }
 
     private
-    fun MutableReadContext.readTasksWithDependencies(): List<Pair<Task, List<String>>> =
+    suspend fun MutableReadContext.readTasksWithDependencies(): List<Pair<Task, List<String>>> =
         readCollectionInto({ size -> ArrayList(size) }) {
             readTask()
         }
@@ -108,7 +108,7 @@ class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
     }
 
     private
-    fun MutableReadContext.readTask(): Pair<Task, List<String>> {
+    suspend fun MutableReadContext.readTask(): Pair<Task, List<String>> {
         val taskType = readClass().asSubclass(Task::class.java)
         val projectPath = readString()
         val taskName = readString()
@@ -293,14 +293,14 @@ fun collectRegisteredInputsOf(task: Task): MutableList<RegisteredProperty> {
 
 
 private
-fun ReadContext.readRegisteredPropertiesOf(task: Task) {
+suspend fun ReadContext.readRegisteredPropertiesOf(task: Task) {
     readInputPropertiesOf(task)
     readOutputPropertiesOf(task)
 }
 
 
 private
-fun ReadContext.readInputPropertiesOf(task: Task) =
+suspend fun ReadContext.readInputPropertiesOf(task: Task) =
     readEachProperty(PropertyKind.InputProperty) { propertyName, propertyValue ->
         val optional = readBoolean()
         val isFileInputProperty = readBoolean()
@@ -333,7 +333,7 @@ fun ReadContext.readInputPropertiesOf(task: Task) =
 
 
 private
-fun ReadContext.readOutputPropertiesOf(task: Task) =
+suspend fun ReadContext.readOutputPropertiesOf(task: Task) =
     readEachProperty(PropertyKind.OutputProperty) { propertyName, propertyValue ->
         val optional = readBoolean()
         val filePropertyType = readEnum<OutputFilePropertyType>()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
@@ -26,7 +26,7 @@ import org.gradle.instantexecution.serialization.logUnsupported
 internal
 object TaskReferenceCodec : Codec<Task> {
 
-    override fun WriteContext.encode(value: Task) {
+    override suspend fun WriteContext.encode(value: Task) {
         if (value === isolate.owner.delegate) {
             writeBoolean(true)
         } else {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskReferenceCodec.kt
@@ -35,6 +35,6 @@ object TaskReferenceCodec : Codec<Task> {
         }
     }
 
-    override fun ReadContext.decode(): Task? =
+    override suspend fun ReadContext.decode(): Task? =
         isolate.owner.delegate.takeIf { readBoolean() } as Task?
 }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import com.nhaarman.mockitokotlin2.mock
+import org.gradle.instantexecution.extensions.uncheckedCast
+
+import org.gradle.instantexecution.serialization.DefaultReadContext
+import org.gradle.instantexecution.serialization.DefaultWriteContext
+import org.gradle.instantexecution.serialization.IsolateOwner
+import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
+import org.gradle.instantexecution.serialization.withIsolate
+
+import org.gradle.internal.serialize.kryo.KryoBackedDecoder
+import org.gradle.internal.serialize.kryo.KryoBackedEncoder
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+
+import org.junit.Test
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+
+class BeanCodecTest {
+
+    @Test
+    fun `can handle deeply nested graphs`() {
+
+        val deepGraph = Peano.fromInt(1024)
+
+        val read = roundtrip(deepGraph)
+
+        assertThat(
+            deepGraph.toInt(),
+            equalTo(read.toInt())
+        )
+    }
+
+    private
+    fun <T : Any> roundtrip(graph: T): T =
+        writeToByteArray(graph).let(::readFrom)!!.uncheckedCast()
+
+    private
+    fun writeToByteArray(graph: Any): ByteArray {
+        val outputStream = ByteArrayOutputStream()
+        writeTo(outputStream, graph)
+        return outputStream.toByteArray()
+    }
+
+    private
+    fun writeTo(outputStream: OutputStream, graph: Any) {
+        KryoBackedEncoder(outputStream).use { encoder ->
+            writeContextFor(encoder).run {
+                withIsolate(IsolateOwner.OwnerGradle(mock())) {
+                    write(graph)
+                }
+            }
+        }
+    }
+
+    private
+    fun readFrom(bytes: ByteArray) =
+        readFrom(ByteArrayInputStream(bytes))
+
+    private
+    fun readFrom(inputStream: ByteArrayInputStream) =
+        readContextFor(inputStream).run {
+            initClassLoader(javaClass.classLoader)
+            withIsolate(IsolateOwner.OwnerGradle(mock())) {
+                read()
+            }
+        }
+
+    private
+    fun writeContextFor(encoder: KryoBackedEncoder) =
+        DefaultWriteContext(
+            encodings = codecs(),
+            encoder = encoder,
+            logger = mock(),
+            problemHandler = mock()
+        )
+
+    private
+    fun readContextFor(inputStream: ByteArrayInputStream) =
+        DefaultReadContext(
+            decoding = codecs(),
+            decoder = KryoBackedDecoder(inputStream),
+            logger = mock(),
+            beanPropertyReaderFactory = BeanPropertyReader.factoryFor(mock())
+        )
+
+    private
+    fun codecs() = Codecs(
+        directoryFileTreeFactory = mock(),
+        fileCollectionFactory = mock(),
+        fileResolver = mock(),
+        instantiator = mock(),
+        listenerManager = mock()
+    )
+
+    @Test
+    fun `Peano sanity check`() {
+
+        assertThat(
+            Peano.fromInt(0),
+            equalTo<Peano>(Peano.Zero)
+        )
+
+        assertThat(
+            Peano.fromInt(1024).toInt(),
+            equalTo(1024)
+        )
+    }
+
+    sealed class Peano {
+
+        companion object {
+
+            fun fromInt(n: Int): Peano {
+                require(n >= 0)
+                tailrec fun build(n: Int, acc: Peano): Peano = when (n) {
+                    0 -> acc
+                    else -> build(n - 1, Succ(acc))
+                }
+                return build(n, Zero)
+            }
+        }
+
+        fun toInt(): Int {
+            tailrec fun count(n: Peano, acc: Int): Int = when (n) {
+                is Zero -> acc
+                is Succ -> count(n.n, acc + 1)
+            }
+            return count(this, 0)
+        }
+
+        object Zero : Peano()
+
+        data class Succ(val n: Peano) : Peano()
+    }
+}

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
@@ -138,26 +138,21 @@ class BeanCodecTest {
 
         companion object {
 
-            fun fromInt(n: Int): Peano {
-                require(n >= 0)
-                tailrec fun build(n: Int, acc: Peano): Peano = when (n) {
-                    0 -> acc
-                    else -> build(n - 1, Succ(acc))
-                }
-                return build(n, Zero)
-            }
+            fun fromInt(n: Int): Peano = (0 until n).fold(Zero as Peano) { acc, _ -> Succ(acc) }
         }
 
-        fun toInt(): Int {
-            tailrec fun count(n: Peano, acc: Int): Int = when (n) {
-                is Zero -> acc
-                is Succ -> count(n.n, acc + 1)
-            }
-            return count(this, 0)
-        }
+        fun toInt(): Int = sequence().count() - 1
 
         object Zero : Peano()
 
         data class Succ(val n: Peano) : Peano()
+
+        private
+        fun sequence() = generateSequence(this) {
+            when (it) {
+                is Zero -> null
+                is Succ -> it.n
+            }
+        }
     }
 }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
@@ -87,7 +87,9 @@ class BeanCodecTest {
         readContextFor(inputStream).run {
             initClassLoader(javaClass.classLoader)
             withIsolate(IsolateOwner.OwnerGradle(mock())) {
-                read()
+                runToCompletion {
+                    read()
+                }
             }
         }
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
@@ -17,8 +17,9 @@
 package org.gradle.instantexecution.serialization.codecs
 
 import com.nhaarman.mockitokotlin2.mock
-import org.gradle.instantexecution.extensions.uncheckedCast
 
+import org.gradle.instantexecution.extensions.uncheckedCast
+import org.gradle.instantexecution.runToCompletion
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
 import org.gradle.instantexecution.serialization.IsolateOwner
@@ -69,7 +70,9 @@ class BeanCodecTest {
         KryoBackedEncoder(outputStream).use { encoder ->
             writeContextFor(encoder).run {
                 withIsolate(IsolateOwner.OwnerGradle(mock())) {
-                    write(graph)
+                    runToCompletion {
+                        write(graph)
+                    }
                 }
             }
         }


### PR DESCRIPTION
By replacing direct recursion on object graphs by loops.