### PR TITLE
MetadataSources: Introduce ignoreGradleMetadataRedirection to prevent gradle metadata redirection when marker is present in POM or Ivy descriptor

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -287,7 +287,7 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
          * Indicates that this repository will contain Ivy descriptors.
          * If the Ivy file contains a marker telling that Gradle metadata exists
          * for this component, Gradle will <i>also</i> look for the Gradle metadata
-         * file.
+         * file. Gradle module metadata redirection will not happen if {@code ignoreGradleMetadataRedirection()} has been used.
          */
         void ivyDescriptor();
 
@@ -296,6 +296,14 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
          * but we can infer it from the presence of an artifact file.
          */
         void artifact();
+
+        /**
+         * Indicates that this repository will ignore Gradle module metadata redirection markers found in Ivy files.
+         *
+         * @since 5.6
+         *
+         */
+        void ignoreGradleMetadataRedirection();
     }
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -119,7 +119,7 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
          * Indicates that this repository will contain Maven POM files.
          * If the POM file contains a marker telling that Gradle metadata exists
          * for this component, Gradle will <i>also</i> look for the Gradle metadata
-         * file.
+         * file. Gradle module metadata redirection will not happen if {@code ignoreGradleMetadataRedirection()} has been used.
          */
         void mavenPom();
 
@@ -128,6 +128,14 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
          * but we can infer it from the presence of an artifact file.
          */
         void artifact();
+
+        /**
+         * Indicates that this repository will ignore Gradle module metadata redirection markers found in POM files.
+         *
+         * @since 5.6
+         *
+         */
+        void ignoreGradleMetadataRedirection();
     }
 
     /**

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
@@ -36,9 +36,7 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
                 maven { url "${mavenHttpRepo.uri}" }
             }
         """
-        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
-        resolve.expectDefaultConfiguration('compile')
-        resolve.prepare()
+        prepareResolution()
     }
 
     def "doesn't try to fetch Gradle metadata if published and marker is not present"() {
@@ -120,6 +118,43 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         }
     }
 
+    def "doesn't try to fetch Gradle metadata if published has marker present and ignoreGradleMetadataRedirection is set"() {
+        setup:
+        buildFile.text = """
+            apply plugin: 'java-library'
+            
+            repositories {
+                maven { 
+                    url "${mavenHttpRepo.uri}"
+                    metadataSources {
+                        mavenPom()
+                        artifact()
+                        ignoreGradleMetadataRedirection()
+                    }
+                }
+            }
+            
+             dependencies {
+                api "org:main:1.0"
+            }
+        """
+        prepareResolution()
+        createPomFile(true)
+
+        when:
+        mainModule.pom.expectGet()
+        mainModule.artifact.expectGet()
+
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:main:1.0')
+            }
+        }
+    }
+
     private void createPomFile(boolean marker) {
         if (marker) {
             mainModule.withGradleMetadataRedirection()
@@ -132,5 +167,11 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         moduleFile.replace('"dependencies":[]', '''"dependencies":[
             { "group": "org", "module": "foo", "version": { "prefers": "1.9" } }
         ]''')
+    }
+
+    private void prepareResolution() {
+        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+        resolve.expectDefaultConfiguration('compile')
+        resolve.prepare()
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -244,7 +244,11 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         }
         if (metadataSources.ivyDescriptor) {
             DefaultIvyDescriptorMetadataSource ivyDescriptorMetadataSource = new DefaultIvyDescriptorMetadataSource(IvyMetadataArtifactProvider.INSTANCE, createIvyDescriptorParser(), fileResourceRepository, moduleIdentifierFactory);
-            sources.add(new RedirectingGradleMetadataModuleMetadataSource(ivyDescriptorMetadataSource, gradleModuleMetadataSource));
+            if(metadataSources.ignoreGradleMetadataRedirection) {
+                sources.add(ivyDescriptorMetadataSource);
+            } else {
+                sources.add(new RedirectingGradleMetadataModuleMetadataSource(ivyDescriptorMetadataSource, gradleModuleMetadataSource));
+            }
         }
         if (metadataSources.artifact) {
             sources.add(new DefaultArtifactMetadataSource(metadataFactory));
@@ -393,6 +397,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         boolean gradleMetadata;
         boolean ivyDescriptor;
         boolean artifact;
+        boolean ignoreGradleMetadataRedirection;
 
         void setDefaults(FeaturePreviews featurePreviews) {
             ivyDescriptor();
@@ -401,12 +406,14 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
             } else {
                 artifact();
             }
+            ignoreGradleMetadataRedirection = false;
         }
 
         void reset() {
             gradleMetadata = false;
             ivyDescriptor = false;
             artifact = false;
+            ignoreGradleMetadataRedirection = false;
         }
 
         /**
@@ -426,6 +433,9 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
             if (artifact) {
                 list.add("artifact");
             }
+            if (ignoreGradleMetadataRedirection) {
+                list.add("ignoreGradleMetadataRedirection");
+            }
             return list;
         }
 
@@ -442,6 +452,11 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         @Override
         public void artifact() {
             artifact = true;
+        }
+
+        @Override
+        public void ignoreGradleMetadataRedirection() {
+            ignoreGradleMetadataRedirection = true;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -265,7 +265,11 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         }
         if (metadataSources.mavenPom) {
             DefaultMavenPomMetadataSource pomMetadataSource = new DefaultMavenPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
-            sources.add(new RedirectingGradleMetadataModuleMetadataSource(pomMetadataSource, gradleModuleMetadataSource));
+            if(metadataSources.ignoreGradleMetadataRedirection) {
+                sources.add(pomMetadataSource);
+            } else {
+                sources.add(new RedirectingGradleMetadataModuleMetadataSource(pomMetadataSource, gradleModuleMetadataSource));
+            }
         }
         if (metadataSources.artifact) {
             sources.add(new DefaultArtifactMetadataSource(metadataFactory));
@@ -325,6 +329,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         boolean gradleMetadata;
         boolean mavenPom;
         boolean artifact;
+        boolean ignoreGradleMetadataRedirection;
 
         void setDefaults(FeaturePreviews featurePreviews) {
             mavenPom();
@@ -333,12 +338,15 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
             } else {
                 artifact();
             }
+            ignoreGradleMetadataRedirection = false;
+
         }
 
         void reset() {
             gradleMetadata = false;
             mavenPom = false;
             artifact = false;
+            ignoreGradleMetadataRedirection = false;
         }
 
         /**
@@ -358,6 +366,9 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
             if (artifact) {
                 list.add("artifact");
             }
+            if (ignoreGradleMetadataRedirection) {
+                list.add("ignoreGradleMetadataRedirection");
+            }
             return list;
         }
 
@@ -374,6 +385,11 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         @Override
         public void artifact() {
             artifact = true;
+        }
+
+        @Override
+        public void ignoreGradleMetadataRedirection() {
+            ignoreGradleMetadataRedirection = true;
         }
     }
 

--- a/subprojects/docs/src/docs/userguide/repository_types.adoc
+++ b/subprojects/docs/src/docs/userguide/repository_types.adoc
@@ -235,6 +235,19 @@ The following metadata sources are supported:
 The defaults for Ivy and Maven repositories change with Gradle 5.0. Before 5.0, `artifact()` was included in the defaults. Leading to some inefficiency when modules are missing completely. To restore this behavior, for example, for Maven central you can use `mavenCentral { mavenPom(); artifact() }`. In a similar way, you can opt into the new behavior in older Gradle versions using `mavenCentral { mavenPom() }`
 ====
 
+
+Since Gradle 5.3, when parsing a metadata file, be it Ivy or Maven, Gradle will look for a marker indicating that a matching Gradle Module Metadata files exists.
+If it is found, it will be used instead of the Ivy or Maven file.
+
+Starting with Gradle 5.6, you can disable this behavior by adding `ignoreGradleMetadataRedirection()` to the metadataSources declaration.
+
+.Maven repository that does not use gradle metadata redirection
+====
+include::sample[dir="userguide/artifacts/defineRepository/groovy",files="build.gradle[tags=maven-repo-with-ignore-gradle-metadata-redirection]"]
+include::sample[dir="userguide/artifacts/defineRepository/kotlin",files="build.gradle.kts[tags=maven-repo-with-ignore-gradle-metadata-redirection]"]
+====
+
+
 [[sub:supported_transport_protocols]]
 == Supported repository transport protocols
 

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/groovy/build.gradle
@@ -244,6 +244,19 @@ repositories {
 }
 // end::maven-repo-with-metadata-sources[]
 
+// tag::maven-repo-with-ignore-gradle-metadata-redirection[]
+repositories {
+    maven {
+        url "http://repo.mycompany.com/repo"
+        metadataSources {
+            mavenPom()
+            artifact()
+            ignoreGradleMetadataRedirection()
+        }
+    }
+}
+// end::maven-repo-with-ignore-gradle-metadata-redirection[]
+
 // tag::authenticated-ivy-repo[]
 repositories {
     ivy {

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/kotlin/build.gradle.kts
@@ -247,6 +247,19 @@ repositories {
 }
 // end::maven-repo-with-metadata-sources[]
 
+// tag::maven-repo-with-ignore-gradle-metadata-redirection[]
+repositories {
+    maven {
+        url = uri("http://repo.mycompany.com/repo")
+        metadataSources {
+            mavenPom()
+            artifact()
+            ignoreGradleMetadataRedirection()
+        }
+    }
+}
+// end::maven-repo-with-ignore-gradle-metadata-redirection[]
+
 // tag::authenticated-ivy-repo[]
 repositories {
     ivy {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/9951

### Context
As discussed in https://github.com/gradle/gradle/issues/9951

POM/Ivy descriptor marker redirection for gradle module metadata won't go away anytime soon. There are use cases where people wouldn't want to apply the marker redirection by default and there isn't an existing mechanism as of Today.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
