### PR TITLE
Do not sort selectors when a force is present

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
@@ -53,6 +53,7 @@ public class ModuleSelectors<T extends ResolvableSelectorState> implements Itera
 
     private final List<T> selectors = Lists.newArrayList();
     private boolean deferSelection;
+    private boolean forced;
 
     public boolean checkDeferSelection() {
         if (deferSelection) {
@@ -70,11 +71,12 @@ public class ModuleSelectors<T extends ResolvableSelectorState> implements Itera
 
     public void add(T selector, boolean deferSelection) {
         this.deferSelection = deferSelection;
-        if (selectors.isEmpty()) {
+        if (selectors.isEmpty() || forced) {
             selectors.add(selector);
         } else {
             doAdd(selector);
         }
+        forced = forced || selector.isForce();
     }
 
     private void doAdd(T selector) {


### PR DESCRIPTION
Otherwise the sorting was breaking the "first force wins" behaviour.

Fixes the issue reported in nebula-plugins/gradle-nebula-integration#63