### PR TITLE
Let instant execution serialize generated task properties

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -626,6 +626,32 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         DefaultConfigurationContainer.name | ConfigurationContainer.name | "project.configurations"
     }
 
+    def "restores task abstract properties"() {
+        buildFile << """
+
+            abstract class SomeTask extends DefaultTask {
+
+                abstract Property<String> getValue()
+
+                @TaskAction
+                void run() {
+                    println "this.value = " + value.getOrNull()
+                }
+            }
+
+            task ok(type: SomeTask) {
+                value = "42"
+            }
+        """
+
+        when:
+        instantRun "ok"
+        instantRun "ok"
+
+        then:
+        outputContains("this.value = 42")
+    }
+
     def "task can reference itself"() {
         buildFile << """
             class SomeBean {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
@@ -204,6 +204,12 @@ suspend fun <T : MutableCollection<Any?>> ReadContext.readCollectionInto(factory
 internal
 suspend fun WriteContext.writeMap(value: Map<*, *>) {
     writeSmallInt(value.size)
+    writeMapEntries(value)
+}
+
+
+internal
+suspend fun WriteContext.writeMapEntries(value: Map<*, *>) {
     for (entry in value.entries) {
         write(entry.key)
         write(entry.value)
@@ -215,12 +221,18 @@ internal
 suspend fun <T : MutableMap<Any?, Any?>> ReadContext.readMapInto(factory: (Int) -> T): T {
     val size = readSmallInt()
     val items = factory(size)
+    readMapEntriesInto(items, size)
+    return items
+}
+
+
+internal
+suspend fun <K, V, T : MutableMap<K, V>> ReadContext.readMapEntriesInto(items: T, size: Int) {
     for (i in 0 until size) {
-        val key = read()
-        val value = read()
+        val key = read() as K
+        val value = read() as V
         items[key] = value
     }
-    return items
 }
 
 
@@ -277,7 +289,7 @@ inline fun <T> Encoder.writeCollection(collection: Collection<T>, writeElement: 
 
 
 internal
-fun Decoder.readCollection(readElement: () -> Unit) {
+inline fun Decoder.readCollection(readElement: () -> Unit) {
     val size = readSmallInt()
     for (i in 0 until size) {
         readElement()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
@@ -69,6 +69,7 @@ val Class<*>.relevantFields: Sequence<Field>
     get() = declaredFields.asSequence()
         .filterNot { field ->
             Modifier.isStatic(field.modifiers)
+                || Modifier.isTransient(field.modifiers)
                 // Ignore the `metaClass` field that Groovy generates
                 || (field.name == "metaClass" && MetaClass::class.java.isAssignableFrom(field.type))
                 // Ignore the `__meta_class__` field that Gradle generates

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -100,12 +100,14 @@ class Codecs(
         bind(ImmutableListCodec)
 
         // Only serialize certain Set implementations for now, as some custom types extend Set (eg DomainObjectContainer)
+        bind(EnumSetCodec)
         bind(linkedHashSetCodec)
         bind(hashSetCodec)
         bind(treeSetCodec)
         bind(ImmutableSetCodec)
 
         // Only serialize certain Map implementations for now, as some custom types extend Map (eg DefaultManifest)
+        bind(EnumMapCodec)
         bind(linkedHashMapCodec)
         bind(hashMapCodec)
         bind(treeMapCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/EnumMapCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/EnumMapCodec.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.instantexecution.extensions.uncheckedCast
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.readCollection
+import org.gradle.instantexecution.serialization.readMapEntriesInto
+import org.gradle.instantexecution.serialization.writeCollection
+import org.gradle.instantexecution.serialization.writeMapEntries
+
+import java.util.EnumMap
+import java.util.EnumSet
+
+
+object EnumMapCodec : Codec<EnumMap<*, Any?>> {
+
+    override suspend fun WriteContext.encode(value: EnumMap<*, Any?>) {
+        writeClass(keyTypeOf(value))
+        writeSmallInt(value.size)
+        writeMapEntries(value)
+    }
+
+    override suspend fun ReadContext.decode(): EnumMap<*, Any?>? {
+        @Suppress("unchecked_cast")
+        val keyType = readClass() as Class<EnumType>
+        val size = readSmallInt()
+        val map: MutableMap<EnumType, Any?> = EnumMap(keyType)
+        readMapEntriesInto(map, size)
+        return map as EnumMap<*, Any?>
+    }
+
+    private
+    fun keyTypeOf(value: EnumMap<*, Any?>) =
+        keyTypeField.get(value) as Class<*>
+
+    private
+    val keyTypeField by lazy {
+        EnumMap::class.java.getDeclaredField("keyType").apply { isAccessible = true }
+    }
+}
+
+
+object EnumSetCodec : Codec<EnumSet<*>> {
+
+    override suspend fun WriteContext.encode(value: EnumSet<*>) {
+        writeClass(elementTypeOf(value))
+        writeCollection(value)
+    }
+
+    override suspend fun ReadContext.decode(): EnumSet<*>? {
+        @Suppress("unchecked_cast")
+        val elementType = readClass() as Class<EnumType>
+        val set = EnumSet.noneOf(elementType)
+        readCollection {
+            set.add(read()!!.uncheckedCast())
+        }
+        return set
+    }
+
+    private
+    fun elementTypeOf(value: EnumSet<*>) =
+        elementTypeField.get(value) as Class<*>
+
+    private
+    val elementTypeField by lazy {
+        EnumSet::class.java.getDeclaredField("elementType").apply { isAccessible = true }
+    }
+}
+
+
+/**
+ * Fools the Kotlin type-system into believing we have an [Enum] subtype above.
+ */
+private
+enum class EnumType

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskGraphCodec.kt
@@ -101,7 +101,7 @@ class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
         writeStrings(dependencies.map { it.path })
 
         withTaskOf(taskType, task) {
-            beanStateWriterFor(taskType).run {
+            beanStateWriterFor(task.javaClass).run {
                 writeStateOf(task)
                 writeRegisteredPropertiesOf(task, this as BeanPropertyWriter)
             }
@@ -118,7 +118,7 @@ class TaskGraphCodec(private val projectStateRegistry: ProjectStateRegistry) {
         val task = createTask(projectPath, taskName, taskType)
 
         withTaskOf(taskType, task) {
-            beanStateReaderFor(taskType).run {
+            beanStateReaderFor(task.javaClass).run {
                 readStateOf(task)
                 readRegisteredPropertiesOf(task)
             }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
@@ -91,6 +91,7 @@ import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
+import static org.objectweb.asm.Opcodes.ACC_TRANSIENT;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ARETURN;
 import static org.objectweb.asm.Opcodes.DUP;
@@ -547,7 +548,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             }
 
             // GENERATE private DynamicObject dynamicObjectHelper
-            visitor.visitField(Opcodes.ACC_PRIVATE, DYNAMIC_OBJECT_HELPER_FIELD, ABSTRACT_DYNAMIC_OBJECT_TYPE.getDescriptor(), null, null);
+            visitor.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_TRANSIENT, DYNAMIC_OBJECT_HELPER_FIELD, ABSTRACT_DYNAMIC_OBJECT_TYPE.getDescriptor(), null, null);
 
             // END
 
@@ -637,7 +638,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         public void mixInConventionAware() {
             // GENERATE private ConventionMapping mapping
 
-            visitor.visitField(Opcodes.ACC_PRIVATE, MAPPING_FIELD, CONVENTION_MAPPING_FIELD_DESCRIPTOR, null, null);
+            visitor.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_TRANSIENT, MAPPING_FIELD, CONVENTION_MAPPING_FIELD_DESCRIPTOR, null, null);
             hasMappingField = true;
 
             // END
@@ -684,7 +685,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
             // GENERATE private MetaClass metaClass = GroovySystem.getMetaClassRegistry().getMetaClass(getClass())
 
-            visitor.visitField(Opcodes.ACC_PRIVATE, META_CLASS_FIELD, META_CLASS_TYPE_DESCRIPTOR, null, null);
+            visitor.visitField(Opcodes.ACC_PRIVATE | ACC_TRANSIENT, META_CLASS_FIELD, META_CLASS_TYPE_DESCRIPTOR, null, null);
 
             // GENERATE public MetaClass getMetaClass() {
             //     if (metaClass == null) {
@@ -902,7 +903,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         public void applyServiceInjectionToProperty(PropertyMetadata property) {
             // GENERATE private <type> <property-field-name>;
             String fieldName = propFieldName(property);
-            visitor.visitField(Opcodes.ACC_PRIVATE, fieldName, Type.getDescriptor(property.getType()), null, null);
+            visitor.visitField(Opcodes.ACC_PRIVATE | ACC_TRANSIENT, fieldName, Type.getDescriptor(property.getType()), null, null);
         }
 
         private void generateServicesField() {
@@ -910,7 +911,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         }
 
         private void generateGetServices() {
-            MethodVisitor mv = visitor.visitMethod(ACC_PRIVATE | ACC_SYNTHETIC, SERVICES_METHOD, RETURN_SERVICE_LOOKUP, null, null);
+            MethodVisitor mv = visitor.visitMethod(ACC_PRIVATE | ACC_SYNTHETIC | ACC_TRANSIENT, SERVICES_METHOD, RETURN_SERVICE_LOOKUP, null, null);
             mv.visitCode();
             // GENERATE if (services != null) { return services; } else { return AsmBackedClassGenerator.getServicesForNext(); }
             mv.visitVarInsn(ALOAD, 0);
@@ -1228,7 +1229,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
             // GENERATE private boolean <flag-name>;
             String flagName = propFieldName(property);
-            visitor.visitField(Opcodes.ACC_PRIVATE, flagName, Type.BOOLEAN_TYPE.getDescriptor(), null, null);
+            visitor.visitField(Opcodes.ACC_PRIVATE | ACC_TRANSIENT, flagName, Type.BOOLEAN_TYPE.getDescriptor(), null, null);
         }
 
         private String propFieldName(PropertyMetadata property) {
@@ -1471,7 +1472,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         }
 
         private void generateInstantiatorField() {
-            visitor.visitField(ACC_PRIVATE | ACC_SYNTHETIC, INSTANTIATOR_FIELD, INSTANTIATOR_TYPE.getDescriptor(), null, null);
+            visitor.visitField(ACC_PRIVATE | ACC_SYNTHETIC | ACC_TRANSIENT, INSTANTIATOR_FIELD, INSTANTIATOR_TYPE.getDescriptor(), null, null);
         }
 
         private void generateGetInstantiator() {


### PR DESCRIPTION
By using the generated task class schema instead of the unwrapped task class one.

Fixes #10001