### PR TITLE
Allow package declarations in Kotlin DSL scripts

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -863,4 +863,22 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
             equalTo("default-value")
         )
     }
+
+    @Test
+    fun `can apply script plugin with package name`() {
+
+        withFile("gradle/script.gradle.kts", """
+            package gradle
+            task("ok") { doLast { println("ok!") } }
+        """)
+
+        withBuildScript("""
+            apply(from = "gradle/script.gradle.kts")
+        """)
+
+        assertThat(
+            build("-q", "ok").output.trim(),
+            equalTo("ok!")
+        )
+    }
 }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ExtractPrecompiledScriptPluginPlugins.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ExtractPrecompiledScriptPluginPlugins.kt
@@ -104,7 +104,7 @@ fun parse(scriptPlugin: PrecompiledScriptPlugin): Program = ProgramParser.parse(
     ProgramSource(scriptPlugin.scriptFileName, scriptPlugin.scriptText),
     ProgramKind.TopLevel,
     ProgramTarget.Project
-)
+).document
 
 
 private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -281,8 +281,9 @@ class Interpreter(val host: Host) {
                     val program =
                         ProgramParser.parse(programSource, programKind, programTarget)
 
-                    val residualProgram =
+                    val residualProgram = program.map { program ->
                         PartialEvaluator(programKind, programTarget).reduce(program)
+                    }
 
                     scriptSource.withLocationAwareExceptionHandling {
                         ResidualProgramCompiler(
@@ -294,8 +295,9 @@ class Interpreter(val host: Host) {
                             implicitImports = host.implicitImports,
                             logger = interpreterLogger,
                             compileBuildOperationRunner = host::runCompileBuildOperation,
-                            pluginAccessorsClassPath = pluginAccessorsClassPath ?: ClassPath.EMPTY
-                        ).compile(residualProgram)
+                            pluginAccessorsClassPath = pluginAccessorsClassPath ?: ClassPath.EMPTY,
+                            packageName = residualProgram.packageName
+                        ).compile(residualProgram.document)
                     }
                 }
             }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Lexer.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Lexer.kt
@@ -17,9 +17,11 @@
 package org.gradle.kotlin.dsl.execution
 
 import org.jetbrains.kotlin.lexer.KotlinLexer
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.lexer.KtTokens.COMMENTS
 import org.jetbrains.kotlin.lexer.KtTokens.IDENTIFIER
 import org.jetbrains.kotlin.lexer.KtTokens.LBRACE
+import org.jetbrains.kotlin.lexer.KtTokens.PACKAGE_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.RBRACE
 import org.jetbrains.kotlin.lexer.KtTokens.WHITE_SPACE
 
@@ -36,14 +38,33 @@ enum class State {
 }
 
 
+data class Packaged<T>(
+    val packageName: String?,
+    val document: T
+) {
+    fun <U> map(transform: (T) -> U): Packaged<U> = Packaged(
+        packageName,
+        document = transform(document)
+    )
+}
+
+
+internal
+data class LexedScript(
+    val comments: List<IntRange>,
+    val topLevelBlocks: List<TopLevelBlock>
+)
+
+
 /**
- * Returns the comments and [top-level blocks][topLevelBlocks] found in the given [script].
+ * Returns the comments and [top-level blocks][topLevelBlockIds] found in the given [script].
  */
 internal
-fun lex(script: String, vararg topLevelBlocks: String): Pair<List<IntRange>, List<TopLevelBlock>> {
+fun lex(script: String, vararg topLevelBlockIds: String): Packaged<LexedScript> {
 
+    var packageName: String? = null
     val comments = mutableListOf<IntRange>()
-    val tokens = mutableListOf<TopLevelBlock>()
+    val topLevelBlocks = mutableListOf<TopLevelBlock>()
 
     var state = State.SearchingTopLevelBlock
     var inTopLevelBlock: String? = null
@@ -62,7 +83,7 @@ fun lex(script: String, vararg topLevelBlocks: String): Pair<List<IntRange>, Lis
     fun KotlinLexer.matchTopLevelIdentifier(): Boolean {
         if (depth == 0) {
             val identifier = tokenText
-            for (topLevelBlock in topLevelBlocks) {
+            for (topLevelBlock in topLevelBlockIds) {
                 if (topLevelBlock == identifier) {
                     state = State.SearchingBlockStart
                     inTopLevelBlock = topLevelBlock
@@ -97,6 +118,11 @@ fun lex(script: String, vararg topLevelBlocks: String): Pair<List<IntRange>, Lis
                         State.SearchingTopLevelBlock -> {
 
                             when (tokenType) {
+                                PACKAGE_KEYWORD -> {
+                                    advance()
+                                    skipWhiteSpaceAndComments()
+                                    packageName = parseQualifiedName()
+                                }
                                 IDENTIFIER -> matchTopLevelIdentifier()
                                 LBRACE -> depth += 1
                                 RBRACE -> depth -= 1
@@ -123,7 +149,7 @@ fun lex(script: String, vararg topLevelBlocks: String): Pair<List<IntRange>, Lis
                                 RBRACE -> {
                                     depth -= 1
                                     if (depth == 0) {
-                                        tokens.add(
+                                        topLevelBlocks.add(
                                             topLevelBlock(
                                                 inTopLevelBlock!!,
                                                 blockIdentifier!!,
@@ -142,7 +168,29 @@ fun lex(script: String, vararg topLevelBlocks: String): Pair<List<IntRange>, Lis
             advance()
         }
     }
-    return comments to tokens
+    return Packaged(
+        packageName,
+        LexedScript(comments, topLevelBlocks)
+    )
+}
+
+
+private
+fun KotlinLexer.parseQualifiedName(): String =
+    StringBuilder().run {
+        while (tokenType == KtTokens.IDENTIFIER || tokenType == KtTokens.DOT) {
+            append(tokenText)
+            advance()
+        }
+        toString()
+    }
+
+
+private
+fun KotlinLexer.skipWhiteSpaceAndComments() {
+    while (tokenType in KtTokens.WHITE_SPACE_OR_COMMENT_BIT_SET) {
+        advance()
+    }
 }
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramParser.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramParser.kt
@@ -24,73 +24,74 @@ import com.google.common.annotations.VisibleForTesting
 @VisibleForTesting
 object ProgramParser {
 
-    fun parse(source: ProgramSource, kind: ProgramKind, target: ProgramTarget): Program = try {
+    fun parse(source: ProgramSource, kind: ProgramKind, target: ProgramTarget): Packaged<Program> = try {
         programFor(source, kind, target)
     } catch (unexpectedBlock: UnexpectedBlock) {
         handleUnexpectedBlock(unexpectedBlock, source.text, source.path)
     }
 
     private
-    fun programFor(source: ProgramSource, kind: ProgramKind, target: ProgramTarget): Program {
+    fun programFor(source: ProgramSource, kind: ProgramKind, target: ProgramTarget): Packaged<Program> {
 
-        val topLevelBlockIds =
-            when (target) {
-                ProgramTarget.Project -> arrayOf("buildscript", "plugins")
-                ProgramTarget.Settings -> arrayOf("buildscript", "pluginManagement")
-                ProgramTarget.Gradle -> arrayOf("initscript")
-            }
+        val topLevelBlockIds = topLevelBlockIdsFor(target)
 
-        val (comments, topLevelBlocks) = lex(source.text, *topLevelBlockIds)
+        return lex(source.text, *topLevelBlockIds).map { (comments, topLevelBlocks) ->
 
-        checkForSingleBlocksOf(topLevelBlockIds, topLevelBlocks)
+            checkForSingleBlocksOf(topLevelBlockIds, topLevelBlocks)
 
-        val sourceWithoutComments =
-            source.map { it.erase(comments) }
+            val sourceWithoutComments =
+                source.map { it.erase(comments) }
 
-        val buildscriptFragment =
-            topLevelBlocks
-                .singleSectionOf(topLevelBlockIds[0])
-                ?.let { sourceWithoutComments.fragment(it) }
+            val buildscriptFragment =
+                topLevelBlocks
+                    .singleSectionOf(topLevelBlockIds[0])
+                    ?.let { sourceWithoutComments.fragment(it) }
 
-        val pluginsFragment =
-            topLevelBlocks
-                .takeIf { target == ProgramTarget.Project && kind == ProgramKind.TopLevel }
-                ?.singleSectionOf("plugins")
-                ?.let { sourceWithoutComments.fragment(it) }
+            val pluginsFragment =
+                topLevelBlocks
+                    .takeIf { target == ProgramTarget.Project && kind == ProgramKind.TopLevel }
+                    ?.singleSectionOf("plugins")
+                    ?.let { sourceWithoutComments.fragment(it) }
 
-        val buildscript =
-            buildscriptFragment?.takeIf { it.isNotBlank() }?.let(Program::Buildscript)
+            val buildscript =
+                buildscriptFragment?.takeIf { it.isNotBlank() }?.let(Program::Buildscript)
 
-        val plugins =
-            pluginsFragment?.takeIf { it.isNotBlank() }?.let(Program::Plugins)
+            val plugins =
+                pluginsFragment?.takeIf { it.isNotBlank() }?.let(Program::Plugins)
 
-        val stage1 =
-            buildscript?.let { bs ->
-                plugins?.let { ps ->
-                    Program.Stage1Sequence(bs, ps)
-                } ?: bs
-            } ?: plugins
+            val stage1 =
+                buildscript?.let { bs ->
+                    plugins?.let { ps ->
+                        Program.Stage1Sequence(bs, ps)
+                    } ?: bs
+                } ?: plugins
 
-        val remainingSource =
-            sourceWithoutComments.map {
-                it.erase(
-                    listOfNotNull(
-                        buildscriptFragment?.range,
-                        pluginsFragment?.range))
-            }
+            val remainingSource =
+                sourceWithoutComments.map {
+                    it.erase(
+                        listOfNotNull(
+                            buildscriptFragment?.range,
+                            pluginsFragment?.range))
+                }
 
-        val stage2 = remainingSource
-            .takeIf { it.text.isNotBlank() }
-            ?.let(Program::Script)
+            val stage2 = remainingSource
+                .takeIf { it.text.isNotBlank() }
+                ?.let(Program::Script)
 
-        stage1?.let { s1 ->
-            return stage2?.let { s2 ->
-                Program.Staged(s1, s2)
-            } ?: s1
-        }
-
-        return stage2
+            stage1?.let { s1 ->
+                stage2?.let { s2 ->
+                    Program.Staged(s1, s2)
+                } ?: s1
+            } ?: stage2
             ?: Program.Empty
+        }
+    }
+
+    private
+    fun topLevelBlockIdsFor(target: ProgramTarget): Array<String> = when (target) {
+        ProgramTarget.Project -> arrayOf("buildscript", "plugins")
+        ProgramTarget.Settings -> arrayOf("buildscript", "pluginManagement")
+        ProgramTarget.Gradle -> arrayOf("initscript")
     }
 
     private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -103,7 +103,8 @@ class ResidualProgramCompiler(
     private val implicitImports: List<String> = emptyList(),
     private val logger: Logger = interpreterLogger,
     private val compileBuildOperationRunner: CompileBuildOperationRunner = { _, _, action -> action() },
-    private val pluginAccessorsClassPath: ClassPath = ClassPath.EMPTY
+    private val pluginAccessorsClassPath: ClassPath = ClassPath.EMPTY,
+    private val packageName: String? = null
 ) {
 
     fun compile(program: ResidualProgram) = when (program) {
@@ -608,7 +609,7 @@ class ResidualProgramCompiler(
         scriptDefinition: KotlinScriptDefinition,
         stage: String,
         compileClassPath: ClassPath = classPath
-    ) = InternalName(
+    ) = InternalName.from(
         compileBuildOperationRunner(originalPath, stage) {
             compileKotlinScriptToDirectory(
                 outputDir,
@@ -620,6 +621,10 @@ class ResidualProgramCompiler(
                     else path
                 }
             )
+        }.let { compiledScriptClassName ->
+            packageName
+                ?.let { "$it.$compiledScriptClassName" }
+                ?: compiledScriptClassName
         }
     )
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/BuildscriptBlockExtractionTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/BuildscriptBlockExtractionTest.kt
@@ -112,5 +112,5 @@ class BuildscriptBlockExtractionTest {
 
     private
     fun extractBuildscriptBlockFrom(script: String) =
-        lex(script, "buildscript").second.singleBlockSectionOrNull()?.wholeRange
+        lex(script, "buildscript").document.topLevelBlocks.singleBlockSectionOrNull()?.wholeRange
 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/LexerTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/LexerTest.kt
@@ -27,8 +27,7 @@ class LexerTest {
     @Test
     fun `extracts comments and top-level blocks`() {
 
-        val (comments, topLevelBlocks) =
-
+        assertThat(
             lex(
                 "/* ... */" +
                     "\n// ..." +
@@ -39,23 +38,31 @@ class LexerTest {
                     "\n ... */" +
                     "\n}" +
                     "\n// ...",
-                "buildscript", "plugins")
-
-        assertThat(
-            comments,
+                "buildscript", "plugins"),
             equalTo(
-                listOf(
-                    0..8,
-                    10..15,
-                    31..40,
-                    54..63,
-                    67..72)))
+                Packaged(
+                    null,
+                    LexedScript(
+                        listOf(
+                            0..8,
+                            10..15,
+                            31..40,
+                            54..63,
+                            67..72),
+                        listOf(
+                            topLevelBlock("buildscript", 17..27, 29..42),
+                            topLevelBlock("plugins", 44..50, 52..65))))))
+    }
 
+    @Test
+    fun `extracts package name`() {
         assertThat(
-            topLevelBlocks,
+            lex("\n/* ... */\npackage com.example\nplugins { }", "plugins"),
             equalTo(
-                listOf(
-                    topLevelBlock("buildscript", 17..27, 29..42),
-                    topLevelBlock("plugins", 44..50, 52..65))))
+                Packaged(
+                    "com.example",
+                    LexedScript(
+                        listOf(1..9),
+                        listOf(topLevelBlock("plugins", 31..37, 39..41))))))
     }
 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ProgramParserTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ProgramParserTest.kt
@@ -195,7 +195,7 @@ class ProgramParserTest {
         programTarget: ProgramTarget = ProgramTarget.Project
     ) {
         val program = ProgramParser.parse(source, programKind, programTarget)
-        assertThat(program, equalTo(expected))
+        assertThat(program.document, equalTo(expected))
     }
 
     private

--- a/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -286,7 +286,7 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
 private
 fun hasBody(script: String) =
-    ProgramParser.parse(ProgramSource("script.gradle.kts", script), TopLevel, ProgramTarget.Project).let {
+    ProgramParser.parse(ProgramSource("script.gradle.kts", script), TopLevel, ProgramTarget.Project).document.let {
         it is Program.Script || it is Program.Staged
     }
 


### PR DESCRIPTION
In order to make it possible to `apply(from = "...")` a script that plays the dual role of local script and precompiled script plugin.

Multi-stage scripts are not supported, more specifically, a script with a `plugins` block or `buildscript` block will throw `NoClassDefFoundError` at runtime.