### PR TITLE
Add zip bomb detection test for final artifacts

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
 }
 
 // TODO This must match the version number in code-quality-configuration.gradle.kts
-def gradleGroovyVersion = "1.1-${groovyVersion}" as String
+def gradleGroovyVersion = "1.2-${groovyVersion}" as String
 
 // All libraries that are required to compile and run Gradle are listed here.
 // Most of them are also part of the distribution as they are declared as dependencies in one of Gradle's subprojects.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
 }
 
 // TODO This must match the version number in code-quality-configuration.gradle.kts
-def gradleGroovyVersion = "1.0-${groovyVersion}" as String
+def gradleGroovyVersion = "1.1-${groovyVersion}" as String
 
 // All libraries that are required to compile and run Gradle are listed here.
 // Most of them are also part of the distribution as they are declared as dependencies in one of Gradle's subprojects.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
 }
 
 // TODO This must match the version number in code-quality-configuration.gradle.kts
-def gradleGroovyVersion = "1.2-${groovyVersion}" as String
+def gradleGroovyVersion = "1.3-${groovyVersion}" as String
 
 // All libraries that are required to compile and run Gradle are listed here.
 // Most of them are also part of the distribution as they are declared as dependencies in one of Gradle's subprojects.

--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -1,5 +1,3 @@
-import java.io.File
-
 /*
  * Copyright 2018 the original author or authors.
  *
@@ -112,11 +110,10 @@ open class CodeNarcRule : ComponentMetadataRule {
                 removeAll { it.group == "org.codehaus.groovy" }
                 add("org.gradle.groovy:groovy-all") {
                     // TODO This must match the version number in dependencies.gradle
-                    version { prefer("1.0-" + groovy.lang.GroovySystem.getVersion()) }
+                    version { prefer("1.1-" + groovy.lang.GroovySystem.getVersion()) }
                     because("We use groovy-all everywhere")
                 }
             }
         }
-
     }
 }

--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -110,7 +110,7 @@ open class CodeNarcRule : ComponentMetadataRule {
                 removeAll { it.group == "org.codehaus.groovy" }
                 add("org.gradle.groovy:groovy-all") {
                     // TODO This must match the version number in dependencies.gradle
-                    version { prefer("1.2-" + groovy.lang.GroovySystem.getVersion()) }
+                    version { prefer("1.3-" + groovy.lang.GroovySystem.getVersion()) }
                     because("We use groovy-all everywhere")
                 }
             }

--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -110,7 +110,7 @@ open class CodeNarcRule : ComponentMetadataRule {
                 removeAll { it.group == "org.codehaus.groovy" }
                 add("org.gradle.groovy:groovy-all") {
                     // TODO This must match the version number in dependencies.gradle
-                    version { prefer("1.1-" + groovy.lang.GroovySystem.getVersion()) }
+                    version { prefer("1.2-" + groovy.lang.GroovySystem.getVersion()) }
                     because("We use groovy-all everywhere")
                 }
             }

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -50,7 +50,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
             'commons-io-2.6.jar' : 'f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513',
             'commons-lang-2.6.jar' : '50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c',
             'failureaccess-1.0.1.jar' : 'a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26',
-            'groovy-all-1.0-2.5.4.jar' : '704d3307616c57234871c4db3a355c3e81ea975db8dac8ee6c9264b91c74d2b7',
+            'groovy-all-1.1-2.5.4.jar' : '244e65e6fb3c336a2bfb71e0fe98fb89ce2304e75e05d129f09766eb7611a444',
             'guava-27.1-android.jar' : '686404f2d1d4d221911f96bd627ff60dac2226a5dfa6fb8ba517073eb97ec0ef',
             'jansi-1.17.1.jar' : 'b2234bfb0d8f245562d64ed9325df6b907093f4daa702c9082d4796db2a2d894',
             'javax.inject-1.jar' : '91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -50,7 +50,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
             'commons-io-2.6.jar' : 'f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513',
             'commons-lang-2.6.jar' : '50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c',
             'failureaccess-1.0.1.jar' : 'a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26',
-            'groovy-all-1.3-2.5.4.jar': 'ba3ecd52ccbbe11d68e69e9b6494b2da8d1d1e3fad89edf8ab0a59e98059bcfc',
+            'groovy-all-1.3-2.5.4.jar': 'b41c83700fd2b59333aea828bb15ffa5b8af7b12c74a7a26e77d4274cef0702b',
             'guava-27.1-android.jar' : '686404f2d1d4d221911f96bd627ff60dac2226a5dfa6fb8ba517073eb97ec0ef',
             'jansi-1.17.1.jar' : 'b2234bfb0d8f245562d64ed9325df6b907093f4daa702c9082d4796db2a2d894',
             'javax.inject-1.jar' : '91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -50,7 +50,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
             'commons-io-2.6.jar' : 'f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513',
             'commons-lang-2.6.jar' : '50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c',
             'failureaccess-1.0.1.jar' : 'a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26',
-            'groovy-all-1.1-2.5.4.jar' : '244e65e6fb3c336a2bfb71e0fe98fb89ce2304e75e05d129f09766eb7611a444',
+            'groovy-all-1.2-2.5.4.jar' : '36df7e810ae4ba662ee6a0d52e43dc7ea996cb1880dabb2d61d89189ff90c56a',
             'guava-27.1-android.jar' : '686404f2d1d4d221911f96bd627ff60dac2226a5dfa6fb8ba517073eb97ec0ef',
             'jansi-1.17.1.jar' : 'b2234bfb0d8f245562d64ed9325df6b907093f4daa702c9082d4796db2a2d894',
             'javax.inject-1.jar' : '91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -205,7 +205,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
 
         then:
         jars != []
-        invalidArchives == [] // TODO fails with: [groovy-all-1.0-2.5.4.jar]
+        invalidArchives == []
     }
 
     private static def collectJars(TestFile file, Collection<File> acc = []) {

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -200,7 +200,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
         def jars = collectJars(unpackDistribution())
         def invalidArchives = jars.findAll {
             def names = new ZipFile(it).entries()*.name
-            names.size() != names.toSet().size()
+            names.size() != names.toUnique().size()
         }*.name
 
         then:

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -50,7 +50,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
             'commons-io-2.6.jar' : 'f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513',
             'commons-lang-2.6.jar' : '50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c',
             'failureaccess-1.0.1.jar' : 'a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26',
-            'groovy-all-1.2-2.5.4.jar' : '36df7e810ae4ba662ee6a0d52e43dc7ea996cb1880dabb2d61d89189ff90c56a',
+            'groovy-all-1.3-2.5.4.jar': 'ba3ecd52ccbbe11d68e69e9b6494b2da8d1d1e3fad89edf8ab0a59e98059bcfc',
             'guava-27.1-android.jar' : '686404f2d1d4d221911f96bd627ff60dac2226a5dfa6fb8ba517073eb97ec0ef',
             'jansi-1.17.1.jar' : 'b2234bfb0d8f245562d64ed9325df6b907093f4daa702c9082d4796db2a2d894',
             'javax.inject-1.jar' : '91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',
@@ -176,12 +176,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
         }
         Map<String, TestFile> depJars = filtered.collectEntries { [libDir.relativePath(it), it] }
 
-        def added = depJars.keySet() - expectedHashes.keySet()
-        def removed = expectedHashes.keySet() - depJars.keySet()
-
-        expect:
-        assert (added + removed).isEmpty()
-
+        when:
         def errors = []
         depJars.each { String jarPath, TestFile jar ->
             def expected = expectedHashes[jarPath]
@@ -190,8 +185,14 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
                 errors << "SHA-256 hash does not match for ${jarPath}: expected=${expected}, actual=${actual}"
             }
         }
+        then:
+        errors.empty
 
-        assert errors.empty
+        when:
+        def added = depJars.keySet() - expectedHashes.keySet()
+        def removed = expectedHashes.keySet() - depJars.keySet()
+        then:
+        (added + removed).isEmpty()
     }
 
     @Issue(['https://github.com/gradle/gradle/issues/9990', 'https://github.com/gradle/gradle/issues/10038'])

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -198,13 +198,17 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
     def "validate dependency archives"() {
         when:
         def jars = collectJars(unpackDistribution())
-        def invalidArchives = jars.findAll {
-            def names = new ZipFile(it).entries()*.name
-            names.size() != names.toUnique().size()
-        }*.name
-
         then:
         jars != []
+
+        when:
+        def invalidArchives = jars.findAll {
+            new ZipFile(it).withCloseable {
+                def names = it.entries()*.name
+                names.size() != names.toUnique().size()
+            }
+        }
+        then:
         invalidArchives == []
     }
 

--- a/subprojects/model-core/model-core.gradle.kts
+++ b/subprojects/model-core/model-core.gradle.kts
@@ -23,11 +23,11 @@ plugins {
 }
 
 dependencies {
+    api(project(":coreApi"))
 
     implementation(project(":baseServices"))
     implementation(project(":logging"))
     implementation(project(":persistentCache"))
-    implementation(project(":coreApi"))
     implementation(project(":baseServicesGroovy"))
     implementation(project(":messaging"))
     implementation(project(":snapshots"))
@@ -53,9 +53,9 @@ dependencies {
     testImplementation(testFixtures(project(":coreApi")))
 
     testRuntimeOnly(project(":runtimeApiInfo"))
-    
+
     integTestImplementation(project(":platformBase"))
-    
+
     integTestRuntimeOnly(project(":apiMetadata"))
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
@@ -85,12 +85,12 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsIntegration
         run "classes", "testClasses"
 
         then:
-        generatedJars
-            .collect { new ZipFile(it) }
-            .findAll {
+        generatedJars.findAll {
+            new ZipFile(it).withCloseable {
                 def names = it.entries()*.name
                 names.size() != names.toUnique().size()
-            } == []
+            }
+        } == []
     }
 
     private TestFile productionCode() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
@@ -17,6 +17,9 @@
 package org.gradle.plugin.devel.impldeps
 
 import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
+
+import java.util.zip.ZipFile
 
 class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsIntegrationTest {
 
@@ -29,17 +32,20 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsIntegration
         setup:
         productionCode()
 
+        def version = distribution.version.version
+        def generatedJarsDirectory = "user-home/caches/$version/generated-gradle-jars"
+
         when:
         succeeds("tasks")
 
         then:
-        file("user-home/caches/${distribution.version.version}/generated-gradle-jars").assertIsEmptyDir()
+        file(generatedJarsDirectory).assertIsEmptyDir()
 
         when:
         succeeds("classes")
 
         then:
-        file("user-home/caches/${distribution.version.version}/generated-gradle-jars/gradle-api-${distribution.version.version}.jar").assertExists()
+        file("$generatedJarsDirectory/gradle-api-${version}.jar").assertExists()
 
     }
 
@@ -47,17 +53,42 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsIntegration
         setup:
         testCode()
 
+        def version = distribution.version.version
+        def generatedJarsDirectory = "user-home/caches/$version/generated-gradle-jars"
+
         when:
         succeeds("classes")
 
         then:
-        file("user-home/caches/${distribution.version.version}/generated-gradle-jars").assertIsEmptyDir()
+        file(generatedJarsDirectory).assertIsEmptyDir()
 
         when:
         succeeds("testClasses")
 
         then:
-        file("user-home/caches/${distribution.version.version}/generated-gradle-jars/gradle-test-kit-${distribution.version.version}.jar").assertExists()
+        file("$generatedJarsDirectory/gradle-test-kit-${version}.jar").assertExists()
+    }
+
+    @Issue(['https://github.com/gradle/gradle/issues/9990', 'https://github.com/gradle/gradle/issues/10038'])
+    def "generated jars (api & test-kit) are valid archives"() {
+        setup:
+        productionCode()
+        testCode()
+
+        def version = distribution.version.version
+        def generatedJarsDirectory = "user-home/caches/$version/generated-gradle-jars"
+        def generatedJars = ["$generatedJarsDirectory/gradle-api-${version}.jar", "$generatedJarsDirectory/gradle-test-kit-${version}.jar"]
+
+        when:
+        run "classes", "testClasses"
+
+        then:
+        generatedJars
+            .collect { new ZipFile(file(it)) }
+            .findAll {
+                def names = it.entries()*.name
+                names.size() != names.toSet().size()
+            } == []
     }
 
     private TestFile productionCode() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
@@ -76,18 +76,20 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsIntegration
         testCode()
 
         def version = distribution.version.version
-        def generatedJarsDirectory = "user-home/caches/$version/generated-gradle-jars"
-        def generatedJars = ["$generatedJarsDirectory/gradle-api-${version}.jar", "$generatedJarsDirectory/gradle-test-kit-${version}.jar"]
+        def generatedJars = [
+            'gradle-api',
+            'gradle-test-kit'
+        ].collect { file("user-home/caches/$version/generated-gradle-jars/${it}-${version}.jar" )}
 
         when:
         run "classes", "testClasses"
 
         then:
         generatedJars
-            .collect { new ZipFile(file(it)) }
+            .collect { new ZipFile(it) }
             .findAll {
                 def names = it.entries()*.name
-                names.size() != names.toSet().size()
+                names.size() != names.toUnique().size()
             } == []
     }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
@@ -67,7 +67,7 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
     def "manualClasspathInjection with #dsl dsl"() {
         expect:
         executer.inDirectory(sample.dir.file(dsl))
-        succeeds "check"
+        succeeds "check", '--stacktrace'
 
         where:
         dsl << ['groovy', 'kotlin']

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
@@ -67,7 +67,7 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
     def "manualClasspathInjection with #dsl dsl"() {
         expect:
         executer.inDirectory(sample.dir.file(dsl))
-        succeeds "check", '--stacktrace'
+        succeeds "check", '--stacktrace', '--info'
 
         where:
         dsl << ['groovy', 'kotlin']


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #10038 

The duplicates in the groovy-all zip are the following:
* `META-INF/INDEX.LIST` (2 copies)
* `META-INF/LICENSE` (19 copies)
* `META-INF/INDEX.LIST` (2 other copies)
* `META-INF/NOTICE` (21 copies)
* `META-INF/groovy-release-info.properties` (23 copies)

- [x] add test for generated jars