### PR TITLE
Fix Kotlin compilation warnings

### DIFF
--- a/buildSrc/subprojects/binary-compatibility/src/main/kotlin/org/gradle/binarycompatibility/BinaryCompatibilityRepositoryLifecycle.kt
+++ b/buildSrc/subprojects/binary-compatibility/src/main/kotlin/org/gradle/binarycompatibility/BinaryCompatibilityRepositoryLifecycle.kt
@@ -38,6 +38,7 @@ class BinaryCompatibilityRepositorySetupRule(private val params: Map<String, Any
         const val sourceCompilationClasspath = "sourceCompilationClasspath"
     }
 
+    @Suppress("unchecked_cast")
     override fun execute(context: ViolationCheckContext) {
         (context.userData as MutableMap<String, Any?>)[REPOSITORY_CONTEXT_KEY] = BinaryCompatibilityRepository.openRepositoryFor(
             param(Params.sourceRoots),
@@ -45,6 +46,7 @@ class BinaryCompatibilityRepositorySetupRule(private val params: Map<String, Any
         )
     }
 
+    @Suppress("unchecked_cast")
     private
     fun param(name: String): List<File> =
         (params[name] as? Set<String>)?.map(::File) ?: emptyList()

--- a/buildSrc/subprojects/binary-compatibility/src/main/kotlin/org/gradle/binarycompatibility/metadata/HasKotlinFlagsMetadataQuery.kt
+++ b/buildSrc/subprojects/binary-compatibility/src/main/kotlin/org/gradle/binarycompatibility/metadata/HasKotlinFlagsMetadataQuery.kt
@@ -165,8 +165,8 @@ class ConstructorFlagsKmClassVisitor(
         else object : KmConstructorVisitor() {
             override fun visitExtensions(type: KmExtensionType): KmConstructorExtensionVisitor =
                 object : JvmConstructorExtensionVisitor() {
-                    override fun visit(desc: JvmMethodSignature?) {
-                        if (jvmSignature == desc?.asString()) {
+                    override fun visit(signature: JvmMethodSignature?) {
+                        if (jvmSignature == signature?.asString()) {
                             isSatisfied = predicate(flags)
                             isDoneVisiting = true
                         }
@@ -292,11 +292,11 @@ class MemberFlagsKmPropertyExtensionVisitor(
 
     private
     val kmPropertyExtensionVisitor = object : JvmPropertyExtensionVisitor() {
-        override fun visit(fieldDesc: JvmFieldSignature?, getterDesc: JvmMethodSignature?, setterDesc: JvmMethodSignature?) {
+        override fun visit(fieldSignature: JvmFieldSignature?, getterSignature: JvmMethodSignature?, setterSignature: JvmMethodSignature?) {
             when (jvmSignature) {
-                fieldDesc?.asString() -> onMatch(predicate(fieldFlags))
-                getterDesc?.asString() -> onMatch(predicate(getterFlags))
-                setterDesc?.asString() -> onMatch(predicate(setterFlags))
+                fieldSignature?.asString() -> onMatch(predicate(fieldFlags))
+                getterSignature?.asString() -> onMatch(predicate(getterFlags))
+                setterSignature?.asString() -> onMatch(predicate(setterFlags))
             }
         }
     }
@@ -316,8 +316,8 @@ class MethodFlagsKmFunctionVisitor(
 
     private
     val kmFunctionExtensionVisitor = object : JvmFunctionExtensionVisitor() {
-        override fun visit(desc: JvmMethodSignature?) {
-            if (jvmSignature == desc?.asString()) {
+        override fun visit(signature: JvmMethodSignature?) {
+            if (jvmSignature == signature?.asString()) {
                 onMatch(predicate(functionFlags))
             }
         }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -21,7 +21,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDependency
 import org.gradle.api.internal.file.FileCollectionFactory
-import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.tasks.CacheableTask
@@ -393,7 +392,7 @@ class SyntheticProjectSchemaBuilder(
             DefaultSelfResolvingDependency(
                 project
                     .serviceOf<FileCollectionFactory>()
-                    .fixed("precompiled-script-plugins-accessors-classpath", rootProjectClassPath) as FileCollectionInternal
+                    .fixed("precompiled-script-plugins-accessors-classpath", rootProjectClassPath)
             )
         )
     }
@@ -403,7 +402,7 @@ class SyntheticProjectSchemaBuilder(
         val targetProjectScope = (project as ProjectInternal).classLoaderScope
         project.serviceOf<PluginRequestApplicator>().applyPlugins(
             pluginRequests,
-            project.buildscript as ScriptHandlerInternal,
+            project.buildscript,
             project.pluginManager,
             targetProjectScope
         )

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
@@ -91,5 +91,5 @@ private constructor(
      * Configures the dependency constraints.
      */
     inline operator fun invoke(configuration: DependencyConstraintHandlerScope.() -> Unit) =
-        configuration()
+        this.configuration()
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.plugins.ExtensionAware
 
 import org.gradle.kotlin.dsl.support.delegates.DependencyHandlerDelegate
 
@@ -43,7 +42,7 @@ private constructor(
         private
         class ExtensionAwareDependencyHandlerScope(
             dependencies: DependencyHandler
-        ) : DependencyHandlerScope(dependencies), ExtensionAware by (dependencies as ExtensionAware)
+        ) : DependencyHandlerScope(dependencies)
     }
 
     override val delegate: DependencyHandler
@@ -217,5 +216,5 @@ private constructor(
      * Configures the dependencies.
      */
     inline operator fun invoke(configuration: DependencyHandlerScope.() -> Unit) =
-        configuration()
+        this.configuration()
 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinMetadataPrintingVisitor.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinMetadataPrintingVisitor.kt
@@ -111,9 +111,9 @@ object KotlinMetadataPrintingVisitor {
         override fun visitExtensions(type: KmExtensionType): KmFunctionExtensionVisitor? {
             println("visitExtensions($type)")
             return object : JvmFunctionExtensionVisitor() {
-                override fun visit(desc: JvmMethodSignature?) {
-                    println("visit($desc)")
-                    super.visit(desc)
+                override fun visit(signature: JvmMethodSignature?) {
+                    println("visit($signature)")
+                    super.visit(signature)
                 }
                 override fun visitEnd() {
                     println("visitEnd()")
@@ -165,9 +165,9 @@ object KotlinMetadataPrintingVisitor {
                     super.visit(jvmFlags, fieldSignature, getterSignature, setterSignature)
                 }
 
-                override fun visitSyntheticMethodForAnnotations(desc: JvmMethodSignature?) {
-                    println("visitSyntheticMethodForAnnotations($desc)")
-                    super.visitSyntheticMethodForAnnotations(desc)
+                override fun visitSyntheticMethodForAnnotations(signature: JvmMethodSignature?) {
+                    println("visitSyntheticMethodForAnnotations($signature)")
+                    super.visitSyntheticMethodForAnnotations(signature)
                 }
 
                 override fun visitEnd() {


### PR DESCRIPTION
- Suppress `unchecked_cast` warnings
- Rename parameters to match base definition
- Remove unnecessary casts
- Remove unnecessary/duplicate interface implementation
- Help the compiler understand the expressions are indeed used