### PR TITLE
Make configuration request attributes available on dependency resolution build operation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationDependenciesBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationDependenciesBuildOperationType.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -69,6 +70,11 @@ public final class ResolveConfigurationDependenciesBuildOperationType implements
         @Nullable
         String getRepositoryId(ResolvedComponentResult resolvedComponentResult);
 
+        /**
+         * Which attributes the resolved configuration was requested with, if any.
+         * @since 5.6
+         */
+        AttributeContainer getRequestedAttributes();
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1753,21 +1753,23 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     // this does the same thing as passing through DesugaredAttributeContainerSerializer / DesugaringAttributeContainerSerializer
     @SuppressWarnings("unchecked")
     private AttributeContainer desugarAttributes(ResolutionResult resolutionResult) {
-        AttributeContainer requestedAttributes = resolutionResult.getRequestedAttributes();
         AttributeContainerInternal result = attributesFactory.mutable();
-        for (Attribute<?> attribute : requestedAttributes.keySet()) {
-            String name = attribute.getName();
-            Class<?> type = attribute.getType();
-            if (type.equals(Boolean.class)) {
-                result.attribute((Attribute<Boolean>) attribute, (Boolean) requestedAttributes.getAttribute(attribute));
-            } else if (type.equals(String.class)) {
-                result.attribute((Attribute<String>) attribute, (String) requestedAttributes.getAttribute(attribute));
-            } else if (type.equals(Integer.class)) {
-                result.attribute((Attribute<Integer>) attribute, (Integer) requestedAttributes.getAttribute(attribute));
-            } else {
-                assert Named.class.isAssignableFrom(type);
-                Named attributeValue = (Named) requestedAttributes.getAttribute(attribute);
-                result.attribute(Attribute.of(name, String.class), attributeValue.getName());
+        AttributeContainer requestedAttributes = resolutionResult.getRequestedAttributes();
+        if (requestedAttributes != null) {
+            for (Attribute<?> attribute : requestedAttributes.keySet()) {
+                String name = attribute.getName();
+                Class<?> type = attribute.getType();
+                if (type.equals(Boolean.class)) {
+                    result.attribute((Attribute<Boolean>) attribute, (Boolean) requestedAttributes.getAttribute(attribute));
+                } else if (type.equals(String.class)) {
+                    result.attribute((Attribute<String>) attribute, (String) requestedAttributes.getAttribute(attribute));
+                } else if (type.equals(Integer.class)) {
+                    result.attribute((Attribute<Integer>) attribute, (Integer) requestedAttributes.getAttribute(attribute));
+                } else {
+                    assert Named.class.isAssignableFrom(type);
+                    Named attributeValue = (Named) requestedAttributes.getAttribute(attribute);
+                    result.attribute(Attribute.of(name, String.class), attributeValue.getName());
+                }
             }
         }
         return result.asImmutable();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -24,7 +24,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Named;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.ArtifactView;
@@ -636,7 +635,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 // 1. the `failed` method will have been called with the user facing error
                 // 2. such an error may still lead to a valid dependency graph
                 ResolutionResult resolutionResult = cachedResolverResults.getResolutionResult();
-                context.setResult(new ResolveConfigurationResolutionBuildOperationResult(resolutionResult, desugarAttributes(resolutionResult)));
+                context.setResult(ResolveConfigurationResolutionBuildOperationResult.create(resolutionResult, attributesFactory));
             }
 
             @Override
@@ -1750,28 +1749,4 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
     }
 
-    // this does the same thing as passing through DesugaredAttributeContainerSerializer / DesugaringAttributeContainerSerializer
-    @SuppressWarnings("unchecked")
-    private AttributeContainer desugarAttributes(ResolutionResult resolutionResult) {
-        AttributeContainerInternal result = attributesFactory.mutable();
-        AttributeContainer requestedAttributes = resolutionResult.getRequestedAttributes();
-        if (requestedAttributes != null) {
-            for (Attribute<?> attribute : requestedAttributes.keySet()) {
-                String name = attribute.getName();
-                Class<?> type = attribute.getType();
-                if (type.equals(Boolean.class)) {
-                    result.attribute((Attribute<Boolean>) attribute, (Boolean) requestedAttributes.getAttribute(attribute));
-                } else if (type.equals(String.class)) {
-                    result.attribute((Attribute<String>) attribute, (String) requestedAttributes.getAttribute(attribute));
-                } else if (type.equals(Integer.class)) {
-                    result.attribute((Attribute<Integer>) attribute, (Integer) requestedAttributes.getAttribute(attribute));
-                } else {
-                    assert Named.class.isAssignableFrom(type);
-                    Named attributeValue = (Named) requestedAttributes.getAttribute(attribute);
-                    result.attribute(Attribute.of(name, String.class), attributeValue.getName());
-                }
-            }
-        }
-        return result.asImmutable();
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.Named;
@@ -27,6 +28,8 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.AttributeValue;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
 
@@ -35,7 +38,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfigurationDependenciesBuildOperationType.Result, CustomOperationTraceSerialization {
     private final ResolutionResult resolutionResult;
@@ -93,11 +95,11 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
 
     // This does almost the same thing as passing through DesugaredAttributeContainerSerializer / DesugaringAttributeContainerSerializer.
     // Those make some assumptions about allowed attribute value types that we can't - we serialize everything else to a string instead.
-    private static final class LazyDesugaringAttributeContainer implements AttributeContainer {
+    private static final class LazyDesugaringAttributeContainer implements ImmutableAttributes {
 
         private final AttributeContainer source;
         private final ImmutableAttributesFactory attributesFactory;
-        private AttributeContainer desugared;
+        private ImmutableAttributes desugared;
 
         private LazyDesugaringAttributeContainer(AttributeContainer source, ImmutableAttributesFactory attributesFactory) {
             this.source = source;
@@ -105,7 +107,7 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
         }
 
         @Override
-        public Set<Attribute<?>> keySet() {
+        public ImmutableSet<Attribute<?>> keySet() {
             return getDesugared().keySet();
         }
 
@@ -135,7 +137,37 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
             return getDesugared().getAttributes();
         }
 
-        private AttributeContainer getDesugared() {
+        @Override
+        public ImmutableAttributes asImmutable() {
+            return getDesugared();
+        }
+
+        @Override
+        public <T> AttributeValue<T> findEntry(Attribute<T> key) {
+            return getDesugared().findEntry(key);
+        }
+
+        @Override
+        public AttributeValue<?> findEntry(String key) {
+            return getDesugared().findEntry(key);
+        }
+
+        @Override
+        public String toString() {
+            return getDesugared().toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return getDesugared().equals(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            return getDesugared().hashCode();
+        }
+
+        private ImmutableAttributes getDesugared() {
             if (desugared == null) {
                 desugarAttributes();
             }
@@ -149,15 +181,15 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
                 for (Attribute<?> attribute : source.keySet()) {
                     String name = attribute.getName();
                     Class<?> type = attribute.getType();
+                    Object attributeValue = source.getAttribute(attribute);
                     if (type.equals(Boolean.class)) {
-                        result.attribute((Attribute<Boolean>) attribute, (Boolean) source.getAttribute(attribute));
+                        result.attribute((Attribute<Boolean>) attribute, (Boolean) attributeValue);
                     } else if (type.equals(String.class)) {
-                        result.attribute((Attribute<String>) attribute, (String) source.getAttribute(attribute));
+                        result.attribute((Attribute<String>) attribute, (String) attributeValue);
                     } else if (type.equals(Integer.class)) {
-                        result.attribute((Attribute<Integer>) attribute, (Integer) source.getAttribute(attribute));
+                        result.attribute((Attribute<Integer>) attribute, (Integer) attributeValue);
                     } else {
                         // just serialize as a String as best we can
-                        Object attributeValue = source.getAttribute(attribute);
                         Attribute<String> stringAtt = Attribute.of(name, String.class);
                         String stringValue;
                         if (attributeValue instanceof Named) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -16,10 +16,14 @@
 
 package org.gradle.api.internal.artifacts.configurations;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
 import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
 
@@ -29,9 +33,11 @@ import java.util.Map;
 
 class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfigurationDependenciesBuildOperationType.Result, CustomOperationTraceSerialization {
     private final ResolutionResult resolutionResult;
+    private final AttributeContainer requestedAttributes;
 
-    ResolveConfigurationResolutionBuildOperationResult(ResolutionResult resolutionResult) {
+    ResolveConfigurationResolutionBuildOperationResult(ResolutionResult resolutionResult, AttributeContainer requestedAttributes) {
         this.resolutionResult = resolutionResult;
+        this.requestedAttributes = requestedAttributes;
     }
 
     @Override
@@ -59,6 +65,17 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
             }
         });
         model.put("components", components);
+        ImmutableList.Builder<Object> requestedAttributesBuilder = new ImmutableList.Builder<Object>();
+        for (Attribute<?> att : requestedAttributes.keySet()) {
+            requestedAttributesBuilder.add(ImmutableMap.of("name", att.getName(), "value", requestedAttributes.getAttribute(att).toString()));
+        }
+        model.put("requestedAttributes", requestedAttributesBuilder.build());
         return model;
     }
+
+    @Override
+    public AttributeContainer getRequestedAttributes() {
+        return requestedAttributes;
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolveConfigurationResolutionBuildOperationResult.java
@@ -20,22 +20,35 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
+import org.gradle.api.Named;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.result.ResolvedComponentResultInternal;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
 
+import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfigurationDependenciesBuildOperationType.Result, CustomOperationTraceSerialization {
     private final ResolutionResult resolutionResult;
     private final AttributeContainer requestedAttributes;
 
-    ResolveConfigurationResolutionBuildOperationResult(ResolutionResult resolutionResult, AttributeContainer requestedAttributes) {
+    static ResolveConfigurationResolutionBuildOperationResult create(ResolutionResult resolutionResult, ImmutableAttributesFactory attributesFactory) {
+        return new ResolveConfigurationResolutionBuildOperationResult(
+                resolutionResult,
+                new LazyDesugaringAttributeContainer(resolutionResult.getRequestedAttributes(), attributesFactory)
+        );
+    }
+
+    private ResolveConfigurationResolutionBuildOperationResult(ResolutionResult resolutionResult, AttributeContainer requestedAttributes) {
         this.resolutionResult = resolutionResult;
         this.requestedAttributes = requestedAttributes;
     }
@@ -76,6 +89,90 @@ class ResolveConfigurationResolutionBuildOperationResult implements ResolveConfi
     @Override
     public AttributeContainer getRequestedAttributes() {
         return requestedAttributes;
+    }
+
+    // This does almost the same thing as passing through DesugaredAttributeContainerSerializer / DesugaringAttributeContainerSerializer.
+    // Those make some assumptions about allowed attribute value types that we can't - we serialize everything else to a string instead.
+    private static final class LazyDesugaringAttributeContainer implements AttributeContainer {
+
+        private final AttributeContainer source;
+        private final ImmutableAttributesFactory attributesFactory;
+        private AttributeContainer desugared;
+
+        private LazyDesugaringAttributeContainer(AttributeContainer source, ImmutableAttributesFactory attributesFactory) {
+            this.source = source;
+            this.attributesFactory = attributesFactory;
+        }
+
+        @Override
+        public Set<Attribute<?>> keySet() {
+            return getDesugared().keySet();
+        }
+
+        @Override
+        public <T> AttributeContainer attribute(Attribute<T> key, T value) {
+            return getDesugared().attribute(key, value);
+        }
+
+        @Nullable
+        @Override
+        public <T> T getAttribute(Attribute<T> key) {
+            return getDesugared().getAttribute(key);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return getDesugared().isEmpty();
+        }
+
+        @Override
+        public boolean contains(Attribute<?> key) {
+            return getDesugared().contains(key);
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return getDesugared().getAttributes();
+        }
+
+        private AttributeContainer getDesugared() {
+            if (desugared == null) {
+                desugarAttributes();
+            }
+            return desugared;
+        }
+
+        @SuppressWarnings("unchecked")
+        private void desugarAttributes() {
+            AttributeContainerInternal result = attributesFactory.mutable();
+            if (source != null) {
+                for (Attribute<?> attribute : source.keySet()) {
+                    String name = attribute.getName();
+                    Class<?> type = attribute.getType();
+                    if (type.equals(Boolean.class)) {
+                        result.attribute((Attribute<Boolean>) attribute, (Boolean) source.getAttribute(attribute));
+                    } else if (type.equals(String.class)) {
+                        result.attribute((Attribute<String>) attribute, (String) source.getAttribute(attribute));
+                    } else if (type.equals(Integer.class)) {
+                        result.attribute((Attribute<Integer>) attribute, (Integer) source.getAttribute(attribute));
+                    } else {
+                        // just serialize as a String as best we can
+                        Object attributeValue = source.getAttribute(attribute);
+                        Attribute<String> stringAtt = Attribute.of(name, String.class);
+                        String stringValue;
+                        if (attributeValue instanceof Named) {
+                            stringValue = ((Named) attributeValue).getName();
+                        } else if (attributeValue instanceof Object[]) { // don't bother trying to handle primitive arrays specially
+                            stringValue = Arrays.toString((Object[]) attributeValue);
+                        } else {
+                            stringValue = attributeValue.toString();
+                        }
+                        result.attribute(stringAtt, stringValue);
+                    }
+                }
+            }
+            desugared = result.asImmutable();
+        }
     }
 
 }


### PR DESCRIPTION
### Context
These are necessary to properly identify dependencies when using variants.

Main item that may be controversial is the lazy desugaring of the attributes, as an attempt to not pay for it when build scans or build op trace isn't being used.

### Contributor Checklist
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
