### PR TITLE
Change calculation of task dependencies for file collections containing a `Callable` backed provider whose value contains a `Buildable` element

### DIFF
--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
@@ -247,7 +247,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         run("merge")
 
         then:
-        output.count("calculating value") == 1
+        output.count("calculating value") == 2 // once for task dependency calculation, once for task execution
     }
 
     def "can connect the elements of a file collection to task input ListProperty"() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
@@ -47,10 +47,7 @@ public class BuildDependenciesOnlyFileCollectionResolveContext implements FileCo
     public boolean maybeAdd(Object element) {
         if (element instanceof ProviderInternal) {
             ProviderInternal provider = (ProviderInternal) element;
-            // When a provider is an element of a file collection and its producing tasks are not known, unpack its value if the value is declared as Buildable
-            if (!provider.maybeVisitBuildDependencies(taskContext) && provider.getType() != null && Buildable.class.isAssignableFrom(provider.getType())) {
-                taskContext.add(provider.get());
-            }
+            return provider.maybeVisitBuildDependencies(taskContext);
         } else if (element instanceof TaskDependencyContainer || element instanceof Buildable) {
             taskContext.add(element);
         } else if (!(element instanceof MinimalFileCollection)) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionResolveContext.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionResolveContext.java
@@ -46,6 +46,8 @@ public interface FileCollectionResolveContext {
      *     <li>{@link org.gradle.api.Buildable}</li>
      *     <li>{@link TaskDependencyContainer}</li>
      * </ul>
+     *
+     * @return true when the element has been handled, false when the caller is responsible for unpacking the element.
      */
     boolean maybeAdd(Object element);
 


### PR DESCRIPTION

### Context

This PR changes the task dependency calculation for file collections containing 'opaque' providers (backed by a `Callable`), to match the behaviour of previous releases. This behaviour was recently changed intentionally, but the change didn't really make sense.

Now, when calculating the task dependencies contributed to a file collection by a `Provider`, if the producing tasks of the provider is not known, then the provider value is queried and resolved recursively. This does mean that the provider value is queried during task graph calculation, but this can be addressed by replacing the 'opaque' provider with one whose producing tasks is known (eg a task output, or collection or mapping of such).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
