### PR TITLE
Allow replacing task actions

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -885,6 +885,14 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         }
 
         @Override
+        public Object set(int index, Object action) {
+            if (action == null) {
+                throw new InvalidUserDataException("Action must not be null!");
+            }
+            return super.set(index, wrap((Action<? super Task>) action));
+        }
+
+        @Override
         public boolean removeAll(Collection actions) {
             return super.removeAll(transformToContextAwareTaskActions(actions));
         }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.Task
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
+import org.gradle.api.internal.tasks.InputChangesAwareTaskAction
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.specs.Spec
 import org.gradle.internal.Actions
@@ -114,6 +115,25 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
 
         then:
         getTask().getActions().size() == 1
+    }
+
+    def "can replace an action"() {
+        given:
+        getTask().setActions([])
+
+        when:
+        getTask().getActions().add(Actions.doNothing())
+        getTask().getActions().set(0, { task -> throw new RuntimeException()} as Action)
+
+        then:
+        getTask().getActions().size() == 1
+        getTask().getActions()[0] instanceof InputChangesAwareTaskAction
+
+        when:
+        getTask().getActions()[0].execute(getTask())
+
+        then:
+        thrown(RuntimeException)
     }
 
     def "addAction with null throws"() {


### PR DESCRIPTION
The overload for List.set was missing from our decorating
action list, which makes it harder to replace a specific action.