### PR TITLE
De-incubate a number of dependency management related APIs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactCollection.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.FileCollection;
 
@@ -51,6 +50,5 @@ public interface ArtifactCollection extends Iterable<ResolvedArtifactResult> {
      *
      * @return A collection of exceptions, one for each failure in resolution.
      */
-    @Incubating
     Collection<Throwable> getFailures();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.HasConfigurableAttributes;
@@ -47,7 +46,6 @@ public interface ArtifactView extends HasAttributes {
      *
      * @since 4.0
      */
-    @Incubating
     interface ViewConfiguration extends HasConfigurableAttributes<ViewConfiguration> {
         /**
          * Specify a filter for the components that should be included in this view.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/CacheableRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/CacheableRule.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -30,6 +28,5 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-@Incubating
 public @interface CacheableRule {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataBuilder.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 
 import java.util.List;
@@ -27,7 +26,6 @@ import java.util.List;
  *
  * @since 4.0
  */
-@Incubating
 public interface ComponentMetadataBuilder {
     /**
      * Sets the status of this component

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataContext.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataContext.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -26,7 +24,6 @@ import javax.annotation.Nullable;
  *
  * @since 4.9
  */
-@Incubating
 public interface ComponentMetadataContext {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 
@@ -62,7 +61,6 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      *
      * @since 4.4
      */
-    @Incubating
     void withVariant(String name, Action<? super VariantMetadata> action);
 
     /**
@@ -72,7 +70,6 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      *
      * @since 4.5
      */
-    @Incubating
     void allVariants(Action<? super VariantMetadata> action);
 
     /**
@@ -82,7 +79,6 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      *
      * @since 4.10
      */
-    @Incubating
     void belongsTo(Object notation);
 
     /**
@@ -93,6 +89,5 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      *
      * @since 5.0
      */
-    @Incubating
     void belongsTo(Object notation, boolean virtual);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataListerDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataListerDetails.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 import java.util.List;
 
 /**
@@ -25,7 +23,6 @@ import java.util.List;
  *
  * @since 4.9
  */
-@Incubating
 public interface ComponentMetadataListerDetails {
     /**
      * Gives access to the module identifier for which the version lister should

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataRule.java
@@ -17,13 +17,11 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * A rule that modify {@link ComponentMetadataDetails component metadata}.
  *
  * @since 4.9
  */
-@Incubating
 public interface ComponentMetadataRule extends Action<ComponentMetadataContext> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataSupplier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataSupplier.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * A component metadata rule is responsible for providing the initial metadata of a component
@@ -26,7 +25,6 @@ import org.gradle.api.Incubating;
  *
  * @since 4.0
  */
-@Incubating
 public interface ComponentMetadataSupplier extends Action<ComponentMetadataSupplierDetails> {
     /**
      * Supply metadata for a component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataSupplierDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataSupplierDetails.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
  *
  * @since 4.0
  */
-@Incubating
 public interface ComponentMetadataSupplierDetails {
     /**
      * Returns the identifier of the component being resolved

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataVersionLister.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataVersionLister.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * Interface for custom version listers. A version lister is responsible for
@@ -29,7 +28,6 @@ import org.gradle.api.Incubating;
  *
  * @since 4.9
  */
-@Incubating
 public interface ComponentMetadataVersionLister extends Action<ComponentMetadataListerDetails> {
     /**
      * Perform a version listing query

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentModuleMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentModuleMetadataDetails.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 
 /**
@@ -54,6 +52,5 @@ public interface ComponentModuleMetadataDetails extends ComponentModuleMetadata 
      *
      * @since 4.5
      */
-    @Incubating
     void replacedBy(Object moduleNotation, @Nullable String reason);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentSelection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentSelection.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -44,7 +43,6 @@ public interface ComponentSelection {
      * @return the {@code ComponentMetadata} or {@code null} if not available
      * @since 5.0
      */
-    @Incubating
     @Nullable
     ComponentMetadata getMetadata();
 
@@ -63,7 +61,6 @@ public interface ComponentSelection {
      * @see org.gradle.api.artifacts.ivy.IvyModuleDescriptor
      * @since 5.0
      */
-    @Incubating
     @Nullable
     <T> T getDescriptor(Class<T> descriptorClass);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -18,7 +18,6 @@ package org.gradle.api.artifacts;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
@@ -328,7 +327,6 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @since 4.6
      */
-    @Incubating
     DependencyConstraintSet getDependencyConstraints();
 
     /**
@@ -339,7 +337,6 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @since 4.6
      */
-    @Incubating
     DependencyConstraintSet getAllDependencyConstraints();
 
     /**
@@ -429,7 +426,6 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * @param action a dependency action to execute before the configuration is used.
      * @return this
      */
-    @Incubating
     Configuration withDependencies(Action<? super DependencySet> action);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.capabilities.Capability;
@@ -74,7 +73,6 @@ public interface ConfigurationPublications extends HasConfigurableAttributes<Con
      *
      * @since 4.7.
      */
-    @Incubating
     void capability(Object notation);
 
     /**
@@ -84,6 +82,5 @@ public interface ConfigurationPublications extends HasConfigurableAttributes<Con
      *
      * @since 4.7
      */
-    @Incubating
     Collection<? extends Capability> getCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependenciesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependenciesMetadata.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 import java.util.Collection;
 import java.util.Map;
@@ -28,7 +27,6 @@ import java.util.Map;
  * @param <T> type of the dependency metadata in this collection
  * @since 4.4
  */
-@Incubating
 public interface DependenciesMetadata<T extends DependencyMetadata> extends Collection<T> {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Dependency.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 
 /**
@@ -74,7 +72,6 @@ public interface Dependency {
      *
      * @since 4.6
      */
-    @Incubating
     @Nullable
     String getReason();
 
@@ -83,6 +80,5 @@ public interface Dependency {
      *
      * @since 4.6
      */
-    @Incubating
     void because(@Nullable String reason);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraint.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 
@@ -27,7 +26,6 @@ import javax.annotation.Nullable;
  *
  * @since 4.5
  */
-@Incubating
 public interface DependencyConstraint extends ModuleVersionSelector, HasConfigurableAttributes<DependencyConstraint> {
 
     /**
@@ -63,7 +61,6 @@ public interface DependencyConstraint extends ModuleVersionSelector, HasConfigur
      * @since 4.8
      */
     @Override
-    @Incubating
     AttributeContainer getAttributes();
 
     /**
@@ -75,7 +72,6 @@ public interface DependencyConstraint extends ModuleVersionSelector, HasConfigur
      * @since 4.8
      */
     @Override
-    @Incubating
     DependencyConstraint attributes(Action<? super AttributeContainer> configureAction);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintMetadata.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 /**
  * Describes a dependency constraint declared in a resolved component's metadata, which typically originates from
  * a component descriptor (Gradle metadata file). This interface can be used to adjust
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  *
  * @since 4.5
  */
-@Incubating
 public interface DependencyConstraintMetadata extends DependencyMetadata<DependencyConstraintMetadata> {
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintSet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintSet.java
@@ -16,13 +16,11 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.Incubating;
 
 /**
  * A set of dependency constraint definitions that are associated with a configuration.
  *
  * @since 4.6
  */
-@Incubating
 public interface DependencyConstraintSet extends DomainObjectSet<DependencyConstraint> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintsMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyConstraintsMetadata.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 /**
  * Describes the dependency constraints of a variant declared in a resolved component's metadata, which typically originate from
  * a component descriptor (Gradle metadata file). This interface can be used to adjust the dependencies
@@ -25,6 +23,5 @@ import org.gradle.api.Incubating;
  *
  * @since 4.5
  */
-@Incubating
 public interface DependencyConstraintsMetadata extends DependenciesMetadata<DependencyConstraintMetadata> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyMetadata.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 
 import javax.annotation.Nullable;
@@ -64,7 +63,6 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      *
      * @since 4.6
      */
-    @Incubating
     @Nullable
     String getReason();
 
@@ -75,7 +73,6 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      *
      * @since 4.6
      */
-    @Incubating
     SELF because(String reason);
 
     /**
@@ -85,7 +82,6 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      *
      * @since 4.8
      */
-    @Incubating
     AttributeContainer getAttributes();
 
     /**
@@ -93,7 +89,6 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      *
      * @since 4.8
      */
-    @Incubating
     SELF attributes(Action<? super AttributeContainer> configureAction);
 
     /**
@@ -104,6 +99,5 @@ public interface DependencyMetadata<SELF extends DependencyMetadata> {
      *
      * @since 4.9
      */
-    @Incubating
     ModuleIdentifier getModule();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyResolveDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyResolveDetails.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 /**
  * Provides details about a dependency when it is resolved.
  * Provides means to manipulate dependency metadata when it is resolved.
@@ -80,6 +78,5 @@ public interface DependencyResolveDetails {
      *
      * @since 4.5
      */
-    @Incubating
     DependencyResolveDetails because(String description);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitution.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitution.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -68,6 +67,5 @@ public interface DependencySubstitution {
      *
      * @since 4.5
      */
-    @Incubating
     void useTarget(Object notation, String reason);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencySubstitutions.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -101,7 +100,6 @@ public interface DependencySubstitutions {
          *
          * @return the substitution
          */
-        @Incubating
         Substitution because(String reason);
 
         /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependenciesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependenciesMetadata.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 /**
  * Describes the dependencies of a variant declared in a resolved component's metadata, which typically originate from
  * a component descriptor (Gradle metadata file, Ivy file, Maven POM). This interface can be used to adjust the dependencies
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  *
  * @since 4.5
  */
-@Incubating
 public interface DirectDependenciesMetadata extends DependenciesMetadata<DirectDependencyMetadata> {
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 /**
  * Describes a dependency declared in a resolved component's metadata, which typically originates from
  * a component descriptor (Gradle metadata file, Ivy file, Maven POM). This interface can be used to adjust
@@ -25,7 +23,6 @@ import org.gradle.api.Incubating;
  *
  * @since 4.5
  */
-@Incubating
 public interface DirectDependencyMetadata extends DependencyMetadata<DirectDependencyMetadata> {
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalDependency.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * <p>An {@code ExternalDependency} is a {@link Dependency} on a source outside the current project hierarchy.</p>
@@ -47,7 +46,6 @@ public interface ExternalDependency extends ModuleDependency, ModuleVersionSelec
      * @param configureAction the configuration action for the module version
      * @since 4.4
      */
-    @Incubating
     void version(Action<? super MutableVersionConstraint> configureAction);
 
     /**
@@ -56,6 +54,5 @@ public interface ExternalDependency extends ModuleDependency, ModuleVersionSelec
      *
      * @since 4.4
      */
-    @Incubating
     VersionConstraint getVersionConstraint();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -18,7 +18,6 @@ package org.gradle.api.artifacts;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.capabilities.Capability;
@@ -152,7 +151,6 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      *
      * @since 4.0
      */
-    @Incubating
     void setTargetConfiguration(@Nullable String name);
 
     /**
@@ -170,7 +168,6 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * @since 4.8
      */
     @Override
-    @Incubating
     AttributeContainer getAttributes();
 
     /**
@@ -182,7 +179,6 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * @since 4.8
      */
     @Override
-    @Incubating
     ModuleDependency attributes(Action<? super AttributeContainer> configureAction);
 
     /**
@@ -191,7 +187,6 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      *
      * @since 5.3
      */
-    @Incubating
     ModuleDependency capabilities(Action<? super ModuleDependencyCapabilitiesHandler> configureAction);
 
     /**
@@ -200,6 +195,5 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      *
      * @since 5.3
      */
-    @Incubating
     List<Capability> getRequestedCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependencyCapabilitiesHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependencyCapabilitiesHandler.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -28,7 +27,6 @@ import org.gradle.internal.HasInternalProtocol;
  * @since 5.3
  */
 @HasInternalProtocol
-@Incubating
 public interface ModuleDependencyCapabilitiesHandler {
     /**
      * Requires a single capability.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleVersionSelector.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 
 /**
@@ -69,6 +67,5 @@ public interface ModuleVersionSelector {
      *
      * @since 4.9
      */
-    @Incubating
     ModuleIdentifier getModule();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import javax.annotation.Nullable;
@@ -26,7 +25,6 @@ import javax.annotation.Nullable;
  *
  * @since 4.4
  */
-@Incubating
 @HasInternalProtocol
 public interface MutableVersionConstraint extends VersionConstraint {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -107,7 +107,6 @@ public interface ResolutionStrategy {
      * @return this resolution strategy instance
      * @since 4.8
      */
-    @Incubating
     ResolutionStrategy activateDependencyLocking();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
@@ -17,7 +17,6 @@ package org.gradle.api.artifacts;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.internal.HasInternalProtocol;
@@ -73,7 +72,6 @@ public interface ResolvableDependencies extends ArtifactView {
      *
      * @since 4.6
      */
-    @Incubating
     DependencyConstraintSet getDependencyConstraints();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantMetadata.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.capabilities.MutableCapabilitiesMetadata;
 
@@ -26,7 +25,6 @@ import org.gradle.api.capabilities.MutableCapabilitiesMetadata;
  *
  * @since 4.4
  */
-@Incubating
 public interface VariantMetadata extends HasConfigurableAttributes<VariantMetadata> {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Describable;
-import org.gradle.api.Incubating;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
@@ -92,7 +91,6 @@ import java.util.List;
  *
  * @since 4.4
  */
-@Incubating
 @UsedByScanPlugin
 public interface VersionConstraint extends Describable {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.component;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -55,7 +54,6 @@ public interface ComponentSelector {
      *
      * @since 4.9
      */
-    @Incubating
     AttributeContainer getAttributes();
 
     /**
@@ -64,6 +62,5 @@ public interface ComponentSelector {
      *
      * @since 5.3
      */
-    @Incubating
     List<Capability> getRequestedCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentIdentifier.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.component;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -58,7 +57,6 @@ public interface ModuleComponentIdentifier extends ComponentIdentifier {
      *
      * @since 4.9
      */
-    @Incubating
     ModuleIdentifier getModuleIdentifier();
 }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ModuleComponentSelector.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.component;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -56,7 +55,6 @@ public interface ModuleComponentSelector extends ComponentSelector {
      *
      * @since 4.4
      */
-    @Incubating
     VersionConstraint getVersionConstraint();
 
     /**
@@ -67,6 +65,5 @@ public interface ModuleComponentSelector extends ComponentSelector {
      *
      * @since 4.9
      */
-    @Incubating
     ModuleIdentifier getModuleIdentifier();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ProjectComponentIdentifier.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.component;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -44,6 +43,5 @@ public interface ProjectComponentIdentifier extends ComponentIdentifier {
      *
      * @since 4.5
      */
-    @Incubating
     String getProjectName();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
@@ -18,7 +18,6 @@ package org.gradle.api.artifacts.dsl;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ComponentMetadataRule;
 
@@ -109,7 +108,6 @@ public interface ComponentMetadataHandler {
      *
      * @since 4.9
      */
-    @Incubating
     ComponentMetadataHandler all(Class<? extends ComponentMetadataRule> rule);
 
     /**
@@ -122,7 +120,6 @@ public interface ComponentMetadataHandler {
      *
      * @since 4.9
      */
-    @Incubating
     ComponentMetadataHandler all(Class<? extends ComponentMetadataRule> rule, Action<? super ActionConfiguration> configureAction);
 
     /**
@@ -165,7 +162,6 @@ public interface ComponentMetadataHandler {
      *
      * @since 4.9
      */
-    @Incubating
     ComponentMetadataHandler withModule(Object id, Class<? extends ComponentMetadataRule> rule);
 
     /**
@@ -177,6 +173,5 @@ public interface ComponentMetadataHandler {
      *
      * @since 4.9
      */
-    @Incubating
     ComponentMetadataHandler withModule(Object id, Class<? extends ComponentMetadataRule> rule, Action<? super ActionConfiguration> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.DependencyConstraint;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.artifacts.DependencyConstraint;
  *
  * @since 4.5
  */
-@Incubating
 public interface DependencyConstraintHandler {
     /**
      * Adds a dependency constraint to the given configuration.
@@ -67,7 +65,6 @@ public interface DependencyConstraintHandler {
      *
      * @since 5.0
      */
-    @Incubating
     DependencyConstraint platform(Object notation);
 
     /**
@@ -79,7 +76,6 @@ public interface DependencyConstraintHandler {
      *
      * @since 5.0
      */
-    @Incubating
     DependencyConstraint platform(Object notation, Action<? super DependencyConstraint> configureAction);
 
     /**
@@ -92,7 +88,6 @@ public interface DependencyConstraintHandler {
      *
      * @since 5.0
      */
-    @Incubating
     DependencyConstraint enforcedPlatform(Object notation);
 
     /**
@@ -106,6 +101,5 @@ public interface DependencyConstraintHandler {
      *
      * @since 5.0
      */
-    @Incubating
     DependencyConstraint enforcedPlatform(Object notation, Action<? super DependencyConstraint> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -348,7 +348,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return the dependency constraint handler for this project
      * @since 4.5
      */
-    @Incubating
     DependencyConstraintHandler getConstraints();
 
     /**
@@ -359,7 +358,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @param configureAction the action to use to configure module metadata
      * @since 4.5
      */
-    @Incubating
     void constraints(Action<? super DependencyConstraintHandler> configureAction);
 
     /**
@@ -428,14 +426,12 @@ public interface DependencyHandler extends ExtensionAware {
      * Returns the artifact type definitions for this handler.
      * @since 4.0
      */
-    @Incubating
     ArtifactTypeContainer getArtifactTypes();
 
     /**
      * Configures the artifact type definitions for this handler.
      * @since 4.0
      */
-    @Incubating
     void artifactTypes(Action<? super ArtifactTypeContainer> configureAction);
 
     /**
@@ -501,7 +497,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 5.0
      */
-    @Incubating
     Dependency platform(Object notation);
 
     /**
@@ -513,7 +508,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 5.0
      */
-    @Incubating
     Dependency platform(Object notation, Action<? super Dependency> configureAction);
 
     /**
@@ -526,7 +520,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 5.0
      */
-    @Incubating
     Dependency enforcedPlatform(Object notation);
 
     /**
@@ -540,7 +533,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 5.0
      */
-    @Incubating
     Dependency enforcedPlatform(Object notation, Action<? super Dependency> configureAction);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -16,14 +16,11 @@
 
 package org.gradle.api.artifacts.dsl;
 
-import org.gradle.api.Incubating;
-
 /**
  * A {@code DependencyLockingHandler} manages the behaviour and configuration of dependency locking.
  *
  * @since 4.8
  */
-@Incubating
 public interface DependencyLockingHandler {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ArtifactRepositoryContainer;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
@@ -87,7 +86,6 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * @return The Gradle Central Plugin Repository
      * @since 4.4
      */
-    @Incubating
     ArtifactRepository gradlePluginPortal();
     
     /**
@@ -97,7 +95,6 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * @return the added resolver
      * @since 5.4
      */
-    @Incubating
     ArtifactRepository gradlePluginPortal(Action<? super ArtifactRepository> action);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.query;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ArtifactResolutionResult;
 import org.gradle.api.component.Artifact;
@@ -69,7 +68,6 @@ public interface ArtifactResolutionQuery {
      *
      * @since 4.5
      */
-    @Incubating
     ArtifactResolutionQuery forModule(String group, String name, String version);
 
     /**
@@ -92,7 +90,6 @@ public interface ArtifactResolutionQuery {
      * @param artifactTypes The artifacts to retrieve for the queried components.
      * @since 4.5
      */
-    @Incubating
     ArtifactResolutionQuery withArtifacts(Class<? extends Component> componentType, Collection<Class<? extends Artifact>> artifactTypes);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ArtifactRepository.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -52,6 +51,5 @@ public interface ArtifactRepository {
      *
      * @since 5.1
      */
-    @Incubating
     void content(Action<? super RepositoryContentDescriptor> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -18,7 +18,6 @@ package org.gradle.api.artifacts.repositories;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
 
 import java.net.URI;
@@ -212,7 +211,6 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      * @param config The action used to configure the layout.
      * @since 5.0
      */
-    @Incubating
     void patternLayout(Action<? super  IvyPatternRepositoryLayout> config);
 
     /**
@@ -244,7 +242,6 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      * @since 4.0
      */
     @Override
-    @Incubating
     void setMetadataSupplier(Class<? extends ComponentMetadataSupplier> rule);
 
     /**
@@ -256,7 +253,6 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      * @since 4.0
      */
     @Override
-    @Incubating
     void setMetadataSupplier(Class<? extends ComponentMetadataSupplier> rule, Action<? super ActionConfiguration> configureAction);
 
     /**
@@ -267,7 +263,6 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      *
      * @since 4.5
      */
-    @Incubating
     void metadataSources(Action<? super MetadataSources> configureAction);
 
     /**
@@ -276,7 +271,6 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      * @since 4.5
      *
      */
-    @Incubating
     interface MetadataSources {
         /**
          * Indicates that this repository will contain Gradle metadata.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 import java.net.URI;
 import java.util.Set;
@@ -99,7 +98,6 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
      *
      * @since 4.5
      */
-    @Incubating
     void metadataSources(Action<? super MetadataSources> configureAction);
 
     /**
@@ -108,7 +106,6 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
      * @since 4.5
      *
      */
-    @Incubating
     interface MetadataSources {
         /**
          * Indicates that this repository will contain Gradle metadata.
@@ -144,6 +141,5 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
      *
      * @since 5.1
      */
-    @Incubating
     void mavenContent(Action<? super MavenRepositoryContentDescriptor> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenRepositoryContentDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenRepositoryContentDescriptor.java
@@ -15,14 +15,11 @@
  */
 package org.gradle.api.artifacts.repositories;
 
-import org.gradle.api.Incubating;
-
 /**
  * Extends the repository content descriptor with Maven repositories specific options.
  *
  * @since 5.1
  */
-@Incubating
 public interface MavenRepositoryContentDescriptor extends RepositoryContentDescriptor {
     /**
      * Declares that this repository only contains releases.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MetadataSupplierAware.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MetadataSupplierAware.java
@@ -17,9 +17,8 @@ package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
-import org.gradle.api.Incubating;
-import org.gradle.api.artifacts.ComponentMetadataVersionLister;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
+import org.gradle.api.artifacts.ComponentMetadataVersionLister;
 
 /**
  * Interface for repositories which support custom metadata suppliers and/or version listers.
@@ -30,7 +29,6 @@ import org.gradle.api.artifacts.ComponentMetadataSupplier;
  *
  * @since 4.9
  */
-@Incubating
 public interface MetadataSupplierAware {
     /**
      * Sets a custom metadata rule, which is capable of supplying the metadata of a component (status, status scheme, changing flag)

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.repositories;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
 
 /**
@@ -28,7 +27,6 @@ import org.gradle.api.attributes.Attribute;
  *
  * @since 5.1
  */
-@Incubating
 public interface RepositoryContentDescriptor {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryResourceAccessor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryResourceAccessor.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 import java.io.InputStream;
 
@@ -27,7 +26,6 @@ import java.io.InputStream;
  *
  * @since 4.0
  */
-@Incubating
 public interface RepositoryResourceAccessor {
     /**
      * Perform an action on the contents of a remote resource.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.result;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  * @since 4.6
  */
 @UsedByScanPlugin
-@Incubating
 public enum ComponentSelectionCause {
     /**
      * This component was selected because it's the root component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionDescriptor.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.result;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -25,7 +24,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  * @since 4.6
  */
 @UsedByScanPlugin
-@Incubating
 @HasInternalProtocol
 public interface ComponentSelectionDescriptor {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionReason.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.result;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -63,7 +62,6 @@ public interface ComponentSelectionReason {
      *
      * @since 4.5
      */
-    @Incubating
     boolean isCompositeSubstitution();
 
     /**
@@ -90,6 +88,5 @@ public interface ComponentSelectionReason {
      *
      * @since 4.6
      */
-    @Incubating
     List<ComponentSelectionDescriptor> getDescriptions();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/DependencyResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/DependencyResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.result;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -53,7 +52,6 @@ public interface DependencyResult {
      * @return true if the dependency is a constraint.
      * @since 5.1
      */
-    @Incubating
     boolean isConstraint();
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
@@ -79,7 +79,6 @@ public interface ResolvedComponentResult extends ComponentResult {
      *
      * @deprecated Use {@link #getVariants()} instead}
      */
-    @Incubating
     @Deprecated
     ResolvedVariantResult getVariant();
 
@@ -91,7 +90,6 @@ public interface ResolvedComponentResult extends ComponentResult {
      *
      * @since 5.2
      */
-    @Incubating
     List<ResolvedVariantResult> getVariants();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.result;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 
@@ -38,7 +37,6 @@ public interface ResolvedVariantResult {
      *
      * @since 4.6
      */
-    @Incubating
     String getDisplayName();
 
     /**
@@ -46,6 +44,5 @@ public interface ResolvedVariantResult {
      *
      * @since 5.3
      */
-    @Incubating
     List<Capability> getCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeContainer.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.type;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 
 /**
@@ -26,6 +25,5 @@ import org.gradle.api.NamedDomainObjectContainer;
  *
  * @since 4.0
  */
-@Incubating
 public interface ArtifactTypeContainer extends NamedDomainObjectContainer<ArtifactTypeDefinition> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeDefinition.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeDefinition.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.type;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasAttributes;
@@ -28,14 +27,12 @@ import java.util.Set;
  *
  * @since 4.0
  */
-@Incubating
 public interface ArtifactTypeDefinition extends HasAttributes, Named {
     /**
      * Represents a JAR file.
      *
      * @since 4.0
      */
-    @Incubating
     String JAR_TYPE = "jar";
 
     /**
@@ -43,7 +40,6 @@ public interface ArtifactTypeDefinition extends HasAttributes, Named {
      *
      * @since 4.0
      */
-    @Incubating
     String JVM_CLASS_DIRECTORY = "java-classes-directory";
 
     /**
@@ -51,7 +47,6 @@ public interface ArtifactTypeDefinition extends HasAttributes, Named {
      *
      * @since 4.0
      */
-    @Incubating
     String JVM_RESOURCES_DIRECTORY = "java-resources-directory";
 
     /**
@@ -59,7 +54,6 @@ public interface ArtifactTypeDefinition extends HasAttributes, Named {
      *
      * @since 5.3
      */
-    @Incubating
     String ZIP_TYPE = "zip";
 
     /**
@@ -67,7 +61,6 @@ public interface ArtifactTypeDefinition extends HasAttributes, Named {
      *
      * @since 5.3
      */
-    @Incubating
     String DIRECTORY_TYPE = "directory";
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeCompatibilityRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeCompatibilityRule.java
@@ -17,7 +17,6 @@
 package org.gradle.api.attributes;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * A rule that determines whether a given attribute value is compatible some provided attribute value.
@@ -32,6 +31,5 @@ import org.gradle.api.Incubating;
  * @param <T> The attribute value type.
  * @see CompatibilityCheckDetails
  */
-@Incubating
 public interface AttributeCompatibilityRule<T> extends Action<CompatibilityCheckDetails<T>> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeDisambiguationRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeDisambiguationRule.java
@@ -17,7 +17,6 @@
 package org.gradle.api.attributes;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * A rule that selects the best value out of a set of two or more candidates.
@@ -25,6 +24,5 @@ import org.gradle.api.Incubating;
  * @since 4.0
  * @param <T> The attribute value type.
  */
-@Incubating
 public interface AttributeDisambiguationRule<T> extends Action<MultipleCandidatesDetails<T>> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Bundling.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Bundling.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
@@ -49,7 +48,6 @@ import org.gradle.api.Named;
  *
  * @since 5.3
  */
-@Incubating
 public interface Bundling extends Named {
     Attribute<Bundling> BUNDLING_ATTRIBUTE = Attribute.of("org.gradle.dependency.bundling", Bundling.class);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -34,7 +33,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  *
  * @since 5.3
  */
-@Incubating
 @UsedByScanPlugin
 public interface Category extends Named {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/CompatibilityRuleChain.java
@@ -17,7 +17,6 @@ package org.gradle.api.attributes;
 
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.util.Comparator;
@@ -66,7 +65,6 @@ public interface CompatibilityRuleChain<T> {
      * @param rule the rule to add to the chain
      * @since 4.0
      */
-    @Incubating
     void add(Class<? extends AttributeCompatibilityRule<T>> rule);
 
     /**
@@ -76,7 +74,6 @@ public interface CompatibilityRuleChain<T> {
      * @param configureAction the action to use to configure the rule
      * @since 4.0
      */
-    @Incubating
     void add(Class<? extends AttributeCompatibilityRule<T>> rule, Action<? super ActionConfiguration> configureAction);
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/DisambiguationRuleChain.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/DisambiguationRuleChain.java
@@ -18,7 +18,6 @@ package org.gradle.api.attributes;
 
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.util.Comparator;
@@ -50,7 +49,6 @@ public interface DisambiguationRuleChain<T> {
      * @param rule the rule to add
      * @since 4.0
      */
-    @Incubating
     void add(Class<? extends AttributeDisambiguationRule<T>> rule);
 
     /**
@@ -60,7 +58,6 @@ public interface DisambiguationRuleChain<T> {
      * @param configureAction the action to use to configure the rule
      * @since 4.0
      */
-    @Incubating
     void add(Class<? extends AttributeDisambiguationRule<T>> rule, Action<? super ActionConfiguration> configureAction);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
-
 import javax.annotation.Nullable;
 import java.util.Set;
 
@@ -34,7 +32,6 @@ public interface MultipleCandidatesDetails<T> {
      * @return The value or {@code null} if the consumer did not specify a value.
      * @since 4.1
      */
-    @Incubating
     @Nullable
     T getConsumerValue();
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
@@ -33,7 +32,6 @@ public interface Usage extends Named {
      *
      * @since 4.0
      */
-    @Incubating
     String JAVA_API = "java-api";
 
     /**
@@ -57,7 +55,6 @@ public interface Usage extends Named {
      *
      * @since 4.0
      */
-    @Incubating
     String JAVA_RUNTIME = "java-runtime";
 
     /**
@@ -89,7 +86,6 @@ public interface Usage extends Named {
      *
      * @since 4.1
      */
-    @Incubating
     String C_PLUS_PLUS_API = "cplusplus-api";
 
     /**
@@ -97,7 +93,6 @@ public interface Usage extends Named {
      *
      * @since 4.1
      */
-    @Incubating
     String NATIVE_LINK = "native-link";
 
     /**
@@ -105,7 +100,6 @@ public interface Usage extends Named {
      *
      * @since 4.1
      */
-    @Incubating
     String NATIVE_RUNTIME = "native-runtime";
 
     /**
@@ -113,6 +107,5 @@ public interface Usage extends Named {
      *
      * @since 4.1
      */
-    @Incubating
     String SWIFT_API = "swift-api";
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJvmVersion.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJvmVersion.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.attributes.java;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.attributes.Attribute;
  *
  * @since 5.3
  */
-@Incubating
 public interface TargetJvmVersion {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/capabilities/CapabilitiesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/capabilities/CapabilitiesMetadata.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.capabilities;
 
-import org.gradle.api.Incubating;
-
 import java.util.List;
 
 /**
@@ -24,7 +22,6 @@ import java.util.List;
  *
  * @since 4.7
  */
-@Incubating
 public interface CapabilitiesMetadata {
     /**
      * Returns an immutable view of the capabilities.

--- a/subprojects/core-api/src/main/java/org/gradle/api/capabilities/Capability.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/capabilities/Capability.java
@@ -15,15 +15,12 @@
  */
 package org.gradle.api.capabilities;
 
-import org.gradle.api.Incubating;
-
 /**
  * Represents a capability. Capabilities are versioned. Only one component for a specific capability
  * can be found on a dependency graph.
  *
  * @since 4.7
  */
-@Incubating
 public interface Capability {
     String getGroup();
     String getName();

--- a/subprojects/core-api/src/main/java/org/gradle/api/capabilities/MutableCapabilitiesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/capabilities/MutableCapabilitiesMetadata.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.capabilities;
 
-import org.gradle.api.Incubating;
-
 /**
  * Describes the capabilities of a component in a mutable way.
  * This interface can be used to adjust the capabilities of a published component via
@@ -24,7 +22,6 @@ import org.gradle.api.Incubating;
  *
  * @since 4.7
  */
-@Incubating
 public interface MutableCapabilitiesMetadata extends CapabilitiesMetadata {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
@@ -16,7 +16,6 @@
 package org.gradle.api.component;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 
 /**
@@ -27,7 +26,6 @@ import org.gradle.api.artifacts.Configuration;
  *
  * @since 5.3
  */
-@Incubating
 public interface AdhocComponentWithVariants extends SoftwareComponent {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithCoordinates.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithCoordinates.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.component;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
  *
  * @since 4.7
  */
-@Incubating
 public interface ComponentWithCoordinates extends SoftwareComponent {
     /**
      * The publication coordinates for this component.

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithVariants.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.component;
 
-import org.gradle.api.Incubating;
-
 import java.util.Set;
 
 /**
@@ -25,7 +23,6 @@ import java.util.Set;
  *
  * @since 4.3
  */
-@Incubating
 public interface ComponentWithVariants extends SoftwareComponent {
     Set<? extends SoftwareComponent> getVariants();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.component;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -25,7 +24,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 5.3
  */
-@Incubating
 @HasInternalProtocol
 public interface ConfigurationVariantDetails {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponentFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponentFactory.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.component;
 
-import org.gradle.api.Incubating;
-
 /**
  * A software component factory is responsible for providing to
  * plugins a way to create software components. Currently the
@@ -29,7 +27,6 @@ import org.gradle.api.Incubating;
  *
  * @since 5.3
  */
-@Incubating
 public interface SoftwareComponentFactory {
     /**
      * Creates an adhoc software component, which can be used by plugins to

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponentVariant.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponentVariant.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.component;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
@@ -33,7 +32,6 @@ import java.util.Set;
  *
  * @since 5.3
  */
-@Incubating
 public interface SoftwareComponentVariant extends HasAttributes, Named {
     Set<? extends PublishArtifact> getArtifacts();
     Set<? extends ModuleDependency> getDependencies();

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Dependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Dependency.java
@@ -16,7 +16,6 @@
 package org.gradle.plugins.ide.idea.model;
 
 import groovy.util.Node;
-import org.gradle.api.Incubating;
 
 /**
  * Represents a dependency of an IDEA module.
@@ -27,14 +26,12 @@ public interface Dependency {
      * The scope of this library. If <tt>null</tt>, the scope attribute is not added.
      * @since 4.5
      */
-    @Incubating
     String getScope();
 
     /**
      * The scope of this library. If <tt>null</tt>, the scope attribute is not added.
      * @since 4.5
      */
-    @Incubating
     void setScope(String scope);
 
     void addToNode(Node parentNode);

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorAuthor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorAuthor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Property;
  * @since 4.8
  * @see IvyModuleDescriptorSpec
  */
-@Incubating
 public interface IvyModuleDescriptorAuthor {
 
     /**

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorDescription.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorDescription.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Property;
  * @since 4.8
  * @see IvyModuleDescriptorSpec
  */
-@Incubating
 public interface IvyModuleDescriptorDescription {
 
     /**

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorLicense.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorLicense.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.ivy;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Property;
  * @since 4.8
  * @see IvyModuleDescriptorSpec
  */
-@Incubating
 public interface IvyModuleDescriptorLicense {
 
     /**

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorSpec.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyModuleDescriptorSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.XmlProvider;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -109,7 +108,6 @@ public interface IvyModuleDescriptorSpec {
      *
      * @since 4.8
      */
-    @Incubating
     void license(Action<? super IvyModuleDescriptorLicense> action);
 
     /**
@@ -117,7 +115,6 @@ public interface IvyModuleDescriptorSpec {
      *
      * @since 4.8
      */
-    @Incubating
     void author(Action<? super IvyModuleDescriptorAuthor> action);
 
     /**
@@ -125,7 +122,6 @@ public interface IvyModuleDescriptorSpec {
      *
      * @since 4.8
      */
-    @Incubating
     void description(Action<? super IvyModuleDescriptorDescription> action);
 
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -359,7 +358,6 @@ public interface IvyPublication extends Publication {
      *
      * @since 5.4
      */
-    @Incubating
     void versionMapping(Action<? super VersionMappingStrategy> configureAction);
 
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerExtensions.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl
 
-import org.gradle.api.Incubating
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 
 
@@ -25,6 +24,5 @@ import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
  *
  * @since 5.0
  */
-@Incubating
 operator fun DependencyConstraintHandler.invoke(configuration: DependencyConstraintHandlerScope.() -> Unit) =
     DependencyConstraintHandlerScope.of(this).configuration()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
@@ -16,11 +16,9 @@
 
 package org.gradle.kotlin.dsl
 
-import org.gradle.api.Incubating
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
-
 import org.gradle.kotlin.dsl.support.delegates.DependencyConstraintHandlerDelegate
 
 
@@ -30,7 +28,6 @@ import org.gradle.kotlin.dsl.support.delegates.DependencyConstraintHandlerDelega
  * @see [DependencyConstraintHandler]
  * @since 5.0
  */
-@Incubating
 class DependencyConstraintHandlerScope
 private constructor(
     val constraints: DependencyConstraintHandler

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl
 
-import org.gradle.api.Incubating
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.Configuration
@@ -24,13 +23,10 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
-
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
-
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.initialization.dsl.ScriptHandler.CLASSPATH_CONFIGURATION
-
 import org.gradle.kotlin.dsl.support.delegates.ScriptHandlerDelegate
 import org.gradle.kotlin.dsl.support.unsafeLazy
 
@@ -159,7 +155,6 @@ private constructor(
      * @see [DependencyConstraintHandler.add]
      * @since 5.0
      */
-    @Incubating
     fun DependencyConstraintHandler.classpath(dependencyConstraintNotation: Any): DependencyConstraint? =
         add(CLASSPATH_CONFIGURATION, dependencyConstraintNotation)
 
@@ -174,7 +169,6 @@ private constructor(
      * @see [DependencyConstraintHandler.add]
      * @since 5.0
      */
-    @Incubating
     fun DependencyConstraintHandler.classpath(dependencyConstraintNotation: Any, configuration: DependencyConstraint.() -> Unit): DependencyConstraint? =
         add(CLASSPATH_CONFIGURATION, dependencyConstraintNotation, configuration)
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/MavenDeployment.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/MavenDeployment.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.PublishArtifact;
 
 import java.util.Set;
@@ -32,7 +31,6 @@ public interface MavenDeployment {
      * @return The packaging. Never null.
      * @since 4.8
      */
-    @Incubating
     String getPackaging();
 
     /**
@@ -41,7 +39,6 @@ public interface MavenDeployment {
      * @return The group ID. Never null.
      * @since 4.8
      */
-    @Incubating
     String getGroupId();
 
     /**
@@ -50,7 +47,6 @@ public interface MavenDeployment {
      * @return The artifact ID. Never null.
      * @since 4.8
      */
-    @Incubating
     String getArtifactId();
 
     /**
@@ -59,7 +55,6 @@ public interface MavenDeployment {
      * @return The version. Never null.
      * @since 4.8
      */
-    @Incubating
     String getVersion();
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -54,7 +53,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     Property<String> getName();
 
     /**
@@ -62,7 +60,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     Property<String> getDescription();
 
     /**
@@ -70,7 +67,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     Property<String> getUrl();
 
     /**
@@ -78,7 +74,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     Property<String> getInceptionYear();
 
     /**
@@ -86,7 +81,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void licenses(Action<? super MavenPomLicenseSpec> action);
 
     /**
@@ -94,7 +88,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void organization(Action<? super MavenPomOrganization> action);
 
     /**
@@ -102,7 +95,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void developers(Action<? super MavenPomDeveloperSpec> action);
 
     /**
@@ -110,7 +102,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void contributors(Action<? super MavenPomContributorSpec> action);
 
     /**
@@ -118,7 +109,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void scm(Action<? super MavenPomScm> action);
 
     /**
@@ -126,7 +116,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void issueManagement(Action<? super MavenPomIssueManagement> action);
 
     /**
@@ -134,7 +123,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void ciManagement(Action<? super MavenPomCiManagement> action);
 
     /**
@@ -142,7 +130,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void distributionManagement(Action<? super MavenPomDistributionManagement> action);
 
     /**
@@ -150,7 +137,6 @@ public interface MavenPom {
      *
      * @since 4.8
      */
-    @Incubating
     void mailingLists(Action<? super MavenPomMailingListSpec> action);
 
     /**
@@ -158,7 +144,6 @@ public interface MavenPom {
      *
      * @since 5.3
      */
-    @Incubating
     MapProperty<String, String> getProperties();
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomCiManagement.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomCiManagement.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Property;
  * @since 4.8
  * @see MavenPom
  */
-@Incubating
 public interface MavenPomCiManagement {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
@@ -28,7 +27,6 @@ import org.gradle.api.provider.SetProperty;
  * @see MavenPom
  * @see MavenPomContributorSpec
  */
-@Incubating
 public interface MavenPomContributor {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributorSpec.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributorSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * Allows to add contributors of a Maven publication.
@@ -26,7 +25,6 @@ import org.gradle.api.Incubating;
  * @see MavenPom
  * @see MavenPomContributor
  */
-@Incubating
 public interface MavenPomContributorSpec {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloper.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloper.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
@@ -28,7 +27,6 @@ import org.gradle.api.provider.SetProperty;
  * @see MavenPom
  * @see MavenPomDeveloperSpec
  */
-@Incubating
 public interface MavenPomDeveloper {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloperSpec.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloperSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * Allows to add developers to a Maven publication.
@@ -26,7 +25,6 @@ import org.gradle.api.Incubating;
  * @see MavenPom
  * @see MavenPomDeveloper
  */
-@Incubating
 public interface MavenPomDeveloperSpec {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDistributionManagement.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDistributionManagement.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -27,7 +26,6 @@ import org.gradle.internal.HasInternalProtocol;
  * @since 4.8
  * @see MavenPom
  */
-@Incubating
 @HasInternalProtocol
 public interface MavenPomDistributionManagement {
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomIssueManagement.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomIssueManagement.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Property;
  * @since 4.8
  * @see MavenPom
  */
-@Incubating
 public interface MavenPomIssueManagement {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomLicense.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomLicense.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -26,7 +25,6 @@ import org.gradle.api.provider.Property;
  * @see MavenPom
  * @see MavenPomLicenseSpec
  */
-@Incubating
 public interface MavenPomLicense {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomLicenseSpec.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomLicenseSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * Allows to add licenses to a Maven publication.
@@ -26,7 +25,6 @@ import org.gradle.api.Incubating;
  * @see MavenPom
  * @see MavenPomLicense
  */
-@Incubating
 public interface MavenPomLicenseSpec {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomMailingList.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomMailingList.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 
@@ -27,7 +26,6 @@ import org.gradle.api.provider.SetProperty;
  * @see MavenPom
  * @see MavenPomMailingListSpec
  */
-@Incubating
 public interface MavenPomMailingList {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomMailingListSpec.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomMailingListSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * Allows to add mailing lists to a Maven publication.
@@ -26,7 +25,6 @@ import org.gradle.api.Incubating;
  * @see MavenPom
  * @see MavenPomMailingList
  */
-@Incubating
 public interface MavenPomMailingListSpec {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomOrganization.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomOrganization.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Property;
  * @since 4.8
  * @see MavenPom
  */
-@Incubating
 public interface MavenPomOrganization {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomRelocation.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomRelocation.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -27,7 +26,6 @@ import org.gradle.api.provider.Property;
  * @see MavenPom
  * @see MavenPomDistributionManagement
  */
-@Incubating
 public interface MavenPomRelocation {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomScm.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomScm.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Property;
  * @since 4.8
  * @see MavenPom
  */
-@Incubating
 public interface MavenPomScm {
 
     /**

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -312,6 +311,5 @@ public interface MavenPublication extends Publication {
      *
      * @since 5.2
      */
-    @Incubating
     void versionMapping(Action<? super VersionMappingStrategy> configureAction);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/FeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/FeatureSpec.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -25,7 +24,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 5.3
  */
-@Incubating
 @HasInternalProtocol
 public interface FeatureSpec {
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -92,7 +92,6 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
      *
      * @since 5.3
      */
-    @Incubating
     public static final Set<String> UNPUBLISHABLE_VARIANT_ARTIFACTS = ImmutableSet.of(
             ArtifactTypeDefinition.JVM_CLASS_DIRECTORY,
             ArtifactTypeDefinition.JVM_RESOURCES_DIRECTORY,

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformExtension.java
@@ -15,14 +15,11 @@
  */
 package org.gradle.api.plugins;
 
-import org.gradle.api.Incubating;
-
 /**
  * The extension to configure a Java platform project.
  *
  * @since 5.2
  */
-@Incubating
 public interface JavaPlatformExtension {
     /**
      * Allow dependencies to be declared. By default, a platform

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -17,7 +17,6 @@ package org.gradle.api.plugins;
 
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -44,7 +43,6 @@ import java.util.Set;
  *
  * @since 5.2
  */
-@Incubating
 public class JavaPlatformPlugin implements Plugin<Project> {
     // Buckets of dependencies
     public static final String API_CONFIGURATION_NAME = "api";

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -200,7 +199,6 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
      *
      * @since 4.6
      */
-    @Incubating
     public static final String ANNOTATION_PROCESSOR_CONFIGURATION_NAME = "annotationProcessor";
 
     public static final String TEST_COMPILE_CONFIGURATION_NAME = "testCompile";
@@ -245,7 +243,6 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
      *
      * @since 4.6
      */
-    @Incubating
     public static final String TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME = "testAnnotationProcessor";
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.java.archives.Manifest;
@@ -169,7 +168,6 @@ public abstract class JavaPluginConvention {
      *
      * @since 5.3
      */
-    @Incubating
     public abstract void disableAutoTargetJvm();
 
     /**
@@ -179,6 +177,5 @@ public abstract class JavaPluginConvention {
      *
      * @since 5.3
      */
-    @Incubating
     public abstract boolean getAutoTargetJvmDisabled();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -17,7 +17,6 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.JavaVersion;
  *
  * @since 4.10
  */
-@Incubating
 public interface JavaPluginExtension {
     /**
      * Returns the source compatibility used for compiling Java sources.
@@ -70,7 +68,6 @@ public interface JavaPluginExtension {
      *
      * @since 5.3
      */
-    @Incubating
     void disableAutoTargetJvm();
 
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -17,7 +17,6 @@ package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.ExtensionAware;
@@ -86,7 +85,6 @@ public interface SourceSet extends ExtensionAware {
      * @return The annotation processor path. Never returns null.
      * @since 4.6
      */
-    @Incubating
     FileCollection getAnnotationProcessorPath();
 
     /**
@@ -98,7 +96,6 @@ public interface SourceSet extends ExtensionAware {
      * @param annotationProcessorPath The annotation processor path. Should not be null.
      * @since 4.6
      */
-    @Incubating
     void setAnnotationProcessorPath(FileCollection annotationProcessorPath);
 
     /**
@@ -281,7 +278,6 @@ public interface SourceSet extends ExtensionAware {
      * @return the name of the annotation processor configuration.
      * @since 4.6
      */
-    @Incubating
     String getAnnotationProcessorConfigurationName();
 
     /**

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/VariantVersionMappingStrategy.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/VariantVersionMappingStrategy.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.publish;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -24,7 +23,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 5.2
  */
-@Incubating
 @HasInternalProtocol
 public interface VariantVersionMappingStrategy {
     /**

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/VersionMappingStrategy.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/VersionMappingStrategy.java
@@ -16,7 +16,6 @@
 package org.gradle.api.publish;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -28,7 +27,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 5.2
  */
-@Incubating
 @HasInternalProtocol
 public interface VersionMappingStrategy {
     /**

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -19,7 +19,6 @@ package org.gradle.api.publish.tasks;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Buildable;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.PublishArtifact;
@@ -65,7 +64,6 @@ import java.util.Set;
  *
  * @since 4.3
  */
-@Incubating
 public class GenerateModuleMetadata extends DefaultTask {
     private final Property<Publication> publication;
     private final ListProperty<Publication> publications;


### PR DESCRIPTION
### Context

This pull request de-incubates a number of _dependency management_ related APIs.
The remaining incubations are from really recent additions (since 5.5/5.6).

This should only be merged once _master_ is 6.0.
