### PR TITLE
Task inputs/outputs runtime API documentation should always configure property names and normalization

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
@@ -62,8 +62,11 @@ class CachedPathSensitivityIntegrationTest extends AbstractPathSensitivityIntegr
             task consumer {
                 dependsOn producer
                 outputs.cacheIf { true }
-                inputs.file("outputs/producer.txt").withPathSensitivity(PathSensitivity.$pathSensitivity)
+                inputs.file("outputs/producer.txt")
+                    .withPropertyName("producer")
+                    .withPathSensitivity(PathSensitivity.$pathSensitivity)
                 outputs.file("outputs/consumer.txt")
+                    .withPropertyName("consumer")
                 doLast {
                     file("outputs/consumer.txt").text = file("outputs/producer.txt").text
                 }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -310,7 +310,7 @@ def javadocAll = tasks.register("javadocAll", Javadoc) {
     options.addStringOption "stylesheetfile", stylesheetFile.absolutePath
     options.addStringOption "source", "8"
     source ProjectGroups.INSTANCE.getPublicJavaProjects(project).collect { project -> project.sourceSets.main.allJava }
-    destinationDir = new File(docsDir, 'javadoc') 
+    destinationDir = new File(docsDir, 'javadoc')
     classpath = configurations.gradleApiRuntime
 
     PublicApi.includes.each {
@@ -334,7 +334,7 @@ def javadocAll = tasks.register("javadocAll", Javadoc) {
 
             // Commit http://hg.openjdk.java.net/jdk/jdk/rev/89dc31d7572b broke use of JSZip (https://bugs.openjdk.java.net/browse/JDK-8214856) fixed in Java 12 by http://hg.openjdk.java.net/jdk/jdk/rev/b4982a22926b
             // TODO: Remove this script.js workaround when we distribute Gradle using JDK 12 or higher
-            project.copy { 
+            project.copy {
             	from(new File(srcDocsDir, "js/javadoc"))
                 into(destinationDir)
             }
@@ -367,11 +367,17 @@ tasks.withType(CacheableAsciidoctorTask).configureEach {
     separateOutputDirs = false
     options doctype: 'book'
 
-    inputs.file("$srcDocsDir/css/manual.css").withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.dir(file("src/main/resources")).withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.dir(samplesSrcDir).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file("$srcDocsDir/css/manual.css")
+        .withPropertyName("manual")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir(file("src/main/resources"))
+        .withPropertyName("resources")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir(samplesSrcDir)
+        .withPropertyName("samples")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 
-    attributes stylesdir           : '../css/',
+    attributes stylesdir    : '../css/',
         stylesheet          : 'manual.css',
         imagesdir           : 'img',
         nofooter            : true,

--- a/subprojects/docs/src/samples/testKit/gradleRunner/manualClasspathInjection/groovy/build.gradle
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/manualClasspathInjection/groovy/build.gradle
@@ -20,8 +20,11 @@ repositories {
 task createClasspathManifest {
     def outputDir = file("$buildDir/$name")
 
-    inputs.files sourceSets.main.runtimeClasspath
-    outputs.dir outputDir
+    inputs.files(sourceSets.main.runtimeClasspath)
+        .withPropertyName("runtimeClasspath")
+        .withNormalizer(ClasspathNormalizer)
+    outputs.dir(outputDir)
+        .withPropertyName("outputDir")
 
     doLast {
         outputDir.mkdirs()

--- a/subprojects/docs/src/samples/testKit/gradleRunner/manualClasspathInjection/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/testKit/gradleRunner/manualClasspathInjection/kotlin/build.gradle.kts
@@ -21,7 +21,10 @@ tasks.register("createClasspathManifest") {
     val outputDir = file("$buildDir/$name")
 
     inputs.files(sourceSets.main.get().runtimeClasspath)
+        .withPropertyName("runtimeClasspath")
+        .withNormalizer(ClasspathNormalizer::class)
     outputs.dir(outputDir)
+        .withPropertyName("outputDir")
 
     doLast {
         outputDir.mkdirs()

--- a/subprojects/docs/src/samples/userguide/files/copy/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/copy/groovy/build.gradle
@@ -168,8 +168,11 @@ task copyMethod {
 // tag::copy-method-with-dependency[]
 task copyMethodWithExplicitDependencies {
     // up-to-date check for inputs, plus add copyTask as dependency
-    inputs.files copyTask
-    outputs.dir 'some-dir' // up-to-date check for outputs
+    inputs.files(copyTask)
+        .withPropertyName("inputs")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir('some-dir') // up-to-date check for outputs
+        .withPropertyName("outputDir")
     doLast{
         copy {
             // Copy the output of copyTask

--- a/subprojects/docs/src/samples/userguide/files/copy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/copy/kotlin/build.gradle.kts
@@ -173,7 +173,10 @@ tasks.register("copyMethod") {
 tasks.register("copyMethodWithExplicitDependencies") {
     // up-to-date check for inputs, plus add copyTask as dependency
     inputs.files(copyTask)
+        .withPropertyName("inputs")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.dir("some-dir") // up-to-date check for outputs
+        .withPropertyName("outputDir")
     doLast {
         copy {
             // Copy the output of copyTask

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/customTaskClass/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/customTaskClass/groovy/build.gradle
@@ -15,9 +15,12 @@ task processTemplates(type: ProcessTemplates) {
 task processTemplatesAdHoc {
     inputs.property("engine", TemplateEngineType.FREEMARKER)
     inputs.files(fileTree("src/templates"))
+        .withPropertyName("sourceFiles")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property("templateData.name", "docs")
     inputs.property("templateData.variables", [year: 2013])
     outputs.dir("$buildDir/genOutput2")
+        .withPropertyName("outputDir")
 
     doLast {
         // Process the templates here
@@ -42,9 +45,12 @@ task processTemplatesRuntime(type: ProcessTemplatesNoAnnotations) {
 
     inputs.property("engine", templateEngine)
     inputs.files(sourceFiles)
+        .withPropertyName("sourceFiles")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property("templateData.name", templateData.name)
     inputs.property("templateData.variables", templateData.variables)
     outputs.dir(outputDir)
+        .withPropertyName("outputDir")
 }
 // end::custom-class-runtime-api[]
 
@@ -60,13 +66,17 @@ task processTemplatesRuntimeConf(type: ProcessTemplatesNoAnnotations) {
         include "**/*.fm"
     }
 
-    inputs.files(sourceFiles).skipWhenEmpty()
+    inputs.files(sourceFiles)
+        .skipWhenEmpty()
+        .withPropertyName("sourceFiles")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     // ...
 // end::runtime-api-conf[]
     inputs.property("engine",templateEngine)
     inputs.property("templateData.name", templateData.name)
     inputs.property("templateData.variables", templateData.variables)
     outputs.dir(outputDir)
+        .withPropertyName("outputDir")
 // tag::runtime-api-conf[]
 }
 // end::runtime-api-conf[]

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/customTaskClass/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalBuild/customTaskClass/kotlin/build.gradle.kts
@@ -15,9 +15,12 @@ val processTemplates by tasks.registering(ProcessTemplates::class) {
 tasks.register("processTemplatesAdHoc") {
     inputs.property("engine", TemplateEngineType.FREEMARKER)
     inputs.files(fileTree("src/templates"))
+        .withPropertyName("sourceFiles")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property("templateData.name", "docs")
     inputs.property("templateData.variables", mapOf("year" to "2013"))
     outputs.dir("$buildDir/genOutput2")
+        .withPropertyName("outputDir")
 
     doLast {
         // Process the templates here
@@ -42,9 +45,12 @@ tasks.register<ProcessTemplatesNoAnnotations>("processTemplatesRuntime") {
 
     inputs.property("engine", templateEngine)
     inputs.files(sourceFiles)
+        .withPropertyName("sourceFiles")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property("templateData.name", templateData.name)
     inputs.property("templateData.variables", templateData.variables)
     outputs.dir(outputDir)
+        .withPropertyName("outputDir")
 }
 // end::custom-class-runtime-api[]
 
@@ -60,13 +66,17 @@ tasks.register<ProcessTemplatesNoAnnotations>("processTemplatesRuntimeConf") {
         include("**/*.fm")
     }
 
-    inputs.files(sourceFiles).skipWhenEmpty()
+    inputs.files(sourceFiles)
+        .skipWhenEmpty()
+        .withPropertyName("sourceFiles")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     // ...
 // end::runtime-api-conf[]
     inputs.property("engine", templateEngine)
     inputs.property("templateData.name", templateData.name)
     inputs.property("templateData.variables", templateData.variables)
     outputs.dir(outputDir)
+        .withPropertyName("outputDir")
 // tag::runtime-api-conf[]
 }
 // end::runtime-api-conf[]

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -86,6 +86,9 @@ java.sourceSets.main { output.dir(mapOf("builtBy" to reportResources), generated
 
 tasks.jar {
     inputs.files(flamegraph)
+        .withPropertyName("flamegraph")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+
     from(files(deferred{ flamegraph.map { zipTree(it) } }))
 }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #7978
