### PR TITLE
Fix TAPI to use client provided stdin InputStream when running in embedded mode

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/StdinSwapper.java
+++ b/subprojects/core/src/main/java/org/gradle/util/StdinSwapper.java
@@ -16,7 +16,7 @@
 package org.gradle.util;
 
 import org.gradle.api.Action;
-import java.util.concurrent.Callable;
+import org.gradle.internal.Factory;
 
 import java.io.InputStream;
 
@@ -24,9 +24,9 @@ public class StdinSwapper extends Swapper<InputStream> {
 
     public StdinSwapper() {
         super(
-            new Callable<InputStream>() {
+            new Factory<InputStream>() {
                 @Override
-                public InputStream call() {
+                public InputStream create() {
                     return System.in;
                 }
             },

--- a/subprojects/core/src/main/java/org/gradle/util/Swapper.java
+++ b/subprojects/core/src/main/java/org/gradle/util/Swapper.java
@@ -16,26 +16,26 @@
 package org.gradle.util;
 
 import org.gradle.api.Action;
-import java.util.concurrent.Callable;
+import org.gradle.internal.Factory;
 
 /**
  * Generic utility for temporarily changing something.
  */
 public class Swapper<T> {
 
-    private final Callable<? extends T> getter;
+    private final Factory<? extends T> getter;
     private final Action<? super T> setter;
 
-    public Swapper(Callable<? extends T> getter, Action<? super T> setter) {
+    public Swapper(Factory<? extends T> getter, Action<? super T> setter) {
         this.getter = getter;
         this.setter = setter;
     }
 
-    public <Y extends T, N> N swap(Y value, Callable<N> whileSwapped) throws Exception {
-        T originalValue = getter.call();
+    public <Y extends T, N> N swap(Y value, Factory<N> whileSwapped) {
+        T originalValue = getter.create();
         setter.execute(value);
         try {
-            return whileSwapped.call();
+            return whileSwapped.create();
         } finally {
             setter.execute(originalValue);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/util/SwapperTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/SwapperTest.groovy
@@ -15,9 +15,9 @@
  */
 package org.gradle.util
 
-import spock.lang.*
 import org.gradle.api.Action
-import java.util.concurrent.Callable
+import org.gradle.internal.Factory
+import spock.lang.Specification
 
 class SwapperTest extends Specification {
 
@@ -27,7 +27,7 @@ class SwapperTest extends Specification {
     def setter = { this.value = it }
 
     def swap(newValue, whileSwapped) {
-        new Swapper(getter as Callable, setter as Action).swap(newValue, whileSwapped as Callable)
+        new Swapper(getter as Factory, setter as Action).swap(newValue, whileSwapped as Factory)
     }
     
     def "can swap values"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -146,6 +146,11 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     @Override
+    public boolean isToolingApiStdinInEmbeddedModeSupported() {
+        return isSameOrNewer("5.6-rc-1");
+    }
+
+    @Override
     public CacheVersion getArtifactCacheLayoutVersion() {
         if (isSameOrNewer("1.9-rc-2")) {
             return CacheLayout.META_DATA.getVersionMapping().getVersionUsedBy(this.version).get();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
@@ -75,6 +75,11 @@ public interface GradleDistribution {
     boolean isToolingApiLoggingInEmbeddedModeSupported();
 
     /**
+     * Returns true if this version handles the client provided standard input stream when running in embedded mode.
+     */
+    boolean isToolingApiStdinInEmbeddedModeSupported();
+
+    /**
      * Returns true if the tooling API of this distribution incorrectly locks build action implementation classes.
      */
     boolean isToolingApiLocksBuildActionClasses();

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
@@ -17,6 +17,7 @@ package org.gradle.launcher.daemon.server.exec;
 
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.Factory;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.launcher.daemon.protocol.ForwardInput;
@@ -28,7 +29,6 @@ import org.gradle.util.StdinSwapper;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.util.concurrent.Callable;
 
 /**
  * Listens for ForwardInput commands during the execution and sends that to a piped input stream that we install.
@@ -72,9 +72,9 @@ public class ForwardClientInput implements DaemonCommandAction {
 
         try {
             try {
-                new StdinSwapper().swap(replacementStdin, new Callable<Void>() {
+                new StdinSwapper().swap(replacementStdin, new Factory<Object>() {
                     @Override
-                    public Void call() {
+                    public Void create() {
                         execution.proceed();
                         return null;
                     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -225,15 +225,18 @@ public class ProviderConnection {
     private BuildActionExecuter<ProviderOperationParameters> createExecuter(ProviderOperationParameters operationParameters, Parameters params) {
         LoggingManagerInternal loggingManager;
         BuildActionExecuter<BuildActionParameters> executer;
+        InputStream standardInput = operationParameters.getStandardInput();
+        if (standardInput == null) {
+            standardInput = SafeStreams.emptyInput();
+        }
         if (Boolean.TRUE.equals(operationParameters.isEmbedded())) {
             loggingManager = sharedServices.getFactory(LoggingManagerInternal.class).create();
             loggingManager.captureSystemSources();
-            executer = embeddedExecutor;
+            executer = new StdInSwapExecuter(standardInput, embeddedExecutor);
         } else {
             LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newNestedLogging();
             loggingManager = loggingServices.getFactory(LoggingManagerInternal.class).create();
-            InputStream standardInput = operationParameters.getStandardInput();
-            ServiceRegistry clientServices = daemonClientFactory.createBuildClientServices(loggingServices.get(OutputEventListener.class), params.daemonParams, standardInput == null ? SafeStreams.emptyInput() : standardInput);
+            ServiceRegistry clientServices = daemonClientFactory.createBuildClientServices(loggingServices.get(OutputEventListener.class), params.daemonParams, standardInput);
             executer = clientServices.get(DaemonClient.class);
         }
         return new LoggingBridgingBuildActionExecuter(new DaemonBuildActionExecuter(executer, params.daemonParams), loggingManager);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/StdInSwapExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/StdInSwapExecuter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider;
+
+import org.gradle.initialization.BuildRequestContext;
+import org.gradle.internal.Factory;
+import org.gradle.internal.invocation.BuildAction;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.launcher.exec.BuildActionExecuter;
+import org.gradle.launcher.exec.BuildActionParameters;
+import org.gradle.launcher.exec.BuildActionResult;
+import org.gradle.util.StdinSwapper;
+
+import java.io.InputStream;
+
+class StdInSwapExecuter implements BuildActionExecuter<BuildActionParameters> {
+    private final InputStream standardInput;
+    private final BuildActionExecuter<BuildActionParameters> embeddedExecutor;
+
+    public StdInSwapExecuter(InputStream standardInput, BuildActionExecuter<BuildActionParameters> embeddedExecutor) {
+        this.standardInput = standardInput;
+        this.embeddedExecutor = embeddedExecutor;
+    }
+
+    @Override
+    public BuildActionResult execute(final BuildAction action, final BuildRequestContext requestContext, final BuildActionParameters actionParameters, final ServiceRegistry contextServices) {
+        return new StdinSwapper().swap(standardInput, new Factory<BuildActionResult>() {
+            @Override
+            public BuildActionResult create() {
+                return embeddedExecutor.execute(action, requestContext, actionParameters, contextServices);
+            }
+        });
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ConsumingStandardInputCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ConsumingStandardInputCrossVersionSpec.groovy
@@ -24,8 +24,10 @@ import spock.lang.Timeout
 class ConsumingStandardInputCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {
-        //since this test treats with standard input I will not run it for embedded daemon for safety.
-        toolingApi.requireDaemons()
+        if (!dist.toolingApiStdinInEmbeddedModeSupported) {
+            // Did not work in embedded mode in older versions
+            toolingApi.requireDaemons()
+        }
     }
 
     @Timeout(90)

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r43/CapturingUserInputCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r43/CapturingUserInputCrossVersionSpec.groovy
@@ -29,7 +29,11 @@ class CapturingUserInputCrossVersionSpec extends ToolingApiSpecification {
     def outputStream = new ByteArrayOutputStream()
 
     def setup() {
-        toolingApi.requireDaemons()
+        if (!dist.toolingApiStdinInEmbeddedModeSupported) {
+            // Did not work in embedded mode in older versions
+            toolingApi.requireDaemons()
+        }
+
         file('buildSrc/src/main/java/BuildScanPlugin.java') << buildScanPlugin()
         file('build.gradle') << buildScanPluginApplication()
     }


### PR DESCRIPTION

### Context

Previously this input stream would be ignored.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
