### PR TITLE
Let kotlin-dsl jars not include duplicated entries

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
@@ -33,6 +33,7 @@ tasks.jar {
     val main by sourceSets.getting
     from(main.allSource) {
         // prevent duplicated zip entries
+        // see https://github.com/gradle/gradle/issues/10005
         exclude { it.file in main.resources }
     }
     manifest.attributes.apply {

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
@@ -30,7 +30,11 @@ plugins {
 
 // including all sources
 tasks.jar {
-    from(sourceSets.main.get().allSource)
+    val main by sourceSets.getting
+    from(main.allSource) {
+        // prevent duplicated zip entries
+        exclude { it.file in main.resources }
+    }
     manifest.attributes.apply {
         put("Implementation-Title", "Gradle Kotlin DSL (${project.name})")
         put("Implementation-Version", archiveVersion.get())


### PR DESCRIPTION
For the jars not to be flagged as _possible zip bomb_ by `unzip` after the addition of a check for `CVE-2019-13232`.

This partly addresses https://github.com/gradle/gradle/issues/9990, see more details there.
