### PR TITLE
Interrupt task workers when build is cancelled

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -9,7 +9,10 @@ Include only their name, impactful features should be called out separately belo
 -->
 
 <!-- 
-## 1
+## Cancellable custom tasks
+
+When a build is cancelled (e.g. using CTRL+C), the threads executing each task are interrupted.
+Task authors only need to make their tasks respond to interrupts in order for the task to be cancellable.
 
 details of 1
 

--- a/subprojects/docs/src/docs/userguide/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_tasks.adoc
@@ -546,6 +546,11 @@ A daemon is considered compatible only if the default character encoding is set 
 
 Worker daemons will remain running until either the build daemon that started them is stopped, or system memory becomes scarce. When available system memory is low, Gradle will begin stopping worker daemons in an attempt to minimize memory consumption.
 
+== Cancellation and timeouts
+
+In order to support cancellation (e.g. when the user stops the build with CTRL+C) and task timeouts, custom tasks should react to their executing thread being interrupted.
+The same is true for work items submitted via the worker API. If a task does not respond to an interrupt within 10s, the daemon will shut down in order to free up system resources.
+
 == More details
 
 It's often a good approach to package custom task types in a custom Gradle plugin.

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CancelExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CancelExecutionStepTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.internal.execution.steps
 
 import org.gradle.api.BuildCancelledException
-import org.gradle.initialization.BuildCancellationToken
+import org.gradle.initialization.DefaultBuildCancellationToken
 import org.gradle.internal.execution.Context
 import org.gradle.internal.execution.Result
 
 class CancelExecutionStepTest extends StepSpec {
-    def cancellationToken = Mock(BuildCancellationToken)
+    def cancellationToken = new DefaultBuildCancellationToken()
     def step = new CancelExecutionStep<Context>(cancellationToken, delegate)
     def context = Mock(Context)
     def delegateResult = Mock(Result)
@@ -37,11 +37,13 @@ class CancelExecutionStepTest extends StepSpec {
         1 * delegate.execute(context) >> delegateResult
 
         then:
-        1 * cancellationToken.cancellationRequested >> false
         0 *_
     }
 
     def "cancels execution when cancellation is requested"() {
+        given:
+        cancellationToken.cancel()
+
         when:
         step.execute(context)
 
@@ -51,7 +53,25 @@ class CancelExecutionStepTest extends StepSpec {
         1 * delegate.execute(context) >> delegateResult
 
         then:
-        1 * cancellationToken.cancellationRequested >> true
+        1 * context.work >> work
+        1 * work.displayName >> "cancelled work"
+        0 *_
+    }
+
+    def "interrupts task worker when cancellation is requested"() {
+        when:
+        step.execute(context)
+
+        then:
+        thrown BuildCancelledException
+
+        1 * delegate.execute(context) >>  {
+            cancellationToken.cancel()
+            wait()
+            delegateResult
+        }
+
+        then:
         1 * context.work >> work
         1 * work.displayName >> "cancelled work"
         0 *_


### PR DESCRIPTION
This allows arbitrary tasks to respond to cancellation, the same
way that task timouts are handled. The task only needs to respond
to interrupts in order to be cancellable. No additional public API
is required.

Fixes #5468