### PR TITLE
Deprecate specifying the local build cache type

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -167,7 +167,7 @@ class HttpBuildCacheConfigurationBuildOperationIntegrationTest extends AbstractI
         given:
         settingsFile << """
             buildCache {  
-                local(DirectoryBuildCache) {
+                local {
                     enabled = false 
                     directory = 'directory'
                     push = false 

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationIntegrationTest.groovy
@@ -28,7 +28,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         def cacheDir = temporaryFolder.file("cache-dir").createDir()
         settingsFile << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     enabled = true 
                     directory = '${cacheDir.absoluteFile.toURI().toString()}'
                     push = true 
@@ -118,7 +118,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
             buildCache {
                 registerBuildCacheService(CustomBuildCache, CustomBuildCacheFactory)
 
-                local(DirectoryBuildCache) {
+                local {
                     enabled = true 
                     directory = '${cacheDir.absoluteFile.toURI().toString()}'
                 }
@@ -146,7 +146,7 @@ class FinalizeBuildCacheConfigurationBuildOperationIntegrationTest extends Abstr
         def cacheDir = temporaryFolder.file("cache-dir").createDir()
         settingsFile << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     enabled = false
                     directory = '${cacheDir.absoluteFile.toURI().toString()}'
                     push = true 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
@@ -207,7 +207,7 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
         executer.inDirectory(remoteProjectDir)
         remoteProjectDir.file("settings.gradle") << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = '${cacheDir.absoluteFile.toURI()}'
                 }
             }
@@ -235,7 +235,7 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
         executer.inDirectory(remoteProjectDir)
         remoteProjectDir.file("settings.gradle") << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = '${cacheDir.absoluteFile.toURI()}'
                 }
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DispatchingBuildCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DispatchingBuildCacheIntegrationTest.groovy
@@ -144,7 +144,7 @@ class DispatchingBuildCacheIntegrationTest extends AbstractIntegrationSpec {
     def 'push to the local cache by default'() {
         settingsFile.text = """
             buildCache {        
-                local(DirectoryBuildCache) {
+                local {
                     directory = '${localCache.cacheDir.toURI()}'                    
                 }
                 remote(DirectoryBuildCache) {

--- a/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/DefaultBuildCacheConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/DefaultBuildCacheConfiguration.java
@@ -26,6 +26,7 @@ import org.gradle.caching.local.DirectoryBuildCache;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.util.DeprecationLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,11 +56,17 @@ public class DefaultBuildCacheConfiguration implements BuildCacheConfigurationIn
 
     @Override
     public <T extends DirectoryBuildCache> T local(Class<T> type) {
-        return local(type, Actions.doNothing());
+        DeprecationLogger.nagUserOfDiscontinuedMethod("BuildCacheConfiguration.local(Class)", "Use getLocal() instead.");
+        return localInternal(type, Actions.doNothing());
     }
 
     @Override
     public <T extends DirectoryBuildCache> T local(Class<T> type, Action<? super T> configuration) {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("BuildCacheConfiguration.local(Class, Action)", "Use local(Action) instead.");
+        return localInternal(type, configuration);
+    }
+
+    private <T extends DirectoryBuildCache> T localInternal(Class<T> type, Action<? super T> configuration) {
         if (!type.equals(DirectoryBuildCache.class)) {
             throw new IllegalArgumentException("Using a local build cache type other than " + DirectoryBuildCache.class.getSimpleName() + " is not allowed");
         }

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -56,7 +56,8 @@ These methods now assume the local build cache type to be `DirectoryBuildCache`.
 In the past it was possible to use any build cache implementation as the `local` cache.
 This is not allowed anymore as the local cache is always a `DirectoryBuildCache`.
 Calls to `BuildCacheConfiguration.local(Class)` with anything other than `DirectoryBuildCache` as the type will fail the build.
-Use `getLocal()` and `local(Action)` instead.
+Calling these methods with the `DirectoryBuildCache` type will produce a deprecation warning.
+Use `getLocal()` and `local(Action)` instead, respectively.
 These methods now assume the local build cache type to be `DirectoryBuildCache`.
 
 ==== Failing to pack or unpack cached results will now fail the build

--- a/subprojects/docs/src/samples/buildCache/configure-built-in-caches/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/buildCache/configure-built-in-caches/groovy/settings.gradle
@@ -16,7 +16,7 @@
 
 // tag::configure-directory-build-cache[]
 buildCache {
-    local(DirectoryBuildCache) {
+    local {
         directory = new File(rootDir, 'build-cache')
         removeUnusedEntriesAfterDays = 30
     }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CachedKotlinTaskExecutionIntegrationTest.groovy
@@ -40,7 +40,7 @@ class CachedKotlinTaskExecutionIntegrationTest extends AbstractPluginIntegration
 
         file("buildSrc/settings.gradle.kts") << """
             buildCache {
-                local(DirectoryBuildCache::class.java) {
+                local {
                     directory = "${cacheDir.absoluteFile.toURI()}"
                     isPush = true
                 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestBuildCache.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestBuildCache.groovy
@@ -30,7 +30,7 @@ class TestBuildCache {
     def localCacheConfiguration(boolean push = true) {
         """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = '${cacheDir.absoluteFile.toURI()}'
                     push = $push
                 }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
@@ -96,9 +96,6 @@ class GradleApiExtensionsIntegrationTest : AbstractPluginIntegrationTest() {
         """)
 
         withDefaultSettings().appendText("""
-            buildCache {
-                local(DirectoryBuildCache::class)
-            }
             sourceControl {
                 vcsMappings {
                     withModule("some:thing") {

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -57,7 +57,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
         withDefaultSettingsIn(firstLocation).appendText("""
             rootProject.name = "test"
             buildCache {
-                local<DirectoryBuildCache> {
+                local {
                     directory = file("${cacheDir.normalisedPath}")
                 }
             }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCacheIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerCacheIntegrationTest.groovy
@@ -20,7 +20,11 @@ import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.testkit.runner.fixtures.NonCrossVersion
 import org.gradle.util.TextUtil
 
-import static org.gradle.testkit.runner.TaskOutcome.*
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
+import static org.gradle.testkit.runner.TaskOutcome.SKIPPED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 
 /**
  * Tests the behavior of a task with a FROM_CACHE result
@@ -55,7 +59,7 @@ class GradleRunnerCacheIntegrationTest extends BaseGradleRunnerIntegrationTest {
         def cacheDir = file("task-output-cache")
         settingsFile << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = "${TextUtil.escapeString(cacheDir.absolutePath)}"
                 }
             }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/CacheableTaskOutcomeCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r33/CacheableTaskOutcomeCrossVersionSpec.groovy
@@ -45,7 +45,7 @@ class CacheableTaskOutcomeCrossVersionSpec extends ToolingApiSpecification {
         def cacheDir = file("task-output-cache")
         settingsFile << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = "${TextUtil.escapeString(cacheDir.absolutePath)}"
                 }
             }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/CacheableTaskProgressEventsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/CacheableTaskProgressEventsCrossVersionSpec.groovy
@@ -46,7 +46,7 @@ class CacheableTaskProgressEventsCrossVersionSpec extends ToolingApiSpecificatio
         def cacheDir = file("task-output-cache")
         settingsFile << """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = "${TextUtil.escapeString(cacheDir.absolutePath)}"
                 }
             }
@@ -79,7 +79,7 @@ class CacheableTaskProgressEventsCrossVersionSpec extends ToolingApiSpecificatio
         TestFile remoteCache = file('remote-cache')
         settingsFile.text = """
             buildCache {
-                local(DirectoryBuildCache) {
+                local {
                     directory = '${localCache.absoluteFile.toURI()}' 
                     push = true
                 }


### PR DESCRIPTION
Fixes #9039.

Should be merged after #10057 is merged and `master` is at 6.0.