### PR TITLE
Introduce forSubgraph dependency version constraints

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
@@ -74,6 +74,16 @@ public interface MutableVersionConstraint extends VersionConstraint {
     void prefer(String version);
 
     /**
+     * Apply the version constraint to other occurrences of the same module in the subgraph of dependencies.
+     * This effectively gives this constraint a higher weight to accept previously rejected versions
+     * (e.g. to downgrade the version of a transitive dependency)
+     *
+     * @since 5.7
+     */
+    @Incubating
+    void forSubgraph();
+
+    /**
      * Sets the version as strict.
      * <p>
      * Any version not matched by this version notation will be excluded. This is the strongest version declaration.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -137,4 +137,12 @@ public interface VersionConstraint extends Describable {
      * @return the list of rejected versions
      */
     List<String> getRejectedVersions();
+
+    /**
+     * Returns true if the version constraint wins over other transitively brought in constraints on the same component.
+     *
+     * @since 5.7
+     */
+    @Incubating
+    boolean isForSubgraph();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
@@ -65,7 +65,15 @@ public enum ComponentSelectionCause {
     /**
      * This component was selected because of a dependency constraint
      */
-    CONSTRAINT("constraint");
+    CONSTRAINT("constraint"),
+
+    /**
+     * This component was selected because it was requested by a parent with {@link org.gradle.api.artifacts.MutableVersionConstraint#forSubgraph()}.
+     *
+     * @since 5.7
+     */
+    @Incubating
+    BY_ANCESTOR("by ancestor");
 
     private final String defaultReason;
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsFeatureInteractionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsFeatureInteractionIntegrationTest.groovy
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve.forsubgraph
+
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        resolve.withStrictReasonsCheck()
+    }
+
+    def "can turn constraint into subgraph constraint by using a component metadata rule"() {
+        given:
+        repository {
+            'org:foo:1.0'() {
+                dependsOn 'org:baz:2.0'
+            }
+            'org:bar:1.0' {
+                dependsOn 'org:baz:1.0'
+                dependsOn 'org:foo:1.0'
+            }
+            'org:baz:1.0'()
+            'org:baz:2.0'()
+        }
+
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org:bar') { ComponentMetadataDetails details ->
+                        details.allVariants {
+                            withDependencies {
+                                it.each { 
+                                    it.version { forSubgraph() } 
+                                }
+                            }
+                        }
+                    }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:baz:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:bar:1.0') {
+                    module('org:baz:1.0').byRequest()
+                    module('org:foo:1.0') {
+                        edge('org:baz:2.0', 'org:baz:1.0').byAncestor()
+                    }
+                }
+            }
+        }
+    }
+
+    def "an ancestor provided versions is not a version conflict"() {
+        given:
+        repository {
+            'org:foo:1.0'()
+            'org:foo:2.0'()
+            'org:bar:1.0' {
+                dependsOn 'org:foo:2.0'
+            }
+        }
+
+        buildFile << """
+            configurations.conf.resolutionStrategy.failOnVersionConflict()
+            dependencies {
+                constraints {
+                    conf('org:foo:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:foo:1.0').byConstraint()
+                module('org:bar:1.0') {
+                    edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                }
+            }
+        }
+    }
+
+    def "can force a version over an ancestor provided version"() {
+        given:
+        repository {
+            'org:bar:1.0'()
+            'org:bar:2.0'()
+        }
+
+        settingsFile << "\ninclude 'foo'"
+        buildFile << """
+            project(':foo') {
+                configurations.create('conf')
+                artifacts { add('conf', file('foo.jar')) }
+                dependencies { 
+                    conf('org:bar:2.0') { force = true }
+                }
+            }
+            dependencies {
+                constraints {
+                    conf('org:bar:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf(project(path: ':foo', configuration: 'conf'))
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:bar:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:bar:1.0', 'org:bar:2.0').byConstraint()
+                project(':foo', 'test:foo:') {
+                    configuration = 'conf'
+                    module('org:bar:2.0').byRequest().forced()
+                }
+            }
+        }
+    }
+
+    def "can force a version over an ancestor provided version via resolution strategy"() {
+        given:
+        repository {
+            'org:bar:1.0'()
+            'org:bar:2.0'()
+        }
+
+        settingsFile << "\ninclude 'foo'"
+        buildFile << """
+            configurations.conf.resolutionStrategy.force('org:bar:2.0')
+            project(':foo') {
+                configurations.create('conf')
+                artifacts { add('conf', file('foo.jar')) }
+                dependencies { 
+                    conf('org:bar:2.0')
+                }
+            }
+            dependencies {
+                constraints {
+                    conf('org:bar:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf(project(path: ':foo', configuration: 'conf'))
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:bar:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:bar:1.0', 'org:bar:2.0').byConstraint()
+                project(':foo', 'test:foo:') {
+                    configuration = 'conf'
+                    module('org:bar:2.0').byRequest().forced()
+                }
+            }
+        }
+    }
+
+    def "subgraph constraints apply to modules provided through substitution"() {
+        given:
+        repository {
+            'org:foo:1.0'()
+            'org:foo:2.0'()
+            'org:old:2.0'()
+            'org:bar:1.0' {
+                dependsOn 'org:old:2.0'
+            }
+        }
+
+        buildFile << """
+            configurations.conf.resolutionStrategy.dependencySubstitution {
+                substitute module("org:old") because "better foo than old" with module("org:foo:2.0")
+            }
+            dependencies {
+                conf('org:foo:1.0') {
+                   version { forSubgraph() }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0').byRequest()
+                module('org:bar:1.0') {
+                    edge('org:old:2.0', 'org:foo:1.0').selectedByRule("better foo than old").byAncestor()
+                }
+            }
+        }
+    }
+
+    def "dependency resolve rules dominate over subgraph constraints"() {
+        given:
+        repository {
+            'org:foo:0.11'()
+            'org:bar:1.0' {
+                dependsOn 'org:foo:2.0'
+            }
+        }
+
+        buildFile << """
+            configurations.conf.resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                if (details.requested.name == 'foo') {
+                    details.useVersion '0.11'
+                    details.because 'because I can'
+                }
+            }
+            dependencies {
+                constraints {
+                    conf('org:foo:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:0.11' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:foo:1.0', 'org:foo:0.11').byConstraint()
+                module('org:bar:1.0') {
+                    edge('org:foo:2.0', 'org:foo:0.11').byAncestor().selectedByRule('because I can')
+                }
+            }
+        }
+    }
+}
+

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsIntegrationTest.groovy
@@ -1,0 +1,600 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve.forsubgraph
+
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        resolve.withStrictReasonsCheck()
+    }
+
+    def "can downgrade version"() {
+        given:
+        repository {
+            'org:foo:1.0'()
+            'org:foo:2.0'()
+            'org:bar:1.0' {
+                dependsOn 'org:foo:2.0'
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0') {
+                   version { forSubgraph() }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0').byRequest()
+                module('org:bar:1.0') {
+                    edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                }
+            }
+        }
+    }
+
+    def "can use dependency constraint to downgrade version"() {
+        given:
+        repository {
+            'org:foo:1.0'()
+            'org:foo:2.0'()
+            'org:bar:1.0' {
+                dependsOn 'org:foo:2.0'
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf('org:foo:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:foo:1.0').byConstraint()
+                module('org:bar:1.0') {
+                    edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                }
+            }
+        }
+    }
+
+    def "a forSubgraph constraint wins over a nested forSubgraph constraint"() {
+        boolean publishedConstraintsSupported = gradleMetadataEnabled
+
+        given:
+        repository {
+            'org:a:1.0' {
+                dependsOn(group: 'org', artifact: 'b', version: '1.0')
+                constraint(group: 'org', artifact: 'c', version: '2.0', forSubgraph: true)
+            }
+            'org:b:1.0' {
+                dependsOn 'org:c:3.0'
+            }
+            'org:c:1.0'()
+            'org:c:2.0'()
+            'org:c:3.0'()
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:a:1.0')
+                constraints {
+                    conf('org:c:1.0') { version { forSubgraph() } }
+                }
+            }    
+        """
+
+        when:
+        repositoryInteractions {
+            'org:a:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:b:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:c:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:a:1.0') {
+                    module('org:b:1.0') {
+                        edge('org:c:3.0', 'org:c:1.0').byAncestor()
+                    }
+                    if (publishedConstraintsSupported) {
+                        constraint('org:c:2.0', 'org:c:1.0')
+                    }
+                }
+                constraint('org:c:1.0').byConstraint()
+            }
+        }
+    }
+
+    def "identical forSubgraph constraints can co-exist in a graph"() {
+        boolean publishedConstraintsSupported = gradleMetadataEnabled
+
+        given:
+        repository {
+            'org:a:1.0' {
+                dependsOn(group: 'org', artifact: 'b', version: '1.0')
+                constraint(group: 'org', artifact: 'c', version: '1.0', forSubgraph: true)
+            }
+            'org:b:1.0' {
+                dependsOn 'org:c:2.0'
+            }
+            'org:c:1.0'()
+            'org:c:2.0'()
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:a:1.0')
+                constraints {
+                    conf('org:c:1.0') { version { forSubgraph() } }
+                }
+            }    
+        """
+
+        when:
+        repositoryInteractions {
+            'org:a:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:b:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:c:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:a:1.0') {
+                    module('org:b:1.0') {
+                        edge('org:c:2.0', 'org:c:1.0').byAncestor()
+                    }
+                    if (publishedConstraintsSupported) {
+                        constraint('org:c:1.0')
+                    }
+                }
+                constraint('org:c:1.0').byConstraint()
+            }
+        }
+    }
+
+    def "conflicting version constraints are conflict resolved"() {
+        boolean subgraphConstraintsSupported = gradleMetadataEnabled
+
+        given:
+        repository {
+            'org:a:1.0' {
+                dependsOn(group: 'org', artifact: 'b', version: '1.0')
+                dependsOn(group: 'org', artifact: 'c', version: '1.0', forSubgraph: true)
+            }
+            'org:b:1.0' {
+                dependsOn 'org:c:2.0'
+            }
+            'org:c:1.0'()
+            'org:c:2.0'()
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:a:1.0')
+                conf('org:c:2.0')
+            }    
+        """
+
+        when:
+        repositoryInteractions {
+            'org:a:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:b:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:c:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:a:1.0') {
+                    module('org:b:1.0') {
+                        module('org:c:2.0')
+                    }
+                    edge('org:c:1.0', 'org:c:2.0').byConflictResolution("between versions 2.0 and 1.0").with {
+                        if (subgraphConstraintsSupported) { it.byAncestor() }
+                    }
+                }
+                module('org:c:2.0').byRequest()
+            }
+        }
+    }
+
+    def "forSubgraph is consumed from Gradle metadata"() {
+        given:
+        // If we do not use Gradle metadata, information is missing and we get a different result
+        String cResult = gradleMetadataEnabled ? 'org:c:1.0' : 'org:c:2.0'
+
+        repository {
+            'org:a:1.0' {
+                dependsOn(group: 'org', artifact: 'b', version: '1.0')
+                dependsOn(group: 'org', artifact: 'c', version: '1.0', forSubgraph: true)
+            }
+            'org:b:1.0' {
+                dependsOn 'org:c:2.0'
+            }
+            'org:c:1.0'()
+            'org:c:2.0'()
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:a:1.0')
+            }    
+        """
+
+        when:
+        repositoryInteractions {
+            'org:a:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:b:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            "$cResult" {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            if (cResult == 'org:c:2.0') {
+                'org:c:1.0' {
+                    expectGetMetadata()
+                }
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:a:1.0') {
+                    module('org:b:1.0') {
+                        edge('org:c:2.0', cResult)
+                    }
+                    edge('org:c:1.0', cResult).byRequest().with {
+                        if (cResult == 'org:c:1.0') { it.byAncestor() } else { it.byConflictResolution("between versions 2.0 and 1.0") }
+                    }
+                }
+            }
+        }
+    }
+
+    def "forSubgraph from selected and later evicted modules are ignored"() {
+        given:
+        repository {
+            'org:a:1.0' {
+                dependsOn(group: 'org', artifact: 'b', version: '1.0')
+                dependsOn(group: 'org', artifact: 'c', version: '1.0', forSubgraph: true)
+            }
+            'org:a:2.0' {
+                dependsOn(group: 'org', artifact: 'b', version: '1.0')
+                dependsOn(group: 'org', artifact: 'c', version: '1.0')
+            }
+            'org:b:1.0' {
+                dependsOn 'org:c:2.0'
+            }
+            'org:c:1.0'()
+            'org:c:2.0'()
+
+            'org:x:1.0' {
+                dependsOn 'org:y:1.0'
+            }
+            'org:y:1.0' {
+                dependsOn 'org:a:2.0'
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:a:1.0')
+                conf('org:x:1.0')
+            }    
+        """
+
+        when:
+        repositoryInteractions {
+            'org:a:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:b:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:c:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+
+            'org:x:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:y:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+
+            'org:a:1.0' {
+                expectGetMetadata()
+            }
+            'org:c:1.0' {
+                expectGetMetadata()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:a:1.0', 'org:a:2.0') {
+                    module('org:b:1.0') {
+                        module('org:c:2.0').byRequest()
+                    }
+                    edge('org:c:1.0', 'org:c:2.0').byConflictResolution("between versions 2.0 and 1.0")
+                }.byConflictResolution("between versions 2.0 and 1.0")
+                module('org:x:1.0') {
+                    module('org:y:1.0') {
+                        module('org:a:2.0').byRequest()
+                    }
+                }
+            }
+        }
+    }
+
+    def "can bring back a rejected version"() {
+        String publishedFooDependencyVersion = gradleMetadataEnabled ? '{require 2.0; reject 1.0}' : '2.0'
+
+        given:
+        repository {
+            'org:foo:1.0'()
+            'org:foo:2.0'()
+            'org:bar:1.0' {
+                dependsOn(group: 'org', artifact: 'foo', version: '2.0', rejects: ['1.0'])
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf('org:foo:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:foo:1.0').byConstraint()
+                module('org:bar:1.0') {
+                    edge("org:foo:$publishedFooDependencyVersion", 'org:foo:1.0').byAncestor()
+                }
+            }
+        }
+    }
+
+    def "can downgrade a version range"() {
+        given:
+        repository {
+            'org:foo:1.0'()
+            'org:foo:2.1'()
+            'org:bar:1.0' {
+                dependsOn(group: 'org', artifact: 'foo', version: '[2.0,3.0)')
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf('org:foo:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            // no version listing needed!
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:foo:1.0').byConstraint()
+                module('org:bar:1.0') {
+                    edge("org:foo:[2.0,3.0)", 'org:foo:1.0').byAncestor()
+                }
+            }
+        }
+    }
+
+    def "can downgrade to a local project"() {
+        given:
+        repository {
+            'org:foo:2.0'()
+            'org:bar:1.0' {
+               dependsOn 'org:foo:2.0'
+            }
+        }
+
+        settingsFile << "\ninclude 'foo'"
+        buildFile << """
+            project(':foo') {
+                configurations.create('default')
+                group = 'org'
+                version = '1.0'
+            }
+            dependencies {
+                constraints {
+                    conf('org:foo:1.0') {
+                       version { forSubgraph() }
+                    }
+                }
+                conf('org:bar:1.0')
+                conf(project(':foo'))
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:foo:1.0', 'project :foo', 'org:foo:1.0').byConstraint()
+                module('org:bar:1.0') {
+                    edge('org:foo:2.0', 'project :foo', 'org:foo:1.0') {}.byAncestor()
+                }
+                project(':foo', 'org:foo:1.0') {
+                    configuration = 'default'
+                    noArtifacts()
+                }.byRequest()
+            }
+        }
+    }
+
+    def "fails if there are more than one subgraph constraint targeting the same module on the same level"() {
+        given:
+        repository {
+            'org:bar:1.0' {
+                dependsOn 'org:foo:2.0'
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0') {
+                   version { forSubgraph() }
+                }
+                conf('org:foo:1.1') {
+                   version { forSubgraph() }
+                }
+                conf('org:bar:1.0')
+            }           
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause('Dependency org:foo of :test:unspecified defines conflicting forSubgraph constraints')
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
@@ -63,7 +63,8 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         for (int i = 0; i < cpt; i++) {
             rejects.add(decoder.readString());
         }
-        return new DefaultImmutableVersionConstraint(preferred, required, strictly, rejects);
+        boolean forSubgraph = decoder.readBoolean();
+        return new DefaultImmutableVersionConstraint(preferred, required, strictly, rejects, forSubgraph);
     }
 
     @Override
@@ -92,6 +93,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         for (String rejectedVersion : rejectedVersions) {
             encoder.writeString(rejectedVersion);
         }
+        encoder.writeBoolean(cst.isForSubgraph());
     }
 
     private ImmutableAttributes readAttributes(Decoder decoder) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -37,12 +37,13 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
             && Objects.equal(getPreferredVersion(), that.getPreferredVersion())
             && Objects.equal(getStrictVersion(), that.getStrictVersion())
             && Objects.equal(getBranch(), that.getBranch())
-            && Objects.equal(getRejectedVersions(), that.getRejectedVersions());
+            && Objects.equal(getRejectedVersions(), that.getRejectedVersions())
+            && Objects.equal(isForSubgraph(), that.isForSubgraph());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getRequiredVersion(), getPreferredVersion(), getStrictVersion(), getRejectedVersions());
+        return Objects.hashCode(getRequiredVersion(), getPreferredVersion(), getStrictVersion(), getRejectedVersions(), isForSubgraph());
     }
 
     @Override
@@ -60,6 +61,16 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
         builder.append(name);
         builder.append(" ");
         builder.append(version);
+    }
+
+    private void append(String name, boolean active, StringBuilder builder) {
+        if (!active) {
+            return;
+        }
+        if (builder.length() != 1) {
+            builder.append("; ");
+        }
+        builder.append(name);
     }
 
     @Override
@@ -82,6 +93,7 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
         }
         append("reject", rejectedVersionsString(), builder);
         append("branch", getBranch(), builder);
+        append("subgraph", isForSubgraph(), builder);
         builder.append("}");
         return builder.toString();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
@@ -34,21 +34,24 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
     private final ImmutableList<String> rejectedVersions;
     @Nullable
     private final String requiredBranch;
+    private final boolean forSubgraph;
 
     private final int hashCode;
 
     public DefaultImmutableVersionConstraint(String preferredVersion,
                                              String requiredVersion,
                                              String strictVersion,
-                                             List<String> rejectedVersions) {
-        this(preferredVersion, requiredVersion, strictVersion, rejectedVersions, null);
+                                             List<String> rejectedVersions,
+                                             boolean forSubgraph) {
+        this(preferredVersion, requiredVersion, strictVersion, rejectedVersions, null, forSubgraph);
     }
 
     public DefaultImmutableVersionConstraint(String preferredVersion,
                                              String requiredVersion,
                                              String strictVersion,
                                              List<String> rejectedVersions,
-                                             @Nullable String requiredBranch) {
+                                             @Nullable String requiredBranch,
+                                             boolean forSubgraph) {
         if (preferredVersion == null) {
             throw new IllegalArgumentException("Preferred version must not be null");
         }
@@ -71,6 +74,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         this.strictVersion = strictVersion;
         this.rejectedVersions = ImmutableList.copyOf(rejectedVersions);
         this.requiredBranch = requiredBranch;
+        this.forSubgraph = forSubgraph;
         this.hashCode = super.hashCode();
     }
 
@@ -83,6 +87,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         this.strictVersion = "";
         this.rejectedVersions = ImmutableList.of();
         this.requiredBranch = null;
+        this.forSubgraph = false;
         this.hashCode = super.hashCode();
     }
 
@@ -117,11 +122,16 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         return rejectedVersions;
     }
 
+    @Override
+    public boolean isForSubgraph() {
+        return forSubgraph;
+    }
+
     public static ImmutableVersionConstraint of(VersionConstraint versionConstraint) {
         if (versionConstraint instanceof ImmutableVersionConstraint) {
             return (ImmutableVersionConstraint) versionConstraint;
         }
-        return new DefaultImmutableVersionConstraint(versionConstraint.getPreferredVersion(), versionConstraint.getRequiredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions());
+        return new DefaultImmutableVersionConstraint(versionConstraint.getPreferredVersion(), versionConstraint.getRequiredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions(), versionConstraint.isForSubgraph());
     }
 
     public static ImmutableVersionConstraint of(String version) {
@@ -131,8 +141,8 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         return new DefaultImmutableVersionConstraint(version);
     }
 
-    public static ImmutableVersionConstraint of(String preferredVersion, String requiredVersion, String strictVersion, List<String> rejects) {
-        return new DefaultImmutableVersionConstraint(preferredVersion, requiredVersion, strictVersion, rejects);
+    public static ImmutableVersionConstraint of(String preferredVersion, String requiredVersion, String strictVersion, List<String> rejects, boolean forSubgraph) {
+        return new DefaultImmutableVersionConstraint(preferredVersion, requiredVersion, strictVersion, rejects, forSubgraph);
     }
 
     public static ImmutableVersionConstraint of() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -32,6 +32,7 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     private String strictVersion;
     private String branch;
     private final List<String> rejectedVersions = Lists.newArrayListWithExpectedSize(1);
+    private boolean forSubgraph;
 
     public DefaultMutableVersionConstraint(VersionConstraint versionConstraint) {
         this(versionConstraint.getPreferredVersion(), versionConstraint.getRequiredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions());
@@ -69,7 +70,7 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
 
     @Override
     public ImmutableVersionConstraint asImmutable() {
-        return new DefaultImmutableVersionConstraint(preferredVersion, requiredVersion, strictVersion, rejectedVersions, branch);
+        return new DefaultImmutableVersionConstraint(preferredVersion, requiredVersion, strictVersion, rejectedVersions, branch, forSubgraph);
     }
 
     @Nullable
@@ -104,6 +105,11 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     }
 
     @Override
+    public void forSubgraph() {
+        forSubgraph = true;
+    }
+
+    @Override
     public String getStrictVersion() {
         return strictVersion;
     }
@@ -128,6 +134,11 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     @Override
     public List<String> getRejectedVersions() {
        return rejectedVersions;
+    }
+
+    @Override
+    public boolean isForSubgraph() {
+        return forSubgraph;
     }
 
     public String getVersion() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
@@ -75,7 +75,8 @@ public class DefaultProjectDependencyConstraint implements DependencyConstraintI
                 projectDependency.getVersion(),
                 "",
                 Collections.emptyList(),
-                ""
+                "",
+                false
         );
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -54,6 +54,7 @@ public enum CacheLayout {
         .changedTo(68, "5.0-milestone-1")
         .changedTo(69, "5.0-rc-1")
         .changedTo(71, "5.3-rc-1")
+        .changedTo(72, "5.7-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -400,6 +400,7 @@ public class GradleModuleMetadataParser {
         String preferredVersion = "";
         String strictVersion = "";
         List<String> rejects = Lists.newArrayList();
+        boolean forSubgraph = false;
 
         reader.beginObject();
         while (reader.peek() != END_OBJECT) {
@@ -422,14 +423,16 @@ public class GradleModuleMetadataParser {
                     }
                     reader.endArray();
                     break;
+                case "forSubgraph":
+                    forSubgraph = reader.nextBoolean();
+                    break;
                 default:
                     consumeAny(reader);
                     break;
             }
         }
         reader.endObject();
-
-        return DefaultImmutableVersionConstraint.of(preferredVersion, requiredVersion, strictVersion, rejects);
+        return DefaultImmutableVersionConstraint.of(preferredVersion, requiredVersion, strictVersion, rejects, forSubgraph);
     }
 
     private ImmutableList<ExcludeMetadata> consumeExcludes(JsonReader reader) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -63,7 +63,7 @@ import static org.apache.commons.lang.StringUtils.capitalize;
 public class GradleModuleMetadataParser {
     private final static Logger LOGGER = Logging.getLogger(GradleModuleMetadataParser.class);
 
-    public static final String FORMAT_VERSION = "1.0";
+    public static final String FORMAT_VERSION = "1.1";
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator instantiator;
     private final ExcludeRuleConverter excludeRuleConverter;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
@@ -27,6 +27,7 @@ import org.gradle.internal.resolve.ModuleVersionResolveException;
 
 import java.util.List;
 
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.BY_ANCESTOR;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.CONSTRAINT;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.FORCED;
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.REQUESTED;
@@ -128,7 +129,12 @@ class DependencyState {
     }
 
     private void addMainReason(List<ComponentSelectionDescriptorInternal> reasons) {
-        ComponentSelectionDescriptorInternal dependencyDescriptor = dependency.isConstraint() ? CONSTRAINT : REQUESTED;
+        ComponentSelectionDescriptorInternal dependencyDescriptor;
+        if (reasons != null && reasons.contains(BY_ANCESTOR)) {
+            dependencyDescriptor = BY_ANCESTOR;
+        } else {
+            dependencyDescriptor = dependency.isConstraint() ? CONSTRAINT : REQUESTED;
+        }
         String reason = dependency.getReason();
         if (reason != null) {
             dependencyDescriptor = dependencyDescriptor.withDescription(Describables.of(reason));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -53,7 +53,6 @@ class EdgeState implements DependencyGraphEdge {
     private final DependencyState dependencyState;
     private final DependencyMetadata dependencyMetadata;
     private final NodeState from;
-    private final SelectorState selector;
     private final ResolveState resolveState;
     private final ExcludeSpec transitiveExclusions;
     private final List<NodeState> targetNodes = Lists.newLinkedList();
@@ -61,6 +60,7 @@ class EdgeState implements DependencyGraphEdge {
     private final boolean isConstraint;
     private final int hashCode;
 
+    private SelectorState selector;
     private ModuleVersionResolveException targetNodeSelectionFailure;
     private ImmutableAttributes cachedAttributes;
     private ExcludeSpec cachedEdgeExclusions;
@@ -75,7 +75,6 @@ class EdgeState implements DependencyGraphEdge {
         // The accumulated exclusions that apply to this edge based on the path from the root
         this.transitiveExclusions = transitiveExclusions;
         this.resolveState = resolveState;
-        this.selector = resolveState.getSelector(dependencyState);
         this.isTransitive = from.isTransitive() && dependencyMetadata.isTransitive();
         this.isConstraint = dependencyMetadata.isConstraint();
         this.hashCode = computeHashCode();
@@ -88,6 +87,10 @@ class EdgeState implements DependencyGraphEdge {
             hashCode = 31 * hashCode + transitiveExclusions.hashCode();
         }
         return hashCode;
+    }
+
+    void computeSelector() {
+        this.selector = resolveState.getSelector(dependencyState, from.versionProvidedByAncestors(dependencyState));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
@@ -51,6 +51,7 @@ class PotentialEdge {
         DependencyState dependencyState = new DependencyState(new LenientPlatformDependencyMetadata(resolveState, from, toSelector, toComponent, owner, force || isForce(from), transitive), resolveState.getComponentSelectorConverter());
         dependencyState = NodeState.maybeSubstitute(dependencyState, resolveState.getDependencySubstitutionApplicator());
         EdgeState edge = new EdgeState(from, dependencyState, from.previousTraversalExclusions, resolveState);
+        edge.computeSelector();
         ModuleVersionIdentifier toModuleVersionId = DefaultModuleVersionIdentifier.newId(toSelector.getModuleIdentifier(), toSelector.getVersion());
         ComponentState version = resolveState.getModule(toSelector.getModuleIdentifier()).getVersion(toModuleVersionId, toComponent);
         SelectorState selector = edge.getSelector();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -40,6 +40,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.Pair;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
@@ -62,7 +63,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     private final Spec<? super DependencyMetadata> edgeFilter;
     private final Map<ModuleIdentifier, ModuleResolveState> modules;
     private final Map<ResolvedConfigurationIdentifier, NodeState> nodes;
-    private final Map<ComponentSelector, SelectorState> selectors;
+    private final Map<Pair<ComponentSelector, Boolean>, SelectorState> selectors;
     private final RootNode root;
     private final IdGenerator<Long> idGenerator;
     private final DependencyToComponentIdResolver idResolver;
@@ -104,7 +105,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         this.versionParser = versionParser;
         this.modules = new LinkedHashMap<ModuleIdentifier, ModuleResolveState>(graphSize);
         this.nodes = new LinkedHashMap<ResolvedConfigurationIdentifier, NodeState>(3 * graphSize / 2);
-        this.selectors = new LinkedHashMap<ComponentSelector, SelectorState>(5 * graphSize / 2);
+        this.selectors = new LinkedHashMap<Pair<ComponentSelector, Boolean>, SelectorState>(5 * graphSize / 2);
         this.queue = new ArrayDeque<NodeState>(graphSize);
         this.resolveOptimizations = new ResolveOptimizations();
         this.attributeDesugaring = new AttributeDesugaring(attributesFactory);
@@ -161,10 +162,10 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         return selectors.values();
     }
 
-    public SelectorState getSelector(DependencyState dependencyState) {
-        SelectorState selectorState = selectors.computeIfAbsent(dependencyState.getRequested(), req -> {
+    public SelectorState getSelector(DependencyState dependencyState, boolean ignoreVersion) {
+        SelectorState selectorState = selectors.computeIfAbsent(Pair.of(dependencyState.getRequested(), ignoreVersion), req -> {
             ModuleIdentifier moduleIdentifier = dependencyState.getModuleIdentifier();
-            return new SelectorState(idGenerator.generateId(), dependencyState, idResolver, this, moduleIdentifier);
+            return new SelectorState(idGenerator.generateId(), dependencyState, idResolver, this, moduleIdentifier, ignoreVersion);
         });
         selectorState.update(dependencyState);
         return selectorState;
@@ -234,10 +235,13 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
 
     ResolvedVersionConstraint resolveVersionConstraint(ComponentSelector selector) {
         if (selector instanceof ModuleComponentSelector) {
-            VersionConstraint vc = ((ModuleComponentSelector) selector).getVersionConstraint();
-            return resolvedVersionConstraints.computeIfAbsent(vc, key -> new DefaultResolvedVersionConstraint(key, versionSelectorScheme));
+            return resolveVersionConstraint(((ModuleComponentSelector) selector).getVersionConstraint());
         }
         return null;
+    }
+
+    ResolvedVersionConstraint resolveVersionConstraint(VersionConstraint vc) {
+        return resolvedVersionConstraints.computeIfAbsent(vc, key -> new DefaultResolvedVersionConstraint(key, versionSelectorScheme));
     }
 
     ImmutableAttributes desugar(ImmutableAttributes attributes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasons.java
@@ -38,6 +38,7 @@ public class ComponentSelectionReasons {
     public static final ComponentSelectionDescriptorInternal COMPOSITE_BUILD = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.COMPOSITE_BUILD);
     public static final ComponentSelectionDescriptorInternal CONSTRAINT = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONSTRAINT);
     public static final ComponentSelectionDescriptorInternal REJECTION = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.REJECTION);
+    public static final ComponentSelectionDescriptorInternal BY_ANCESTOR = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.BY_ANCESTOR);
 
     public static ComponentSelectionReason requested() {
         return new DefaultComponentSelectionReason(REQUESTED);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -101,7 +101,8 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         for (int i = 0; i < rejectCount; i++) {
             rejects.add(decoder.readString());
         }
-        return new DefaultImmutableVersionConstraint(prefers, requires, strictly, rejects);
+        boolean forSubgraph = decoder.readBoolean();
+        return new DefaultImmutableVersionConstraint(prefers, requires, strictly, rejects, forSubgraph);
     }
 
     private List<Capability> readCapabilities(Decoder decoder) throws IOException {
@@ -191,6 +192,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         for (String rejectedVersion : rejectedVersions) {
             encoder.writeString(rejectedVersion);
         }
+        encoder.writeBoolean(versionConstraint.isForSubgraph());
     }
 
     private ComponentSelectorSerializer.Implementation resolveImplementation(ComponentSelector value) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/subgraphconstraints/SubgraphConstraints.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/subgraphconstraints/SubgraphConstraints.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.subgraphconstraints;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.ModuleIdentifier;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class SubgraphConstraints {
+
+    public static final SubgraphConstraints EMPTY = new SubgraphConstraints();
+
+    private final Set<ModuleIdentifier> modules;
+
+    private SubgraphConstraints() {
+        modules = Collections.emptySet();
+    }
+
+    private SubgraphConstraints(Set<ModuleIdentifier> modules) {
+        this.modules = modules;
+    }
+
+    public static SubgraphConstraints of(Set<ModuleIdentifier> modules) {
+        if (modules.isEmpty()) {
+            return EMPTY;
+        }
+        return new SubgraphConstraints(modules);
+    }
+
+    public static SubgraphConstraints of(SubgraphConstraints subgraphConstraints1, SubgraphConstraints subgraphConstraints2) {
+        return of(new ImmutableSet.Builder<ModuleIdentifier>().addAll(subgraphConstraints1.modules).addAll(subgraphConstraints2.modules).build());
+    }
+
+    public Set<ModuleIdentifier> getModules() {
+        return modules;
+    }
+
+    public boolean isEmpty() {
+        return this == EMPTY;
+    }
+
+    public boolean contains(ModuleIdentifier module) {
+        return modules.contains(module);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
@@ -104,7 +104,7 @@ public class DefaultIvyModulePublishMetadata implements IvyModulePublishMetadata
                     VERSION_TRANSFORMER.transform(versionConstraint.getPreferredVersion()),
                     VERSION_TRANSFORMER.transform(versionConstraint.getRequiredVersion()),
                     VERSION_TRANSFORMER.transform(versionConstraint.getStrictVersion()),
-                    CollectionUtils.collect(versionConstraint.getRejectedVersions(), VERSION_TRANSFORMER));
+                    CollectionUtils.collect(versionConstraint.getRejectedVersions(), VERSION_TRANSFORMER), versionConstraint.isForSubgraph());
             ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), transformedConstraint, selector.getAttributes(), selector.getRequestedCapabilities());
             return dependency.withTarget(newSelector);
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
@@ -38,26 +38,30 @@ class ModuleComponentSelectorSerializerTest extends SerializerSpec {
     @Unroll
     def "serializes"() {
         when:
-        def result = serialize(newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar'), [capability("foo")]), serializer)
+        def result = serialize(newSelector(UTIL, constraint(version, strict, rejects, forSubgraph), attributes(foo: 'bar'), [capability("foo")]), serializer)
 
         then:
-        result == newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar'), [capability("foo")])
+        result == newSelector(UTIL, constraint(version, strict, rejects, forSubgraph), attributes(foo: 'bar'), [capability("foo")])
 
         where:
-        version | strict   | rejects
-        '5.0'   | ''       | []
-        '5.0'   | ''       | ['1.0']
-        '5.0'   | ''       | ['1.0', '2.0']
-        '5.0'   | '[1.0,)' | []
+        version | strict   | rejects        | forSubgraph
+        '5.0'   | ''       | []             | false
+        '5.0'   | ''       | ['1.0']        | false
+        '5.0'   | ''       | ['1.0', '2.0'] | false
+        '5.0'   | '[1.0,)' | []             | false
+        '5.0'   | ''       | []             | true
     }
 
-    private static MutableVersionConstraint constraint(String version, String strictVersion, List<String> rejectedVersions) {
+    private static MutableVersionConstraint constraint(String version, String strictVersion, List<String> rejectedVersions, boolean forSubgraph) {
         MutableVersionConstraint constraint = new DefaultMutableVersionConstraint(version)
         if (strictVersion != null) {
             constraint.strictly(strictVersion)
         }
         for (String reject : rejectedVersions) {
             constraint.reject(reject)
+        }
+        if (forSubgraph) {
+            constraint.forSubgraph()
         }
         return constraint
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
@@ -29,22 +29,36 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         v.preferredVersion == ''
         v.strictVersion == ''
         v.rejectedVersions == []
+        !v.forSubgraph
     }
 
     def "can create an immutable version constraint with rejects"() {
         given:
-        def v = new DefaultImmutableVersionConstraint('1.1', '1.0', '1.1.1', ['1.2', '2.0'])
+        def v = new DefaultImmutableVersionConstraint('1.1', '1.0', '1.1.1', ['1.2', '2.0'], false)
 
         expect:
         v.requiredVersion == '1.0'
         v.preferredVersion == '1.1'
         v.strictVersion == '1.1.1'
         v.rejectedVersions == ['1.2','2.0']
+        !v.forSubgraph
+    }
+
+    def "can create an immutable version constraint that applies for the subgraph"() {
+        given:
+        def v = new DefaultImmutableVersionConstraint('', '1.0', '', [], true)
+
+        expect:
+        v.requiredVersion == '1.0'
+        v.preferredVersion == ''
+        v.strictVersion == ''
+        v.rejectedVersions == []
+        v.forSubgraph
     }
 
     def "cannot mutate rejection list"() {
         given:
-        def v = new DefaultImmutableVersionConstraint('1.1', '1.0', '1.1.1', ['1.2', '2.0'])
+        def v = new DefaultImmutableVersionConstraint('1.1', '1.0', '1.1.1', ['1.2', '2.0'], false)
 
         when:
         v.rejectedVersions.add('3.0')
@@ -55,21 +69,21 @@ class DefaultImmutableVersionConstraintTest extends Specification {
 
     def "cannot use null as any version"() {
         when:
-        new DefaultImmutableVersionConstraint('1.1', null, '1.1', ['1.2', '2.0'])
+        new DefaultImmutableVersionConstraint('1.1', null, '1.1', ['1.2', '2.0'], false)
 
         then:
         def e = thrown(IllegalArgumentException)
         e.message == 'Required version must not be null'
 
         when:
-        new DefaultImmutableVersionConstraint(null, '1.0', '1.0', ['1.2', '2.0'])
+        new DefaultImmutableVersionConstraint(null, '1.0', '1.0', ['1.2', '2.0'], false)
 
         then:
         e = thrown(IllegalArgumentException)
         e.message == 'Preferred version must not be null'
 
         when:
-        new DefaultImmutableVersionConstraint('1.0', '1.0', null, ['1.2', '2.0'])
+        new DefaultImmutableVersionConstraint('1.0', '1.0', null, ['1.2', '2.0'], false)
 
         then:
         e = thrown(IllegalArgumentException)
@@ -79,14 +93,14 @@ class DefaultImmutableVersionConstraintTest extends Specification {
     def "cannot use empty or null as rejected version"() {
 
         when:
-        new DefaultImmutableVersionConstraint('', '', '', [null])
+        new DefaultImmutableVersionConstraint('', '', '', [null], false)
 
         then:
         def e = thrown(IllegalArgumentException)
         e.message == 'Rejected version must not be empty'
 
         when:
-        new DefaultImmutableVersionConstraint('', '', '', [''])
+        new DefaultImmutableVersionConstraint('', '', '', [''], false)
 
         then:
         e = thrown(IllegalArgumentException)
@@ -103,7 +117,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         v.rejectedVersions.empty
 
         when:
-        v = new DefaultImmutableVersionConstraint('', '', '', ['1.1', '2.0'])
+        v = new DefaultImmutableVersionConstraint('', '', '', ['1.1', '2.0'], false)
 
         then:
         v.preferredVersion == ''
@@ -113,7 +127,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
 
     def "cannot use null as rejected versions"() {
         when:
-        def v = new DefaultImmutableVersionConstraint('', '1.0', '', null)
+        def v = new DefaultImmutableVersionConstraint('', '1.0', '', null, false)
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -134,6 +148,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
     def "can convert mutable version constraint to immutable version constraint"() {
         given:
         def v = new DefaultMutableVersionConstraint('1.0', '2.0', '3.0', ['1.1', '2.0'])
+        v.forSubgraph()
 
         when:
         def c = DefaultImmutableVersionConstraint.of(v)
@@ -145,6 +160,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         c.preferredVersion == v.preferredVersion
         c.strictVersion == v.strictVersion
         c.rejectedVersions == v.rejectedVersions
+        c.forSubgraph == v.forSubgraph
     }
 
 
@@ -158,6 +174,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
 
         displayNameFor('1.0', '2.0', '3.0', ['1.0', '2.0']) == "{strictly 3.0; require 2.0; prefer 1.0; reject 1.0 & 2.0}"
         displayNameFor('1.0', '', '', [], 'br') == "{prefer 1.0; branch br}"
+        displayNameFor('1.0', '', '', [], null, true) == "{prefer 1.0; subgraph}"
 
         displayNameFor('1.0', '1.0', '', []) == "1.0" // prefer == require
         displayNameFor('', '1.0', '1.0', []) == "{strictly 1.0}" // strictly == require
@@ -165,8 +182,8 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         displayNameFor('1.0', '1.0', '1.0', []) == "{strictly 1.0}" // strictly == prefer == require
     }
 
-    private String displayNameFor(String preferred, String required, String strict, List<String> rejects, branch = null) {
-        new DefaultImmutableVersionConstraint(preferred, required, strict, rejects, branch).displayName
+    private String displayNameFor(String preferred, String required, String strict, List<String> rejects, branch = null, forSubgraph = false) {
+        new DefaultImmutableVersionConstraint(preferred, required, strict, rejects, branch, forSubgraph).displayName
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -190,4 +190,18 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.getRejectedVersions() == ['+']
     }
 
+    def "calling forSubgraph modifies only the isForSubgraph detail"() {
+        when:
+        def version = new DefaultMutableVersionConstraint('1.0')
+        version.reject('1.0.1', '1.0.2')
+        version.forSubgraph()
+
+        then:
+        version.requiredVersion == '1.0'
+        version.preferredVersion == ''
+        version.strictVersion == ''
+        version.rejectedVersions == ['1.0.1', '1.0.2']
+        version.forSubgraph
+    }
+
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 71
+        expectedVersion = 72
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -38,7 +38,7 @@ import static org.gradle.util.AttributeTestUtil.attributes
 class GradleModuleMetadataParserTest extends Specification {
     private static final String UNKNOWN_FILE_VALUES = '''
     { 
-        "formatVersion": "1.0", 
+        "formatVersion": "1.1", 
         "variants": [
             {
                 "name": "api",
@@ -131,20 +131,24 @@ class GradleModuleMetadataParserTest extends Specification {
         DefaultImmutableVersionConstraint.of(version)
     }
 
+    VersionConstraint requiresForSubgraph(String version) {
+        DefaultImmutableVersionConstraint.of('', version, '', [], true)
+    }
+
     VersionConstraint prefers(String version) {
-        DefaultImmutableVersionConstraint.of(version, '', '', [])
+        DefaultImmutableVersionConstraint.of(version, '', '', [], false)
     }
 
     VersionConstraint strictly(String version) {
-        DefaultImmutableVersionConstraint.of('', '', version, [])
+        DefaultImmutableVersionConstraint.of('', '', version, [], false)
     }
 
     VersionConstraint prefersAndStrictly(String prefers, String strictly) {
-        DefaultImmutableVersionConstraint.of(prefers, '', strictly, [])
+        DefaultImmutableVersionConstraint.of(prefers, '', strictly, [], false)
     }
 
     VersionConstraint prefersAndRejects(String version, List<String> rejects) {
-        DefaultImmutableVersionConstraint.of(version, version, "", rejects)
+        DefaultImmutableVersionConstraint.of(version, version, "", rejects, false)
     }
 
     List<Exclude> excludes(String... input) {
@@ -316,7 +320,7 @@ class GradleModuleMetadataParserTest extends Specification {
                     { 
                         "group": "g3", 
                         "module": "m3", 
-                        "version": { "requires": "v3" },
+                        "version": { "requires": "v3", "forSubgraph": true },
                         "excludes": [
                             {"group": "gx", "module": "mx" },
                             {"group": "*", "module": "*" }
@@ -344,7 +348,7 @@ class GradleModuleMetadataParserTest extends Specification {
         1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null, ImmutableAttributes.EMPTY, [])
         1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, ImmutableAttributes.EMPTY, [])
         1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY, [])
-        1 * variant1.addDependency("g3", "m3", requires("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY, [])
+        1 * variant1.addDependency("g3", "m3", requiresForSubgraph("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY, [])
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY, { it[0].group == 'org' && it[0].name == 'foo' && it[0].version == '1.0' })
         1 * variant2.addDependency("g4", "m4", strictly("v5"), [], null, ImmutableAttributes.EMPTY, [])
@@ -372,7 +376,7 @@ class GradleModuleMetadataParserTest extends Specification {
                     { 
                         "group": "g3", 
                         "module": "m3", 
-                        "version": { "requires": "v3" }
+                        "version": { "requires": "v3", "forSubgraph": true }
                     }
                 ],
                 "attributes": { "usage": "compile" }
@@ -395,7 +399,7 @@ class GradleModuleMetadataParserTest extends Specification {
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
         1 * variant1.addDependencyConstraint("g1", "m1", requires("v1"), null, ImmutableAttributes.EMPTY)
         1 * variant1.addDependencyConstraint("g2", "m2", prefers("v2"), null, ImmutableAttributes.EMPTY)
-        1 * variant1.addDependencyConstraint("g3", "m3", requires("v3"), null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependencyConstraint("g3", "m3", requiresForSubgraph("v3"), null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependencyConstraint("g3", "m3", prefers("v3"), null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependencyConstraint("g4", "m4", prefersAndRejects("v4", ["v5"]), null, ImmutableAttributes.EMPTY)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -748,7 +748,7 @@ class GradleModuleMetadataParserTest extends Specification {
 
         then:
         def e = thrown(MetaDataParseException)
-        e.message == "Could not parse module metadata <resource>: unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 1.0."
+        e.message == "Could not parse module metadata <resource>: unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 1.1."
         e.cause.message == "Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 1 column 42 path \$.variants"
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
@@ -108,7 +108,8 @@ class DefaultCapabilitiesConflictHandlerTest extends Specification {
     }
 
     NodeState node(ComponentState cs) {
-        return new NodeState(id++, Mock(ResolvedConfigurationIdentifier), cs, null, Mock(ConfigurationMetadata) {
+        return new NodeState(id++, Mock(ResolvedConfigurationIdentifier) { getId() >> Mock(ModuleVersionIdentifier) }, cs, null, Mock(ConfigurationMetadata) {
+            getDependencies() >> []
             getCapabilities() >> Mock(CapabilitiesMetadata) {
                 getCapabilities() >> []
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -42,12 +42,13 @@ import static org.gradle.util.Path.path
 class ComponentSelectorSerializerTest extends SerializerSpec {
     private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new DesugaredAttributeContainerSerializer(AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator()))
 
-    private static ImmutableVersionConstraint constraint(String version, String preferredVersion = '', String strictVersion = '', List<String> rejectVersions = []) {
+    private static ImmutableVersionConstraint constraint(String version, String preferredVersion = '', String strictVersion = '', List<String> rejectVersions = [], boolean forSubgraph = false) {
         return new DefaultImmutableVersionConstraint(
             preferredVersion,
             version,
             strictVersion,
-            rejectVersions
+            rejectVersions,
+            forSubgraph
         )
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
@@ -34,11 +34,11 @@ class DefaultModuleComponentSelectorTest extends Specification {
     }
 
     private static ImmutableVersionConstraint v(String version, String branch) {
-        return new DefaultImmutableVersionConstraint("", version, "", [], branch)
+        return new DefaultImmutableVersionConstraint("", version, "", [], branch, false)
     }
 
     private static ImmutableVersionConstraint b(String branch) {
-        return new DefaultImmutableVersionConstraint("", "", "", [], branch)
+        return new DefaultImmutableVersionConstraint("", "", "", [], branch, false)
     }
 
     def "is instantiated with non-null constructor parameter values"() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -655,7 +655,7 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         VersionConstraint getVersionConstraint() {
-            DefaultImmutableVersionConstraint.of("", "", "", [version])
+            DefaultImmutableVersionConstraint.of("", "", "", [version], false)
         }
 
         @Override

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
@@ -1,4 +1,4 @@
-# Gradle module metadata 1.0 specification
+# Gradle module metadata 1.1 specification
 
 Consumption of Gradle metadata is automatic. However publication needs to be enabled explicitly for any Gradle version prior to Gradle 6.
 
@@ -137,7 +137,8 @@ This value defines the version constraint of a dependency or dependency constrai
 - `requires`: optional. The required version for this dependency.
 - `prefers`: optional. The preferred version for this dependency.
 - `strictly`: optional. A strictly enforced version requirement for this dependency.
-- `rejects`: optional: An array of rejected versions for this dependency.
+- `rejects`: optional. An array of rejected versions for this dependency.
+- `forSubgraph`: optional. If set to `true`, the version constraint applies for each dependency to the corresponding module in the subgraph originating from the containing variant.
 
 #### `excludes` value
 
@@ -169,6 +170,15 @@ This value must contain an array with zero or more elements. Each element must b
 - `size`: The size of the file in bytes. A number.
 - `sha1`: The SHA1 hash of the file content. A hex string.
 - `md5`: The MD5 hash of the file content. A hex string.
+
+### Changelog
+
+#### 1.1
+
+- Added support for _subgraph version constraints_: `version { forSubgraph = true }`
+
+#### 1.0
+- Initial release
 
 ## Example
 
@@ -237,7 +247,7 @@ This value must contain an array with zero or more elements. Each element must b
                 { 
                     "group": "some.group", 
                     "module": "other-lib", 
-                    "version": { "requires": "[3.0, 4.0)", "prefers": "3.4", "rejects": ["3.4.1"] } 
+                    "version": { "requires": "[3.0, 4.0)", "prefers": "3.4", "rejects": ["3.4.1"], "forSubgraph": true } 
                 }
             ]
         }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -35,6 +35,27 @@ See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html#changes_@b
 
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. --> 
 
+## Introducing subgraph constraints for dependency versions
+
+When you declare a dependency to a module that is already on your dependency graph, due to a transitive dependency, you sometimes need to change the version of that module according to your needs.
+So far, this was limited to cases where the existing constraint should be limited further (e.g. choosing a specific version from a range).
+Version constraints can now made into [subgraph constraints](userguide/declaring_dependency_versions.html#sec:declaring_for_subgraph) by using `forSubgraph()`, which will prompt Gradle to ignore the corresponding version constraints defined further down the graph.
+This can, for example, be used to downgrade a version. Subgraph constraints are published to [Gradle Module Metadata](userguide/publishing.html#understanding-gradle-module-md).
+
+```groovy
+dependencies {
+    implementation('org.apache.hadoop:hadoop-common')
+    implementation('commons-io:commons-io')
+    constraints {
+        // 'hadoop-common:3.2.0' brings in 'commons-io:2.5'
+        implementation('org.apache.hadoop:hadoop-common:3.2.0') 
+        implementation('commons-io:commons-io:2.4') {
+            version { forSubgraph() } // '2.4' takes precedence
+        }
+    }
+}
+```
+
 ## Debug support for forked Java processes
 
 Gradle has now a new DSL element to configure debugging for Java processes.  

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/declaring_dependency_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/declaring_dependency_versions.adoc
@@ -1,9 +1,9 @@
 [[declaring-dependency-versions]]
 = Declaring dependency versions
 
-include::rich_versions.adoc[]
+include::rich_versions.adoc[leveloffset=+1]
 
-[[sub::declaring_without_version]]
+[[sec:declaring_without_version]]
 == Declaring a dependency without version
 
 A recommended practice for larger projects is to declare dependencies without versions and use <<controlling_transitive_dependencies.adoc#sec:adding-constraints-transitive-deps,dependency constraints>> for version declaration.
@@ -14,6 +14,26 @@ The advantage is that dependency constraints allow you to manage versions of all
 include::sample[dir="userguide/dependencyManagement/declaringDependencies/withoutVersion/groovy",files="build.gradle[tags=dependencies-without-version]"]
 include::sample[dir="userguide/dependencyManagement/declaringDependencies/withoutVersion/kotlin",files="build.gradle.kts[tags=dependencies-without-version]"]
 ====
+
+[[sec:declaring_for_subgraph]]
+== Declaring a dependency that is already part of the dependency graph
+
+In larger projects, you often get into a situation where a module you require is already added transitively by one of your existing dependencies.
+In this case, declaring the dependency without a version is recommended, if the version that is already in your dependency graph suits your needs.
+However, sometimes you might need a different version.
+
+To make sure that your own version declaration takes precedence over other declarations for the same module, you can declare it as a `forSubgraph` version.
+If you do this, the (rich) versions of the dependencies that came in transitively will be ignored.
+
+====
+include::sample[dir="userguide/dependencyManagement/declaringDependencies/forSubgraph/groovy",files="build.gradle[tags=dependencies-for-subgraph]"]
+include::sample[dir="userguide/dependencyManagement/declaringDependencies/forSubgraph/kotlin",files="build.gradle.kts[tags=dependencies-for-subgraph]"]
+====
+
+Note that if you change the version of another dependency in your context, it is your responsibility that the resulting combination of modules works.
+In particular, if you are developing a library that others consume.
+The `forSubgraph` property of a dependency is published in <<publishing.adoc#understanding-gradle-module-md,Gradle Module Metadata>> and honored when your library is consumed, as long as there is no other library requesting the originally declared version to be used.
+More details about dealing with such situations are found in the <<controlling_transitive_dependencies.adoc#, controlling transitive dependencies>> chapter.
 
 [[sec:dynamic_versions_and_changing_modules]]
 == Dealing with versions which change over time

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/rich_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/rich_versions.adoc
@@ -1,5 +1,5 @@
 [[rich-version-constraints]]
-== Rich version declarations
+= Rich version declarations
 
 Gradle supports a rich model for declaring versions, which allows to combine different level of version information.
 The terms and their meaning are explained below, from the strongest to the weakest:

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/controlling_transitive_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/controlling_transitive_dependencies.adoc
@@ -37,11 +37,12 @@ In the example, all versions are omitted from the dependency declaration.
 Instead, the versions are defined in the constraints block.
 The version definition for `commons-codec:1.11` is only taken into account if `commons-codec` is brought in as transitive dependency, since `commons-codec` is not defined as dependency in the project.
 Otherwise, the constraint has no effect.
+Dependency constraints can also define a <<rich_versions.adoc#,rich version constraint>> and support <<declaring_dependency_versions.adoc#sec:declaring_for_subgraph,subgraph version constraints>> to enforce a version even if it contradicts with the version defined by a transitive dependency (e.g. if the version needs to be downgraded).
 
 [NOTE]
 ====
-Dependency constraints are not yet published, but that will be added in a future release.
-This means that their use currently only targets builds that do not publish artifacts to maven or ivy repositories.
+Dependency constraints are only published when using <<publishing.adoc#understanding-gradle-module-md,Gradle Module Metadata>>.
+This means that currently they are only fully supported if Gradle is used for publishing and consuming (i.e. they are 'lost' when consuming modules with Maven or Ivy).
 ====
 
 Dependency constraints themselves can also be added transitively.

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/dependencies-for-subgraph.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/dependencies-for-subgraph.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: tasks
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: tasks
+}]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/groovy/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::dependencies-for-subgraph[]
+dependencies {
+    implementation('org.apache.hadoop:hadoop-common:3.2.0') // depends on 'commons-io:commons-io:2.5'
+    implementation('commons-io:commons-io:2.4') {
+        version { forSubgraph() }
+    }
+}
+// end::dependencies-for-subgraph[]
+
+task copyLibs(type: Copy) {
+    from configurations.compileClasspath
+    into "$buildDir/libs"
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'declaring-dependencies-for-subgraph'

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/kotlin/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    `java-library`
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::dependencies-for-subgraph[]
+dependencies {
+    implementation("org.apache.hadoop:hadoop-common:3.2.0") // depends on 'commons-io:commons-io:2.5'
+    implementation("commons-io:commons-io:2.4") {
+        version { forSubgraph() }
+    }
+}
+// end::dependencies-for-subgraph[]
+
+tasks.register<Copy>("copyLibs") {
+    from(configurations.compileClasspath)
+    into("$buildDir/libs")
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/forSubgraph/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "declaring-dependencies-for-subgraph"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -789,8 +789,8 @@ allprojects {
             this
         }
 
-        NodeBuilder byParent() {
-            byReason(ComponentSelectionCause.BY_PARENT.defaultReason)
+        NodeBuilder byAncestor() {
+            byReason(ComponentSelectionCause.BY_ANCESTOR.defaultReason)
         }
 
         /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -765,6 +765,11 @@ allprojects {
             this
         }
 
+        NodeBuilder byRequest() {
+            reasons << 'requested'
+            this
+        }
+
         NodeBuilder byConstraint(String reason = null) {
             if (reason == null) {
                 reasons << ComponentSelectionCause.CONSTRAINT.defaultReason
@@ -772,6 +777,10 @@ allprojects {
                 reasons << "${ComponentSelectionCause.CONSTRAINT.defaultReason}: $reason".toString()
             }
             this
+        }
+
+        NodeBuilder byParent() {
+            byReason(ComponentSelectionCause.BY_PARENT.defaultReason)
         }
 
         /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -43,6 +43,7 @@ class ResolveTestFixture {
     private final String config
     private String defaultConfig = "default"
     private boolean buildArtifacts = true
+    private boolean strictReasonsCheck;
 
     ResolveTestFixture(TestFile buildFile, String config = "runtimeClasspath") {
         this.config = config
@@ -51,6 +52,11 @@ class ResolveTestFixture {
 
     ResolveTestFixture withoutBuildingArtifacts() {
         buildArtifacts = false
+        return this
+    }
+
+    ResolveTestFixture withStrictReasonsCheck() {
+        strictReasonsCheck = true
         return this
     }
 
@@ -212,11 +218,11 @@ allprojects {
         return lines.findAll { it.startsWith(prefix + ":") }.collect { it.substring(prefix.length() + 1) }
     }
 
-    static List<ParsedNode> parseNodes(List<String> nodes) {
+    List<ParsedNode> parseNodes(List<String> nodes) {
         nodes.collect { parseNode(it) }
     }
 
-    static ParsedNode parseNode(String line) {
+    ParsedNode parseNode(String line) {
         int start = 4
         // we look for ][ instead of just ], because of that one test that checks that we can have random characters in id
         // see IvyDynamicRevisionRemoteResolveIntegrationTest. uses latest version from version range with punctuation characters
@@ -254,7 +260,7 @@ allprojects {
             start = idx + 15 // '@@'
             variants << new Variant(name: variant, attributes: attributes)
         }
-        new ParsedNode(id: id, module: module, reasons: reasons, variants: variants)
+        new ParsedNode(id: id, module: module, reasons: reasons, variants: variants, strictReasonsCheck: strictReasonsCheck)
     }
 
     static class ParsedNode {
@@ -262,6 +268,7 @@ allprojects {
         String module
         List<String> reasons
         Set<Variant> variants = []
+        boolean strictReasonsCheck
 
         boolean diff(ParsedNode actual, StringBuilder sb) {
             List<String> errors = []
@@ -277,6 +284,9 @@ allprojects {
                         errors << "Expected reason '$reason' but wasn't found. Actual reasons: ${actual.reasons}"
                     }
                 }
+            }
+            if (strictReasonsCheck && actual.reasons.size() != reasons.size()) {
+                errors << "Unexpected reason. Expected: $reasons Actual: ${actual.reasons}"
             }
             variants.each { variant ->
                 def actualVariant = actual.variants.find { it.name == variant.name }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -660,6 +660,17 @@ allprojects {
             return node
         }
 
+        NodeBuilder constraint(String requested, String id, String selectedModuleVersionId, @DelegatesTo(NodeBuilder) Closure cl = {}) {
+            def node = graph.node(id, selectedModuleVersionId)
+            def edge = new EdgeBuilder(this, requested, node)
+            edge.constraint = true
+            deps << edge
+            cl.resolveStrategy = Closure.DELEGATE_ONLY
+            cl.delegate = node
+            cl.call()
+            return node
+        }
+
         /**
          * Defines a dependency from the current node to the given node.
          */

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -35,7 +35,7 @@ class GradleModuleMetadata {
             JsonReader reader = new JsonReader(r)
             values = readObject(reader)
         }
-        assert values.formatVersion == '1.0'
+        assert values.formatVersion == '1.1'
         assert values.createdBy.gradle.version == GradleVersion.current().version
         assert values.createdBy.gradle.buildId
         variants = (values.variants ?: []).collect { new Variant(it.name, it) }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
@@ -25,16 +25,18 @@ class DependencyConstraintSpec {
     String version
     String preferredVersion
     String strictVersion
+    boolean forSubgraph
     List<String> rejects
     String reason
     Map<String, ?> attributes
 
-    DependencyConstraintSpec(String g, String m, String v, String preferredVersion, String strictVersion, List<String> r, String desc, Map<String, ?> attrs) {
+    DependencyConstraintSpec(String g, String m, String v, String preferredVersion, String strictVersion, Boolean forSubgraph, List<String> r, String desc, Map<String, ?> attrs) {
         group = g
         module = m
         version = v
         this.preferredVersion = preferredVersion
         this.strictVersion = strictVersion
+        this.forSubgraph = forSubgraph
         rejects = r?:Collections.<String>emptyList()
         reason = desc
         attributes = attrs

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -27,18 +27,20 @@ class DependencySpec {
     String version
     String preferredVersion
     String strictVersion
+    boolean forSubgraph
     List<String> rejects
     List<ExcludeSpec> exclusions = []
     String reason
     Map<String, Object> attributes
     List<CapabilitySpec> requestedCapabilities = []
 
-    DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, List<String> rejects, Collection<Map> excludes, String reason, Map<String, Object> attributes) {
+    DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, Boolean forSubgraph, List<String> rejects, Collection<Map> excludes, String reason, Map<String, Object> attributes) {
         group = g
         module = m
         version = v
         this.preferredVersion = preferredVersion
         this.strictVersion = strictVersion
+        this.forSubgraph = forSubgraph
         this.rejects = rejects?:Collections.<String>emptyList()
         if (excludes) {
             exclusions = excludes.collect { Map exclusion ->

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -84,6 +84,9 @@ class GradleFileModuleAdapter {
                                 } else if (d.preferredVersion) {
                                     prefers d.preferredVersion
                                 }
+                                if (d.forSubgraph) {
+                                    forSubgraph d.forSubgraph
+                                }
                                 rejects d.rejects
                             }
                             if (d.reason) {
@@ -129,6 +132,9 @@ class GradleFileModuleAdapter {
                                 }
                                 if (dc.rejects) {
                                     rejects dc.rejects
+                                }
+                                if (dc.forSubgraph) {
+                                    forSubgraph dc.forSubgraph
                                 }
                             }
                             if (dc.reason) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -53,11 +53,11 @@ class VariantMetadataSpec {
     }
 
     void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes = [:]) {
-        dependencies << new DependencySpec(group, module, version, null, null, null, null, reason, attributes)
+        dependencies << new DependencySpec(group, module, version, null, null, null, null, null, reason, attributes)
     }
 
     void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {
-        def spec = new DependencySpec(group, module, version, null, null, null, null, null, [:])
+        def spec = new DependencySpec(group, module, version, null, null, null, null, null, null, [:])
         config.delegate = spec
         config.resolveStrategy = Closure.DELEGATE_FIRST
         config()
@@ -75,7 +75,7 @@ class VariantMetadataSpec {
     }
 
     void constraint(String group, String module, String version, String reason = null, Map<String, ?> attributes = [:]) {
-        dependencyConstraints << new DependencyConstraintSpec(group, module, version, null, null, null, reason, attributes)
+        dependencyConstraints << new DependencyConstraintSpec(group, module, version, null, null, null, null, reason, attributes)
     }
 
     void constraint(String notation) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -407,10 +407,10 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->
-                        new DependencySpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
-                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.rejects, d.reason, d.attributes)
+                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.reason, d.attributes)
                     },
                     v.artifacts ?: defaultArtifacts,
                     v.capabilities,

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -130,7 +130,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         this.dependencies << [groupId: target.group, artifactId: target.module, version: target.version,
                               type: attributes.type, scope: attributes.scope, classifier: attributes.classifier,
                               optional: attributes.optional, exclusions: attributes.exclusions, rejects: attributes.rejects,
-                              prefers: attributes.prefers, strictly: attributes.strictly, reason: attributes.reason
+                              prefers: attributes.prefers, strictly: attributes.strictly, forSubgraph: attributes.forSubgraph,
+                              reason: attributes.reason
         ]
         return this
     }
@@ -463,10 +464,10 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencies.findAll { it.optional }.collect { d ->
-                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.rejects, d.reason, d.attributes)
+                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.reason, d.attributes)
                     },
                     artifacts,
                     v.capabilities,

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance.regression.corefeature
 
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.WithExternalRepository
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
@@ -74,6 +75,27 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
         where:
         parallel << [false, true, false, true]
         locking << [false, false, true, true]
+    }
+
+    @Ignore // TODO activate once PR #10097 is merged
+    def "resolve large dependency graph with subgraph constraints"() {
+        runner.minimumVersion = '5.7'
+        runner.testProject = TEST_PROJECT_NAME
+        startServer()
+
+        given:
+        runner.tasksToRun = ['resolveDependencies']
+        runner.gradleOpts = [MIN_MEMORY, MAX_MEMORY]
+        runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", '-PnoExcludes', '-PuseSubgraphConstraints']
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+
+        cleanup:
+        stopServer()
     }
 
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -170,6 +170,10 @@ public class GradleModuleMetadataWriter {
             }
             jsonWriter.endArray();
         }
+        if (versionConstraint.isForSubgraph()) {
+            jsonWriter.name("forSubgraph");
+            jsonWriter.value(true);
+        }
         jsonWriter.endObject();
     }
 

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -52,11 +52,11 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     }
 
     VersionConstraint strictly(String version) {
-        DefaultImmutableVersionConstraint.of("", "", version, [])
+        DefaultImmutableVersionConstraint.of("", "", version, [], false)
     }
 
     VersionConstraint prefersAndRejects(String version, List<String> rejects) {
-        DefaultImmutableVersionConstraint.of(version, "", "", rejects)
+        DefaultImmutableVersionConstraint.of(version, "", "", rejects, false)
     }
 
     @Rule


### PR DESCRIPTION
Implementation of #9684.

Done:
- [x] DSL constructs are added and data model updated (naming might still change)
- [x] Gradle Module Metadata updated (targeting 1.1) 
- [x] Implementation by utilizing `SelectorState`s
- [x] integration tests (including test fixture updates)
- [x] integration tests for interaction with other dependency management features
- [x] performance test
- [x] Update of Gradle Metadata to version and specification to 1.1
- [x] Documentation of the feature and release notes

Performance:

- Existing performance tests indicate that there are no regression if the new feature is not used.
- I added an option to our [performance test project with many dependencies](performance-comparisons/exclude-merging/build.gradle). The option adds `forSubgraph()` to all dependency declarations using a component metadata rule. This is used by the newly added performance test to ensure this feature does not regress in the future.
- To get a feeling for the performance impact when using the new feature, I also compared the performance of the project with and without the _forSubgraph_ option enabled.

**'5.6' vs 'current version with subgraph constraints'**:
```
Speed Results for test project 'excludeRuleMergingBuild' with tasks resolveDependencies: we're slower than 5.6-rc-1 with 99% confidence.
Difference: 57.5 ms slower (57.5 ms), 1.64%
  Current Gradle median: 3.574 s min: 3.502 s, max: 4.313 s, se: 159.56 ms}
  > [3.679 s, 3.604 s, 3.57 s, 3.563 s, 3.538 s, 3.611 s, 3.557 s, 3.647 s, 3.598 s, 3.531 s, 3.691 s, 3.606 s, 3.559 s, 3.652 s, 3.533 s, 3.705 s, 3.595 s, 3.528 s, 3.577 s, 3.628 s, 3.502 s, 3.526 s, 3.657 s, 3.571 s, 3.567 s, 3.535 s, 3.606 s, 3.599 s, 3.553 s, 3.517 s, 3.663 s, 3.65 s, 3.524 s, 3.55 s, 3.665 s, 3.57 s, 3.565 s, 3.544 s, 4.313 s, 4.245 s]
  Gradle 5.6-rc-1 median: 3.516 s min: 3.132 s, max: 3.643 s, se: 157.68 ms}
  > [3.512 s, 3.527 s, 3.446 s, 3.497 s, 3.574 s, 3.537 s, 3.615 s, 3.628 s, 3.53 s, 3.523 s, 3.62 s, 3.614 s, 3.525 s, 3.587 s, 3.643 s, 3.52 s, 3.601 s, 3.569 s, 3.473 s, 3.474 s, 3.608 s, 3.513 s, 3.484 s, 3.612 s, 3.546 s, 3.49 s, 3.587 s, 3.6 s, 3.455 s, 3.16 s, 3.259 s, 3.132 s, 3.187 s, 3.276 s, 3.253 s, 3.185 s, 3.263 s, 3.255 s, 3.173 s, 3.244 s]
```

**'5.6 with excludes' vs 'current version with subgraph constraints but without excludes'**
```
Speed Results for test project 'excludeRuleMergingBuild' with tasks resolveDependencies: Results were inconclusive with 45% confidence.
Difference: 26 ms faster (26 ms), -0.71%
  Current Gradle median: 3.63 s min: 3.502 s, max: 4.139 s, se: 146.82 ms}
  > [3.592 s, 3.629 s, 3.56 s, 3.592 s, 3.634 s, 3.632 s, 3.553 s, 3.683 s, 3.541 s, 3.549 s, 3.669 s, 3.678 s, 3.541 s, 3.574 s, 3.682 s, 3.682 s, 3.548 s, 3.677 s, 3.576 s, 3.628 s, 3.601 s, 3.72 s, 3.627 s, 3.548 s, 3.619 s, 3.616 s, 3.502 s, 3.643 s, 3.65 s, 3.556 s, 3.54 s, 3.632 s, 3.652 s, 4.066 s, 4.139 s, 3.99 s, 3.854 s, 3.831 s, 3.906 s, 3.897 s]
  Gradle 5.6-rc-1 median: 3.656 s min: 3.393 s, max: 3.784 s, se: 79.3 ms}
  > [3.393 s, 3.71 s, 3.672 s, 3.651 s, 3.586 s, 3.636 s, 3.658 s, 3.658 s, 3.417 s, 3.668 s, 3.643 s, 3.655 s, 3.622 s, 3.784 s, 3.749 s, 3.703 s, 3.777 s, 3.667 s, 3.698 s, 3.6 s, 3.682 s, 3.703 s, 3.533 s, 3.663 s, 3.692 s, 3.617 s, 3.617 s, 3.669 s, 3.73 s, 3.561 s, 3.546 s, 3.655 s, 3.702 s, 3.58 s, 3.585 s, 3.662 s, 3.673 s, 3.614 s, 3.553 s, 3.587 s]
```

The results indicate that the feature is not more expensive than exclude rules, which is good.