### PR TITLE
Conversion rule for deprecated org.gradle.usage values

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.attributes;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
@@ -31,6 +32,7 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
     private final ImmutableAttributes root;
     private final Map<ImmutableAttributes, List<DefaultImmutableAttributes>> children;
     private final IsolatableFactory isolatableFactory;
+    private final UsageCompatibilityHandler usageCompatibilityHandler;
     private NamedObjectInstantiator instantiator;
 
     public DefaultImmutableAttributesFactory(IsolatableFactory isolatableFactory, NamedObjectInstantiator instantiator) {
@@ -39,6 +41,7 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
         this.root = ImmutableAttributes.EMPTY;
         this.children = Maps.newHashMap();
         children.put(root, new ArrayList<DefaultImmutableAttributes>());
+        usageCompatibilityHandler = new UsageCompatibilityHandler(isolatableFactory, instantiator);
     }
 
     public int size() {
@@ -75,10 +78,14 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
 
     @Override
     public <T> ImmutableAttributes concat(ImmutableAttributes node, Attribute<T> key, Isolatable<T> value) {
-        return doConcatIsolatable(node, key, value);
+        if (key.equals(Usage.USAGE_ATTRIBUTE) || key.getName().equals(Usage.USAGE_ATTRIBUTE.getName())) {
+            return usageCompatibilityHandler.doConcat(this, node, key, value);
+        } else {
+            return doConcatIsolatable(node, key, value);
+        }
     }
 
-    private <T> ImmutableAttributes doConcatIsolatable(ImmutableAttributes node, Attribute<?> key, Isolatable<?> value) {
+    <T> ImmutableAttributes doConcatIsolatable(ImmutableAttributes node, Attribute<?> key, Isolatable<?> value) {
         synchronized (this) {
             List<DefaultImmutableAttributes> nodeChildren = children.get(node);
             if (nodeChildren == null) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/UsageCompatibilityHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/UsageCompatibilityHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes;
+
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.isolation.Isolatable;
+import org.gradle.internal.isolation.IsolatableFactory;
+import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
+
+class UsageCompatibilityHandler {
+    private final IsolatableFactory isolatableFactory;
+    private final NamedObjectInstantiator instantiator;
+
+    UsageCompatibilityHandler(IsolatableFactory isolatableFactory, NamedObjectInstantiator instantiator) {
+        this.isolatableFactory = isolatableFactory;
+        this.instantiator = instantiator;
+    }
+
+    public <T> ImmutableAttributes doConcat(DefaultImmutableAttributesFactory factory, ImmutableAttributes node, Attribute<T> key, Isolatable<T> value) {
+        assert key.getName().equals(Usage.USAGE_ATTRIBUTE.getName()) : "Should only be invoked for 'org.gradle.usage', got '" + key.getName() + "'";
+        // Replace deprecated usage values
+        String val;
+        boolean typedUsage = false;
+        if (value instanceof CoercingStringValueSnapshot) {
+            val = ((CoercingStringValueSnapshot) value).getValue();
+        } else {
+            typedUsage = true;
+            val = value.isolate().toString();
+        }
+        // TODO Add a deprecation warning in Gradle 6.0
+        if (val.endsWith("-jars")) {
+            return doConcatWithReplacement(factory, node, key, typedUsage, val.replace("-jars", ""), LibraryElements.JAR);
+        } else if (val.endsWith("-classes")) {
+            return doConcatWithReplacement(factory, node, key, typedUsage, val.replace("-classes", ""), LibraryElements.CLASSES);
+        } else if (val.endsWith("-resources")) {
+            return doConcatWithReplacement(factory, node, key, typedUsage, val.replace("-resources", ""), LibraryElements.RESOURCES);
+        } else {
+            return factory.doConcatIsolatable(node, key, value);
+        }
+
+    }
+
+    private <T> ImmutableAttributes doConcatWithReplacement(DefaultImmutableAttributesFactory factory, ImmutableAttributes node, Attribute<T> key, boolean typedUsage, String usage, String libraryElements) {
+        if (typedUsage) {
+            ImmutableAttributes usageNode = factory.doConcatIsolatable(node, key, isolatableFactory.isolate(instantiator.named(Usage.class, usage)));
+            return factory.doConcatIsolatable(usageNode, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, isolatableFactory.isolate(instantiator.named(LibraryElements.class, libraryElements)));
+        } else {
+            ImmutableAttributes usageNode = factory.doConcatIsolatable(node, key, new CoercingStringValueSnapshot(usage, instantiator));
+            return factory.doConcatIsolatable(usageNode, Attribute.of(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.getName(), String.class), new CoercingStringValueSnapshot(libraryElements, instantiator));
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
@@ -40,6 +40,8 @@ public class GradleModuleMetadataCompatibilityConverter {
     }
 
     public void process(MutableModuleComponentResolveMetadata metaDataFromResource) {
+        // This code path will always be a no-op following the changes in DefaultImmutableAttributesFactory
+        // However this code will have to remain forever while the other one should be removed at some point (Gradle 7.0?)
         for (MutableComponentVariant variant : metaDataFromResource.getMutableVariants()) {
             ImmutableAttributes attributes = variant.getAttributes();
             ImmutableAttributes updatedAttributes = ImmutableAttributes.EMPTY;


### PR DESCRIPTION
The org.gradle.usage attributes has all values ending in -jars, -classes
 and -resources deprecated. This commit replaces their usage with a
cleaned up value and adds the matching org.gradle.libraryelements value.