### PR TITLE
Improvements to the Worker API

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
@@ -18,6 +18,8 @@ package org.gradle.internal.work;
 
 import org.gradle.internal.operations.BuildOperationRef;
 
+import java.util.List;
+
 /**
  * Allows asynchronous work to be tracked based on the build operation it is associated with.
  */
@@ -44,6 +46,17 @@ public interface AsyncWorkTracker {
      * @param lockRetention - How project locks should be treated while waiting on work
      */
     void waitForCompletion(BuildOperationRef operation, ProjectLockRetention lockRetention);
+
+    /**
+     * Blocks waiting for the completion of the specified items of asynchronous work.
+     * Only waits for work in the list at the moment the method is called.  In the event that there are failures in
+     * the asynchronous work, a {@link org.gradle.internal.exceptions.MultiCauseException} will be thrown with any exceptions
+     * thrown.
+     *
+     * @param workCompletions - The items of work that should be waited on
+     * @param lockRetention - How project locks should be treated while waiting on work
+     */
+    void waitForCompletion(BuildOperationRef operation, List<AsyncWorkCompletion> workCompletions, ProjectLockRetention lockRetention);
 
     /**
      * Returns true if the given operation has work registered that has not completed.

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -81,9 +81,9 @@
         {
             "type": "org.gradle.workers.WorkerConfiguration",
             "member": "Class org.gradle.workers.WorkerConfiguration",
-            "acceptation": "Common functionality moved to an incubating class",
+            "acceptation": "Common functionality moved to an incubating parent class",
             "changes": [
-                "org.gradle.workers.BaseWorkerSpec"
+                "org.gradle.workers.ForkingWorkerSpec"
             ]
         }
     ]

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/daemon/AbstractDaemonCompiler.java
@@ -24,8 +24,8 @@ import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
 import org.gradle.workers.internal.ActionExecutionSpecFactory;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DefaultWorkResult;
@@ -55,7 +55,7 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
         Worker worker = workerFactory.getWorker(daemonForkOptions);
 
         CompilerParameters parameters = getCompilerParameters(spec);
-        DefaultWorkResult result = worker.execute(actionExecutionSpecFactory.newIsolatedSpec("compiler daemon", CompilerWorkerExecution.class, parameters, daemonForkOptions.getClassLoaderStructure()));
+        DefaultWorkResult result = worker.execute(actionExecutionSpecFactory.newIsolatedSpec("compiler daemon", CompilerWorkAction.class, parameters, daemonForkOptions.getClassLoaderStructure()));
         if (result.isSuccess()) {
             return result;
         } else {
@@ -77,7 +77,7 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
         return merged;
     }
 
-    public abstract static class CompilerParameters implements WorkerParameters, Serializable {
+    public abstract static class CompilerParameters implements WorkParameters, Serializable {
         private final String compilerClassName;
         private final Object[] compilerInstanceParameters;
 
@@ -97,12 +97,12 @@ public abstract class AbstractDaemonCompiler<T extends CompileSpec> implements C
         abstract public CompileSpec getCompileSpec();
     }
 
-    public static abstract class CompilerWorkerExecution implements WorkerExecution<CompilerParameters>, ProvidesWorkResult {
+    public static abstract class CompilerWorkAction implements WorkAction<CompilerParameters>, ProvidesWorkResult {
         private DefaultWorkResult workResult;
         private final Instantiator instantiator;
 
         @Inject
-        public CompilerWorkerExecution(Instantiator instantiator) {
+        public CompilerWorkAction(Instantiator instantiator) {
             this.instantiator = instantiator;
         }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -53,7 +53,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
     }
 
     def setup() {
-        def targetVersion = "5.7-20190721220031+0000"
+        def targetVersion = "5.6-20190723234933+0000"
         runner.targetVersions = [targetVersion]
         runner.minimumVersion = targetVersion
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
@@ -26,11 +26,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.nativeplatform.toolchain.internal.PCHUtils;
-import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkQueue;
-import org.gradle.workers.WorkerExecution;
+import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkerExecutor;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkParameters;
 import org.gradle.workers.WorkerSpec;
 
 import javax.annotation.Nonnull;
@@ -92,12 +91,12 @@ public class PrefixHeaderFileGenerateTask extends DefaultTask {
         this.prefixHeaderFile = prefixHeaderFile;
     }
 
-    interface PrefixHeaderFileParameters extends WorkerParameters {
+    interface PrefixHeaderFileParameters extends WorkParameters {
         Property<String> getHeader();
         RegularFileProperty getPrefixHeaderFile();
     }
 
-    static abstract class GeneratePrefixHeaderFile implements WorkerExecution<PrefixHeaderFileParameters> {
+    static abstract class GeneratePrefixHeaderFile implements WorkAction<PrefixHeaderFileParameters> {
         @Inject
         public GeneratePrefixHeaderFile() { }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
@@ -27,11 +27,13 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.nativeplatform.toolchain.internal.PCHUtils;
 import org.gradle.workers.IsolationMode;
+import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecution;
 import org.gradle.workers.WorkerExecutor;
 import org.gradle.workers.WorkerParameters;
 import org.gradle.workers.WorkerSpec;
 
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.File;
 
@@ -56,17 +58,18 @@ public class PrefixHeaderFileGenerateTask extends DefaultTask {
 
     @TaskAction
     void generatePrefixHeaderFile() {
-        workerExecutor.execute(GeneratePrefixHeaderFile.class, new Action<WorkerSpec<PrefixHeaderFileParameters>>() {
+        WorkQueue workQueue = workerExecutor.noIsolation(new Action<WorkerSpec>() {
             @Override
-            public void execute(WorkerSpec<PrefixHeaderFileParameters> config) {
-                config.setIsolationMode(IsolationMode.NONE);
-                config.parameters(new Action<PrefixHeaderFileParameters>() {
-                    @Override
-                    public void execute(PrefixHeaderFileParameters parameters) {
-                        parameters.getHeader().set(header);
-                        parameters.getPrefixHeaderFile().set(prefixHeaderFile);
-                    }
-                });
+            public void execute(WorkerSpec config) {
+                config.setDisplayName("Generate prefix header for " + header);
+            }
+        });
+
+        workQueue.submit(GeneratePrefixHeaderFile.class, new Action<PrefixHeaderFileParameters>() {
+            @Override
+            public void execute(@Nonnull PrefixHeaderFileParameters parameters) {
+                parameters.getHeader().set(header);
+                parameters.getPrefixHeaderFile().set(prefixHeaderFile);
             }
         });
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/PrefixHeaderFileGenerateTask.java
@@ -30,7 +30,6 @@ import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkerExecutor;
 import org.gradle.workers.WorkParameters;
-import org.gradle.workers.WorkerSpec;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -57,12 +56,7 @@ public class PrefixHeaderFileGenerateTask extends DefaultTask {
 
     @TaskAction
     void generatePrefixHeaderFile() {
-        WorkQueue workQueue = workerExecutor.noIsolation(new Action<WorkerSpec>() {
-            @Override
-            public void execute(WorkerSpec config) {
-                config.setDisplayName("Generate prefix header for " + header);
-            }
-        });
+        WorkQueue workQueue = workerExecutor.noIsolation();
 
         workQueue.submit(GeneratePrefixHeaderFile.class, new Action<PrefixHeaderFileParameters>() {
             @Override

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractDaemonWorkerExecutorIntegrationSpec.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractDaemonWorkerExecutorIntegrationSpec.groovy
@@ -18,13 +18,19 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.integtests.fixtures.daemon.DaemonsFixture
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 
 
 abstract class AbstractDaemonWorkerExecutorIntegrationSpec extends AbstractWorkerExecutorIntegrationTest {
     def setup() {
         executer.requireDaemon()
         executer.requireIsolatedDaemons()
+    }
+
+    @Override
+    protected ExecutionResult succeeds(String... tasks) {
         executer.withWorkerDaemonsExpirationDisabled()
+        return super.succeeds(tasks)
     }
 
     void stopDaemonsNow() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkQueueIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkQueueIntegrationTest.groovy
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.workers.fixtures.WorkerExecutorFixture
+import org.junit.Rule
+import spock.lang.Unroll
+
+import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
+
+class WorkQueueIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
+    @Rule BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
+    WorkerExecutorFixture.ParameterClass parallelParameterType
+    WorkerExecutorFixture.ExecutionClass parallelWorkerExecution
+
+    def setup() {
+        blockingHttpServer.start()
+
+        parallelParameterType = fixture.parameterClass("ParallelParameter", "org.gradle.test").withFields([
+                "itemName": "String",
+                "shouldFail": "Boolean"
+        ])
+
+        parallelWorkerExecution = fixture.executionClass("ParallelWorkerExecution", "org.gradle.test", parallelParameterType)
+        parallelWorkerExecution.with {
+            imports += ["java.net.URI", "org.gradle.test.FileHelper"]
+            extraFields = "private static final String id = UUID.randomUUID().toString()"
+            action = """
+                System.out.println("Running \${parameters.itemName}...")
+                new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${parameters.itemName}", null, null).toURL().text
+                if (parameters.shouldFail) {
+                    throw new Exception("Failure from " + parameters.itemName)
+                }
+                File outputDir = new File("${fixture.outputFileDirPath}")
+                File outputFile = new File(outputDir, parameters.itemName)
+                FileHelper.write(id, outputFile)
+            """
+        }
+        parallelWorkerExecution.writeToBuildFile()
+
+        buildFile << """
+            ${workItemTask}
+        """
+    }
+
+    @Unroll
+    def "can wait on work items submitted to a queue with #isolationMode"() {
+        buildFile << """
+            task runWork(type: WorkItemTask) {
+                doLast {
+                    def workQueue1 = submit(ParallelWorkerExecution.class, [ "item1", "item2"])
+                    def workQueue2 = submit(ParallelWorkerExecution.class, [ "item3" ])
+                    
+                    signal("submitted")
+
+                    workQueue1.await()
+                    
+                    signal("finished")
+                }
+            }
+        """
+
+        def started = blockingHttpServer.expectConcurrentAndBlock("item1", "item2", "item3", "submitted")
+        def finished = blockingHttpServer.expectConcurrentAndBlock("finished")
+
+        when:
+        def gradle = executer.withTasks("runWork").start()
+
+        then:
+        started.waitForAllPendingCalls()
+
+        then:
+        started.release("submitted")
+        started.release("item1")
+        started.release("item2")
+
+        then:
+        finished.waitForAllPendingCalls()
+
+        then:
+        finished.releaseAll()
+        started.release("item3")
+
+        then:
+        gradle.waitForFinish()
+
+        and:
+        assertWorkItemsExecuted("item1", "item2", "item3")
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
+    @Unroll
+    def "all errors are reported when waiting on work submitted to a queue in #isolationMode"() {
+        buildFile << """
+            task runWork(type: WorkItemTask) {
+                doLast {
+                    def workQueue1 = submitFailure(ParallelWorkerExecution.class, [ "item1", "item2"])
+                    def workQueue2 = submit(ParallelWorkerExecution.class, [ "item3" ])
+                    
+                    signal("submitted")
+
+                    try {
+                        workQueue1.await()
+                    } catch (Exception e) {
+                        printMessages(e)
+                    }
+                    
+                    signal("finished")
+                }
+            }
+        """
+
+        def started = blockingHttpServer.expectConcurrentAndBlock("item1", "item2", "item3", "submitted")
+        def finished = blockingHttpServer.expectConcurrentAndBlock("finished")
+
+        when:
+        def gradle = executer.withTasks("runWork").start()
+
+        then:
+        started.waitForAllPendingCalls()
+
+        then:
+        started.release("submitted")
+        started.release("item1")
+        started.release("item2")
+
+        then:
+        finished.waitForAllPendingCalls()
+
+        then:
+        finished.releaseAll()
+        started.release("item3")
+
+        then:
+        def result = gradle.waitForFinish()
+
+        and:
+        assertWorkItemsExecuted("item3")
+
+        and:
+        result.groupedOutput.task(":runWork").output.readLines().containsAll("Failure from item1", "Failure from item2")
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
+    @Unroll
+    def "errors in work submitted to other queues cause a task failure when waiting for work in #isolationMode"() {
+        buildFile << """
+            task runWork(type: WorkItemTask) {
+                doLast {
+                    def workQueue1 = submitFailure(ParallelWorkerExecution.class, [ "item1", "item2"])
+                    def workQueue2 = submitFailure(ParallelWorkerExecution.class, [ "item3" ])
+                    
+                    signal("submitted")
+
+                    try {
+                        workQueue1.await()
+                    } catch (Exception e) {
+                        printMessages(e)
+                    }
+                    
+                    signal("finished")
+                }
+            }
+        """
+
+        def started = blockingHttpServer.expectConcurrentAndBlock("item1", "item2", "item3", "submitted")
+        def finished = blockingHttpServer.expectConcurrentAndBlock("finished")
+
+        when:
+        def gradle = executer.withTasks("runWork").start()
+
+        then:
+        started.waitForAllPendingCalls()
+
+        then:
+        started.release("submitted")
+        started.release("item1")
+        started.release("item2")
+
+        then:
+        finished.waitForAllPendingCalls()
+
+        then:
+        finished.releaseAll()
+        started.release("item3")
+
+        then:
+        def result = gradle.waitForFailure()
+
+        and:
+        result.groupedOutput.task(":runWork").output.readLines().containsAll("Failure from item1", "Failure from item2")
+
+        and:
+        result.assertHasNoCause("Failure from item1")
+        result.assertHasNoCause("Failure from item2")
+        result.assertHasCause("Failure from item3")
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
+    void assertWorkItemsExecuted(String... items) {
+        File outputDir = new File("${fixture.outputFileDirPath}")
+        assert items.every { item ->
+            new File(outputDir, item).exists()
+        }
+    }
+
+    String getWorkItemTask() {
+        return """
+            import org.gradle.internal.exceptions.MultiCauseException
+
+            class WorkItemTask extends DefaultTask {
+                IsolationMode isolationMode = IsolationMode.AUTO
+
+                @Inject
+                WorkerExecutor getWorkerExecutor() {
+                    throw new UnsupportedOperationException()
+                }
+                
+                def submitFailure(Class<?> executionClass, List<String> items) {
+                    return submit(executionClass, items, true)
+                }
+
+                def submit(Class<?> executionClass, List<String> items, boolean error = false) {
+                    def workQueue = workerExecutor."\${getWorkerMethod(isolationMode)}"()
+                    items.each { name ->
+                        workQueue.submit(executionClass) {
+                            itemName = name
+                            shouldFail = error
+                        }
+                    }
+                    return workQueue
+                }
+                
+                def signal(String signal) {
+                    new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${signal}", null, null).toURL().text
+                }
+                
+                def printMessages(Exception e) {
+                    println e.message
+                    if (e.cause == null || e.cause == e) {
+                        return
+                    }
+                    if (e instanceof MultiCauseException) {
+                        e.causes.each {
+                            printMessages(it)
+                        }
+                    } else {
+                        printMessages(e.cause)
+                    }
+                }
+                
+                ${fixture.workerMethodTranslation}
+            }
+        """
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkQueueIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkQueueIntegrationTest.groovy
@@ -25,19 +25,19 @@ import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 
 class WorkQueueIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Rule BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
-    WorkerExecutorFixture.ParameterClass parallelParameterType
-    WorkerExecutorFixture.ExecutionClass parallelWorkerExecution
+    WorkerExecutorFixture.WorkParameterClass parallelParameterType
+    WorkerExecutorFixture.WorkActionClass parallelWorkAction
 
     def setup() {
         blockingHttpServer.start()
 
-        parallelParameterType = fixture.parameterClass("ParallelParameter", "org.gradle.test").withFields([
+        parallelParameterType = fixture.workParameterClass("ParallelParameter", "org.gradle.test").withFields([
                 "itemName": "String",
                 "shouldFail": "Boolean"
         ])
 
-        parallelWorkerExecution = fixture.executionClass("ParallelWorkerExecution", "org.gradle.test", parallelParameterType)
-        parallelWorkerExecution.with {
+        parallelWorkAction = fixture.workActionClass("ParallelWorkAction", "org.gradle.test", parallelParameterType)
+        parallelWorkAction.with {
             imports += ["java.net.URI", "org.gradle.test.FileHelper"]
             extraFields = "private static final String id = UUID.randomUUID().toString()"
             action = """
@@ -51,7 +51,7 @@ class WorkQueueIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
                 FileHelper.write(id, outputFile)
             """
         }
-        parallelWorkerExecution.writeToBuildFile()
+        parallelWorkAction.writeToBuildFile()
 
         buildFile << """
             ${workItemTask}
@@ -63,8 +63,8 @@ class WorkQueueIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
         buildFile << """
             task runWork(type: WorkItemTask) {
                 doLast {
-                    def workQueue1 = submit(ParallelWorkerExecution.class, [ "item1", "item2"])
-                    def workQueue2 = submit(ParallelWorkerExecution.class, [ "item3" ])
+                    def workQueue1 = submit(ParallelWorkAction.class, [ "item1", "item2"])
+                    def workQueue2 = submit(ParallelWorkAction.class, [ "item3" ])
                     
                     signal("submitted")
 
@@ -111,8 +111,8 @@ class WorkQueueIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
         buildFile << """
             task runWork(type: WorkItemTask) {
                 doLast {
-                    def workQueue1 = submitFailure(ParallelWorkerExecution.class, [ "item1", "item2"])
-                    def workQueue2 = submit(ParallelWorkerExecution.class, [ "item3" ])
+                    def workQueue1 = submitFailure(ParallelWorkAction.class, [ "item1", "item2"])
+                    def workQueue2 = submit(ParallelWorkAction.class, [ "item3" ])
                     
                     signal("submitted")
 
@@ -166,8 +166,8 @@ class WorkQueueIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
         buildFile << """
             task runWork(type: WorkItemTask) {
                 doLast {
-                    def workQueue1 = submitFailure(ParallelWorkerExecution.class, [ "item1", "item2"])
-                    def workQueue2 = submitFailure(ParallelWorkerExecution.class, [ "item3" ])
+                    def workQueue1 = submitFailure(ParallelWorkAction.class, [ "item1", "item2"])
+                    def workQueue2 = submitFailure(ParallelWorkAction.class, [ "item3" ])
                     
                     signal("submitted")
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -47,9 +47,11 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
         """
 
         when:
+        //executer.startBuildProcessInDebugger(true)
         succeeds "runInWorker1"
 
         and:
+       // executer.startBuildProcessInDebugger(true)
         succeeds "runInWorker2"
 
         then:

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -47,11 +47,9 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
         """
 
         when:
-        //executer.startBuildProcessInDebugger(true)
         succeeds "runInWorker1"
 
         and:
-       // executer.startBuildProcessInDebugger(true)
         succeeds "runInWorker2"
 
         then:

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -28,7 +28,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     String logSnapshot = ""
 
     def "worker daemons are reused across builds"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
         buildFile << """
             import org.gradle.workers.internal.WorkerDaemonFactory
             
@@ -59,7 +59,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons can be restarted when daemon is stopped"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -84,7 +84,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are stopped when daemon is stopped"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -107,7 +107,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are stopped and not reused when log level is changed"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -137,7 +137,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are not reused when classpath changes"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -202,7 +202,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "only compiler daemons are stopped with the build session"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
         file('src/main/java').createDir()
         file('src/main/java/Test.java') << "public class Test {}"
         buildFile << """
@@ -236,7 +236,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
 
     @Requires(TestPrecondition.UNIX)
     def "worker daemons exit when the parent build daemon is killed"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -276,8 +276,8 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
         return daemons.daemon.log - logSnapshot
     }
 
-    WorkerExecutorFixture.ExecutionClass getWorkerExecutorThatCanFailUnexpectedly() {
-        def executionClass = fixture.workerExecutionThatCreatesFiles
+    WorkerExecutorFixture.WorkActionClass getWorkerExecutorThatCanFailUnexpectedly() {
+        def executionClass = fixture.workActionThatCreatesFiles
         executionClass.action += """
             if (getParameters().getFiles().contains("poisonPill")) {
                 System.exit(127);

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -28,18 +28,18 @@ import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 
 @IntegrationTestTimeout(120)
 class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
-    WorkerExecutorFixture.ExecutionClass executionThatFailsInstantiation
-    WorkerExecutorFixture.ExecutionClass executionThatThrowsUnserializableMemberException
+    WorkerExecutorFixture.WorkActionClass executionThatFailsInstantiation
+    WorkerExecutorFixture.WorkActionClass executionThatThrowsUnserializableMemberException
 
     def setup() {
-        executionThatFailsInstantiation = fixture.getWorkerExecutionThatCreatesFiles("ExecutionThatFailsInstantiation")
+        executionThatFailsInstantiation = fixture.getWorkActionThatCreatesFiles("ActionThatFailsInstantiation")
         executionThatFailsInstantiation.with {
             constructorAction = """
                 throw new IllegalArgumentException("You shall not pass!");
             """
         }
 
-        executionThatThrowsUnserializableMemberException = fixture.getWorkerExecutionThatCreatesFiles("ExecutionThatFails")
+        executionThatThrowsUnserializableMemberException = fixture.getWorkActionThatCreatesFiles("ActionThatFails")
         executionThatThrowsUnserializableMemberException.with {
             extraFields = """
                 private class Bar { }
@@ -60,13 +60,13 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when there is a failure in the worker runnable in #isolationMode"() {
-        def failureExecution = fixture.workerExecutionThatFails.writeToBuildFile()
-        fixture.withWorkerExecutionClassInBuildSrc()
+        def failureExecution = fixture.workActionThatFails.writeToBuildFile()
+        fixture.withWorkActionClassInBuildSrc()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
-                workerExecutionClass = ${failureExecution.name}.class
+                workActionClass = ${failureExecution.name}.class
             }
         """.stripIndent()
 
@@ -77,7 +77,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         failureHasCause("A failure occurred while executing ${failureExecution.name}")
 
         and:
-        failureHasCause("Failure from worker execution")
+        failureHasCause("Failure from work action")
 
         where:
         isolationMode << ISOLATION_MODES
@@ -85,15 +85,15 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when there is a failure in the worker runnable and work completes before the task in #isolationMode"() {
-        def failureExecution = fixture.workerExecutionThatFails.writeToBuildFile()
-        fixture.withWorkerExecutionClassInBuildSrc()
+        def failureExecution = fixture.workActionThatFails.writeToBuildFile()
+        fixture.withWorkActionClassInBuildSrc()
 
         buildFile << """
             $workerTaskThatWaits
 
             task runInWorker(type: WorkerTaskThatWaits) {
                 isolationMode = $isolationMode
-                workerExecutionClass = ${failureExecution.name}.class
+                workActionClass = ${failureExecution.name}.class
             }
         """.stripIndent()
 
@@ -104,7 +104,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         failureHasCause("A failure occurred while executing ${failureExecution.name}")
 
         and:
-        failureHasCause("Failure from worker execution")
+        failureHasCause("Failure from work action")
 
         where:
         isolationMode << ISOLATION_MODES
@@ -112,7 +112,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     def "produces a sensible error when there is a failure starting a worker daemon"() {
         executer.withStackTraceChecksDisabled()
-        def workerExecution = fixture.workerExecutionThatCreatesFiles.writeToBuildSrc()
+        def workAction = fixture.workActionThatCreatesFiles.writeToBuildSrc()
 
         buildFile << """
             task runInDaemon(type: WorkerTask) {
@@ -130,7 +130,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         failure.assertHasErrorOutput(unrecognizedOptionError)
 
         and:
-        failureHasCause("A failure occurred while executing ${workerExecution.packageName}.${workerExecution.name}")
+        failureHasCause("A failure occurred while executing ${workAction.packageName}.${workAction.name}")
 
         and:
         failureHasCause("Failed to run Gradle Worker Daemon")
@@ -138,14 +138,14 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when a parameter can't be serialized to the worker in #isolationMode"() {
-        def workerExecution = fixture.workerExecutionThatCreatesFiles.writeToBuildSrc()
-        def alternateExecution = fixture.alternateWorkerExecution.writeToBuildSrc()
+        def workAction = fixture.workActionThatCreatesFiles.writeToBuildSrc()
+        def alternateExecution = fixture.alternateWorkAction.writeToBuildSrc()
         withParameterMemberThatFailsSerialization()
 
         buildFile << """
             task runAgainInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
-                workerExecutionClass = ${alternateExecution.name}.class
+                workActionClass = ${alternateExecution.name}.class
             }
             
             task runInWorker(type: WorkerTask) {
@@ -159,7 +159,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         fails("runInWorker")
 
         then:
-        failureHasCause("A failure occurred while executing ${workerExecution.packageName}.${workerExecution.name}")
+        failureHasCause("A failure occurred while executing ${workAction.packageName}.${workAction.name}")
         failureHasCause("Could not isolate value")
         failureHasCause("Could not serialize value of type 'org.gradle.other.FooWithUnserializableBar'")
 
@@ -174,14 +174,14 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
     @Unroll
     def "produces a sensible error when a parameter can't be de-serialized in the worker in #isolationMode"() {
         def parameterJar = file("parameter.jar")
-        def workerExecution = fixture.workerExecutionThatCreatesFiles.writeToBuildSrc()
-        def alternateExecution = fixture.alternateWorkerExecution.writeToBuildSrc()
+        def workAction = fixture.workActionThatCreatesFiles.writeToBuildSrc()
+        def alternateExecution = fixture.alternateWorkAction.writeToBuildSrc()
         withParameterMemberThatFailsDeserialization()
 
         buildFile << """  
             task runAgainInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.$isolationMode
-                workerExecutionClass = ${alternateExecution.name}.class
+                workActionClass = ${alternateExecution.name}.class
             }
 
             task runInWorker(type: WorkerTask) {
@@ -196,7 +196,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         fails("runInWorker")
 
         then:
-        failureHasCause("A failure occurred while executing ${workerExecution.packageName}.${workerExecution.name}")
+        failureHasCause("A failure occurred while executing ${workAction.packageName}.${workAction.name}")
         failureHasCause("Couldn't populate class org.gradle.other.FooWithUnserializableBar")
 
         and:
@@ -209,19 +209,19 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error even if the action failure cannot be fully serialized in #isolationMode"() {
-        fixture.withWorkerExecutionClassInBuildSrc()
+        fixture.withWorkActionClassInBuildSrc()
         def failureExecution = executionThatThrowsUnserializableMemberException.writeToBuildSrc()
-        def alternateExecution = fixture.alternateWorkerExecution.writeToBuildSrc()
+        def alternateExecution = fixture.alternateWorkAction.writeToBuildSrc()
 
         buildFile << """
             task runAgainInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
-                workerExecutionClass = ${alternateExecution.name}.class
+                workActionClass = ${alternateExecution.name}.class
             }
 
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
-                workerExecutionClass = ${failureExecution.name}.class
+                workActionClass = ${failureExecution.name}.class
                 finalizedBy runAgainInWorker
             }
         """
@@ -243,7 +243,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Requires(TestPrecondition.NOT_WINDOWS)
     def "produces a sensible error when worker fails before logging is initialized"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+        fixture.withWorkActionClassInBuildScript()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
@@ -262,20 +262,20 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         result.assertHasErrorOutput("net.rubygrapefruit.platform.NativeException: Failed to load native library")
     }
 
-    def "produces a sensible error when the worker execution is not implemented properly"() {
-        fixture.withWorkerExecutionClassInBuildScript()
+    def "produces a sensible error when the work action is not implemented properly"() {
+        fixture.withWorkActionClassInBuildScript()
 
         buildFile << """
-            abstract class BadWorkerExecution implements WorkerExecution<WorkerParameters> {
+            abstract class BadWorkAction implements WorkAction<WorkParameters> {
                 @Inject
-                BadWorkerExecution() { }
+                BadWorkAction() { }
                 
                 void execute() { }
             }
             
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
-                workerExecutionClass = BadWorkerExecution.class
+                workActionClass = BadWorkAction.class
             }
         """.stripIndent()
 
@@ -284,7 +284,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         fails("runInWorker")
 
         then:
-        failure.assertHasCause("Could not create worker parameters: must use a sub-type of WorkerParameters as parameter type. Use WorkerParameters.None for executions without parameters.")
+        failure.assertHasCause("Could not create worker parameters: must use a sub-type of WorkParameters as parameter type. Use WorkParameters.None for executions without parameters.")
     }
 
     String getUnrecognizedOptionError() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
@@ -26,7 +26,7 @@ class WorkerExecutorInjectionIntegrationTest extends AbstractWorkerExecutorInteg
     @Unroll
     def "workers cannot inject #forbiddenType"() {
         buildFile << """
-            ${getWorkerExecutionInjecting(forbiddenType.name)}
+            ${getWorkActionInjecting(forbiddenType.name)}
             task runInWorker(type: InjectingWorkerTask)
         """.stripIndent()
 
@@ -41,14 +41,14 @@ class WorkerExecutorInjectionIntegrationTest extends AbstractWorkerExecutorInteg
         forbiddenType << [Project]
     }
 
-    String getWorkerExecutionInjecting(String injectedClass) {
+    String getWorkActionInjecting(String injectedClass) {
         return """
             import javax.inject.Inject
             import org.gradle.workers.WorkerExecutor
-            import org.gradle.workers.WorkerExecution
-            import org.gradle.workers.WorkerParameters
+            import org.gradle.workers.WorkAction
+            import org.gradle.workers.WorkParameters
 
-            abstract class InjectingExecution implements WorkerExecution<WorkerParameters.None> {
+            abstract class InjectingExecution implements WorkAction<WorkParameters.None> {
                 
                 @Inject
                 public InjectingExecution($injectedClass injected) {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
@@ -69,9 +69,7 @@ class WorkerExecutorInjectionIntegrationTest extends AbstractWorkerExecutorInteg
 
                 @TaskAction
                 public void runInWorker() {
-                    executor.execute(InjectingExecution) {
-                        isolationMode = IsolationMode.NONE
-                    }
+                    executor.noIsolation().submit(InjectingExecution) { }
                 }
             }
         """.stripIndent()

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -297,13 +297,12 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         workerMethod << WORKER_METHODS.values().toUnique()
     }
 
-    def "can set a custom display name for work items in #isolationMode"() {
+    def "uses an inferred display name for work items in #isolationMode"() {
         given:
         fixture.withWorkActionClassInBuildSrc()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
-                displayName = "Test Work"
             }
         """
 
@@ -312,10 +311,10 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
         then:
         def operation = buildOperations.only(ExecuteWorkItemBuildOperationType)
-        operation.displayName == "Test Work"
+        operation.displayName == "org.gradle.test.TestWorkAction"
         with (operation.details) {
             className == "org.gradle.test.TestWorkAction"
-            displayName == "Test Work"
+            displayName == "org.gradle.test.TestWorkAction"
         }
 
         where:

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
@@ -241,8 +241,6 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
     }
 
     String getOptionVerifyingRunnable() {
-        boolean isOracleJDK = TestPrecondition.JDK_ORACLE.fulfilled
-
         return """
             import java.util.regex.Pattern;
             import java.util.List;

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.workers.internal
 
-import org.gradle.workers.fixtures.WorkerExecutorFixture.ExecutionClass
+import org.gradle.workers.fixtures.WorkerExecutorFixture.WorkActionClass
 import spock.lang.Timeout
 import spock.lang.Unroll
 
@@ -24,10 +24,10 @@ import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 
 @Timeout(120)
 class WorkerExecutorLoggingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
-    ExecutionClass executionWithLogging
+    WorkActionClass executionWithLogging
 
     def setup() {
-        executionWithLogging = fixture.workerExecutionThatCreatesFiles
+        executionWithLogging = fixture.workActionThatCreatesFiles
         executionWithLogging.with {
             imports.add("org.gradle.api.logging.Logging")
             action = """
@@ -54,7 +54,7 @@ class WorkerExecutorLoggingIntegrationTest extends AbstractWorkerExecutorIntegra
 
     @Unroll
     def "worker lifecycle is logged in #isolationMode"() {
-        def workerExecution = fixture.workerExecutionThatCreatesFiles.writeToBuildSrc()
+        def workAction = fixture.workActionThatCreatesFiles.writeToBuildSrc()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
@@ -70,8 +70,8 @@ class WorkerExecutorLoggingIntegrationTest extends AbstractWorkerExecutorIntegra
         gradle.waitForFinish()
 
         and:
-        gradle.standardOutput.contains("Build operation '${workerExecution.packageName}.${workerExecution.name}' started")
-        gradle.standardOutput.contains("Build operation '${workerExecution.packageName}.${workerExecution.name}' completed")
+        gradle.standardOutput.contains("Build operation '${workAction.packageName}.${workAction.name}' started")
+        gradle.standardOutput.contains("Build operation '${workAction.packageName}.${workAction.name}' completed")
 
         where:
         isolationMode << ISOLATION_MODES

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
@@ -25,7 +25,7 @@ import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 
 @IntegrationTestTimeout(120)
 class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
-    def nestingParameterType = fixture.parameterClass("NestingParameter", "org.gradle.test").withFields([
+    def nestingParameterType = fixture.workParameterClass("NestingParameter", "org.gradle.test").withFields([
         "greeting": "String",
         "childSubmissions": "int"
     ])
@@ -33,7 +33,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
     @Unroll
     def "workers with no isolation can spawn more work with #nestedIsolationMode"() {
         buildFile << """
-            ${getWorkerExecutionWithNesting("IsolationMode.NONE", nestedIsolationMode)}
+            ${getWorkActionWithNesting("IsolationMode.NONE", nestedIsolationMode)}
             task runInWorker(type: NestingWorkerTask)
         """.stripIndent()
 
@@ -49,7 +49,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
 
     def "workers with no isolation can wait on spawned work"() {
         buildFile << """
-            ${getWorkerExecutionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
+            ${getWorkActionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
             task runInWorker(type: NestingWorkerTask) {
                 waitForChildren = true 
             }
@@ -65,7 +65,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
     def "workers with no isolation can spawn more than max workers items of work"() {
         def maxWorkers = 4
         buildFile << """
-            ${getWorkerExecutionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
+            ${getWorkActionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
             task runInWorker(type: NestingWorkerTask) {
                 submissions = ${maxWorkers * 2}
                 childSubmissions = ${maxWorkers}
@@ -83,7 +83,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
     def "workers with no isolation can spawn and wait for more than max workers items of work"() {
         def maxWorkers = 4
         buildFile << """
-            ${getWorkerExecutionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
+            ${getWorkActionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
             task runInWorker(type: NestingWorkerTask) {
                 waitForChildren = true 
                 submissions = ${maxWorkers * 2}
@@ -106,7 +106,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
     @Unroll
     def "workers with classpath isolation cannot spawn more work with #nestedIsolationMode"() {
         buildFile << """
-            ${getWorkerExecutionWithNesting("IsolationMode.CLASSLOADER", nestedIsolationMode)}
+            ${getWorkActionWithNesting("IsolationMode.CLASSLOADER", nestedIsolationMode)}
             task runInWorker(type: NestingWorkerTask)
         """.stripIndent()
 
@@ -128,7 +128,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
     @Unroll
     def "workers with process isolation cannot spawn more work with #nestedIsolationMode"() {
         buildFile << """
-            ${getWorkerExecutionWithNesting("IsolationMode.PROCESS", nestedIsolationMode)}
+            ${getWorkActionWithNesting("IsolationMode.PROCESS", nestedIsolationMode)}
             task runInWorker(type: NestingWorkerTask)
         """.stripIndent()
 
@@ -147,7 +147,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
         def maxWorkers = 4
 
         buildFile << """
-            ${getWorkerExecutionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
+            ${getWorkActionWithNesting("IsolationMode.NONE", "IsolationMode.NONE")}
             task runInWorker(type: NestingWorkerTask) {
                 submissions = ${maxWorkers * 2}
                 childSubmissions = ${maxWorkers * 10}
@@ -191,8 +191,8 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
         result.groupedOutput.task(':runInWorker').output.contains("Hello World")
     }
 
-    WorkerExecutorFixture.ExecutionClass getFirstLevelExecution(String nestedIsolationMode) {
-        def workerClass = fixture.executionClass("FirstLevelExecution", "org.gradle.test", nestingParameterType)
+    WorkerExecutorFixture.WorkActionClass getFirstLevelExecution(String nestedIsolationMode) {
+        def workerClass = fixture.workActionClass("FirstLevelExecution", "org.gradle.test", nestingParameterType)
         workerClass.imports += ["org.gradle.workers.WorkerExecutor"]
         workerClass.extraFields = """
             WorkerExecutor executor
@@ -212,15 +212,15 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
         return workerClass
     }
 
-    WorkerExecutorFixture.ExecutionClass getSecondLevelExecution() {
-        def workerClass = fixture.executionClass("SecondLevelExecution", "org.gradle.test", nestingParameterType)
+    WorkerExecutorFixture.WorkActionClass getSecondLevelExecution() {
+        def workerClass = fixture.workActionClass("SecondLevelExecution", "org.gradle.test", nestingParameterType)
         workerClass.action = """
             System.out.println(parameters.greeting)
         """
         return workerClass
     }
 
-    String getWorkerExecutionWithNesting(String isolationMode, String nestedIsolationMode) {
+    String getWorkActionWithNesting(String isolationMode, String nestedIsolationMode) {
         getFirstLevelExecution(nestedIsolationMode).writeToBuildFile()
         secondLevelExecution.writeToBuildFile()
         return """

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
@@ -182,11 +182,8 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
                 }
                 
                 def submitWorkItem(item) {
-                    return workerExecutor.execute(${parallelWorkerExecution.name}.class) {
-                        isolationMode = IsolationMode.NONE
-                        parameters {
-                            itemName = item.toString()
-                        }
+                    return workerExecutor.noIsolation().submit(${parallelWorkerExecution.name}.class) {
+                        itemName = item.toString()
                     }
                 }
             }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
@@ -32,8 +32,8 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
     @Rule
     BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
     def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
-    WorkerExecutorFixture.ParameterClass parallelParameterType
-    WorkerExecutorFixture.ExecutionClass parallelWorkerExecution
+    WorkerExecutorFixture.WorkParameterClass parallelParameterType
+    WorkerExecutorFixture.WorkActionClass parallelWorkAction
 
 
     def setup() {
@@ -47,12 +47,12 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
             }
         """
 
-        parallelParameterType = fixture.parameterClass("ParallelParameter", "org.gradle.test").withFields([
+        parallelParameterType = fixture.workParameterClass("ParallelParameter", "org.gradle.test").withFields([
                 "itemName": "String"
         ])
 
-        parallelWorkerExecution = fixture.executionClass("ParallelWorkerExecution", "org.gradle.test", parallelParameterType)
-        parallelWorkerExecution.with {
+        parallelWorkAction = fixture.workActionClass("ParallelWorkAction", "org.gradle.test", parallelParameterType)
+        parallelWorkAction.with {
             imports += ["java.net.URI"]
             action = """
                 System.out.println("Running \${parameters.itemName}...")
@@ -182,7 +182,7 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
                 }
                 
                 def submitWorkItem(item) {
-                    return workerExecutor.noIsolation().submit(${parallelWorkerExecution.name}.class) {
+                    return workerExecutor.noIsolation().submit(${parallelWorkAction.name}.class) {
                         itemName = item.toString()
                     }
                 }
@@ -191,7 +191,7 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
     }
 
     def withMultipleActionTaskTypeInBuildScript() {
-        parallelWorkerExecution.writeToBuildFile()
+        parallelWorkAction.writeToBuildFile()
         buildFile << """
             $multipleActionTaskType
         """

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -244,12 +244,8 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 doLast { 
-                    submitWorkItem("workItem1", ${failingWorkAction.name}.class, $isolationMode1) { config ->
-                        config.displayName = "work item 1"
-                    }
-                    submitWorkItem("workItem2", ${failingWorkAction.name}.class, $isolationMode2) { config ->
-                        config.displayName = "work item 2"
-                    }
+                    submitWorkItem("workItem1", ${failingWorkAction.name}.class, $isolationMode1) 
+                    submitWorkItem("workItem2", ${failingWorkAction.name}.class, $isolationMode2) 
                 }
             }
         """
@@ -262,11 +258,11 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         failureHasCause("Multiple task action failures occurred")
 
         and:
-        failureHasCause("A failure occurred while executing work item 1")
+        failureHasCause("A failure occurred while executing ${failingWorkAction.name}")
         failureHasCause("Failure from workItem1")
 
         and:
-        failureHasCause("A failure occurred while executing work item 2")
+        failureHasCause("A failure occurred while executing ${failingWorkAction.name}")
         failureHasCause("Failure from workItem2")
 
         where:
@@ -287,9 +283,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast { 
-                    submitWorkItem("workItem1", ${failingWorkAction.name}.class) { config ->
-                        config.displayName = "work item 1"
-                    }
+                    submitWorkItem("workItem1", ${failingWorkAction.name}.class)
                     throw new RuntimeException("Failure from task action")
                 }
             }
@@ -306,7 +300,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         failureHasCause("Failure from task action")
 
         and:
-        failureHasCause("A failure occurred while executing work item 1")
+        failureHasCause("A failure occurred while executing ${failingWorkAction.name}")
         failureHasCause("Failure from workItem1")
 
         where:
@@ -327,9 +321,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 doLast { 
                     submitWorkItem("workItem1", workActionClass)
 
-                    submitWorkItem("workItem2", ${failingWorkAction.name}.class) { config ->
-                        config.displayName = "work item 2"
-                    }
+                    submitWorkItem("workItem2", ${failingWorkAction.name}.class)
 
                     try {
                         workerExecutor.await()
@@ -348,7 +340,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         succeeds("parallelWorkTask")
 
         and:
-        output.contains("A failure occurred while executing work item 2")
+        output.contains("A failure occurred while executing ${failingWorkAction.name}")
 
         where:
         isolationMode << ISOLATION_MODES

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -32,20 +32,20 @@ import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Rule
     BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
-    WorkerExecutorFixture.ParameterClass parallelParameterType
-    WorkerExecutorFixture.ExecutionClass parallelWorkerExecution
-    WorkerExecutorFixture.ExecutionClass failingWorkerExecution
-    WorkerExecutorFixture.ExecutionClass alternateParallelWorkerExecution
+    WorkerExecutorFixture.WorkParameterClass parallelParameterType
+    WorkerExecutorFixture.WorkActionClass parallelWorkAction
+    WorkerExecutorFixture.WorkActionClass failingWorkAction
+    WorkerExecutorFixture.WorkActionClass alternateParallelWorkAction
 
     def setup() {
         blockingHttpServer.start()
 
-        parallelParameterType = fixture.parameterClass("ParallelParameter", "org.gradle.test").withFields([
+        parallelParameterType = fixture.workParameterClass("ParallelParameter", "org.gradle.test").withFields([
                 "itemName": "String"
         ])
 
-        parallelWorkerExecution = fixture.executionClass("ParallelWorkerExecution", "org.gradle.test", parallelParameterType)
-        parallelWorkerExecution.with {
+        parallelWorkAction = fixture.workActionClass("ParallelWorkAction", "org.gradle.test", parallelParameterType)
+        parallelWorkAction.with {
             imports += ["java.net.URI", "org.gradle.test.FileHelper"]
             extraFields = "private static final String id = UUID.randomUUID().toString()"
             action = """
@@ -57,15 +57,15 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             """
         }
 
-        failingWorkerExecution = fixture.executionClass("FailingWorkerExecution", "org.gradle.test", parallelParameterType)
-        failingWorkerExecution.with {
+        failingWorkAction = fixture.workActionClass("FailingWorkAction", "org.gradle.test", parallelParameterType)
+        failingWorkAction.with {
             action = """
                 throw new RuntimeException("Failure from \${parameters.itemName}");
             """
         }
 
-        alternateParallelWorkerExecution = fixture.executionClass("AlternateParallelWorkerExecution", "org.gradle.test", parallelParameterType)
-        alternateParallelWorkerExecution.with {
+        alternateParallelWorkAction = fixture.workActionClass("AlternateParallelWorkAction", "org.gradle.test", parallelParameterType)
+        alternateParallelWorkAction.with {
             imports += ["java.net.URI", "org.gradle.test.FileHelper"]
             extraFields = "private static final String id = UUID.randomUUID().toString()"
             action = """
@@ -74,8 +74,8 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             """
         }
 
-        parallelWorkerExecution.writeToBuildFile()
-        alternateParallelWorkerExecution.writeToBuildFile()
+        parallelWorkAction.writeToBuildFile()
+        alternateParallelWorkAction.writeToBuildFile()
         withMultipleActionTaskTypeInBuildScript()
     }
 
@@ -119,9 +119,9 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast {
-                    submitWorkItem("workItem0", ${parallelWorkerExecution.name}.class) { it.classpath.from([ new File("foo") ]) }
-                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class) { it.classpath.from([ new File("bar") ]) }
-                    submitWorkItem("workItem2", ${parallelWorkerExecution.name}.class) { it.classpath.from([ new File("baz") ]) }
+                    submitWorkItem("workItem0", ${parallelWorkAction.name}.class) { it.classpath.from([ new File("foo") ]) }
+                    submitWorkItem("workItem1", ${parallelWorkAction.name}.class) { it.classpath.from([ new File("bar") ]) }
+                    submitWorkItem("workItem2", ${parallelWorkAction.name}.class) { it.classpath.from([ new File("baz") ]) }
                 }
             }
         """
@@ -142,9 +142,9 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast {
-                    submitWorkItem("workItem0", ${alternateParallelWorkerExecution.name}.class)
-                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class)
-                    submitWorkItem("workItem2", ${alternateParallelWorkerExecution.name}.class)
+                    submitWorkItem("workItem0", ${alternateParallelWorkAction.name}.class)
+                    submitWorkItem("workItem1", ${parallelWorkAction.name}.class)
+                    submitWorkItem("workItem2", ${alternateParallelWorkAction.name}.class)
                 }
             }
         """
@@ -162,12 +162,12 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         given:
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
-                doLast { submitWorkItem("taskAction1", runnableClass) { isolationMode = IsolationMode.PROCESS } }
-                doLast { submitWorkItem("taskAction2", runnableClass) { isolationMode = IsolationMode.CLASSLOADER } }
-                doLast { submitWorkItem("taskAction3", runnableClass) { isolationMode = IsolationMode.PROCESS } }
-                doLast { submitWorkItem("taskAction4", runnableClass) { isolationMode = IsolationMode.PROCESS } }
-                doLast { submitWorkItem("taskAction5", runnableClass) { isolationMode = IsolationMode.CLASSLOADER } }
-                doLast { submitWorkItem("taskAction6", runnableClass) { isolationMode = IsolationMode.CLASSLOADER } }
+                doLast { submitWorkItem("taskAction1", workActionClass) { isolationMode = IsolationMode.PROCESS } }
+                doLast { submitWorkItem("taskAction2", workActionClass) { isolationMode = IsolationMode.CLASSLOADER } }
+                doLast { submitWorkItem("taskAction3", workActionClass) { isolationMode = IsolationMode.PROCESS } }
+                doLast { submitWorkItem("taskAction4", workActionClass) { isolationMode = IsolationMode.PROCESS } }
+                doLast { submitWorkItem("taskAction5", workActionClass) { isolationMode = IsolationMode.CLASSLOADER } }
+                doLast { submitWorkItem("taskAction6", workActionClass) { isolationMode = IsolationMode.CLASSLOADER } }
             }
         """
         blockingHttpServer.expectConcurrent("taskAction1")
@@ -184,13 +184,13 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "a second task action does not start if work submitted in #isolationMode by a previous task action fails"() {
-        failingWorkerExecution.writeToBuildFile()
+        failingWorkAction.writeToBuildFile()
 
         given:
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
-                doLast { submitWorkItem("taskAction1", ${parallelWorkerExecution.name}.class) { isolationMode = $isolationMode } }
-                doLast { submitWorkItem("taskAction2", ${failingWorkerExecution.name}.class) }
+                doLast { submitWorkItem("taskAction1", ${parallelWorkAction.name}.class) { isolationMode = $isolationMode } }
+                doLast { submitWorkItem("taskAction2", ${failingWorkAction.name}.class) }
                 doLast { submitWorkItem("taskAction3") }
             }
         """
@@ -201,7 +201,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         fails("parallelWorkTask")
 
         and:
-        failureHasCause("A failure occurred while executing ${failingWorkerExecution.name}")
+        failureHasCause("A failure occurred while executing ${failingWorkAction.name}")
         failureHasCause("Failure from taskAction2")
 
         where:
@@ -210,15 +210,15 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "all other submitted work executes when a work item fails in #isolationMode"() {
-        failingWorkerExecution.writeToBuildFile()
+        failingWorkAction.writeToBuildFile()
 
         given:
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 doLast { 
-                    submitWorkItem("workItem1", ${parallelWorkerExecution.name}.class, IsolationMode.PROCESS)
-                    submitWorkItem("workItem2", ${failingWorkerExecution.name}.class, $isolationMode)
-                    submitWorkItem("workItem3", ${parallelWorkerExecution.name}.class, IsolationMode.CLASSLOADER)
+                    submitWorkItem("workItem1", ${parallelWorkAction.name}.class, IsolationMode.PROCESS)
+                    submitWorkItem("workItem2", ${failingWorkAction.name}.class, $isolationMode)
+                    submitWorkItem("workItem3", ${parallelWorkAction.name}.class, IsolationMode.CLASSLOADER)
                 }
             }
         """
@@ -229,7 +229,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
         fails("parallelWorkTask")
 
         and:
-        failureHasCause("A failure occurred while executing ${failingWorkerExecution.name}")
+        failureHasCause("A failure occurred while executing ${failingWorkAction.name}")
         failureHasCause("Failure from workItem2")
 
         where:
@@ -238,16 +238,16 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "all errors are reported when submitting failing work in #isolationModeDescription"() {
-        failingWorkerExecution.writeToBuildFile()
+        failingWorkAction.writeToBuildFile()
 
         given:
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 doLast { 
-                    submitWorkItem("workItem1", ${failingWorkerExecution.name}.class, $isolationMode1) { config ->
+                    submitWorkItem("workItem1", ${failingWorkAction.name}.class, $isolationMode1) { config ->
                         config.displayName = "work item 1"
                     }
-                    submitWorkItem("workItem2", ${failingWorkerExecution.name}.class, $isolationMode2) { config ->
+                    submitWorkItem("workItem2", ${failingWorkAction.name}.class, $isolationMode2) { config ->
                         config.displayName = "work item 2"
                     }
                 }
@@ -280,14 +280,14 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "both errors in work items in #isolationMode and errors in the task action are reported"() {
-        failingWorkerExecution.writeToBuildFile()
+        failingWorkAction.writeToBuildFile()
 
         given:
         buildFile << """
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast { 
-                    submitWorkItem("workItem1", ${failingWorkerExecution.name}.class) { config ->
+                    submitWorkItem("workItem1", ${failingWorkAction.name}.class) { config ->
                         config.displayName = "work item 1"
                     }
                     throw new RuntimeException("Failure from task action")
@@ -315,7 +315,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
 
     @Unroll
     def "user can take responsibility for failing work items in #isolationMode"() {
-        failingWorkerExecution.writeToBuildFile()
+        failingWorkAction.writeToBuildFile()
 
         given:
         buildFile << """
@@ -325,9 +325,9 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             task parallelWorkTask(type: MultipleWorkItemTask) {
                 isolationMode = $isolationMode
                 doLast { 
-                    submitWorkItem("workItem1", runnableClass)
+                    submitWorkItem("workItem1", workActionClass)
 
-                    submitWorkItem("workItem2", ${failingWorkerExecution.name}.class) { config ->
+                    submitWorkItem("workItem2", ${failingWorkAction.name}.class) { config ->
                         config.displayName = "work item 2"
                     }
 
@@ -812,18 +812,18 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
     }
 
     def "cannot mutate worker parameters when using IsolationMode.NONE"() {
-        def verifyingParameterType = fixture.parameterClass("VerifyingParameter", "org.gradle.test").withFields([
+        def verifyingParameterType = fixture.workParameterClass("VerifyingParameter", "org.gradle.test").withFields([
                 "itemName": "String",
                 "list": "List<String>"
         ])
-        def verifyingWorkerExecution = fixture.executionClass("VerifyingWorkerExecution", "org.gradle.test", verifyingParameterType)
-        verifyingWorkerExecution.imports += ["java.net.URI"]
-        verifyingWorkerExecution.action = """
+        def verifyingWorkAction = fixture.workActionClass("VerifyingWorkAction", "org.gradle.test", verifyingParameterType)
+        verifyingWorkAction.imports += ["java.net.URI"]
+        verifyingWorkAction.action = """
             assert parameters.list.size() == 1
             new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${parameters.itemName}", null, null).toURL().text
             assert parameters.list.size() == 1
         """
-        verifyingWorkerExecution.writeToBuildFile()
+        verifyingWorkAction.writeToBuildFile()
 
         given:
         buildFile << """
@@ -840,7 +840,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 
                 @TaskAction
                 void executeRunnable() {
-                    workerExecutor.noIsolation().submit(${verifyingWorkerExecution.name}.class) { 
+                    workerExecutor.noIsolation().submit(${verifyingWorkAction.name}.class) { 
                         itemName = item.toString()
                         list = testList
                     }
@@ -876,7 +876,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
             class MultipleWorkItemTask extends DefaultTask {
                 def isolationMode = IsolationMode.NONE
                 def additionalForkOptions = {}
-                def runnableClass = ${parallelWorkerExecution.name}.class
+                def workActionClass = ${parallelWorkAction.name}.class
                 def additionalClasspath = project.layout.files()
 
                 @Inject
@@ -885,7 +885,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 }
                 
                 def submitWorkItem(String item) {
-                    return submitWorkItem(item, runnableClass) 
+                    return submitWorkItem(item, workActionClass) 
                 }
                 
                 def submitWorkItem(String item, Class<?> actionClass) {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -44,7 +44,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
                 @TaskAction
                 void doWork() {
                     def parameterAction = paramConfig != null ? paramConfig : {}
-                    workerExecutor."\${getWorkerMethod(isolationMode)}"().submit(ParameterWorkerExecution.class, parameterAction)
+                    workerExecutor."\${getWorkerMethod(isolationMode)}"().submit(ParameterWorkAction.class, parameterAction)
                 }
                 
                 void parameters(Closure closure) {
@@ -61,7 +61,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             interface Foo extends Named { }
             ext.testObject = objects.named(Foo.class, "bar")
 
-            ${parameterWorkerExecution('Named', 'println parameters.testParam.name', true)}
+            ${parameterWorkAction('Named', 'println parameters.testParam.name', true)}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -83,7 +83,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('Property<String>', 'println parameters.testParam.get()')}
+            ${parameterWorkAction('Property<String>', 'println parameters.testParam.get()')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -105,7 +105,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide file collection parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('ConfigurableFileCollection', 'parameters.testParam.files.each { println it.name }')}
+            ${parameterWorkAction('ConfigurableFileCollection', 'parameters.testParam.files.each { println it.name }')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -129,7 +129,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             ext.testObject = ["foo", "bar"] as String[]
 
-            ${parameterWorkerExecution('String[]', 'println "param = " + Arrays.asList(parameters.testParam)', true) }
+            ${parameterWorkAction('String[]', 'println "param = " + Arrays.asList(parameters.testParam)', true) }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -153,7 +153,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             ext.testObject = [] as String[]
 
-            ${parameterWorkerExecution('String[]', 'println "param = " + Arrays.asList(parameters.testParam)', true) }
+            ${parameterWorkAction('String[]', 'println "param = " + Arrays.asList(parameters.testParam)', true) }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -175,7 +175,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide list property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('ListProperty<String>', 'println parameters.testParam.get().join(",")') }
+            ${parameterWorkAction('ListProperty<String>', 'println parameters.testParam.get().join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -198,7 +198,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide set property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('SetProperty<String>', 'println parameters.testParam.get().join(",")') }
+            ${parameterWorkAction('SetProperty<String>', 'println parameters.testParam.get().join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -221,7 +221,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide map property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('MapProperty<String, String>', 'println parameters.testParam.get().collect { it.key + ":" + it.value }.join(",")') }
+            ${parameterWorkAction('MapProperty<String, String>', 'println parameters.testParam.get().collect { it.key + ":" + it.value }.join(",")') }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -244,7 +244,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide file property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('RegularFileProperty', 'println parameters.testParam.get().getAsFile().name')}
+            ${parameterWorkAction('RegularFileProperty', 'println parameters.testParam.get().getAsFile().name')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -266,7 +266,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide directory property parameters with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('DirectoryProperty', 'println parameters.testParam.get().getAsFile().name')}
+            ${parameterWorkAction('DirectoryProperty', 'println parameters.testParam.get().getAsFile().name')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -301,7 +301,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
             ext.testObject = getServices().get(InstantiatorFactory.class).inject().newInstance(SomeExtension)
             ext.testObject.value = "bar"
 
-            ${parameterWorkerExecution('SomeExtension', 'println parameters.testParam.value', true) }
+            ${parameterWorkAction('SomeExtension', 'println parameters.testParam.value', true) }
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -323,7 +323,7 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
     def "can provide a null parameter with isolation mode #isolationMode"() {
         buildFile << """
-            ${parameterWorkerExecution('String', 'println "testParam is " + parameters.testParam', true)}
+            ${parameterWorkAction('String', 'println "testParam is " + parameters.testParam', true)}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -343,9 +343,9 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         isolationMode << ISOLATION_MODES
     }
 
-    def "can use a worker execution with a None parameter and isolation mode #isolationMode"() {
+    def "can use a work action with a None parameter and isolation mode #isolationMode"() {
         buildFile << """
-            ${noneParameterWorkerExecution('println "there is no parameter"')}
+            ${noneParameterWorkAction('println "there is no parameter"')}
 
             task runWork(type: ParameterTask) {
                 isolationMode = ${isolationMode}
@@ -362,17 +362,17 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         isolationMode << ISOLATION_MODES
     }
 
-    String parameterWorkerExecution(String type, String action, boolean requiresSetter = false) {
+    String parameterWorkAction(String type, String action, boolean requiresSetter = false) {
         return """
-            import org.gradle.workers.WorkerExecution
-            import org.gradle.workers.WorkerParameters
+            import org.gradle.workers.WorkAction
+            import org.gradle.workers.WorkParameters
 
-            interface TestParameters extends WorkerParameters {
+            interface TestParameters extends WorkParameters {
                 ${type} getTestParam();
                 ${-> requiresSetter ? "void setTestParam(${type} testParam);" : ''}
             }
             
-            abstract class ParameterWorkerExecution implements WorkerExecution<TestParameters> {
+            abstract class ParameterWorkAction implements WorkAction<TestParameters> {
                 void execute() {
                     ${action}
                 }
@@ -380,12 +380,12 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-    String noneParameterWorkerExecution(String action) {
+    String noneParameterWorkAction(String action) {
         return """
-            import org.gradle.workers.WorkerExecution
-            import org.gradle.workers.WorkerParameters
+            import org.gradle.workers.WorkAction
+            import org.gradle.workers.WorkParameters
 
-            abstract class ParameterWorkerExecution implements WorkerExecution<WorkerParameters.None> {
+            abstract class ParameterWorkAction implements WorkAction<WorkParameters.None> {
                 void execute() {
                     ${action}
                 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/ClassLoaderWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/ClassLoaderWorkerSpec.java
@@ -16,23 +16,20 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
-import org.gradle.internal.HasInternalProtocol;
+import org.gradle.api.file.ConfigurableFileCollection;
 
 /**
- * Represents the common configuration of a worker.  Used when submitting an item of work
- * to the {@link WorkerExecutor}.
+ * A worker spec providing the requirements of an isolated classpath.
  *
  * @since 5.6
  */
 @Incubating
-@HasInternalProtocol
-public interface WorkerSpec extends Describable {
+public interface ClassLoaderWorkerSpec extends WorkerSpec {
     /**
-     * Sets the name to use when displaying this item of work.
+     * Gets the classpath associated with the worker.
      *
-     * @param displayName the name of this item of work
+     * @return the classpath associated with the worker
      */
-    void setDisplayName(String displayName);
+    ConfigurableFileCollection getClasspath();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/ForkingWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/ForkingWorkerSpec.java
@@ -17,36 +17,16 @@
 package org.gradle.workers;
 
 import org.gradle.api.Action;
-import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
 import org.gradle.process.JavaForkOptions;
 
 /**
- * Represents the common configuration of a worker.  Used when submitting an item of work
- * to the {@link WorkerExecutor}.
+ * A worker spec providing the requirements of a forked process.
  *
  * @since 5.6
  */
 @Incubating
-public interface BaseWorkerSpec extends Describable {
-    /**
-     * Gets the isolation mode for this worker, see {@link IsolationMode}.
-     *
-     * @return the isolation mode for this worker, see {@link IsolationMode}, defaults to {@link IsolationMode#AUTO}
-     *
-     * @since 4.0
-     */
-    IsolationMode getIsolationMode();
-
-    /**
-     * Sets the isolation mode for this worker, see {@link IsolationMode}.
-     *
-     * @param isolationMode the forking mode for this worker, see {@link IsolationMode}
-     *
-     * @since 4.0
-     */
-    void setIsolationMode(IsolationMode isolationMode);
-
+public interface ForkingWorkerSpec extends WorkerSpec {
     /**
      * Executes the provided action against the {@link JavaForkOptions} object associated with this builder.
      *
@@ -60,11 +40,4 @@ public interface BaseWorkerSpec extends Describable {
      * @return the {@link JavaForkOptions} of this builder
      */
     JavaForkOptions getForkOptions();
-
-    /**
-     * Sets the name to use when displaying this item of work.
-     *
-     * @param displayName the name of this item of work
-     */
-    void setDisplayName(String displayName);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/ProcessWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/ProcessWorkerSpec.java
@@ -16,23 +16,14 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
-import org.gradle.internal.HasInternalProtocol;
 
 /**
- * Represents the common configuration of a worker.  Used when submitting an item of work
- * to the {@link WorkerExecutor}.
+ * A worker spec providing the requirements of a forked process with a custom classpath.
  *
  * @since 5.6
  */
 @Incubating
-@HasInternalProtocol
-public interface WorkerSpec extends Describable {
-    /**
-     * Sets the name to use when displaying this item of work.
-     *
-     * @param displayName the name of this item of work
-     */
-    void setDisplayName(String displayName);
+public interface ProcessWorkerSpec extends ForkingWorkerSpec, ClassLoaderWorkerSpec {
+
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkAction.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkAction.java
@@ -25,18 +25,18 @@ import javax.inject.Inject;
  * {@link WorkerExecutor}.
  *
  * <p>
- *     A worker execution implementation is an abstract class implementing the {@link #execute()} method.
+ *     A work action implementation is an abstract class implementing the {@link #execute()} method.
  *     A minimal implementation may look like this:
  * </p>
  *
  * <pre class='autoTested'>
- * import org.gradle.workers.WorkerParameters;
+ * import org.gradle.workers.WorkParameters;
  *
- * public abstract class MyExecution implements WorkerExecution&lt;WorkerParameters.None&gt; {
+ * public abstract class MyWorkAction implements WorkAction&lt;WorkParameters.None&gt; {
  *     private final String greeting;
  *
  *     {@literal @}Inject
- *     public MyExecution() {
+ *     public MyWorkAction() {
  *         this.greeting = "hello";
  *     }
  *
@@ -47,17 +47,17 @@ import javax.inject.Inject;
  * }
  * </pre>
  *
- * Implementations of WorkerExecution are subject to the following constraints:
+ * Implementations of WorkAction are subject to the following constraints:
  * <ul>
  *     <li>Do not implement {@link #getParameters()} in your class, the method will be implemented by Gradle.</li>
  *     <li>Constructors must be annotated with {@link Inject}.</li>
  * </ul>
  *
- * @param <T> Parameter type for the worker execution. Should be {@link WorkerParameters.None} if the execution does not have parameters.
+ * @param <T> Parameter type for the work action. Should be {@link WorkParameters.None} if the action does not have parameters.
  * @since 5.6
  **/
 @Incubating
-public interface WorkerExecution<T extends WorkerParameters> {
+public interface WorkAction<T extends WorkParameters> {
     /**
      * The parameters associated with a concrete work item.
      */

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkParameters.java
@@ -19,14 +19,14 @@ package org.gradle.workers;
 import org.gradle.api.Incubating;
 
 /**
- * Marker interface for parameter objects to {@link WorkerExecution}s.
+ * Marker interface for parameter objects to {@link WorkAction}s.
  *
  * <p>
  *     Parameter types should be interfaces, only declaring getters for {@link org.gradle.api.provider.Property}-like objects.
  *     Example:
  * </p>
  * <pre class='autoTested'>
- * public interface MyParameters extends WorkerParameters {
+ * public interface MyParameters extends WorkParameters {
  *     Property&lt;String&gt; getStringParameter();
  *     ConfigurableFileCollection getFiles();
  * }
@@ -35,16 +35,16 @@ import org.gradle.api.Incubating;
  * @since 5.6
  */
 @Incubating
-public interface WorkerParameters {
+public interface WorkParameters {
     /**
-     * Used for worker executions without parameters.
+     * Used for work actions without parameters.
      *
-     * <p>When {@link None} is used as parameters, calling {@link WorkerExecution#getParameters()} throws an exception.</p>
+     * <p>When {@link None} is used as parameters, calling {@link WorkAction#getParameters()} throws an exception.</p>
      *
      * @since 5.6
      */
     @Incubating
-    final class None implements WorkerParameters {
+    final class None implements WorkParameters {
         private None() {}
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
@@ -39,7 +39,7 @@ public interface WorkQueue {
      *
      *
      */
-    <T extends WorkerParameters> void submit(Class<? extends WorkerExecution<T>> workerExecutionClass, Action<T> parameterAction);
+    <T extends WorkParameters> void submit(Class<? extends WorkAction<T>> workActionClass, Action<T> parameterAction);
 
     /**
      * Blocks until all work associated with this queue is complete.  Note that when using this method inside

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+/**
+ * Represents a queue of work items with a uniform set of worker requirements.
+ *
+ * @since 5.6
+ */
+@Incubating
+public interface WorkQueue {
+    /**
+     * Submits a piece of work to be executed asynchronously.
+     *
+     * Execution of the work may begin immediately.
+     *
+     * Work submitted using {@link WorkerExecutor#processIsolation()} will execute in an idle daemon that meets the requirements set
+     * in the {@link ProcessWorkerSpec}.  If no idle daemons are available, a new daemon will be started.  Any errors
+     * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
+     *
+     *
+     */
+    <T extends WorkerParameters> void submit(Class<? extends WorkerExecution<T>> workerExecutionClass, Action<T> parameterAction);
+
+    /**
+     * Blocks until all work associated with this queue is complete.  Note that when using this method inside
+     * a task action, it will block completion of the task action until the submitted work is complete.  This means that other
+     * tasks from the same project cannot be run in parallel while the task action is still executing.
+     *
+     * @throws WorkerExecutionException when a failure occurs while executing the work.
+     */
+    void await() throws WorkerExecutionException;
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
@@ -22,6 +22,8 @@ import org.gradle.api.Incubating;
 /**
  * Represents a queue of work items with a uniform set of worker requirements.
  *
+ * Note that this object is not thread-safe.
+ *
  * @since 5.6
  */
 @Incubating

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
@@ -17,6 +17,7 @@
 package org.gradle.workers;
 
 import org.gradle.api.ActionConfiguration;
+import org.gradle.api.Describable;
 
 import java.io.File;
 
@@ -42,7 +43,7 @@ import java.io.File;
  *
  * @since 3.5
  */
-public interface WorkerConfiguration extends ActionConfiguration, ForkingWorkerSpec {
+public interface WorkerConfiguration extends ActionConfiguration, ForkingWorkerSpec, Describable {
     /**
      * Gets the isolation mode for this worker, see {@link IsolationMode}.
      *
@@ -98,4 +99,10 @@ public interface WorkerConfiguration extends ActionConfiguration, ForkingWorkerS
     @Deprecated
     void setForkMode(ForkMode forkMode);
 
+    /**
+     * Sets the name to use when displaying this item of work.
+     *
+     * @param displayName the name of this item of work
+     */
+    void setDisplayName(String displayName);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerConfiguration.java
@@ -42,7 +42,25 @@ import java.io.File;
  *
  * @since 3.5
  */
-public interface WorkerConfiguration extends ActionConfiguration, BaseWorkerSpec {
+public interface WorkerConfiguration extends ActionConfiguration, ForkingWorkerSpec {
+    /**
+     * Gets the isolation mode for this worker, see {@link IsolationMode}.
+     *
+     * @return the isolation mode for this worker, see {@link IsolationMode}, defaults to {@link IsolationMode#AUTO}
+     *
+     * @since 4.0
+     */
+    IsolationMode getIsolationMode();
+
+    /**
+     * Sets the isolation mode for this worker, see {@link IsolationMode}.
+     *
+     * @param isolationMode the forking mode for this worker, see {@link IsolationMode}
+     *
+     * @since 4.0
+     */
+    void setIsolationMode(IsolationMode isolationMode);
+
     /**
      * Adds a set of files to the classpath associated with the worker.
      *

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
@@ -60,18 +60,53 @@ public interface WorkerExecutor {
     void submit(Class<? extends Runnable> actionClass, Action<? super WorkerConfiguration> configAction);
 
     /**
-     * Submits a piece of work to be executed asynchronously.
-     *
-     * Execution of the work may begin immediately.
-     *
-     * Work configured with {@link IsolationMode#PROCESS} will execute in an idle daemon that meets the requirements set
-     * in the {@link WorkerSpec}.  If no idle daemons are available, a new daemon will be started.  Any errors
-     * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
+     * Creates a {@link WorkQueue} to submit work for asynchronous execution with no isolation.
      *
      * @since 5.6
      */
     @Incubating
-    <T extends WorkerParameters> void execute(Class<? extends WorkerExecution<T>> workerExecutionClass, Action<? super WorkerSpec<T>> configAction);
+    WorkQueue noIsolation();
+
+    /**
+     * Creates a {@link WorkQueue} to submit work for asynchronous execution with an isolated classloader.
+     *
+     * @since 5.6
+     */
+    @Incubating
+    WorkQueue classLoaderIsolation();
+
+    /**
+     * Creates a {@link WorkQueue} to submit work for asynchronous execution in a daemon process.
+     *
+     * Work will execute in an idle daemon, if available.  If no idle daemons are available, a new daemon will be started.
+     *
+     * @since 5.6
+     */
+    @Incubating
+    WorkQueue processIsolation();
+
+    /**
+     * Creates a {@link WorkQueue} to submit work for asynchronous execution with no isolation and the requirements specified in the supplied {@link WorkerSpec}.
+     *
+     * @since 5.6
+     */
+    WorkQueue noIsolation(Action<WorkerSpec> action);
+
+    /**
+     * Creates a {@link WorkQueue} to submit work for asynchronous execution with an isolated classloader and the requirements specified in the supplied {@link ClassLoaderWorkerSpec}.
+     *
+     * @since 5.6
+     */
+    WorkQueue classLoaderIsolation(Action<ClassLoaderWorkerSpec> action);
+
+    /**
+     * Creates a {@link WorkQueue} to submit work for asynchronous execution in a daemon process.
+     *
+     * Work will execute in an idle daemon matching the requirements specified in the supplied {@link ProcessWorkerSpec}, if available.  If no idle daemons are available, a new daemon will be started.
+     *
+     * @since 5.6
+     */
+    WorkQueue processIsolation(Action<ProcessWorkerSpec> action);
 
     /**
      * Blocks until all work associated with the current build operation is complete.  Note that when using this method inside

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerExecutor.java
@@ -90,6 +90,7 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
+    @Incubating
     WorkQueue noIsolation(Action<WorkerSpec> action);
 
     /**
@@ -97,6 +98,7 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
+    @Incubating
     WorkQueue classLoaderIsolation(Action<ClassLoaderWorkerSpec> action);
 
     /**
@@ -106,6 +108,7 @@ public interface WorkerExecutor {
      *
      * @since 5.6
      */
+    @Incubating
     WorkQueue processIsolation(Action<ProcessWorkerSpec> action);
 
     /**

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerParameters.java
@@ -47,6 +47,4 @@ public interface WorkerParameters {
     final class None implements WorkerParameters {
         private None() {}
     }
-
-    WorkerParameters.None NONE = new WorkerParameters.None();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkerSpec.java
@@ -16,7 +16,6 @@
 
 package org.gradle.workers;
 
-import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -28,11 +27,5 @@ import org.gradle.internal.HasInternalProtocol;
  */
 @Incubating
 @HasInternalProtocol
-public interface WorkerSpec extends Describable {
-    /**
-     * Sets the name to use when displaying this item of work.
-     *
-     * @param displayName the name of this item of work
-     */
-    void setDisplayName(String displayName);
+public interface WorkerSpec {
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
@@ -57,8 +57,8 @@ public abstract class AbstractWorker implements BuildOperationAwareWorker {
     }
 
     private static String getImplementationClassName(ActionExecutionSpec spec) {
-        if (spec.getImplementationClass() == AdapterWorkerExecution.class) {
-            AdapterWorkerParameters parameters = (AdapterWorkerParameters) spec.getParameters();
+        if (spec.getImplementationClass() == AdapterWorkAction.class) {
+            AdapterWorkParameters parameters = (AdapterWorkParameters) spec.getParameters();
             return parameters.getImplementationClassName();
         } else {
             return spec.getImplementationClass().getName();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpec.java
@@ -17,13 +17,13 @@
 package org.gradle.workers.internal;
 
 import org.gradle.api.Describable;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
 
 import java.io.Serializable;
 
-public interface ActionExecutionSpec<T extends WorkerParameters> extends Serializable, Describable {
-    Class<? extends WorkerExecution<T>> getImplementationClass();
+public interface ActionExecutionSpec<T extends WorkParameters> extends Serializable, Describable {
+    Class<? extends WorkAction<T>> getImplementationClass();
 
     @Override
     String getDisplayName();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
@@ -16,11 +16,11 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
 
 public interface ActionExecutionSpecFactory {
-    <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec);
-    <T extends WorkerParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkerExecution<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure);
-    <T extends WorkerParameters> SimpleActionExecutionSpec<T> newSimpleSpec(ActionExecutionSpec<T> spec);
+    <T extends WorkParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec);
+    <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure);
+    <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(ActionExecutionSpec<T> spec);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkAction.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkAction.java
@@ -18,7 +18,7 @@ package org.gradle.workers.internal;
 
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.workers.WorkerExecution;
+import org.gradle.workers.WorkAction;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -30,18 +30,18 @@ import static org.gradle.internal.classloader.ClassLoaderUtils.classFromContextL
  * parameter api.  It allows us to maintain backwards compatibility at the api layer, but use
  * only typed parameters under the covers.  This can be removed once the old api is retired.
  */
-public abstract class AdapterWorkerExecution implements WorkerExecution<AdapterWorkerParameters>, ProvidesWorkResult {
+public abstract class AdapterWorkAction implements WorkAction<AdapterWorkParameters>, ProvidesWorkResult {
     private final Instantiator instantiator;
     private DefaultWorkResult workResult;
 
     @Inject
-    public AdapterWorkerExecution(Instantiator instantiator) {
+    public AdapterWorkAction(Instantiator instantiator) {
         this.instantiator = instantiator;
     }
 
     @Override
     public void execute() {
-        AdapterWorkerParameters parameters = getParameters();
+        AdapterWorkParameters parameters = getParameters();
         String implementationClassName = parameters.getImplementationClassName();
         Class<?> actionClass = classFromContextLoader(implementationClassName);
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkParameters.java
@@ -16,14 +16,14 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkParameters;
 
 /**
  * This is used to bridge between the "old" worker api with untyped parameters and the typed
  * parameter api.  It allows us to maintain backwards compatibility at the api layer, but use
  * only typed parameters under the covers.  This can be removed once the old api is retired.
  */
-public interface AdapterWorkerParameters extends WorkerParameters {
+public interface AdapterWorkParameters extends WorkParameters {
     void setImplementationClassName(String implementationClassName);
     String getImplementationClassName();
     void setParams(Object[] params);

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkParameters.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AdapterWorkParameters.java
@@ -26,6 +26,10 @@ import org.gradle.workers.WorkParameters;
 public interface AdapterWorkParameters extends WorkParameters {
     void setImplementationClassName(String implementationClassName);
     String getImplementationClassName();
+
     void setParams(Object[] params);
     Object[] getParams();
+
+    void setDisplayName(String displayName);
+    String getDisplayName();
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
@@ -23,8 +23,8 @@ import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder;
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -41,7 +41,7 @@ public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFac
     }
 
     @Override
-    public <T extends WorkerParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec) {
+    public <T extends WorkParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec) {
         if (spec instanceof IsolatedParametersActionExecutionSpec) {
             IsolatedParametersActionExecutionSpec isolatedSpec = (IsolatedParametersActionExecutionSpec) spec;
             return new TransportableActionExecutionSpec<T>(isolatedSpec.getDisplayName(), isolatedSpec.getImplementationClass().getName(), serialize(isolatedSpec.getIsolatedParams()), isolatedSpec.getClassLoaderStructure());
@@ -53,12 +53,12 @@ public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFac
     }
 
     @Override
-    public <T extends WorkerParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkerExecution<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure) {
+    public <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure) {
         return new IsolatedParametersActionExecutionSpec<T>(implementationClass, displayName, isolatableFactory.isolate(params), classLoaderStructure);
     }
 
     @Override
-    public <T extends WorkerParameters> SimpleActionExecutionSpec<T> newSimpleSpec(ActionExecutionSpec<T> spec) {
+    public <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(ActionExecutionSpec<T> spec) {
         if (spec instanceof TransportableActionExecutionSpec) {
             TransportableActionExecutionSpec<T> transportableSpec = (TransportableActionExecutionSpec<T>) spec;
             T params = Cast.uncheckedCast(deserialize(transportableSpec.getSerializedParameters()).isolate());

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultClassLoaderWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultClassLoaderWorkerSpec.java
@@ -16,35 +16,28 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.workers.ClassLoaderWorkerSpec;
 import org.gradle.workers.IsolationMode;
 
 import javax.inject.Inject;
 
-public class DefaultWorkerSpec implements WorkerSpecInternal {
-    private final IsolationMode isolationMode;
-    private String displayName;
+public class DefaultClassLoaderWorkerSpec extends DefaultWorkerSpec implements ClassLoaderWorkerSpec {
+    private final ConfigurableFileCollection classpath;
 
     @Inject
-    public DefaultWorkerSpec() {
-        this(IsolationMode.NONE);
+    public DefaultClassLoaderWorkerSpec(ObjectFactory objectFactory) {
+        this(IsolationMode.CLASSLOADER, objectFactory);
     }
 
-    protected DefaultWorkerSpec(IsolationMode isolationMode) {
-        this.isolationMode = isolationMode;
-    }
-
-    @Override
-    public IsolationMode getIsolationMode() {
-        return isolationMode;
+    protected DefaultClassLoaderWorkerSpec(IsolationMode isolationMode, ObjectFactory objectFactory) {
+        super(isolationMode);
+        this.classpath = objectFactory.fileCollection();
     }
 
     @Override
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    @Override
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
+    public ConfigurableFileCollection getClasspath() {
+        return classpath;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultProcessWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultProcessWorkerSpec.java
@@ -18,29 +18,23 @@ package org.gradle.workers.internal;
 
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
-import org.gradle.workers.BaseWorkerSpec;
+import org.gradle.workers.ClassLoaderWorkerSpec;
 import org.gradle.workers.IsolationMode;
+import org.gradle.workers.ProcessWorkerSpec;
 
-public class DefaultBaseWorkerSpec implements BaseWorkerSpec {
+import javax.inject.Inject;
+
+public class DefaultProcessWorkerSpec extends DefaultClassLoaderWorkerSpec implements ProcessWorkerSpec, ClassLoaderWorkerSpec {
     protected final JavaForkOptions forkOptions;
-    protected IsolationMode isolationMode = IsolationMode.AUTO;
-    private String displayName;
 
-    public DefaultBaseWorkerSpec(JavaForkOptionsFactory forkOptionsFactory) {
-        this.forkOptions = forkOptionsFactory.newJavaForkOptions();
+    @Inject
+    public DefaultProcessWorkerSpec(JavaForkOptionsFactory javaForkOptionsFactory, ObjectFactory objectFactory) {
+        super(IsolationMode.PROCESS, objectFactory);
+        this.forkOptions = javaForkOptionsFactory.newJavaForkOptions();
         getForkOptions().setEnvironment(Maps.<String, Object>newHashMap());
-    }
-
-    @Override
-    public IsolationMode getIsolationMode() {
-        return isolationMode;
-    }
-
-    @Override
-    public void setIsolationMode(IsolationMode isolationMode) {
-        this.isolationMode = isolationMode == null ? IsolationMode.AUTO : isolationMode;
     }
 
     @Override
@@ -51,15 +45,5 @@ public class DefaultBaseWorkerSpec implements BaseWorkerSpec {
     @Override
     public void forkOptions(Action<? super JavaForkOptions> forkOptionsAction) {
         forkOptionsAction.execute(forkOptions);
-    }
-
-    @Override
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    @Override
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
@@ -135,17 +135,13 @@ public class DefaultWorkerConfiguration extends DefaultActionConfiguration imple
     }
 
     void adaptTo(WorkerSpec workerSpec) {
-        workerSpec.setDisplayName(getDisplayName());
-
         if (workerSpec instanceof ClassLoaderWorkerSpec) {
             ClassLoaderWorkerSpec classLoaderWorkerSpec = (ClassLoaderWorkerSpec) workerSpec;
-            classLoaderWorkerSpec.setDisplayName(getDisplayName());
             classLoaderWorkerSpec.getClasspath().from(getClasspath());
         }
 
         if (workerSpec instanceof ProcessWorkerSpec) {
             ProcessWorkerSpec processWorkerSpec = (ProcessWorkerSpec) workerSpec;
-            processWorkerSpec.setDisplayName(getDisplayName());
             processWorkerSpec.getClasspath().from(getClasspath());
             getForkOptions().copyTo(processWorkerSpec.getForkOptions());
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerConfiguration.java
@@ -17,23 +17,61 @@
 package org.gradle.workers.internal;
 
 import com.google.common.collect.Lists;
+import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
 import org.gradle.api.internal.DefaultActionConfiguration;
+import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.util.GUtil;
+import org.gradle.workers.ClassLoaderWorkerSpec;
 import org.gradle.workers.ForkMode;
 import org.gradle.workers.IsolationMode;
+import org.gradle.workers.ProcessWorkerSpec;
 import org.gradle.workers.WorkerConfiguration;
+import org.gradle.workers.WorkerSpec;
 
 import java.io.File;
 import java.util.List;
 
-public class DefaultWorkerConfiguration extends DefaultBaseWorkerSpec implements WorkerConfiguration {
+public class DefaultWorkerConfiguration extends DefaultActionConfiguration implements WorkerConfiguration {
     private final ActionConfiguration actionConfiguration = new DefaultActionConfiguration();
+    private final JavaForkOptions forkOptions;
+    private IsolationMode isolationMode = IsolationMode.AUTO;
+    private String displayName;
     private List<File> classpath = Lists.newArrayList();
 
     public DefaultWorkerConfiguration(JavaForkOptionsFactory forkOptionsFactory) {
-        super(forkOptionsFactory);
+        this.forkOptions = forkOptionsFactory.newJavaForkOptions();
+    }
+
+    @Override
+    public IsolationMode getIsolationMode() {
+        return isolationMode;
+    }
+
+    @Override
+    public void setIsolationMode(IsolationMode isolationMode) {
+        this.isolationMode = isolationMode == null ? IsolationMode.AUTO : isolationMode;
+    }
+
+    @Override
+    public void forkOptions(Action<? super JavaForkOptions> forkOptionsAction) {
+        forkOptionsAction.execute(forkOptions);
+    }
+
+    @Override
+    public JavaForkOptions getForkOptions() {
+        return forkOptions;
+    }
+
+    @Override
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
     }
 
     @Override
@@ -93,6 +131,23 @@ public class DefaultWorkerConfiguration extends DefaultBaseWorkerSpec implements
             case ALWAYS:
                 setIsolationMode(IsolationMode.PROCESS);
                 break;
+        }
+    }
+
+    void adaptTo(WorkerSpec workerSpec) {
+        workerSpec.setDisplayName(getDisplayName());
+
+        if (workerSpec instanceof ClassLoaderWorkerSpec) {
+            ClassLoaderWorkerSpec classLoaderWorkerSpec = (ClassLoaderWorkerSpec) workerSpec;
+            classLoaderWorkerSpec.setDisplayName(getDisplayName());
+            classLoaderWorkerSpec.getClasspath().from(getClasspath());
+        }
+
+        if (workerSpec instanceof ProcessWorkerSpec) {
+            ProcessWorkerSpec processWorkerSpec = (ProcessWorkerSpec) workerSpec;
+            processWorkerSpec.setDisplayName(getDisplayName());
+            processWorkerSpec.getClasspath().from(getClasspath());
+            getForkOptions().copyTo(processWorkerSpec.getForkOptions());
         }
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -145,6 +145,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
             public void execute(AdapterWorkParameters parameters) {
                 parameters.setImplementationClassName(actionClass.getName());
                 parameters.setParams(configuration.getParams());
+                parameters.setDisplayName(configuration.getDisplayName());
             }
         };
 
@@ -187,7 +188,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         }
 
         ActionExecutionSpec spec;
-        String description = getWorkerDisplayName(workerSpec, workActionClass, parameters);
+        String description = getWorkerDisplayName(workActionClass, parameters);
         DaemonForkOptions forkOptions = getDaemonForkOptions(workActionClass, workerSpec, parameters);
         try {
             // Isolate parameters in this thread prior to starting work in a separate thread
@@ -219,13 +220,14 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
         return execution;
     }
 
-    private static String getWorkerDisplayName(WorkerSpec workerSpec, Class<?> workActionClass, WorkParameters parameters) {
-        if (workerSpec.getDisplayName() != null) {
-            return workerSpec.getDisplayName();
-        }
-
+    private static String getWorkerDisplayName(Class<?> workActionClass, WorkParameters parameters) {
         if (workActionClass == AdapterWorkAction.class) {
-            return ((AdapterWorkParameters) parameters).getImplementationClassName();
+            AdapterWorkParameters adapterWorkParameters = (AdapterWorkParameters) parameters;
+            if (adapterWorkParameters.getDisplayName() != null) {
+                return adapterWorkParameters.getDisplayName();
+            } else {
+                return adapterWorkParameters.getImplementationClassName();
+            }
         } else {
             return workActionClass.getName();
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
@@ -21,7 +21,7 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.workers.WorkerExecution;
+import org.gradle.workers.WorkAction;
 
 import javax.inject.Inject;
 
@@ -36,14 +36,14 @@ public class DefaultWorkerServer implements WorkerProtocol {
     @Override
     public DefaultWorkResult execute(ActionExecutionSpec spec) {
         try {
-            Class<? extends WorkerExecution> implementationClass = Cast.uncheckedCast(spec.getImplementationClass());
+            Class<? extends WorkAction> implementationClass = Cast.uncheckedCast(spec.getImplementationClass());
             DefaultServiceRegistry serviceRegistry = new DefaultServiceRegistry(parent);
             Instantiator instantiator = parent.get(InstantiatorFactory.class).inject(serviceRegistry);
             if (spec.getParameters() != null) {
                 serviceRegistry.add(spec.getParameters().getClass(), Cast.uncheckedCast(spec.getParameters()));
             }
             serviceRegistry.add(Instantiator.class, instantiator);
-            WorkerExecution execution = instantiator.newInstance(implementationClass);
+            WorkAction execution = instantiator.newInstance(implementationClass);
             execution.execute();
             if (execution instanceof ProvidesWorkResult) {
                 return ((ProvidesWorkResult) execution).getWorkResult();

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerSpec.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 public class DefaultWorkerSpec implements WorkerSpecInternal {
     private final IsolationMode isolationMode;
-    private String displayName;
 
     @Inject
     public DefaultWorkerSpec() {
@@ -36,15 +35,5 @@ public class DefaultWorkerSpec implements WorkerSpecInternal {
     @Override
     public IsolationMode getIsolationMode() {
         return isolationMode;
-    }
-
-    @Override
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    @Override
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedParametersActionExecutionSpec.java
@@ -17,16 +17,16 @@
 package org.gradle.workers.internal;
 
 import org.gradle.internal.isolation.Isolatable;
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
 
-public class IsolatedParametersActionExecutionSpec<T extends WorkerParameters> implements ActionExecutionSpec<T> {
+public class IsolatedParametersActionExecutionSpec<T extends WorkParameters> implements ActionExecutionSpec<T> {
     private final String displayName;
-    private final Class<? extends WorkerExecution<T>> implementationClass;
+    private final Class<? extends WorkAction<T>> implementationClass;
     private final Isolatable<T> isolatedParams;
     private final ClassLoaderStructure classLoaderStructure;
 
-    public IsolatedParametersActionExecutionSpec(Class<? extends WorkerExecution<T>> implementationClass, String displayName, Isolatable<T> isolatedParams, ClassLoaderStructure classLoaderStructure) {
+    public IsolatedParametersActionExecutionSpec(Class<? extends WorkAction<T>> implementationClass, String displayName, Isolatable<T> isolatedParams, ClassLoaderStructure classLoaderStructure) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
         this.isolatedParams = isolatedParams;
@@ -34,7 +34,7 @@ public class IsolatedParametersActionExecutionSpec<T extends WorkerParameters> i
     }
 
     @Override
-    public Class<? extends WorkerExecution<T>> getImplementationClass() {
+    public Class<? extends WorkAction<T>> getImplementationClass() {
         return implementationClass;
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/SimpleActionExecutionSpec.java
@@ -16,16 +16,16 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
 
-public class SimpleActionExecutionSpec<T extends WorkerParameters> implements ActionExecutionSpec<T> {
-    private final Class<? extends WorkerExecution<T>> implementationClass;
+public class SimpleActionExecutionSpec<T extends WorkParameters> implements ActionExecutionSpec<T> {
+    private final Class<? extends WorkAction<T>> implementationClass;
     private final String displayName;
     private final T params;
     private final ClassLoaderStructure classLoaderStructure;
 
-    public SimpleActionExecutionSpec(Class<? extends WorkerExecution<T>> implementationClass, String displayName, T params, ClassLoaderStructure classLoaderStructure) {
+    public SimpleActionExecutionSpec(Class<? extends WorkAction<T>> implementationClass, String displayName, T params, ClassLoaderStructure classLoaderStructure) {
         this.implementationClass = implementationClass;
         this.displayName = displayName;
         this.params = params;
@@ -33,7 +33,7 @@ public class SimpleActionExecutionSpec<T extends WorkerParameters> implements Ac
     }
 
     @Override
-    public Class<? extends WorkerExecution<T>> getImplementationClass() {
+    public Class<? extends WorkAction<T>> getImplementationClass() {
         return implementationClass;
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/TransportableActionExecutionSpec.java
@@ -16,10 +16,10 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.WorkerExecution;
-import org.gradle.workers.WorkerParameters;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
 
-public class TransportableActionExecutionSpec<T extends WorkerParameters> implements ActionExecutionSpec<T> {
+public class TransportableActionExecutionSpec<T extends WorkParameters> implements ActionExecutionSpec<T> {
     private final String displayName;
     private final String implementationClassName;
     private final byte[] serializedParameters;
@@ -38,7 +38,7 @@ public class TransportableActionExecutionSpec<T extends WorkerParameters> implem
     }
 
     @Override
-    public Class<? extends WorkerExecution<T>> getImplementationClass() {
+    public Class<? extends WorkAction<T>> getImplementationClass() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerSpecInternal.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerSpecInternal.java
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.workers;
+package org.gradle.workers.internal;
 
-import org.gradle.api.Describable;
-import org.gradle.api.Incubating;
-import org.gradle.internal.HasInternalProtocol;
+import org.gradle.workers.WorkerSpec;
+import org.gradle.workers.IsolationMode;
 
-/**
- * Represents the common configuration of a worker.  Used when submitting an item of work
- * to the {@link WorkerExecutor}.
- *
- * @since 5.6
- */
-@Incubating
-@HasInternalProtocol
-public interface WorkerSpec extends Describable {
-    /**
-     * Sets the name to use when displaying this item of work.
-     *
-     * @param displayName the name of this item of work
-     */
-    void setDisplayName(String displayName);
+public interface WorkerSpecInternal extends WorkerSpec {
+    IsolationMode getIsolationMode();
 }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.model.ObjectFactory
+import org.gradle.internal.Actions
 import org.gradle.internal.Factory
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -30,8 +31,9 @@ import org.gradle.process.internal.JavaForkOptionsInternal
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.UsesNativeServices
-import org.gradle.workers.IsolationMode
+import org.gradle.workers.WorkerExecution
 import org.gradle.workers.WorkerExecutionException
+import org.gradle.workers.WorkerParameters
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Unroll
@@ -60,30 +62,26 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
     def classLoaderStructureProvider = Mock(ClassLoaderStructureProvider)
     def actionExecutionSpecFactory = Mock(ActionExecutionSpecFactory)
     def instantiator = Mock(Instantiator)
-    def parameters = Mock(AdapterWorkerParameters)
     DefaultWorkerExecutor workerExecutor
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
-        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(forkOptionsFactory, objectFactory, args[1][0]) }
-        _ * parameters.implementationClassName >> TestRunnable.class.getName()
-        _ * parameters.params >> []
+        _ * instantiator.newInstance(DefaultWorkerSpec) >> { args -> new DefaultWorkerSpec() }
+        _ * instantiator.newInstance(DefaultClassLoaderWorkerSpec) >> { args -> new DefaultClassLoaderWorkerSpec(objectFactory) }
+        _ * instantiator.newInstance(DefaultProcessWorkerSpec) >> { args -> new DefaultProcessWorkerSpec(forkOptionsFactory, objectFactory) }
+        _ * instantiator.newInstance(DefaultWorkerExecutor.DefaultWorkQueue, _, _) >> { args -> new DefaultWorkerExecutor.DefaultWorkQueue(args[1][0], args[1][1]) }
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 
     @Unroll
-    def "work can be submitted concurrently in IsolationMode.#isolationMode"() {
+    def "work can be submitted concurrently using #isolationMode"() {
         when:
         async {
             6.times {
                 start {
                     thread.blockUntil.allStarted
-                    workerExecutor.submit(TestRunnable.class) { config ->
-                        config.isolationMode = isolationMode
-                        config.params = []
-                    }
+                    workerExecutor."${isolationMode}"().submit(TestExecution.class, Actions.doNothing())
                 }
             }
             instant.allStarted
@@ -94,7 +92,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         6 * executionQueue.submit(_)
 
         where:
-        isolationMode << IsolationMode.values()
+        isolationMode << ["noIsolation", "classLoaderIsolation", "processIsolation"]
     }
 
     def "can wait on results to complete"() {
@@ -127,9 +125,10 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         }
     }
 
-    static class TestRunnable implements Runnable {
+    abstract static class TestExecution implements WorkerExecution<WorkerParameters.None> {
         @Override
-        void run() {
+        void execute() {
+
         }
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -31,9 +31,9 @@ import org.gradle.process.internal.JavaForkOptionsInternal
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.UsesNativeServices
-import org.gradle.workers.WorkerExecution
+import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkerExecutionException
-import org.gradle.workers.WorkerParameters
+import org.gradle.workers.WorkParameters
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Unroll
@@ -125,7 +125,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         }
     }
 
-    abstract static class TestExecution implements WorkerExecution<WorkerParameters.None> {
+    abstract static class TestExecution implements WorkAction<WorkParameters.None> {
         @Override
         void execute() {
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.model.ObjectFactory
+import org.gradle.internal.Actions
 import org.gradle.internal.classloader.VisitableURLClassLoader
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
@@ -27,6 +28,7 @@ import org.gradle.internal.work.ConditionalExecutionQueue
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.workers.WorkerExecution
 import org.gradle.workers.WorkerParameters
 import org.gradle.workers.WorkerSpec
 import spock.lang.Specification
@@ -35,7 +37,6 @@ import org.gradle.util.UsesNativeServices
 import org.gradle.workers.IsolationMode
 import org.gradle.workers.WorkerConfiguration
 import org.junit.Rule
-import spock.lang.Unroll
 
 @UsesNativeServices
 class DefaultWorkerExecutorTest extends Specification {
@@ -69,7 +70,10 @@ class DefaultWorkerExecutorTest extends Specification {
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
         _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
-        _ * instantiator.newInstance(DefaultWorkerSpec, _) >> { args -> new DefaultWorkerSpec<>(forkOptionsFactory, objectFactory, args[1][0]) }
+        _ * instantiator.newInstance(DefaultWorkerSpec) >> { args -> new DefaultWorkerSpec() }
+        _ * instantiator.newInstance(DefaultClassLoaderWorkerSpec) >> { args -> new DefaultClassLoaderWorkerSpec(objectFactory) }
+        _ * instantiator.newInstance(DefaultProcessWorkerSpec) >> { args -> new DefaultProcessWorkerSpec(forkOptionsFactory, objectFactory) }
+        _ * instantiator.newInstance(DefaultWorkerExecutor.DefaultWorkQueue, _, _) >> { args -> new DefaultWorkerExecutor.DefaultWorkQueue(args[1][0], args[1][1]) }
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
@@ -107,7 +111,7 @@ class DefaultWorkerExecutorTest extends Specification {
     }
 
     def "can convert javaForkOptions to daemonForkOptions"() {
-        WorkerSpec configuration = new DefaultWorkerSpec<WorkerParameters.None>(forkOptionsFactory, objectFactory, null)
+        WorkerSpec configuration = new DefaultProcessWorkerSpec(forkOptionsFactory, objectFactory)
 
         given:
         configuration.forkOptions { options ->
@@ -120,7 +124,7 @@ class DefaultWorkerExecutorTest extends Specification {
         }
 
         when:
-        def daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration)
+        def daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration, null)
 
         then:
         daemonForkOptions.javaForkOptions.minHeapSize == "128m"
@@ -133,12 +137,12 @@ class DefaultWorkerExecutorTest extends Specification {
 
     def "can add to classpath on executor"() {
         given:
-        WorkerSpec configuration = new DefaultWorkerSpec<WorkerParameters.None>(forkOptionsFactory, objectFactory, null)
+        WorkerSpec configuration = new DefaultClassLoaderWorkerSpec(objectFactory)
         def foo = temporaryFolder.createFile("foo")
         configuration.classpath.from([foo])
 
         when:
-        DaemonForkOptions daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration)
+        DaemonForkOptions daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration, null)
 
         then:
         1 * classLoaderStructureProvider.getInProcessClassLoaderStructure(_, _) >> { args -> new HierarchicalClassLoaderStructure(new VisitableURLClassLoader.Spec("test", args[0].collect { it.toURI().toURL() }))}
@@ -149,13 +153,10 @@ class DefaultWorkerExecutorTest extends Specification {
 
     def "executor executes a given runnable in a daemon"() {
         when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = IsolationMode.PROCESS
-            configuration.params = []
-        }
+        workerExecutor.processIsolation().submit(TestExecutable.class, Actions.doNothing())
 
         then:
-        _ * parameters.implementationClassName >> TestRunnable.class.getName()
+        _ * parameters.implementationClassName >> TestExecutable.class.getName()
         _ * parameters.params >> []
         1 * buildOperationWorkerRegistry.getCurrentWorkerLease()
         1 * executionQueue.submit(_) >> { args -> task = args[0] }
@@ -166,20 +167,17 @@ class DefaultWorkerExecutorTest extends Specification {
         then:
         1 * workerDaemonFactory.getWorker(_) >> worker
         1 * worker.execute(_, _) >> { spec, buildOperation ->
-            assert spec.implementationClass == TestRunnable
+            assert spec.implementationClass == TestExecutable.class
             return new DefaultWorkResult(true, null)
         }
     }
 
     def "executor executes a given runnable in-process"() {
         when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = IsolationMode.CLASSLOADER
-            configuration.params = []
-        }
+        workerExecutor.classLoaderIsolation().submit(TestExecutable.class, Actions.doNothing())
 
         then:
-        _ * parameters.implementationClassName >> TestRunnable.class.getName()
+        _ * parameters.implementationClassName >> TestExecutable.class.getName()
         _ * parameters.params >> []
         1 * buildOperationWorkerRegistry.getCurrentWorkerLease()
         1 * executionQueue.submit(_) >> { args -> task = args[0] }
@@ -190,20 +188,17 @@ class DefaultWorkerExecutorTest extends Specification {
         then:
         1 * inProcessWorkerFactory.getWorker(_) >> worker
         1 * worker.execute(_, _) >> { spec, workOperation, buildOperation ->
-            assert spec.implementationClass == TestRunnable
+            assert spec.implementationClass == TestExecutable
             return new DefaultWorkResult(true, null)
         }
     }
 
     def "executor executes a given runnable with no isolation"() {
         when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = IsolationMode.NONE
-            configuration.params = []
-        }
+        workerExecutor.noIsolation().submit(TestExecutable.class, Actions.doNothing())
 
         then:
-        _ * parameters.implementationClassName >> TestRunnable.class.getName()
+        _ * parameters.implementationClassName >> TestExecutable.class.getName()
         _ * parameters.params >> []
         1 * buildOperationWorkerRegistry.getCurrentWorkerLease()
         1 * executionQueue.submit(_) >> { args -> task = args[0] }
@@ -214,112 +209,14 @@ class DefaultWorkerExecutorTest extends Specification {
         then:
         1 * noIsolationWorkerFactory.getWorker(_) >> worker
         1 * worker.execute(_, _) >> { spec, workOperation, buildOperation ->
-            assert spec.implementationClass == TestRunnable
+            assert spec.implementationClass == TestExecutable
             return new DefaultWorkResult(true, null)
         }
     }
 
-    def "cannot set classpath in isolation mode NONE"() {
-        when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = IsolationMode.NONE
-            configuration.params = []
-            configuration.classpath([temporaryFolder.createFile("foo")])
-        }
-
-        then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "The worker classpath cannot be set when using isolation mode NONE"
-    }
-
-    @Unroll
-    def "cannot set bootstrap classpath in isolation mode #isolationMode"() {
-        when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = isolationMode
-            configuration.params = []
-            configuration.forkOptions.bootstrapClasspath new File("foo")
-        }
-
-        then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "The worker bootstrap classpath cannot be set when using isolation mode $isolationMode".toString()
-
-        where:
-        isolationMode << [IsolationMode.NONE, IsolationMode.CLASSLOADER]
-    }
-
-    @Unroll
-    def "cannot set jvm arguments in isolation mode #isolationMode"() {
-        when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = isolationMode
-            configuration.params = []
-            configuration.forkOptions.jvmArgs "foo"
-        }
-
-        then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "The worker jvm arguments cannot be set when using isolation mode $isolationMode".toString()
-
-        where:
-        isolationMode << [IsolationMode.NONE, IsolationMode.CLASSLOADER]
-    }
-
-    @Unroll
-    def "cannot set system properties in isolation mode #isolationMode"() {
-        when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = isolationMode
-            configuration.params = []
-            configuration.forkOptions.systemProperty "FOO", "bar"
-        }
-
-        then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "The worker system properties cannot be set when using isolation mode $isolationMode".toString()
-
-        where:
-        isolationMode << [IsolationMode.NONE, IsolationMode.CLASSLOADER]
-    }
-
-    @Unroll
-    def "cannot set maximum heap in isolation mode #isolationMode"() {
-        when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = isolationMode
-            configuration.params = []
-            configuration.forkOptions.maxHeapSize = "foo"
-        }
-
-        then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "The worker maximum heap size cannot be set when using isolation mode $isolationMode".toString()
-
-        where:
-        isolationMode << [IsolationMode.NONE, IsolationMode.CLASSLOADER]
-    }
-
-    @Unroll
-    def "cannot set minimum heap in isolation mode #isolationMode"() {
-        when:
-        workerExecutor.submit(TestRunnable.class) { WorkerConfiguration configuration ->
-            configuration.isolationMode = isolationMode
-            configuration.params = []
-            configuration.forkOptions.minHeapSize = "foo"
-        }
-
-        then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "The worker minimum heap size cannot be set when using isolation mode $isolationMode".toString()
-
-        where:
-        isolationMode << [IsolationMode.NONE, IsolationMode.CLASSLOADER]
-    }
-
-    static class TestRunnable implements Runnable {
+    abstract static class TestExecutable implements WorkerExecution<WorkerParameters.None> {
         @Override
-        void run() {
+        void execute() {
             println "executing"
         }
     }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -28,8 +28,8 @@ import org.gradle.internal.work.ConditionalExecutionQueue
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.process.internal.worker.child.WorkerDirectoryProvider
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.workers.WorkerExecution
-import org.gradle.workers.WorkerParameters
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerSpec
 import spock.lang.Specification
 import org.gradle.util.RedirectStdOutAndErr
@@ -63,13 +63,13 @@ class DefaultWorkerExecutorTest extends Specification {
     def worker = Mock(BuildOperationAwareWorker)
     def actionExecutionSpecFactory = Mock(ActionExecutionSpecFactory)
     def instantiator = Mock(Instantiator)
-    def parameters = Mock(AdapterWorkerParameters)
+    def parameters = Mock(AdapterWorkParameters)
     ConditionalExecution task
     DefaultWorkerExecutor workerExecutor
 
     def setup() {
         _ * executionQueueFactory.create() >> executionQueue
-        _ * instantiator.newInstance(AdapterWorkerParameters) >> parameters
+        _ * instantiator.newInstance(AdapterWorkParameters) >> parameters
         _ * instantiator.newInstance(DefaultWorkerSpec) >> { args -> new DefaultWorkerSpec() }
         _ * instantiator.newInstance(DefaultClassLoaderWorkerSpec) >> { args -> new DefaultClassLoaderWorkerSpec(objectFactory) }
         _ * instantiator.newInstance(DefaultProcessWorkerSpec) >> { args -> new DefaultProcessWorkerSpec(forkOptionsFactory, objectFactory) }
@@ -214,7 +214,7 @@ class DefaultWorkerExecutorTest extends Specification {
         }
     }
 
-    abstract static class TestExecutable implements WorkerExecution<WorkerParameters.None> {
+    abstract static class TestExecutable implements WorkAction<WorkParameters.None> {
         @Override
         void execute() {
             println "executing"

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonClientTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.workers.internal
 
 import org.gradle.api.logging.LogLevel
 import org.gradle.internal.operations.BuildOperationRef
-import org.gradle.workers.WorkerExecution
-import org.gradle.workers.WorkerParameters
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
 import spock.lang.Specification
 
 class WorkerDaemonClientTest extends Specification {
@@ -66,10 +66,10 @@ class WorkerDaemonClientTest extends Specification {
     }
 
     def spec() {
-        return new SimpleActionExecutionSpec(TestWorkerExecution, "test", null, null)
+        return new SimpleActionExecutionSpec(TestWorkAction, "test", null, null)
     }
 
-    static abstract class TestWorkerExecution implements WorkerExecution<WorkerParameters.None> {
+    static abstract class TestWorkAction implements WorkAction<WorkParameters.None> {
         @Override
         void execute() { }
     }

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/OptionsVerifier.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/OptionsVerifier.groovy
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.fixtures
+
+import groovy.json.JsonSlurper
+import org.gradle.util.TextUtil
+
+class OptionsVerifier {
+    private static final ARGUMENTS = "arguments"
+    private static final BOOTSTRAP_CLASSPATH = "bootstrapClassPath"
+    private static final ENV_VARIABLES = "environmentVariables"
+    List<Option> options = []
+    File processJsonFile
+
+    OptionsVerifier(File processJsonFile) {
+        this.processJsonFile = processJsonFile
+    }
+
+    void minHeap(String value) {
+        options.add(new MinHeap(value))
+    }
+
+    void maxHeap(String value) {
+        options.add(new MaxHeap(value))
+    }
+
+    void jvmArgs(String value) {
+        options.add(new JvmArg(value))
+    }
+
+    void systemProperty(String name, String value) {
+        options.add(new SystemProperty(name, value))
+    }
+
+    void environmentVariable(String name, String value) {
+        options.add(new EnvironmentVariable(name, value))
+    }
+
+    void defaultCharacterEncoding(String value) {
+        options.add(new DefaultCharacterEncoding(value))
+    }
+
+    void enableAssertions() {
+        options.add(new EnableAssertions())
+    }
+
+    void bootstrapClasspath(String path) {
+        options.add(new BootstrapClassPath(path))
+    }
+
+    String toDsl() {
+        options.collect { it.dsl }.join("\n")
+    }
+
+    void verifyAllOptions() {
+        def processEnv = new JsonSlurper().parse(processJsonFile)
+        options.each {
+            it.verify(processEnv)
+        }
+    }
+
+    String dumpProcessEnvironment(boolean includeBootstrapClasspath) {
+        return """
+            Map processEnv = [:]
+            
+            RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+            List<String> arguments = runtimeMxBean.getInputArguments();
+            
+            processEnv["${ARGUMENTS}"] = arguments
+            
+            if (${includeBootstrapClasspath}) {
+                processEnv["${BOOTSTRAP_CLASSPATH}"] = runtimeMxBean.getBootClassPath().replaceAll(Pattern.quote(File.separator),'/')
+            }
+            
+            processEnv["${ENV_VARIABLES}"] = [:]
+            System.getenv().each { key, value ->
+                processEnv["${ENV_VARIABLES}"][key] = value
+            }
+            
+            new File('${TextUtil.normaliseFileSeparators(processJsonFile.absolutePath)}').text = groovy.json.JsonOutput.toJson(processEnv)
+        """
+    }
+
+    interface Option {
+        String getDsl();
+
+        void verify(Map processEnv);
+    }
+
+    class MinHeap implements Option {
+        String value
+
+        MinHeap(String value) {
+            this.value = value
+        }
+
+        @Override
+        String getDsl() {
+            return "minHeapSize = '${value}'"
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            assert processEnv[ARGUMENTS].contains("-Xms${value}".toString())
+        }
+    }
+
+    class MaxHeap implements Option {
+        String value
+
+        MaxHeap(String value) {
+            this.value = value
+        }
+
+        @Override
+        String getDsl() {
+            return "maxHeapSize = '${value}'"
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            assert processEnv[ARGUMENTS].contains("-Xmx${value}".toString())
+        }
+    }
+
+    class JvmArg implements Option {
+        String value
+
+        JvmArg(String value) {
+            this.value = value
+        }
+
+        @Override
+        String getDsl() {
+            return "jvmArgs('${value}')"
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            assert processEnv[ARGUMENTS].contains(value)
+        }
+    }
+
+    class SystemProperty implements Option {
+        String name
+        String value
+
+        SystemProperty(String name, String value) {
+            this.name = name
+            this.value = value
+        }
+
+        @Override
+        String getDsl() {
+            return "systemProperty('${name}', '${value}')"
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            assert processEnv[ARGUMENTS].contains("-D${name}=${value}".toString())
+        }
+    }
+
+    class EnvironmentVariable implements Option {
+        String name
+        String value
+
+        EnvironmentVariable(String name, String value) {
+            this.name = name
+            this.value = value
+        }
+
+        @Override
+        String getDsl() {
+            return "environment('${name}', '${value}')"
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            assert processEnv[ENV_VARIABLES].containsKey(name) && processEnv[ENV_VARIABLES][name] == value
+        }
+    }
+
+    class DefaultCharacterEncoding implements Option {
+        String value
+
+        DefaultCharacterEncoding(String value) {
+            this.value = value
+        }
+
+        @Override
+        String getDsl() {
+            return "defaultCharacterEncoding  = '${value}'"
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            assert processEnv[ARGUMENTS].contains("-Dfile.encoding=${value}".toString())
+        }
+    }
+
+    class EnableAssertions implements Option {
+        @Override
+        String getDsl() {
+            return "enableAssertions = true"
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            assert processEnv[ARGUMENTS].contains('-ea')
+        }
+    }
+
+    class BootstrapClassPath implements Option {
+        String path
+
+        BootstrapClassPath(String path) {
+            this.path = path
+        }
+
+        @Override
+        String getDsl() {
+            return """
+                bootstrapClasspath = fileTree(new File(Jvm.current().jre.homeDir, "lib")).include("*.jar")
+                bootstrapClasspath(new File('${path}'))
+            """
+        }
+
+        @Override
+        void verify(Map processEnv) {
+            processEnv[BOOTSTRAP_CLASSPATH].endsWith(path)
+        }
+    }
+}


### PR DESCRIPTION
This introduces changes to the Worker API to make it more coherent and easier to use.  The changes involve separating the worker requirements from the parameters for a given item of work.  It also introduces a typed configuration object for the worker requirements that only allows you to configure the requirements appropriate for the type of worker you're using.  Typical usage would look like:

### Workers with no isolation
```
// Get a work queue for work without isolation
WorkQueue queue = workerExecutor.noIsolation()

// OR

// Get a work queue for work with classloader isolation
WorkQueue queue = workerExecutor.classLoaderIsolation() {
    classpath.from(configurations.extraClasspath)
}

// OR

// Get a work queue for work with process isolation
WorkQueue queue = workerExecutor.processIsolation() {
    classpath.from(configurations.extraClasspath)
    forkOptions {
        maxHeapSize = "128m"
        systemProperty("foo", "bar")
    }
}

// Then submit as many items to the queue as you want, specifying the parameters for each item of work
inputFiles.each { File inputFile ->
    queue.submit(TestWorkAction.class) { TestWorkParameters ->
        fileParameter = inputFile
    }
}

// Optionally wait for all work submitted to this queue
queue.await()
```

This also renames the recently introduced `WorkerExecution` and `WorkerParameters` classes to `WorkAction` and `WorkParameters`, respectively.