### PR TITLE
Migrate to new Kotlin Js plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ import org.gradle.build.BuildReceipt
 import org.gradle.build.Install
 import org.gradle.gradlebuild.ProjectGroups.implementationPluginProjects
 import org.gradle.gradlebuild.ProjectGroups.javaProjects
+import org.gradle.gradlebuild.ProjectGroups.kotlinJsProjects
 import org.gradle.gradlebuild.ProjectGroups.pluginProjects
 import org.gradle.gradlebuild.ProjectGroups.publicJavaProjects
 import org.gradle.gradlebuild.buildquality.incubation.IncubatingApiAggregateReportTask
@@ -211,7 +212,11 @@ subprojects {
     }
 
     apply(from = "$rootDir/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")
-    apply(plugin = "gradlebuild.task-properties-validation")
+
+    if (project !in kotlinJsProjects) {
+        apply(plugin = "gradlebuild.task-properties-validation")
+    }
+
     apply(plugin = "gradlebuild.test-files-cleanup")
 }
 

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/ProjectGroups.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/ProjectGroups.kt
@@ -22,22 +22,30 @@ object ProjectGroups {
     private
     val Project.internalProjects
         get() = rootProject.subprojects.filter {
-            it.name.startsWith("internal") || it.name in internalProjectNames
+            it.name.startsWith("internal")
+                || it.name in internalProjectNames
+                || it.name in kotlinJsProjectNames
         }.toSet()
 
     private
     val internalProjectNames = setOf(
         "integTest", "distributions", "performance", "buildScanPerformance",
-        "kotlinCompilerEmbeddable", "kotlinDslTestFixtures", "kotlinDslIntegTests",
+        "kotlinCompilerEmbeddable", "kotlinDslTestFixtures", "kotlinDslIntegTests"
+    )
+
+    private
+    val kotlinJsProjectNames = setOf(
         "instantExecutionReport"
     )
 
+    val Project.kotlinJsProjects
+        get() = kotlinJsProjectNames.map { project(":$it") }
+
     val Project.javaProjects
-        get() = rootProject.subprojects - listOf(project(":distributionsDependencies"))
+        get() = rootProject.subprojects - kotlinJsProjects - listOf(project(":distributionsDependencies"))
 
     val Project.publicJavaProjects
         get() = javaProjects - internalProjects
-
 
     val Project.pluginProjects
         get() = setOf("announce", "antlr", "plugins", "codeQuality", "wrapper", "osgi", "maven",

--- a/subprojects/instant-execution-report/README.md
+++ b/subprojects/instant-execution-report/README.md
@@ -1,9 +1,9 @@
 The `:instantExecutionReport` project produces the Javascript / HTML
-app for browsing and understanding failures occurred when running a
+app for browsing and understanding problems occurred when running a
 build with instant execution.
 
 The output of `:instantExecutionReport` is completely produced by the
-`processResources` task into `build/resources/main` which then gets
+`assembleReport` task into `build/report` which then gets
 embedded into the `:instantExecution` module (see
 [../instant-execution/instant-execution.gradle.kts](../instant-execution/instant-execution.gradle.kts)).
 
@@ -30,6 +30,6 @@ Start a continuous build on one shell:
 
 Start `browser-sync` on another:
 
-    $ browser-sync start -s subprojects/instant-execution-report/build/resources/main --startPath instant-execution-report.html -w
+    $ browser-sync start -s subprojects/instant-execution-report/build/report --startPath instant-execution-report.html -w
 
 Hack away!

--- a/subprojects/instant-execution-report/instant-execution-report.gradle.kts
+++ b/subprojects/instant-execution-report/instant-execution-report.gradle.kts
@@ -57,8 +57,14 @@ tasks {
         includeEmptyDirs = false
     }
 
-    processResources {
-        from(compileKotlin2Js.map { it.outputFile })
+    val assembleReport by registering(Copy::class) {
+        from(processResources)
         from(unpackKotlinJsStdlib)
+        from(compileKotlin2Js.map { it.outputFile })
+        into("$buildDir/report")
+    }
+
+    assemble {
+        dependsOn(assembleReport)
     }
 }

--- a/subprojects/instant-execution-report/instant-execution-report.gradle.kts
+++ b/subprojects/instant-execution-report/instant-execution-report.gradle.kts
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-import org.gradle.gradlebuild.unittestandcompile.ModuleType
-
 plugins {
-    id("kotlin2js")
-}
-
-gradlebuildJava {
-    moduleType = ModuleType.INTERNAL
+    kotlin("js")
 }
 
 dependencies {
@@ -30,7 +24,7 @@ dependencies {
 
 tasks {
 
-    compileKotlin2Js {
+    compileKotlinJs {
         kotlinOptions {
             outputFile = "$buildDir/js/instant-execution-report.js"
             metaInfo = false
@@ -60,7 +54,7 @@ tasks {
     val assembleReport by registering(Copy::class) {
         from(processResources)
         from(unpackKotlinJsStdlib)
-        from(compileKotlin2Js.map { it.outputFile })
+        from(compileKotlinJs.map { it.outputFile })
         into("$buildDir/report")
     }
 

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 tasks {
     processResources {
-        from(project(":instantExecutionReport").tasks.processResources) {
+        from({ project(":instantExecutionReport").tasks.named("assembleReport") }) {
             into("org/gradle/instantexecution")
         }
     }


### PR DESCRIPTION
The old plugin seems to be causing some intermittent ` ConcurrentModificationException` failures and the new plugin has support for testing.

This requires removing `instantExecutionReport` from the set of java projects as the new plugin is not compatible with it.
