### PR TITLE
Check for ModelMap duplicated element inside TaskContainer

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskBridgingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskBridgingIntegrationTest.groovy
@@ -300,6 +300,41 @@ class RuleTaskBridgingIntegrationTest extends AbstractIntegrationSpec implements
         failure.assertHasCause("Cannot create 'tasks.foo' using creation rule 'MyPlugin#addTask(ModelMap<Task>) > create(foo)' as the rule 'Project.<init>.tasks.foo()' is already registered to create this model element.")
     }
 
+    def "registering creation rules to create a task using legacy container DSL that is already defined using container DSL"() {
+        when:
+        buildFile << """
+            class MyPlugin extends RuleSource {
+                @Mutate
+                void addTaskInContainer(TaskContainer tasks) {
+                    println("create task in container")
+                    tasks.create("foo") {
+                        doLast {
+                            println("created on TaskContainer")
+                        }
+                    }
+                }
+
+                @Mutate
+                void addTask(ModelMap<Task> tasks) {
+                    println("create task in model map")
+                    tasks.create("foo") {
+                        doLast {
+                            println("created on ModelMap")
+                        }
+                    }
+                }
+            }
+
+            apply type: MyPlugin
+        """
+
+        then:
+        fails "foo"
+
+        and:
+        failure.assertHasCause("Cannot add task 'foo' as a task with that name already exists.")
+    }
+
     def "a non-rule-source task can depend on a rule-source task"() {
         given:
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.model.internal.core.ModelPath;
 
 import java.util.Map;
 
@@ -135,6 +136,11 @@ public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObj
     @Override
     protected <I extends T> Action<? super I> withMutationDisabled(Action<? super I> action) {
         return parentMutationGuard.withMutationDisabled(super.withMutationDisabled(action));
+    }
+
+    @Override
+    protected boolean hasWithName(String name) {
+        return (project.getModelRegistry() != null && project.getModelRegistry().state(ModelPath.path("tasks." + name)) != null) || super.hasWithName(name);
     }
 
     @Override


### PR DESCRIPTION
A ModelMap<Task> is a shadow version of the TaskContainer inside the
software model. The ModelMap only check if the type of the created
element match the container. With this commit, the ModelMap will check
against the backing container to ensure there isn't an element already
present with the same name. This scenario caused different task instance
to be used because of the duplication. It is an error to create tasks
with the same name in both the TaskContainer and ModelMap<Task>.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-private/issues/2248

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fsoftware-model%2Fprevent-duplicated-tasks)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
