### PR TITLE
Unexport wmain/_wmain on Windows

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -105,6 +105,8 @@ public class UnexportMainSymbol extends DefaultTask {
                 final SymbolHider symbolHider = new SymbolHider(object);
                 symbolHider.hideSymbol("main");     // 64 bit
                 symbolHider.hideSymbol("_main");    // 32 bit
+                symbolHider.hideSymbol("wmain");    // 64 bit
+                symbolHider.hideSymbol("_wmain");   // 32 bit
                 symbolHider.saveTo(relocatedObject);
             } catch (IOException e) {
                 throw UncheckedException.throwAsUncheckedException(e);


### PR DESCRIPTION
For gradle-native Issue gradle/gradle-native#277

It is possible for windows application to use wmain/_wmain as their entrypoint
rather than main/main.

https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa299386(v=vs.60)

These entrypoints must also be unexported when linking executable object files
to the cpp-unit executable.

Signed-off-by: Nigel Banks <nigel.g.banks@gmail.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
