### PR TITLE
Fix execution of the `clean` task when instant execution is enabled

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
@@ -62,6 +62,37 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         new ZipTestFixture(jarFile).assertContainsFile("Thing.class")
     }
 
+    def "clean on Java build with a single source file and no dependencies"() {
+        given:
+        settingsFile << """
+            rootProject.name = 'somelib'
+        """
+        buildFile << """
+            plugins { id 'java' }
+        """
+        file("src/main/java/Thing.java") << """
+            class Thing {
+            }
+        """
+        def buildDir = file("build")
+        buildDir.mkdirs()
+
+        expect:
+        instantRun "clean"
+        instantExecution.assertStateStored()
+        result.assertTasksExecuted(":clean")
+        !buildDir.exists()
+
+        when:
+        buildDir.mkdirs()
+        instantRun "clean"
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksExecuted(":clean")
+        !buildDir.exists()
+    }
+
     def "assemble on Java build with multiple source directories"() {
         given:
         settingsFile << """

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/plugins/LifecycleBasePluginIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/plugins/LifecycleBasePluginIntegrationTest.groovy
@@ -61,4 +61,21 @@ class LifecycleBasePluginIntegrationTest extends AbstractIntegrationSpec {
         where:
         taskName << ["check", "build"]
     }
+
+    def "clean task honors changes to build dir location"() {
+        buildFile << """
+            buildDir = 'target'
+        """
+        def buildDir = file("build")
+        buildDir.mkdirs()
+        def targetDir = file("target")
+        targetDir.mkdirs()
+
+        when:
+        succeeds("clean")
+
+        then:
+        buildDir.directory
+        !targetDir.exists()
+    }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LifecycleBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LifecycleBasePlugin.java
@@ -20,15 +20,12 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.Directory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Delete;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.language.base.internal.plugins.CleanRule;
-
-import java.io.File;
-import java.util.concurrent.Callable;
 
 /**
  * <p>A {@link org.gradle.api.Plugin} which defines a basic project lifecycle.</p>
@@ -52,31 +49,18 @@ public class LifecycleBasePlugin implements Plugin<Project> {
     }
 
     private void addClean(final ProjectInternal project) {
-        final Callable<File> buildDir = new Callable<File>() {
-            @Override
-            public File call() {
-                return project.getBuildDir();
-            }
-        };
+        Provider<Directory> buildDir = project.getLayout().getBuildDirectory();
 
         // Register at least the project buildDir as a directory to be deleted.
         final BuildOutputCleanupRegistry buildOutputCleanupRegistry = project.getServices().get(BuildOutputCleanupRegistry.class);
         buildOutputCleanupRegistry.registerOutputs(buildDir);
 
-        final Provider<Delete> clean = project.getTasks().register(CLEAN_TASK_NAME, Delete.class, new Action<Delete>() {
-            @Override
-            public void execute(final Delete cleanTask) {
-                cleanTask.setDescription("Deletes the build directory.");
-                cleanTask.setGroup(BUILD_GROUP);
-                cleanTask.delete(buildDir);
-            }
+        final Provider<Delete> clean = project.getTasks().register(CLEAN_TASK_NAME, Delete.class, cleanTask -> {
+            cleanTask.setDescription("Deletes the build directory.");
+            cleanTask.setGroup(BUILD_GROUP);
+            cleanTask.delete(buildDir);
         });
-        buildOutputCleanupRegistry.registerOutputs(new Callable<FileCollection>() {
-            @Override
-            public FileCollection call() {
-                return clean.get().getTargetFiles();
-            }
-        });
+        buildOutputCleanupRegistry.registerOutputs(clean.map(cl -> cl.getTargetFiles()));
     }
 
     private void addCleanRule(Project project) {


### PR DESCRIPTION

### Context

This PR uses more a descriptive type to keep track of the files that a `Delete` task should destroy, which has a number of advantages, including working well with instant execution.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
