### PR TITLE
Initial changes to expose the presence of artifact transforms to instant execution serialization

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/CalculatedTaskInputFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/CalculatedTaskInputFileCollection.java
@@ -17,9 +17,7 @@
 package org.gradle.api.internal.file;
 
 import org.gradle.api.internal.file.collections.MinimalFileSet;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.properties.LifecycleAwareValue;
-import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -36,7 +34,7 @@ public class CalculatedTaskInputFileCollection extends AbstractFileCollection im
     public CalculatedTaskInputFileCollection(String taskPath, MinimalFileSet calculatedFiles, Object[] inputs) {
         this.taskPath = taskPath;
         this.calculatedFiles = calculatedFiles;
-        targets = new ArrayList<LifecycleAwareValue>(1 + inputs.length);
+        targets = new ArrayList<>(1 + inputs.length);
         for (Object input : inputs) {
             if (input instanceof LifecycleAwareValue) {
                 targets.add((LifecycleAwareValue) input);
@@ -50,11 +48,6 @@ public class CalculatedTaskInputFileCollection extends AbstractFileCollection im
     @Override
     public String getDisplayName() {
         return calculatedFiles.getDisplayName();
-    }
-
-    @Override
-    public TaskDependency getBuildDependencies() {
-        return TaskDependencyInternal.EMPTY;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -18,14 +18,13 @@ package org.gradle.api.internal.file;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.Buildable;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
 import org.gradle.api.internal.file.collections.FileCollectionAdapter;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.file.collections.UnpackingVisitor;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.file.PathToFileResolver;
@@ -66,13 +65,11 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public FileCollectionInternal create(final TaskDependency builtBy, MinimalFileSet contents) {
-        if (contents instanceof Buildable) {
-            throw new UnsupportedOperationException("Not implemented yet.");
-        }
         return new FileCollectionAdapter(contents) {
             @Override
-            public TaskDependency getBuildDependencies() {
-                return builtBy;
+            public void visitDependencies(TaskDependencyResolveContext context) {
+                super.visitDependencies(context);
+                context.add(builtBy);
             }
         };
     }
@@ -158,11 +155,6 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         }
 
         @Override
-        public TaskDependency getBuildDependencies() {
-            return TaskDependencyInternal.EMPTY;
-        }
-
-        @Override
         public Set<File> getFiles() {
             return ImmutableSet.of();
         }
@@ -189,11 +181,6 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         @Override
         public Set<File> getFiles() {
             return files;
-        }
-
-        @Override
-        public TaskDependency getBuildDependencies() {
-            return TaskDependencyInternal.EMPTY;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -83,21 +83,24 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
     }
 
     @Override
-    public FileCollectionInternal resolving(String displayName, List<?> files) {
-        if (files.isEmpty()) {
+    public FileCollectionInternal resolving(String displayName, List<?> sources) {
+        if (sources.isEmpty()) {
             return new EmptyFileCollection(displayName);
         }
-        return new ResolvingFileCollection(displayName, fileResolver, ImmutableList.copyOf(files));
+        return new ResolvingFileCollection(displayName, fileResolver, ImmutableList.copyOf(sources));
     }
 
     @Override
-    public FileCollectionInternal resolving(Object... files) {
-        return resolving(DEFAULT_DISPLAY_NAME, files);
+    public FileCollectionInternal resolving(String displayName, Object... sources) {
+        return resolving(displayName, ImmutableList.copyOf(sources));
     }
 
     @Override
-    public FileCollectionInternal resolving(String displayName, Object... files) {
-        return resolving(displayName, ImmutableList.copyOf(files));
+    public FileCollectionInternal resolving(Object... sources) {
+        if (sources.length == 1 && sources[0] instanceof FileCollectionInternal) {
+            return (FileCollectionInternal) sources[0];
+        }
+        return resolving(DEFAULT_DISPLAY_NAME, sources);
     }
 
     @Override
@@ -112,11 +115,14 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public FileCollectionInternal fixed(File... files) {
+        if (files.length == 0) {
+            return empty();
+        }
         return fixed(DEFAULT_DISPLAY_NAME, files);
     }
 
     @Override
-    public FileCollectionInternal fixed(final String displayName, File... files) {
+    public FileCollectionInternal fixed(String displayName, File... files) {
         if (files.length == 0) {
             return new EmptyFileCollection(displayName);
         }
@@ -125,6 +131,9 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public FileCollectionInternal fixed(Collection<File> files) {
+        if (files.isEmpty()) {
+            return empty();
+        }
         return fixed(DEFAULT_DISPLAY_NAME, files);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
@@ -23,10 +23,8 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
-import org.gradle.api.internal.file.DefaultFileVisitDetails;
 import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.internal.file.collections.ArchiveFileTree;
-import org.gradle.api.internal.file.collections.DefaultSingletonFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
@@ -159,32 +157,6 @@ public class TarFileTree implements MinimalFileTree, ArchiveFileTree {
         File backingFile = getBackingFile();
         if (backingFile != null) {
             builder.add(backingFile);
-        }
-    }
-
-    @Override
-    public void visitTreeOrBackingFile(final FileVisitor visitor) {
-        File backingFile = getBackingFile();
-        if (backingFile != null) {
-            new DefaultSingletonFileTree(backingFile).visit(visitor);
-        } else {
-            // We need to wrap the visitor so that the file seen by the visitor has already
-            // been extracted from the archive and we do not try to extract it again.
-            // It's unsafe to keep the FileVisitDetails provided by TarFileTree directly
-            // because we do not expect to visit the same paths again (after extracting everything).
-            visit(new FileVisitor() {
-                private final AtomicBoolean stopFlag = new AtomicBoolean();
-
-                @Override
-                public void visitDir(FileVisitDetails dirDetails) {
-                    visitor.visitDir(new DefaultFileVisitDetails(dirDetails.getFile(), dirDetails.getRelativePath(), stopFlag, chmod, stat));
-                }
-
-                @Override
-                public void visitFile(FileVisitDetails fileDetails) {
-                    visitor.visitFile(new DefaultFileVisitDetails(fileDetails.getFile(), fileDetails.getRelativePath(), stopFlag, chmod, stat));
-                }
-            });
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
@@ -26,7 +26,6 @@ import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
 import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.internal.file.collections.ArchiveFileTree;
-import org.gradle.api.internal.file.collections.DefaultSingletonFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
@@ -203,15 +202,5 @@ public class ZipFileTree implements MinimalFileTree, ArchiveFileTree {
     @Override
     public void registerWatchPoints(FileSystemSubset.Builder builder) {
         builder.add(zipFile);
-    }
-
-    @Override
-    public void visitTreeOrBackingFile(FileVisitor visitor) {
-        File backingFile = getBackingFile();
-        if (backingFile!=null) {
-            new DefaultSingletonFileTree(backingFile).visit(visitor);
-        } else {
-            visit(visitor);
-        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -146,7 +146,7 @@ public class FileParameterUtils {
                 }
 
                 @Override
-                public void visitFileTree(File root, PatternSet patterns) {
+                public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
                     // We could support an unfiltered DirectoryFileTree here as a cacheable root,
                     // but because @OutputDirectory also doesn't support it we choose not to.
                     nonFileRoot.set(true);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -146,6 +146,11 @@ public class FileParameterUtils {
                 }
 
                 @Override
+                public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree) {
+                    nonFileRoot.set(true);
+                }
+
+                @Override
                 public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
                     // We could support an unfiltered DirectoryFileTree here as a cacheable root,
                     // but because @OutputDirectory also doesn't support it we choose not to.

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -72,6 +72,11 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
             roots.add(fileSystemSnapshotter.snapshotDirectoryTree(root, new PatternSetSnapshottingFilter(patterns, stat)));
         }
 
+        @Override
+        public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree) {
+            roots.add(fileSystemSnapshotter.snapshot(file));
+        }
+
         public List<FileSystemSnapshot> getRoots() {
             return roots;
         }
@@ -79,7 +84,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
 
     private FileSystemSnapshot snapshotFileTree(final FileTreeInternal tree) {
         final FileSystemSnapshotBuilder builder = fileSystemSnapshotter.newFileSystemSnapshotBuilder();
-        tree.visitTreeOrBackingFile(new FileVisitor() {
+        tree.visit(new FileVisitor() {
             @Override
             public void visitDir(FileVisitDetails dirDetails) {
                 builder.addDir(dirDetails.getFile(), dirDetails.getRelativePath().getSegments());

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -68,7 +68,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
         }
 
         @Override
-        public void visitFileTree(File root, PatternSet patterns) {
+        public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
             roots.add(fileSystemSnapshotter.snapshotDirectoryTree(root, new PatternSetSnapshottingFilter(patterns, stat)));
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileVisitorUtil
-import org.gradle.api.internal.tasks.TaskDependencyInternal
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.test.fixtures.file.TestFile
@@ -364,11 +364,6 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         Set<File> getFiles() {
             return files
         }
-
-        @Override
-        TaskDependency getBuildDependencies() {
-            TaskDependencyInternal.EMPTY
-        }
     }
 
     private class TestFileCollectionWithDependency extends TestFileCollection {
@@ -377,8 +372,8 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         }
 
         @Override
-        TaskDependency getBuildDependencies() {
-            return dependency
+        void visitDependencies(TaskDependencyResolveContext context) {
+            context.add(dependency)
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -328,7 +328,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         assertHasSameDependencies(collection.filter(TestUtil.toClosure("{true}")))
     }
 
-    void canVisitRootElements() {
+    void visitsSelfAsLeafCollection() {
         def collection = new TestFileCollection()
         def visitor = Mock(FileCollectionLeafVisitor)
 
@@ -336,7 +336,20 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
         1 * visitor.visitCollection(collection)
+        0 * visitor._
+    }
+
+    void doesNotVisitSelfWhenVisitorIsNotInterested() {
+        def collection = new TestFileCollection()
+        def visitor = Mock(FileCollectionLeafVisitor)
+
+        when:
+        collection.visitLeafCollections(visitor)
+
+        then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -23,10 +23,8 @@ import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.util.PatternFilterable
-import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
-@UsesNativeServices
 class AbstractFileTreeTest extends Specification {
     def isEmptyWhenVisitsNoFiles() {
         def tree = new TestFileTree([])
@@ -133,7 +131,7 @@ class AbstractFileTreeTest extends Specification {
         sum.files.sort() == [file1, file2]
     }
 
-    public void "can visit root elements"() {
+    void "visits self as leaf collection"() {
         def tree = new TestFileTree([])
         def visitor = Mock(FileCollectionLeafVisitor)
 
@@ -141,7 +139,20 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
         1 * visitor.visitGenericFileTree(tree)
+        0 * visitor._
+    }
+
+    void "does not visit self when visitor is not interested"() {
+        def tree = new TestFileTree([])
+        def visitor = Mock(FileCollectionLeafVisitor)
+
+        when:
+        tree.visitLeafCollections(visitor)
+
+        then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -110,7 +110,23 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection2.toString() == "some collection"
     }
 
-    def "returns empty collection when constructed with a list containing nothing"() {
+    def "constructs empty collection with display name"() {
+        expect:
+        def collection = factory.empty("some collection")
+        collection.files.empty
+        collection.buildDependencies.getDependencies(null).empty
+        collection.toString() == "some collection"
+    }
+
+    def "returns empty collection when constructed with no sources"() {
+        expect:
+        def collection = factory.resolving()
+        collection.files.empty
+        collection.buildDependencies.getDependencies(null).empty
+        collection.toString() == "file collection"
+    }
+
+    def "returns empty collection when constructed with display name and a list containing nothing"() {
         expect:
         def collection = factory.resolving("some collection", [])
         collection.files.empty
@@ -118,7 +134,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         collection.toString() == "some collection"
     }
 
-    def "returns empty collection when constructed with an array containing nothing"() {
+    def "returns empty collection when constructed with display name and an array containing nothing"() {
         expect:
         def collection = factory.resolving("some collection")
         collection.files.empty

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -297,5 +297,10 @@ class DefaultFileCollectionFactoryTest extends Specification {
         void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
             Assert.fail()
         }
+
+        @Override
+        void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree) {
+            Assert.fail()
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -92,6 +92,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         def collection = factory.empty("some collection")
         collection.files.empty
         collection.buildDependencies.getDependencies(null).empty
+        collection.visitLeafCollections(new BrokenVisitor())
         collection.toString() == "some collection"
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
 
@@ -47,6 +48,11 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     @Override
     public void visitFailure(Throwable failure) {
         throw UncheckedException.throwAsUncheckedException(failure);
+    }
+
+    @Override
+    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        return true;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -39,7 +39,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Visit
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.CompositeDependencyArtifactsVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.CompositeDependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
-import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.FailOnVersionConflictArtifactsVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.DefaultResolvedConfigurationBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.ResolutionFailureCollector;
@@ -57,6 +56,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.StoreSet
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.transform.ArtifactTransforms;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
+import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -131,7 +131,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         CompositeDependencyGraphVisitor graphVisitor = new CompositeDependencyGraphVisitor(failureCollector, resolutionResultBuilder);
         DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(currentBuild, buildProjectDependencies, resolutionStrategy.getSortOrder());
         resolver.resolve(configuration, ImmutableList.<ResolutionAwareRepository>of(), metadataHandler, IS_LOCAL_EDGE, graphVisitor, artifactsVisitor, attributesSchema, artifactTypeRegistry);
-        result.graphResolved(resolutionResultBuilder.getResolutionResult(), new ResolvedLocalComponentsResultGraphVisitor(currentBuild), new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.<UnresolvedDependency>emptySet()), artifactsVisitor.complete(), artifactTransforms, configuration.getIncoming(), configuration.getDependenciesResolver()));
+        result.graphResolved(resolutionResultBuilder.getResolutionResult(), new ResolvedLocalComponentsResultGraphVisitor(currentBuild), new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.<UnresolvedDependency>emptySet()), artifactsVisitor.complete(), artifactTransforms, configuration.getDependenciesResolver()));
     }
 
     @Override
@@ -183,7 +183,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
             ? Collections.<UnresolvedDependency>emptySet()
             : lockingVisitor.collectLockingFailures();
         Set<UnresolvedDependency> failures = failureCollector.complete(extraFailures);
-        results.graphResolved(newModelBuilder.complete(extraFailures), localComponentsVisitor, new BuildDependenciesOnlyVisitedArtifactSet(failures, artifactsResults, artifactTransforms, configuration.getIncoming(), configuration.getDependenciesResolver()));
+        results.graphResolved(newModelBuilder.complete(extraFailures), localComponentsVisitor, new BuildDependenciesOnlyVisitedArtifactSet(failures, artifactsResults, artifactTransforms, configuration.getDependenciesResolver()));
 
         results.retainState(new ArtifactResolveState(graphResults, artifactsResults, fileDependencyResults, failures, oldTransientModelBuilder));
         if (!results.hasError() && failures.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -44,6 +44,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.Tran
 import org.gradle.api.internal.artifacts.transform.ArtifactTransforms;
 import org.gradle.api.internal.artifacts.transform.VariantSelector;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -302,6 +303,11 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
             } catch (org.gradle.internal.resolve.ArtifactResolveException e) {
                 //ignore
             }
+        }
+
+        @Override
+        public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+            return true;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -24,6 +24,7 @@ import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
@@ -51,6 +52,11 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
         } catch (Exception t) {
             failures.add(t);
         }
+    }
+
+    @Override
+    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        return true;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
@@ -30,6 +31,15 @@ import java.util.Set;
 public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     private final Set<File> files = Sets.newLinkedHashSet();
     private final Set<Throwable> failures = Sets.newLinkedHashSet();
+    private final boolean visitScheduledTransforms;
+
+    public ResolvedFilesCollectingVisitor() {
+        this(true);
+    }
+
+    public ResolvedFilesCollectingVisitor(boolean visitScheduledTransforms) {
+        this.visitScheduledTransforms = visitScheduledTransforms;
+    }
 
     @Override
     public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
@@ -39,6 +49,11 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
         } catch (Exception t) {
             failures.add(t);
         }
+    }
+
+    @Override
+    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        return collectionType != FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult || visitScheduledTransforms;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
@@ -26,6 +27,8 @@ import java.io.File;
  * A visitor over the contents of a {@link ResolvedArtifactSet}.
  */
 public interface ArtifactVisitor {
+    boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType);
+
     /**
      * Visits an artifact. Artifacts are resolved but not necessarily available unless {@link #requireArtifactFiles()} returns true.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -27,7 +27,7 @@ import java.io.File;
  */
 public interface ArtifactVisitor {
     /**
-     * Visits an artifact. Artifacts are resolved but not necessarily downloaded unless {@link #requireArtifactFiles()} returns true.
+     * Visits an artifact. Artifacts are resolved but not necessarily available unless {@link #requireArtifactFiles()} returns true.
      */
     void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ResolvableDependencies;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactTransforms;
@@ -33,14 +32,12 @@ public class BuildDependenciesOnlyVisitedArtifactSet implements VisitedArtifactS
     private final Set<UnresolvedDependency> unresolvedDependencies;
     private final VisitedArtifactsResults artifactsResults;
     private final ArtifactTransforms artifactTransforms;
-    private final ResolvableDependencies resolvableDependencies;
     private final ExtraExecutionGraphDependenciesResolverFactory resolverFactory;
 
-    public BuildDependenciesOnlyVisitedArtifactSet(Set<UnresolvedDependency> unresolvedDependencies, VisitedArtifactsResults artifactsResults, ArtifactTransforms artifactTransforms, ResolvableDependencies resolvableDependencies, ExtraExecutionGraphDependenciesResolverFactory resolverFactory) {
+    public BuildDependenciesOnlyVisitedArtifactSet(Set<UnresolvedDependency> unresolvedDependencies, VisitedArtifactsResults artifactsResults, ArtifactTransforms artifactTransforms, ExtraExecutionGraphDependenciesResolverFactory resolverFactory) {
         this.unresolvedDependencies = unresolvedDependencies;
         this.artifactsResults = artifactsResults;
         this.artifactTransforms = artifactTransforms;
-        this.resolvableDependencies = resolvableDependencies;
         this.resolverFactory = resolverFactory;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -75,6 +76,11 @@ public abstract class ParallelResolveArtifactSet {
             @Override
             public void artifactAvailable(ResolvableArtifact artifact) {
                 // Don't care, collect the artifacts later (in the correct order)
+            }
+
+            @Override
+            public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+                return visitor.startVisit(collectionType);
             }
 
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -72,6 +73,8 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
      * A listener that is notified as artifacts are made available while visiting the contents of a set. Implementations must be thread safe as they are notified from multiple threads concurrently.
      */
     interface AsyncArtifactListener {
+        boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType);
+
         /**
          * Visits an artifact once its file is available. Only called when {@link #requireArtifactFiles()} returns true. Called from any thread and in any order.
          */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -57,6 +58,9 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
 
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
+        if (!listener.startVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult)) {
+            return EMPTY_RESULT;
+        }
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();
         Map<File, TransformationResult> fileResults = Maps.newConcurrentMap();
         Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, listener, actions, artifactResults, fileResults, getDependenciesResolver(), transformationNodeRegistry));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.DefaultResolvedArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
@@ -66,6 +67,11 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     @Override
     public void visitFailure(Throwable failure) {
         visitor.visitFailure(failure);
+    }
+
+    @Override
+    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        return visitor.startVisit(collectionType);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
@@ -65,6 +66,12 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
             TransformationResult result = createTransformationResult(initialSubject);
             artifactResults.put(artifactId, result);
         }
+    }
+
+    @Override
+    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        // Visit everything
+        return true;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -43,7 +43,6 @@ import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultResolverResults
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ResolverResults
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
@@ -94,7 +93,6 @@ class DefaultConfigurationSpec extends Specification {
     def projectAccessListener = Mock(ProjectAccessListener)
     def projectFinder = Mock(ProjectFinder)
     def immutableAttributesFactory = AttributeTestUtil.attributesFactory()
-    def moduleIdentifierFactory = Mock(ImmutableModuleIdentifierFactory)
     def rootComponentMetadataBuilder = Mock(RootComponentMetadataBuilder)
     def projectStateRegistry = Mock(ProjectStateRegistry)
     def projectState = Mock(ProjectState)
@@ -538,7 +536,7 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         configuration.allArtifacts.files.files == [artifact1.file, artifact2.file] as Set
-        configuration.allArtifacts.files.buildDependencies == configuration.allArtifacts.buildDependencies
+        configuration.allArtifacts.files.buildDependencies.getDependencies(Mock(Task)) == [artifactTask1, artifactTask2] as Set
         configuration.allArtifacts.buildDependencies.getDependencies(Mock(Task)) == [artifactTask1, artifactTask2] as Set
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.file.FileCollectionLeafVisitor
 import org.gradle.internal.Describables
 import org.gradle.internal.Try
 import org.gradle.internal.component.AmbiguousVariantSelectionException
@@ -187,6 +188,7 @@ class DefaultArtifactTransformsTest extends Specification {
         1 * invocation2.getCachedResult() >> Optional.empty()
         1 * invocation2.invoke() >> Try.successful(TransformationSubject.initial(sourceFile).createSubjectFromResult(ImmutableList.of(outFile3, outFile4)))
 
+        1 * listener.startVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult) >> true
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile1})
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile2})
         1 * visitor.visitFile(new ComponentFileArtifactIdentifier(id, outFile3.name), variant1DisplayName, targetAttributes, outFile3)

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -246,12 +246,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal, 
 
     @Override
     public FileCollection filter(final Spec<? super File> filterSpec) {
-        final Predicate<File> predicate = new Predicate<File>() {
-            @Override
-            public boolean apply(@Nullable File input) {
-                return filterSpec.isSatisfiedBy(input);
-            }
-        };
+        final Predicate<File> predicate = filterSpec::isSatisfiedBy;
         return new AbstractFileCollection() {
             @Override
             public String getDisplayName() {
@@ -282,7 +277,9 @@ public abstract class AbstractFileCollection implements FileCollectionInternal, 
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        visitor.visitCollection(this);
+        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other)) {
+            visitor.visitCollection(this);
+        }
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -27,6 +27,8 @@ import org.gradle.api.internal.file.collections.FileBackedDirectoryFileTree;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.ResolvableFileCollectionResolveContext;
 import org.gradle.api.internal.provider.AbstractProviderWithValue;
+import org.gradle.api.internal.tasks.AbstractTaskDependency;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
@@ -44,7 +46,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-public abstract class AbstractFileCollection implements FileCollectionInternal {
+public abstract class AbstractFileCollection implements FileCollectionInternal, TaskDependencyContainer {
     /**
      * Returns the display name of this file collection. Used in log and error messages.
      *
@@ -55,6 +57,27 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
     @Override
     public String toString() {
         return getDisplayName();
+    }
+
+    // This is final - use {@link TaskDependencyContainer#visitDependencies} to provide the dependencies instead.
+    @Override
+    public final TaskDependency getBuildDependencies() {
+        return new AbstractTaskDependency() {
+            @Override
+            public String toString() {
+                return "Dependencies of " + getDisplayName();
+            }
+
+            @Override
+            public void visitDependencies(TaskDependencyResolveContext context) {
+                context.add(AbstractFileCollection.this);
+            }
+        };
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        // Assume no dependencies
     }
 
     @Override
@@ -129,8 +152,8 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
             }
 
             @Override
-            public TaskDependency getBuildDependencies() {
-                return AbstractFileCollection.this.getBuildDependencies();
+            public void visitDependencies(TaskDependencyResolveContext context) {
+                AbstractFileCollection.this.visitDependencies(context);
             }
 
             @Override
@@ -236,8 +259,8 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
             }
 
             @Override
-            public TaskDependency getBuildDependencies() {
-                return AbstractFileCollection.this.getBuildDependencies();
+            public void visitDependencies(TaskDependencyResolveContext context) {
+                AbstractFileCollection.this.visitDependencies(context);
             }
 
             @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -168,7 +168,9 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        visitor.visitGenericFileTree(this);
+        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other)) {
+            visitor.visitGenericFileTree(this);
+        }
     }
 
     private static class FilteredFileTreeImpl extends AbstractFileTree {
@@ -208,6 +210,12 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
                 }
             });
             return this;
+        }
+
+        @Override
+        public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+            // TODO: should consider the filter
+            fileTree.visitLeafCollections(visitor);
         }
 
         @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -23,8 +23,8 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.api.tasks.util.internal.PatternSets;
@@ -191,8 +191,8 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
         }
 
         @Override
-        public TaskDependency getBuildDependencies() {
-            return fileTree.getBuildDependencies();
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            context.add(fileTree);
         }
 
         @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -167,11 +167,6 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     }
 
     @Override
-    public void visitTreeOrBackingFile(FileVisitor visitor) {
-        visit(visitor);
-    }
-
-    @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
         visitor.visitGenericFileTree(this);
     }
@@ -219,11 +214,6 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
         public void registerWatchPoints(FileSystemSubset.Builder builder) {
             // TODO: we aren't considering the filter
             fileTree.registerWatchPoints(builder);
-        }
-
-        @Override
-        public void visitTreeOrBackingFile(FileVisitor visitor) {
-            fileTree.visitTreeOrBackingFile(visitor);
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -25,11 +25,9 @@ import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.FileCollectionContainer;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.ResolvableFileCollectionResolveContext;
-import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -160,22 +158,6 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
             @Override
             public String getDisplayName() {
                 return CompositeFileCollection.this.getDisplayName();
-            }
-        };
-    }
-
-    // This is final - use {@link TaskDependencyContainer#visitDependencies} to provide the dependencies instead.
-    @Override
-    public final TaskDependency getBuildDependencies() {
-        return new AbstractTaskDependency() {
-            @Override
-            public String toString() {
-                return CompositeFileCollection.this.toString() + " dependencies";
-            }
-
-            @Override
-            public void visitDependencies(TaskDependencyResolveContext context) {
-                CompositeFileCollection.this.visitDependencies(context);
             }
         };
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileTree.java
@@ -96,11 +96,6 @@ public abstract class CompositeFileTree extends CompositeFileCollection implemen
     }
 
     @Override
-    public void visitTreeOrBackingFile(FileVisitor visitor) {
-        visit(visitor);
-    }
-
-    @Override
     public FileTree getAsFileTree() {
         return this;
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -77,21 +77,21 @@ public interface FileCollectionFactory {
      *
      * The collection is live and resolves the files on each query.
      */
-    FileCollectionInternal resolving(String displayName, List<?> files);
+    FileCollectionInternal resolving(String displayName, List<?> sources);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
      *
      * The collection is live and resolves the files on each query.
      */
-    FileCollectionInternal resolving(String displayName, Object... files);
+    FileCollectionInternal resolving(String displayName, Object... sources);
 
     /**
      * Creates a {@link FileCollection} with the given files as content.
      *
      * The collection is live and resolves the files on each query.
      */
-    FileCollectionInternal resolving(Object... files);
+    FileCollectionInternal resolving(Object... sources);
 
     /**
      * Creates an empty {@link ConfigurableFileCollection} instance.

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -36,8 +36,6 @@ public interface FileCollectionInternal extends FileCollection {
     /**
      * In a {@link FileCollection} hierarchy visits the leaves of the hierarchy.
      *
-     * <p>The implementation of this method should not do any work to calculate the files that make up this collection. The visitor may choose to query each element it receives for its elements, or may not.
-     *
      * <p>The implementation should call the most specific method on {@link FileCollectionLeafVisitor} that it is able to.</p>
      */
     void visitLeafCollections(FileCollectionLeafVisitor visitor);

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -39,4 +39,9 @@ public interface FileCollectionLeafVisitor {
      * Visits a file tree at a root file on the file system (potentially filtered).
      */
     void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree);
+
+    /**
+     * Visits a file tree whose content is backed by the contents of a file.
+     */
+    void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -22,7 +22,7 @@ import java.io.File;
 
 /**
  * Used with {@link FileCollectionInternal#visitLeafCollections(FileCollectionLeafVisitor)} this visitor
- * gets called for each element in a file collection that represents a root of a file tree.
+ * is called for each element in a file collection that represents a root of a file tree.
  */
 public interface FileCollectionLeafVisitor {
     /**
@@ -38,5 +38,5 @@ public interface FileCollectionLeafVisitor {
     /**
      * Visits a file tree at a root file on the file system (potentially filtered).
      */
-    void visitFileTree(File root, PatternSet patterns);
+    void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -25,6 +25,22 @@ import java.io.File;
  * is called for each element in a file collection that represents a root of a file tree.
  */
 public interface FileCollectionLeafVisitor {
+    enum CollectionType {
+        ArtifactTransformResult, Other
+    }
+
+    /**
+     * Called prior to visiting a file collection of the given type, and allows this visitor to skip the collection.
+     *
+     * This is only intended to be step towards some fine-grained visiting of the contents of a `Configuration` and other collections that may
+     * contain files that are expensive to visit, or task/transform outputs that don't yet exist.
+     *
+     * @return true to indicate that the collection should be visited, false to indicate it should be skipped.
+     */
+    default boolean beforeVisit(CollectionType type) {
+        return true;
+    }
+
     /**
      * Visits a {@link FileCollectionInternal} element that cannot be visited in further detail.
      */

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileTreeInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileTreeInternal.java
@@ -17,8 +17,6 @@
 package org.gradle.api.internal.file;
 
 import org.gradle.api.file.FileTree;
-import org.gradle.api.file.FileVisitor;
 
 public interface FileTreeInternal extends FileTree, FileCollectionInternal {
-    void visitTreeOrBackingFile(FileVisitor visitor);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/AbstractSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/AbstractSingletonFileTree.java
@@ -43,11 +43,6 @@ public abstract class AbstractSingletonFileTree implements SingletonFileTree, Pa
         return patterns;
     }
 
-    @Override
-    public void visitTreeOrBackingFile(FileVisitor visitor) {
-        visit(visitor);
-    }
-
     protected PatternSet filterPatternSet(PatternFilterable patterns) {
         PatternSet patternSet = this.patterns.intersect();
         patternSet.copyFrom(patterns);

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -114,11 +114,6 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
     }
 
     @Override
-    public void visitTreeOrBackingFile(FileVisitor visitor) {
-        visit(visitor);
-    }
-
-    @Override
     public void visit(FileVisitor visitor) {
         visitFrom(visitor, dir, RelativePath.EMPTY_ROOT);
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileCollectionAdapter.java
@@ -17,8 +17,7 @@ package org.gradle.api.internal.file.collections;
 
 import org.gradle.api.Buildable;
 import org.gradle.api.internal.file.AbstractFileCollection;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
-import org.gradle.api.tasks.TaskDependency;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.io.File;
 import java.util.Set;
@@ -49,11 +48,9 @@ public class FileCollectionAdapter extends AbstractFileCollection implements Fil
     }
 
     @Override
-    public TaskDependency getBuildDependencies() {
+    public void visitDependencies(TaskDependencyResolveContext context) {
         if (fileCollection instanceof Buildable) {
-            Buildable buildable = (Buildable) fileCollection;
-            return buildable.getBuildDependencies();
+            context.add(fileCollection);
         }
-        return TaskDependencyInternal.EMPTY;
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -21,8 +21,7 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.AbstractFileTree;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.file.FileSystemSubset;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
-import org.gradle.api.tasks.TaskDependency;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
@@ -82,12 +81,10 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
     }
 
     @Override
-    public TaskDependency getBuildDependencies() {
+    public void visitDependencies(TaskDependencyResolveContext context) {
         if (tree instanceof Buildable) {
-            Buildable buildable = (Buildable) tree;
-            return buildable.getBuildDependencies();
+            context.add(tree);
         }
-        return TaskDependencyInternal.EMPTY;
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -124,10 +124,10 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
         if (tree instanceof DirectoryFileTree) {
             DirectoryFileTree directoryFileTree = (DirectoryFileTree) tree;
-            visitor.visitFileTree(directoryFileTree.getDir(), directoryFileTree.getPatterns());
+            visitor.visitFileTree(directoryFileTree.getDir(), directoryFileTree.getPatterns(), this);
         } else if (tree instanceof SingletonFileTree) {
             SingletonFileTree singletonFileTree = (SingletonFileTree) tree;
-            visitor.visitFileTree(singletonFileTree.getFile(), singletonFileTree.getPatterns());
+            visitor.visitFileTree(singletonFileTree.getFile(), singletonFileTree.getPatterns(), this);
         } else if (tree instanceof ArchiveFileTree) {
             ArchiveFileTree archiveFileTree = (ArchiveFileTree) tree;
             File backingFile = archiveFileTree.getBackingFile();

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -119,6 +119,9 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+        if (!visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other)) {
+            return;
+        }
         if (tree instanceof DirectoryFileTree) {
             DirectoryFileTree directoryFileTree = (DirectoryFileTree) tree;
             visitor.visitFileTree(directoryFileTree.getDir(), directoryFileTree.getPatterns(), this);

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -129,17 +129,12 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
             ArchiveFileTree archiveFileTree = (ArchiveFileTree) tree;
             File backingFile = archiveFileTree.getBackingFile();
             if (backingFile != null) {
-                visitor.visitCollection(ImmutableFileCollection.of(backingFile));
+                visitor.visitFileTreeBackedByFile(backingFile, this);
             } else {
                 visitor.visitGenericFileTree(this);
             }
         } else {
             visitor.visitGenericFileTree(this);
         }
-    }
-
-    @Override
-    public void visitTreeOrBackingFile(FileVisitor visitor) {
-        tree.visitTreeOrBackingFile(visitor);
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ImmutableFileCollection.java
@@ -19,8 +19,6 @@ package org.gradle.api.internal.file.collections;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.gradle.api.internal.file.AbstractFileCollection;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
-import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 import java.util.Set;
@@ -69,11 +67,6 @@ public abstract class ImmutableFileCollection extends AbstractFileCollection {
     @Override
     public String getDisplayName() {
         return "file collection";
-    }
-
-    @Override
-    public TaskDependency getBuildDependencies() {
-        return TaskDependencyInternal.EMPTY;
     }
 
     private static class FileOnlyImmutableFileCollection extends ImmutableFileCollection {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/MinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/MinimalFileTree.java
@@ -34,6 +34,4 @@ public interface MinimalFileTree extends MinimalFileCollection {
     void visit(FileVisitor visitor);
 
     void registerWatchPoints(FileSystemSubset.Builder builder);
-
-    void visitTreeOrBackingFile(FileVisitor visitor);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
@@ -139,9 +139,4 @@ public class SingleIncludePatternFileTree implements MinimalFileTree {
     public void registerWatchPoints(FileSystemSubset.Builder builder) {
         builder.add(baseDir, new PatternSet().include(includePattern).exclude(excludeSpec));
     }
-
-    @Override
-    public void visitTreeOrBackingFile(FileVisitor visitor) {
-        visit(visitor);
-    }
 }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileCollectionAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileCollectionAdapterTest.groovy
@@ -15,9 +15,9 @@
  */
 package org.gradle.api.internal.file.collections
 
-import spock.lang.Specification
 import org.gradle.api.Buildable
-import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import spock.lang.Specification
 
 class FileCollectionAdapterTest extends Specification {
 
@@ -48,17 +48,28 @@ class FileCollectionAdapterTest extends Specification {
         0 * _._
     }
 
-    def getBuildDependenciesDelegatesToTargetCollectionWhenItImplementsBuildable() {
+    def visitDependenciesDelegatesToTargetCollectionWhenItImplementsBuildable() {
         TestFileSet fileSet = Mock()
-        TaskDependency expectedDependency = Mock()
         FileCollectionAdapter adapter = new FileCollectionAdapter(fileSet)
+        TaskDependencyResolveContext context = Mock()
 
         when:
-        def dependencies = adapter.buildDependencies
+        adapter.visitDependencies(context)
 
         then:
-        dependencies == expectedDependency
-        1 * fileSet.buildDependencies >> expectedDependency
+        1 * context.add(fileSet)
+    }
+
+    def visitDependenciesDoesNotDelegateToTargetCollectionWhenItDoesNotImplementBuildable() {
+        MinimalFileSet fileSet = Mock()
+        FileCollectionAdapter adapter = new FileCollectionAdapter(fileSet)
+        TaskDependencyResolveContext context = Mock()
+
+        when:
+        adapter.visitDependencies(context)
+
+        then:
+        0 * context._
     }
 
     interface TestFileSet extends MinimalFileSet, Buildable {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.Buildable
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.file.FileCollectionLeafVisitor
-import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
@@ -105,17 +105,28 @@ class FileTreeAdapterTest extends Specification {
         0 * _._
     }
 
-    def getBuildDependenciesDelegatesToTargetTreeWhenItImplementsBuildable() {
+    def visitDependenciesDelegatesToTargetTreeWhenItImplementsBuildable() {
         TestFileTree tree = Mock()
-        TaskDependency expectedDependency = Mock()
+        TaskDependencyResolveContext context = Mock()
         FileTreeAdapter adapter = new FileTreeAdapter(tree)
 
         when:
-        def dependencies = adapter.buildDependencies
+        adapter.visitDependencies(context)
 
         then:
-        dependencies == expectedDependency
-        1 * tree.buildDependencies >> expectedDependency
+        1 * context.add(tree)
+    }
+
+    def visitDependenciesDoesNotDelegateToTargetTreeWhenItDoesNotImplementBuildable() {
+        MinimalFileTree tree = Mock()
+        TaskDependencyResolveContext context = Mock()
+        FileTreeAdapter adapter = new FileTreeAdapter(tree)
+
+        when:
+        adapter.visitDependencies(context)
+
+        then:
+        0 * context._
     }
 
     def matchingDelegatesToTargetTreeWhenItImplementsPatternFilterableFileTree() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -167,7 +167,22 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
         1 * visitor.visitFileTree(tree.getDir(), tree.getPatterns(), adapter)
+        0 * visitor._
+    }
+
+    def doesNotVisitsBackingDirectoryTreeWhenListenerIsNotInterested() {
+        def visitor = Mock(FileCollectionLeafVisitor)
+        def directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory()
+        def tree = directoryFileTreeFactory.create(new File("dir"))
+        def adapter = new FileTreeAdapter(tree)
+
+        when:
+        adapter.visitLeafCollections(visitor)
+
+        then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
         0 * visitor._
     }
 
@@ -180,7 +195,21 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
         1 * visitor.visitGenericFileTree(adapter)
+        0 * visitor._
+    }
+
+    def doesNotVisitsSelfWhenListenerIsNotInterested() {
+        def visitor = Mock(FileCollectionLeafVisitor)
+        def tree = Mock(MinimalFileTree)
+        def adapter = new FileTreeAdapter(tree)
+
+        when:
+        adapter.visitLeafCollections(visitor)
+
+        then:
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
         0 * visitor._
     }
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -156,7 +156,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.visitFileTree(tree.getDir(), tree.getPatterns())
+        1 * visitor.visitFileTree(tree.getDir(), tree.getPatterns(), adapter)
         0 * visitor._
     }
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
@@ -17,10 +17,8 @@
 package org.gradle.instantexecution
 
 import org.gradle.integtests.resolve.transform.ArtifactTransformTestFixture
-import spock.lang.Ignore
 
 class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstantExecutionIntegrationTest implements ArtifactTransformTestFixture {
-    @Ignore
     def "task input files can include artifact transform output"() {
         setupBuildWithColorTransformAction()
         settingsFile << """
@@ -47,6 +45,9 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
 
         expect:
         instantRun(":resolve")
+        outputContains("result = [a.jar.green, b.jar.green]")
         instantRun(":resolve")
+        // For now, transforms are ignored when writing to the cache
+        outputContains("result = []")
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -119,7 +119,7 @@ class Codecs(
         bind(LoggerCodec)
 
         bind(ConfigurableFileCollectionCodec(fileSetSerializer, fileCollectionFactory))
-        bind(FileCollectionCodec(fileSetSerializer, fileCollectionFactory, directoryFileTreeFactory))
+        bind(FileCollectionCodec(fileSetSerializer, fileCollectionFactory))
         bind(ArtifactCollectionCodec)
 
         bind(DefaultCopySpecCodec(fileResolver, instantiator))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -20,8 +20,6 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionLeafVisitor
 import org.gradle.api.internal.file.FileTreeInternal
-import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
-import org.gradle.api.internal.file.collections.FileTreeAdapter
 import org.gradle.api.internal.file.collections.MinimalFileSet
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.instantexecution.serialization.Codec
@@ -34,13 +32,12 @@ import java.io.File
 internal
 class FileCollectionCodec(
     private val fileSetSerializer: SetSerializer<File>,
-    private val fileCollectionFactory: FileCollectionFactory,
-    private val directoryFileTreeFactory: DirectoryFileTreeFactory
+    private val fileCollectionFactory: FileCollectionFactory
 ) : Codec<FileCollectionInternal> {
 
     override suspend fun WriteContext.encode(value: FileCollectionInternal) {
         runCatching {
-            val visitor = CollectingVisitor(directoryFileTreeFactory)
+            val visitor = CollectingVisitor()
             value.visitLeafCollections(visitor)
             visitor.files
         }.apply {
@@ -62,9 +59,7 @@ class FileCollectionCodec(
 
 
 private
-class CollectingVisitor(
-    private val directoryFileTreeFactory: DirectoryFileTreeFactory
-) : FileCollectionLeafVisitor {
+class CollectingVisitor : FileCollectionLeafVisitor {
     val files: MutableSet<File> = mutableSetOf()
 
     override fun visitCollection(fileCollection: FileCollectionInternal) {
@@ -75,10 +70,9 @@ class CollectingVisitor(
         visitCollection(fileTree)
     }
 
-    override fun visitFileTree(root: File, patterns: PatternSet) {
+    override fun visitFileTree(root: File, patterns: PatternSet, fileTree: FileTreeInternal) {
         // TODO - should serialize a spec for the tree instead of its current elements
-        val fileTree = directoryFileTreeFactory.create(root, patterns)
-        visitCollection(FileTreeAdapter(fileTree))
+        visitCollection(fileTree)
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -62,6 +62,11 @@ private
 class CollectingVisitor : FileCollectionLeafVisitor {
     val files: MutableSet<File> = mutableSetOf()
 
+    override fun beforeVisit(type: FileCollectionLeafVisitor.CollectionType): Boolean {
+        // Ignore scheduled transforms for now
+        return type != FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult
+    }
+
     override fun visitCollection(fileCollection: FileCollectionInternal) {
         files.addAll(fileCollection.files)
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -67,10 +67,16 @@ class CollectingVisitor : FileCollectionLeafVisitor {
     }
 
     override fun visitGenericFileTree(fileTree: FileTreeInternal) {
+        // TODO - should serialize a spec for the tree instead of its current elements
         visitCollection(fileTree)
     }
 
     override fun visitFileTree(root: File, patterns: PatternSet, fileTree: FileTreeInternal) {
+        // TODO - should serialize a spec for the tree instead of its current elements
+        visitCollection(fileTree)
+    }
+
+    override fun visitFileTreeBackedByFile(file: File, fileTree: FileTreeInternal) {
         // TODO - should serialize a spec for the tree instead of its current elements
         visitCollection(fileTree)
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -67,5 +67,7 @@ class FileTreeCodec(
         override fun visitFileTree(root: File, patterns: PatternSet, fileTree: FileTreeInternal) {
             roots.add(root)
         }
+
+        override fun visitFileTreeBackedByFile(file: File, fileTree: FileTreeInternal) = throw UnsupportedOperationException()
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -64,7 +64,7 @@ class FileTreeCodec(
 
         override fun visitGenericFileTree(fileTree: FileTreeInternal) = throw UnsupportedOperationException()
 
-        override fun visitFileTree(root: File, patterns: PatternSet) {
+        override fun visitFileTree(root: File, patterns: PatternSet, fileTree: FileTreeInternal) {
             roots.add(root)
         }
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
@@ -79,7 +79,7 @@ public class CompilationSourceDirs {
         }
 
         @Override
-        public void visitFileTree(File root, PatternSet patterns) {
+        public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
             // We need to add missing files as source roots, since the package name for deleted files provided by IncrementalTaskInputs also need to be determined.
             if (!root.exists() || root.isDirectory()) {
                 sourceRoots.add(root);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
@@ -79,6 +79,11 @@ public class CompilationSourceDirs {
         }
 
         @Override
+        public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree) {
+            cannotInferSourceRoots(fileTree);
+        }
+
+        @Override
         public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
             // We need to add missing files as source roots, since the package name for deleted files provided by IncrementalTaskInputs also need to be determined.
             if (!root.exists() || root.isDirectory()) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -46,11 +46,9 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.AbstractFileCollection;
-import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Specs;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
@@ -139,18 +137,13 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
     }
 
     @Override
-    public TaskDependency getBuildDependencies() {
-        return new AbstractTaskDependency() {
-            @Override
-            public void visitDependencies(final TaskDependencyResolveContext context) {
-                ensureResolved(false);
-                FailureCollectingTaskDependencyResolveContext collectingContext = new FailureCollectingTaskDependencyResolveContext(context);
-                resolveResult.artifactsResults.getArtifacts().visitDependencies(collectingContext);
-                if (!collectingContext.getFailures().isEmpty()) {
-                    throw new ResolveException(getDisplayName(), collectingContext.getFailures());
-                }
-            }
-        };
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        ensureResolved(false);
+        FailureCollectingTaskDependencyResolveContext collectingContext = new FailureCollectingTaskDependencyResolveContext(context);
+        resolveResult.artifactsResults.getArtifacts().visitDependencies(collectingContext);
+        if (!collectingContext.getFailures().isEmpty()) {
+            throw new ResolveException(getDisplayName(), collectingContext.getFailures());
+        }
     }
 
     private void ensureResolved(boolean failFast) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -46,6 +46,7 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.AbstractFileCollection;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Specs;
@@ -116,6 +117,11 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             @Override
             public void visitFailure(Throwable failure) {
                 throw UncheckedException.throwAsUncheckedException(failure);
+            }
+
+            @Override
+            public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+                return true;
             }
 
             @Override


### PR DESCRIPTION

### Context

This PR refactors the mechanism for visiting the structure of a file collection just enough so that instant execution serialization can ignore the outputs of artifact transforms. Clearly this isn't the end goal but just a step in exposing the information that instant execution needs from dependency resolution, and allowing a file collection visitor finer grained control over what exact details it needs from the collection.

This PR also contains some clean ups of the way that task dependencies are visited/calculated for a file collection so that each implementation is consistent, and merges `visitBackingFileOrTree()` into `visitLeafCollections()`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
