### PR TITLE
Better names for execution state-related steps

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -50,7 +50,7 @@ import org.gradle.internal.execution.steps.CatchExceptionStep;
 import org.gradle.internal.execution.steps.CleanupOutputsStep;
 import org.gradle.internal.execution.steps.CreateOutputsStep;
 import org.gradle.internal.execution.steps.ExecuteStep;
-import org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep;
+import org.gradle.internal.execution.steps.LoadExecutionStateStep;
 import org.gradle.internal.execution.steps.RecordOutputsStep;
 import org.gradle.internal.execution.steps.ResolveCachingStateStep;
 import org.gradle.internal.execution.steps.ResolveChangesStep;
@@ -58,7 +58,7 @@ import org.gradle.internal.execution.steps.ResolveInputChangesStep;
 import org.gradle.internal.execution.steps.SkipEmptyWorkStep;
 import org.gradle.internal.execution.steps.SkipUpToDateStep;
 import org.gradle.internal.execution.steps.SnapshotOutputsStep;
-import org.gradle.internal.execution.steps.StoreSnapshotsStep;
+import org.gradle.internal.execution.steps.StoreExecutionStateStep;
 import org.gradle.internal.execution.steps.TimeoutStep;
 import org.gradle.internal.execution.steps.ValidateStep;
 import org.gradle.internal.execution.steps.legacy.MarkSnapshottingInputsFinishedStep;
@@ -140,7 +140,7 @@ public class ExecutionGradleServices {
     ) {
         // @formatter:off
         return new DefaultWorkExecutor<>(
-            new LoadPreviousExecutionStateStep<>(
+            new LoadExecutionStateStep<>(
             new MarkSnapshottingInputsStartedStep<>(
             new SkipEmptyWorkStep<>(
             new ValidateStep<>(
@@ -150,7 +150,7 @@ public class ExecutionGradleServices {
             new ResolveChangesStep<>(changeDetector,
             new SkipUpToDateStep<>(
             new RecordOutputsStep<>(outputFilesRepository,
-            new StoreSnapshotsStep<>(
+            new StoreExecutionStateStep<>(
             new BroadcastChangingOutputsStep<>(outputChangeListener,
             new CacheStep(buildCacheController, buildCacheCommandFactory,
             new SnapshotOutputsStep<>(buildOperationExecutor, buildInvocationScopeId.getId(),

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -52,7 +52,7 @@ import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep
 import org.gradle.internal.execution.steps.CatchExceptionStep
 import org.gradle.internal.execution.steps.CleanupOutputsStep
 import org.gradle.internal.execution.steps.ExecuteStep
-import org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep
+import org.gradle.internal.execution.steps.LoadExecutionStateStep
 import org.gradle.internal.execution.steps.ResolveCachingStateStep
 import org.gradle.internal.execution.steps.ResolveChangesStep
 import org.gradle.internal.execution.steps.ResolveInputChangesStep
@@ -149,7 +149,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
 
     // @formatter:off
     def workExecutor = new DefaultWorkExecutor<>(
-        new LoadPreviousExecutionStateStep<>(
+        new LoadExecutionStateStep<>(
         new SkipEmptyWorkStep<>(
         new ValidateStep<>(
         new CaptureStateBeforeExecutionStep(buildOperationExecutor, classloaderHierarchyHasher, valueSnapshotter, overlappingOutputDetector,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -139,12 +139,12 @@ import org.gradle.internal.execution.steps.CatchExceptionStep;
 import org.gradle.internal.execution.steps.CleanupOutputsStep;
 import org.gradle.internal.execution.steps.CreateOutputsStep;
 import org.gradle.internal.execution.steps.ExecuteStep;
-import org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep;
+import org.gradle.internal.execution.steps.LoadExecutionStateStep;
 import org.gradle.internal.execution.steps.ResolveChangesStep;
 import org.gradle.internal.execution.steps.ResolveInputChangesStep;
 import org.gradle.internal.execution.steps.SkipUpToDateStep;
 import org.gradle.internal.execution.steps.SnapshotOutputsStep;
-import org.gradle.internal.execution.steps.StoreSnapshotsStep;
+import org.gradle.internal.execution.steps.StoreExecutionStateStep;
 import org.gradle.internal.execution.steps.TimeoutStep;
 import org.gradle.internal.execution.steps.ValidateStep;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
@@ -256,14 +256,14 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             UniqueId fixedUniqueId = UniqueId.from("dhwwyv4tqrd43cbxmdsf24wquu");
             // @formatter:off
             return new DefaultWorkExecutor<>(
-                new LoadPreviousExecutionStateStep<>(
+                new LoadExecutionStateStep<>(
                 new ValidateStep<>(
                 new CaptureStateBeforeExecutionStep(buildOperationExecutor, classLoaderHierarchyHasher, valueSnapshotter, overlappingOutputDetector,
                 new NoOpCachingStateStep(
                 new ResolveChangesStep<>(changeDetector,
                 new SkipUpToDateStep<>(
                 new BroadcastChangingOutputsStep<>(outputChangeListener,
-                new StoreSnapshotsStep<>(
+                new StoreExecutionStateStep<>(
                 new SnapshotOutputsStep<>(buildOperationExecutor, fixedUniqueId,
                 new CreateOutputsStep<>(
                 new CatchExceptionStep<>(

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -37,14 +37,14 @@ import org.gradle.internal.execution.steps.CatchExceptionStep
 import org.gradle.internal.execution.steps.CleanupOutputsStep
 import org.gradle.internal.execution.steps.CreateOutputsStep
 import org.gradle.internal.execution.steps.ExecuteStep
-import org.gradle.internal.execution.steps.LoadPreviousExecutionStateStep
+import org.gradle.internal.execution.steps.LoadExecutionStateStep
 import org.gradle.internal.execution.steps.RecordOutputsStep
 import org.gradle.internal.execution.steps.ResolveCachingStateStep
 import org.gradle.internal.execution.steps.ResolveChangesStep
 import org.gradle.internal.execution.steps.ResolveInputChangesStep
 import org.gradle.internal.execution.steps.SkipUpToDateStep
 import org.gradle.internal.execution.steps.SnapshotOutputsStep
-import org.gradle.internal.execution.steps.StoreSnapshotsStep
+import org.gradle.internal.execution.steps.StoreExecutionStateStep
 import org.gradle.internal.execution.steps.ValidateStep
 import org.gradle.internal.file.TreeType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
@@ -137,7 +137,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
     WorkExecutor<ExecutionRequestContext, CachingResult> getExecutor() {
         // @formatter:off
         new DefaultWorkExecutor<>(
-            new LoadPreviousExecutionStateStep<>(
+            new LoadExecutionStateStep<>(
             new ValidateStep<>(
             new CaptureStateBeforeExecutionStep<>(buildOperationExecutor, classloaderHierarchyHasher, valueSnapshotter, overlappingOutputDetector,
             new ResolveCachingStateStep<>(buildCacheController, false,
@@ -145,7 +145,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
             new SkipUpToDateStep<>(
             new RecordOutputsStep<>(outputFilesRepository,
             new BroadcastChangingOutputsStep<>(outputChangeListener,
-            new StoreSnapshotsStep<>(
+            new StoreExecutionStateStep<>(
             new SnapshotOutputsStep<>(buildOperationExecutor, buildInvocationScopeId.getId(),
             new CreateOutputsStep<>(
             new CatchExceptionStep<>(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/LoadExecutionStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/LoadExecutionStateStep.java
@@ -25,16 +25,16 @@ import org.gradle.internal.execution.history.AfterPreviousExecutionState;
 
 import java.util.Optional;
 
-public class LoadPreviousExecutionStateStep<C extends ExecutionRequestContext, R extends Result> implements Step<C, R> {
+public class LoadExecutionStateStep<C extends ExecutionRequestContext, R extends Result> implements Step<C, R> {
     private final Step<? super AfterPreviousExecutionContext, ? extends R> delegate;
 
-    public LoadPreviousExecutionStateStep(Step<? super AfterPreviousExecutionContext, ? extends R> delegate) {
+    public LoadExecutionStateStep(Step<? super AfterPreviousExecutionContext, ? extends R> delegate) {
         this.delegate = delegate;
     }
 
     @Override
     public R execute(C context) {
-        final UnitOfWork work = context.getWork();
+        UnitOfWork work = context.getWork();
         Optional<AfterPreviousExecutionState> afterPreviousExecutionState = work.getExecutionHistoryStore().load(work.getIdentity());
         return delegate.execute(new AfterPreviousExecutionContext() {
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
@@ -42,7 +42,7 @@ public class ResolveInputChangesStep<C extends IncrementalChangesContext> implem
 
     @Override
     public Result execute(C context) {
-        final UnitOfWork work = context.getWork();
+        UnitOfWork work = context.getWork();
         Optional<InputChangesInternal> inputChanges = work.getInputChangeTrackingStrategy().requiresInputChanges()
             ? Optional.of(determineInputChanges(work, context))
             : Optional.empty();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
@@ -29,10 +29,10 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 
 import java.util.Optional;
 
-public class StoreSnapshotsStep<C extends BeforeExecutionContext> implements Step<C, CurrentSnapshotResult> {
+public class StoreExecutionStateStep<C extends BeforeExecutionContext> implements Step<C, CurrentSnapshotResult> {
     private final Step<? super C, ? extends CurrentSnapshotResult> delegate;
 
-    public StoreSnapshotsStep(
+    public StoreExecutionStateStep(
         Step<? super C, ? extends CurrentSnapshotResult> delegate
     ) {
         this.delegate = delegate;

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 
-class StoreSnapshotsStepTest extends StepSpec<BeforeExecutionContext> implements FingerprinterFixture {
+class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> implements FingerprinterFixture {
     def executionHistoryStore = Mock(ExecutionHistoryStore)
 
     def originMetadata = Mock(OriginMetadata)
@@ -48,7 +48,7 @@ class StoreSnapshotsStepTest extends StepSpec<BeforeExecutionContext> implements
     def outputFile = file("output.txt").text = "output"
     def finalOutputs = fingerprintsOf(output: outputFile)
 
-    def step = new StoreSnapshotsStep<>(delegate)
+    def step = new StoreExecutionStateStep<BeforeExecutionContext>(delegate)
     def delegateResult = Mock(CurrentSnapshotResult)
 
     @Override


### PR DESCRIPTION
Using `LoadExecutionState` and `StoreExecutionState` reflects the symmetry better than what we had before.
