### PR TITLE
Plugin uses Guava immutable collection types when instant execution is enabled

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
@@ -61,13 +61,13 @@ public class DefaultClassLoaderCache implements ClassLoaderCacheInternal, Stoppa
 
     @Override
     public ClassLoader get(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, @Nullable FilteringClassLoader.Spec filterSpec, HashCode implementationHash) {
-        usedInThisBuild.add(id);
         if (implementationHash == null) {
             implementationHash = classpathHasher.hash(classPath);
         }
         ManagedClassLoaderSpec spec = new ManagedClassLoaderSpec(id.toString(), parent, classPath, implementationHash, filterSpec);
 
         synchronized (lock) {
+            usedInThisBuild.add(id);
             CachedClassLoader cachedLoader = byId.get(id);
             if (cachedLoader == null || !cachedLoader.is(spec)) {
                 CachedClassLoader newLoader = getAndRetainLoader(classPath, spec, id);

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -318,6 +318,8 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         "SomeEnum"                       | "SomeEnum.Two"                                                | "Two"
         "SomeEnum[]"                     | "[SomeEnum.Two] as SomeEnum[]"                                | "[Two]"
         "List<String>"                   | "['a', 'b', 'c']"                                             | "[a, b, c]"
+        "ArrayList<String>"              | "['a', 'b', 'c'] as ArrayList"                                | "[a, b, c]"
+        "LinkedList<String>"             | "['a', 'b', 'c'] as LinkedList"                               | "[a, b, c]"
         "Set<String>"                    | "['a', 'b', 'c'] as Set"                                      | "[a, b, c]"
         "HashSet<String>"                | "['a', 'b', 'c'] as HashSet"                                  | "[a, b, c]"
         "LinkedHashSet<String>"          | "['a', 'b', 'c'] as LinkedHashSet"                            | "[a, b, c]"

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.instantexecution
 
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -330,6 +333,108 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         "LinkedHashMap<String, Integer>" | "new LinkedHashMap([a: 1, b: 2])"                             | "[a:1, b:2]"
         "TreeMap<String, Integer>"       | "new TreeMap([a: 1, b: 2])"                                   | "[a:1, b:2]"
         "EnumMap<SomeEnum, String>"      | "new EnumMap([(SomeEnum.One): 'one', (SomeEnum.Two): 'two'])" | "[One:one, Two:two]"
+    }
+
+    @Unroll
+    def "restores task fields whose value is instance of plugin specific version of Guava #type"() {
+        buildFile << """
+            import ${type.name}
+
+            buildscript {
+                repositories {
+                    jcenter()
+                }
+                dependencies {
+                    classpath 'com.google.guava:guava:28.0-jre' 
+                }
+            }
+
+            class SomeBean {
+                ${type.simpleName} value 
+            }
+
+            class SomeTask extends DefaultTask {
+                private final SomeBean bean = new SomeBean()
+                private final ${type.simpleName} value
+                
+                SomeTask() {
+                    value = ${reference}
+                    bean.value = ${reference}
+                }
+
+                @TaskAction
+                void run() {
+                    println "this.value = " + value
+                    println "bean.value = " + bean.value
+                }
+            }
+
+            task ok(type: SomeTask)
+        """
+
+        when:
+        instantRun "ok"
+        instantRun "ok"
+
+        then:
+        outputContains("this.value = ${output}")
+        outputContains("bean.value = ${output}")
+
+        where:
+        type          | reference                         | output
+        ImmutableList | "ImmutableList.of('a', 'b', 'c')" | "[a, b, c]"
+        ImmutableSet  | "ImmutableSet.of('a', 'b', 'c')"  | "[a, b, c]"
+        ImmutableMap  | "ImmutableMap.of(1, 'a', 2, 'b')" | "[1:a, 2:b]"
+    }
+
+    def "restores task fields whose value is Serializable and has writeReplace method"() {
+        buildFile << """
+            class Placeholder implements Serializable {
+                String value
+                
+                private Object readResolve() {
+                    return new OtherBean(prop: "[\$value]")
+                } 
+            }
+
+            class OtherBean implements Serializable {
+                String prop
+
+                private Object writeReplace() {
+                    return new Placeholder(value: prop)
+                }
+            }
+
+            class SomeBean {
+                OtherBean value 
+            }
+
+            class SomeTask extends DefaultTask {
+                private final SomeBean bean = new SomeBean()
+                private final OtherBean value
+                
+                SomeTask() {
+                    value = new OtherBean(prop: 'a')
+                    bean.value = new OtherBean(prop: 'b')
+                }
+
+                @TaskAction
+                void run() {
+                    println "this.value = " + value.prop
+                    println "bean.value = " + bean.value.prop
+                }
+            }
+
+            task ok(type: SomeTask)
+        """
+
+        when:
+        instantRun "ok"
+        instantRun "ok"
+
+        then:
+        outputContains("this.value = [a]")
+        outputContains("bean.value = [b]")
     }
 
     @Unroll

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -45,11 +45,7 @@ interface WriteContext : IsolateContext, Encoder {
 
     fun beanPropertyWriterFor(beanType: Class<*>): BeanPropertyWriter
 
-    fun writeActionFor(value: Any?): Encoding?
-
-    suspend fun write(value: Any?) {
-        writeActionFor(value)!!(value)
-    }
+    suspend fun write(value: Any?)
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -46,6 +46,8 @@ interface WriteContext : IsolateContext, Encoder {
     fun beanPropertyWriterFor(beanType: Class<*>): BeanPropertyWriter
 
     suspend fun write(value: Any?)
+
+    fun writeClass(type: Class<*>)
 }
 
 
@@ -63,6 +65,8 @@ interface ReadContext : IsolateContext, Decoder {
     fun getProject(path: String): ProjectInternal
 
     suspend fun read(): Any?
+
+    fun readClass(): Class<*>
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -21,8 +21,8 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.logging.Logger
-import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
-import org.gradle.instantexecution.serialization.beans.BeanPropertyWriter
+import org.gradle.instantexecution.serialization.beans.BeanStateReader
+import org.gradle.instantexecution.serialization.beans.BeanStateWriter
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import kotlin.reflect.KClass
@@ -43,7 +43,7 @@ interface WriteContext : IsolateContext, Encoder {
 
     override val isolate: WriteIsolate
 
-    fun beanPropertyWriterFor(beanType: Class<*>): BeanPropertyWriter
+    fun beanStateWriterFor(beanType: Class<*>): BeanStateWriter
 
     suspend fun write(value: Any?)
 
@@ -60,7 +60,7 @@ interface ReadContext : IsolateContext, Decoder {
 
     val classLoader: ClassLoader
 
-    fun beanPropertyReaderFor(beanType: Class<*>): BeanPropertyReader
+    fun beanStateReaderFor(beanType: Class<*>): BeanStateReader
 
     fun getProject(path: String): ProjectInternal
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
@@ -168,17 +168,6 @@ data class SerializerCodec<T>(val serializer: Serializer<T>) : Codec<T> {
 
 
 internal
-fun WriteContext.writeClass(value: Class<*>) {
-    writeString(value.name)
-}
-
-
-internal
-fun ReadContext.readClass(): Class<*> =
-    Class.forName(readString(), false, classLoader)
-
-
-internal
 fun WriteContext.writeClassArray(values: Array<Class<*>>) {
     writeArray(values) { writeClass(it) }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -49,8 +49,10 @@ class DefaultWriteContext(
     override val isolate: WriteIsolate
         get() = getIsolate()
 
-    override fun writeActionFor(value: Any?): Encoding? = encodings.run {
-        encodingFor(value)
+    override suspend fun write(value: Any?) {
+        encodings.run {
+            encode(value)
+        }
     }
 
     // TODO: consider interning strings
@@ -68,7 +70,7 @@ class DefaultWriteContext(
 
 internal
 interface EncodingProvider {
-    fun WriteContext.encodingFor(candidate: Any?): Encoding?
+    suspend fun WriteContext.encode(candidate: Any?)
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -20,8 +20,14 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.logging.Logger
 import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.instantexecution.serialization.beans.BeanPropertyWriter
+import org.gradle.instantexecution.serialization.beans.BeanStateReader
+import org.gradle.instantexecution.serialization.beans.BeanStateWriter
+import org.gradle.instantexecution.serialization.beans.SerializableReadReplaceReader
+import org.gradle.instantexecution.serialization.beans.SerializableWriteReplaceWriter
+import org.gradle.internal.reflect.ClassInspector
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
+import java.io.Serializable
 
 
 internal
@@ -41,13 +47,27 @@ class DefaultWriteContext(
 ) : AbstractIsolateContext<WriteIsolate>(), MutableWriteContext, Encoder by encoder {
 
     private
-    val beanPropertyWriters = hashMapOf<Class<*>, BeanPropertyWriter>()
+    val beanPropertyWriters = hashMapOf<Class<*>, BeanStateWriter>()
 
     private
     val classes = hashMapOf<Class<*>, Int>()
 
-    override fun beanPropertyWriterFor(beanType: Class<*>): BeanPropertyWriter =
-        beanPropertyWriters.computeIfAbsent(beanType, ::BeanPropertyWriter)
+    override fun beanStateWriterFor(beanType: Class<*>): BeanStateWriter =
+        beanPropertyWriters.computeIfAbsent(beanType, this::createWriterFor)
+
+    private
+    fun createWriterFor(beanType: Class<*>): BeanStateWriter {
+        // When the type is serializable and has a writeReplace() method, then use this method to unpack the state of the object and serialize the result
+        if (Serializable::class.java.isAssignableFrom(beanType)) {
+            val details = ClassInspector.inspect(beanType)
+            val method = details.allMethods.find { it.name == "writeReplace" && it.parameters.isEmpty() }
+            if (method != null) {
+                return SerializableWriteReplaceWriter(method)
+            }
+        }
+        // Otherwise, serialize the fields of the bean
+        return BeanPropertyWriter(beanType)
+    }
 
     override val isolate: WriteIsolate
         get() = getIsolate()
@@ -106,7 +126,7 @@ class DefaultReadContext(
 ) : AbstractIsolateContext<ReadIsolate>(), MutableReadContext, Decoder by decoder {
 
     private
-    val beanPropertyReaders = hashMapOf<Class<*>, BeanPropertyReader>()
+    val beanStateReaders = hashMapOf<Class<*>, BeanStateReader>()
 
     private
     val classes = hashMapOf<Int, Class<*>>()
@@ -133,8 +153,22 @@ class DefaultReadContext(
     override val isolate: ReadIsolate
         get() = getIsolate()
 
-    override fun beanPropertyReaderFor(beanType: Class<*>): BeanPropertyReader =
-        beanPropertyReaders.computeIfAbsent(beanType, beanPropertyReaderFactory)
+    override fun beanStateReaderFor(beanType: Class<*>): BeanStateReader =
+        beanStateReaders.computeIfAbsent(beanType, this::createReaderFor)
+
+    private
+    fun createReaderFor(beanType: Class<*>): BeanStateReader {
+        // When the type is serializable and has a writeReplace() method, then use the corresponding readReplace() method from the placeholder
+        if (Serializable::class.java.isAssignableFrom(beanType)) {
+            val details = ClassInspector.inspect(beanType)
+            val method = details.allMethods.find { it.name == "writeReplace" && it.parameters.isEmpty() }
+            if (method != null) {
+                return SerializableReadReplaceReader()
+            }
+        }
+        // Otherwise, serialize the fields of the bean
+        return beanPropertyReaderFactory(beanType)
+    }
 
     override fun readClass(): Class<*> {
         val id = readSmallInt()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -68,11 +68,22 @@ class BeanPropertyReader(
 
     private
     val constructorForSerialization by lazy {
+        // Initialize the super types of the bean type, as this does not seem to happen via the generated constructors
+        maybeInit(beanType)
         if (GroovyObjectSupport::class.java.isAssignableFrom(beanType)) {
             // Run the `GroovyObjectSupport` constructor, to initialize the metadata field
             newConstructorForSerialization(beanType, GroovyObjectSupport::class.java.getConstructor())
         } else {
             newConstructorForSerialization(beanType, Object::class.java.getConstructor())
+        }
+    }
+
+    private
+    fun maybeInit(beanType: Class<*>) {
+        val superclass = beanType.superclass
+        if (superclass?.classLoader != null) {
+            Class.forName(superclass.name, true, superclass.classLoader)
+            maybeInit(superclass)
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -49,7 +49,7 @@ import java.util.function.Supplier
 class BeanPropertyReader(
     private val beanType: Class<*>,
     private val filePropertyFactory: FilePropertyFactory
-) {
+) : BeanStateReader {
 
     companion object {
 
@@ -87,10 +87,10 @@ class BeanPropertyReader(
         }
     }
 
-    fun newBean(): Any =
+    override suspend fun ReadContext.newBean() =
         constructorForSerialization.newInstance()
 
-    suspend fun ReadContext.readFieldsOf(bean: Any) {
+    override suspend fun ReadContext.readStateOf(bean: Any) {
         readEachProperty(PropertyKind.Field) { fieldName, fieldValue ->
             val setter = setterByFieldName.getValue(fieldName)
             setter(bean, fieldValue)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -29,7 +29,6 @@ import org.gradle.instantexecution.serialization.PropertyKind
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.logPropertyError
 import org.gradle.instantexecution.serialization.logPropertyInfo
-import org.gradle.instantexecution.serialization.logPropertyWarning
 import java.io.IOException
 import java.util.concurrent.Callable
 import java.util.function.Supplier
@@ -81,17 +80,9 @@ class BeanPropertyWriter(
  */
 suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: PropertyKind): Boolean {
     withPropertyTrace(kind, name) {
-        val writeValue = writeActionFor(value)
-        if (writeValue == null) {
-            logPropertyWarning("serialize") {
-                text("there's no serializer for type")
-                reference(unpackedTypeNameOf(value!!))
-            }
-            return false
-        }
         writeString(name)
         try {
-            writeValue(value)
+            write(value)
         } catch (passThrough: IOException) {
             throw passThrough
         } catch (passThrough: InstantExecutionException) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -36,7 +36,7 @@ import java.util.function.Supplier
 
 class BeanPropertyWriter(
     beanType: Class<*>
-) {
+) : BeanStateWriter {
 
     private
     val relevantFields = relevantStateOf(beanType).toList()
@@ -44,7 +44,7 @@ class BeanPropertyWriter(
     /**
      * Serializes a bean by serializing the value of each of its fields.
      */
-    suspend fun WriteContext.writeFieldsOf(bean: Any) {
+    override suspend fun WriteContext.writeStateOf(bean: Any) {
         writingProperties {
             for (field in relevantFields) {
                 val fieldName = field.name

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanStateReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanStateReader.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.beans
+
+import org.gradle.instantexecution.serialization.ReadContext
+
+
+interface BeanStateReader {
+    suspend fun ReadContext.newBean(): Any
+
+    suspend fun ReadContext.readStateOf(bean: Any)
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanStateWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanStateWriter.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.beans
+
+import org.gradle.instantexecution.serialization.WriteContext
+
+
+interface BeanStateWriter {
+    suspend fun WriteContext.writeStateOf(bean: Any)
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/SerializableReadReplaceReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/SerializableReadReplaceReader.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.beans
+
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.internal.reflect.ClassInspector
+
+
+class SerializableReadReplaceReader() : BeanStateReader {
+    override suspend fun ReadContext.newBean(): Any {
+        // Read the entire state of the placeholder. This means there cannot be a reference to this object in the state of the placeholder
+        val placeholder = read()!!
+        // TODO - this method lookup will need some kind of caching
+        val details = ClassInspector.inspect(placeholder.javaClass)
+        val method = details.allMethods.find { it.name == "readResolve" && it.parameters.isEmpty() }!!
+        method.isAccessible = true
+        return method.invoke(placeholder)
+    }
+
+    override suspend fun ReadContext.readStateOf(bean: Any) {
+        // Nothing to do
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/SerializableWriteReplaceWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/SerializableWriteReplaceWriter.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.beans
+
+import org.gradle.instantexecution.serialization.WriteContext
+import java.lang.reflect.Method
+
+
+class SerializableWriteReplaceWriter(private val writeReplaceMethod: Method) : BeanStateWriter {
+    init {
+        writeReplaceMethod.isAccessible = true
+    }
+
+    override suspend fun WriteContext.writeStateOf(bean: Any) {
+        write(writeReplaceMethod.invoke(bean))
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
@@ -22,9 +22,7 @@ import org.gradle.instantexecution.serialization.IsolateContext
 import org.gradle.instantexecution.serialization.PropertyTrace
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.instantexecution.serialization.readClass
 import org.gradle.instantexecution.serialization.withPropertyTrace
-import org.gradle.instantexecution.serialization.writeClass
 
 
 internal

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodec.kt
@@ -37,8 +37,8 @@ class BeanCodec : Codec<Any> {
             val beanType = GeneratedSubclasses.unpackType(value)
             writeClass(beanType)
             withBeanTrace(beanType) {
-                beanPropertyWriterFor(beanType).run {
-                    writeFieldsOf(value)
+                beanStateWriterFor(beanType).run {
+                    writeStateOf(value)
                 }
             }
         }
@@ -52,10 +52,10 @@ class BeanCodec : Codec<Any> {
         }
         val beanType = readClass()
         return withBeanTrace(beanType) {
-            beanPropertyReaderFor(beanType).run {
+            beanStateReaderFor(beanType).run {
                 val bean = newBean()
                 isolate.identities.putInstance(id, bean)
-                readFieldsOf(bean)
+                readStateOf(bean)
                 bean
             }
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClassCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClassCodec.kt
@@ -19,8 +19,6 @@ package org.gradle.instantexecution.serialization.codecs
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.instantexecution.serialization.readClass
-import org.gradle.instantexecution.serialization.writeClass
 
 
 internal

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -94,6 +94,7 @@ class Codecs(
         bind(ClassCodec)
         bind(MethodCodec)
 
+        // Only serialize certain List implementations
         bind(arrayListCodec)
         bind(linkedListCodec)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -94,7 +94,8 @@ class Codecs(
         bind(ClassCodec)
         bind(MethodCodec)
 
-        bind(listCodec)
+        bind(arrayListCodec)
+        bind(linkedListCodec)
 
         // Only serialize certain Set implementations for now, as some custom types extend Set (eg DomainObjectContainer)
         bind(linkedHashSetCodec)
@@ -147,9 +148,14 @@ class Codecs(
     private
     val encodings = HashMap<Class<*>, Encoding?>()
 
-    override fun WriteContext.encodingFor(candidate: Any?): Encoding? = when (candidate) {
+    override suspend fun WriteContext.encode(candidate: Any?) {
+        encodingFor(candidate)(candidate)
+    }
+
+    private
+    fun encodingFor(candidate: Any?): Encoding = when (candidate) {
         null -> nullEncoding
-        else -> encodings.computeIfAbsent(candidate.javaClass, ::computeEncoding)
+        else -> encodings.computeIfAbsent(candidate.javaClass, ::computeEncoding)!!
     }
 
     override suspend fun ReadContext.decode(): Any? = when (val tag = readByte()) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -97,11 +97,13 @@ class Codecs(
         // Only serialize certain List implementations
         bind(arrayListCodec)
         bind(linkedListCodec)
+        bind(ImmutableListCodec)
 
         // Only serialize certain Set implementations for now, as some custom types extend Set (eg DomainObjectContainer)
         bind(linkedHashSetCodec)
         bind(hashSetCodec)
         bind(treeSetCodec)
+        bind(ImmutableSetCodec)
 
         // Only serialize certain Map implementations for now, as some custom types extend Map (eg DefaultManifest)
         bind(linkedHashMapCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
@@ -20,28 +20,29 @@ import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.codec
 import org.gradle.instantexecution.serialization.readArray
 import org.gradle.instantexecution.serialization.readCollectionInto
-import org.gradle.instantexecution.serialization.readList
 import org.gradle.instantexecution.serialization.readMapInto
 import org.gradle.instantexecution.serialization.writeArray
 import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.instantexecution.serialization.writeMap
+import java.util.LinkedList
 import java.util.TreeMap
 import java.util.TreeSet
 
 
 internal
-val listCodec: Codec<List<*>> = codec(
-    { writeCollection(it) },
-    { readList() }
-)
+val arrayListCodec: Codec<ArrayList<Any?>> = collectionCodec { ArrayList<Any?>(it) }
 
 
 internal
-val hashSetCodec: Codec<HashSet<Any?>> = setCodec { HashSet<Any?>(it) }
+val linkedListCodec: Codec<LinkedList<Any?>> = collectionCodec { LinkedList<Any?>() }
 
 
 internal
-val linkedHashSetCodec: Codec<LinkedHashSet<Any?>> = setCodec { LinkedHashSet<Any?>(it) }
+val hashSetCodec: Codec<HashSet<Any?>> = collectionCodec { HashSet<Any?>(it) }
+
+
+internal
+val linkedHashSetCodec: Codec<LinkedHashSet<Any?>> = collectionCodec { LinkedHashSet<Any?>(it) }
 
 
 internal
@@ -58,7 +59,7 @@ val treeSetCodec: Codec<TreeSet<Any?>> = codec(
 
 
 internal
-fun <T : MutableSet<Any?>> setCodec(factory: (Int) -> T) = codec(
+fun <T : MutableCollection<Any?>> collectionCodec(factory: (Int) -> T) = codec(
     { writeCollection(it) },
     { readCollectionInto(factory) }
 )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ImmutableListCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ImmutableListCodec.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import com.google.common.collect.ImmutableList
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.writeCollection
+
+
+object ImmutableListCodec : Codec<ImmutableList<Any>> {
+
+    override suspend fun WriteContext.encode(value: ImmutableList<Any>) {
+        writeCollection(value)
+    }
+
+    override suspend fun ReadContext.decode(): ImmutableList<Any>? {
+        val size = readSmallInt()
+        val builder = ImmutableList.builderWithExpectedSize<Any>(size)
+        for (i in 0 until size) {
+            val value = read()!!
+            builder.add(value)
+        }
+        return builder.build()
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ImmutableSetCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ImmutableSetCodec.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import com.google.common.collect.ImmutableSet
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.writeCollection
+
+
+object ImmutableSetCodec : Codec<ImmutableSet<Any>> {
+
+    override suspend fun WriteContext.encode(value: ImmutableSet<Any>) {
+        writeCollection(value)
+    }
+
+    override suspend fun ReadContext.decode(): ImmutableSet<Any>? {
+        val size = readSmallInt()
+        val builder = ImmutableSet.builderWithExpectedSize<Any>(size)
+        for (i in 0 until size) {
+            val value = read()!!
+            builder.add(value)
+        }
+        return builder.build()
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ListenerBroadcastCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ListenerBroadcastCodec.kt
@@ -19,8 +19,6 @@ package org.gradle.instantexecution.serialization.codecs
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.instantexecution.serialization.readClass
-import org.gradle.instantexecution.serialization.writeClass
 import org.gradle.internal.event.AnonymousListenerBroadcast
 import org.gradle.internal.event.ListenerManager
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/MethodCodec.kt
@@ -19,9 +19,7 @@ package org.gradle.instantexecution.serialization.codecs
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.instantexecution.serialization.readClass
 import org.gradle.instantexecution.serialization.readClassArray
-import org.gradle.instantexecution.serialization.writeClass
 import org.gradle.instantexecution.serialization.writeClassArray
 import java.lang.reflect.Method
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -101,9 +101,9 @@ class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
         writeStrings(dependencies.map { it.path })
 
         withTaskOf(taskType, task) {
-            beanPropertyWriterFor(taskType).run {
-                writeFieldsOf(task)
-                writeRegisteredPropertiesOf(task, this)
+            beanStateWriterFor(taskType).run {
+                writeStateOf(task)
+                writeRegisteredPropertiesOf(task, this as BeanPropertyWriter)
             }
         }
     }
@@ -118,8 +118,8 @@ class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
         val task = createTask(projectPath, taskName, taskType)
 
         withTaskOf(taskType, task) {
-            beanPropertyReaderFor(taskType).run {
-                readFieldsOf(task)
+            beanStateReaderFor(taskType).run {
+                readStateOf(task)
                 readRegisteredPropertiesOf(task)
             }
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -45,13 +45,11 @@ import org.gradle.instantexecution.serialization.beans.BeanPropertyWriter
 import org.gradle.instantexecution.serialization.beans.readEachProperty
 import org.gradle.instantexecution.serialization.beans.writeNextProperty
 import org.gradle.instantexecution.serialization.beans.writingProperties
-import org.gradle.instantexecution.serialization.readClass
 import org.gradle.instantexecution.serialization.readCollectionInto
 import org.gradle.instantexecution.serialization.readEnum
 import org.gradle.instantexecution.serialization.readStrings
 import org.gradle.instantexecution.serialization.withIsolate
 import org.gradle.instantexecution.serialization.withPropertyTrace
-import org.gradle.instantexecution.serialization.writeClass
 import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.instantexecution.serialization.writeEnum
 import org.gradle.instantexecution.serialization.writeStrings


### PR DESCRIPTION

### Context

This PR makes some changes to the instant execution cache serialization to allow a plugin to use the Guava immutable collections. 

The serialization honors the `writeReplace()` method for `Serializable` types, to allow a type some control over how it is serialized, and as a work around to allow the Guava types to be serialized without support for serializing multiple classes with the same name.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
