### PR TITLE
Ensure context classloader is reset for no isolation workers

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -17,6 +17,7 @@ package org.gradle.internal.classloader;
 
 import org.gradle.api.JavaVersion;
 import org.gradle.internal.Cast;
+import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.reflect.JavaMethod;
@@ -86,6 +87,17 @@ public abstract class ClassLoaderUtils {
             return Thread.currentThread().getContextClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
             throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Nullable
+    public static <T> T executeInClassloader(ClassLoader classLoader, Factory<T> factory) {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return factory.create();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
         }
     }
 


### PR DESCRIPTION
This ensures that the context classloader is reset after executing work in no isolation mode.  

This may be the issue we are seeing with https://github.com/gradle/gradle/pull/10021#issuecomment-513244375.  Regardless, there is a potential failure scenario that this fixes.