### PR TITLE
docs: Clarify that gradle-wrapper.properties is not for configuring a proxy

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle_wrapper.adoc
@@ -117,7 +117,7 @@ A Gradle project typically provides a `build.gradle` and a `settings.gradle` fil
 The Wrapper JAR file containing code for downloading the Gradle distribution.
 
 `gradle-wrapper.properties`::
-A properties file responsible for configuring the Wrapper runtime behavior e.g. the Gradle version compatible with this version.
+A properties file responsible for configuring the Wrapper runtime behavior e.g. the Gradle version compatible with this version. Note that more generic settings, like <<build_environment.adoc#sec:accessing_the_web_via_a_proxy,configuring the Wrapper to use a proxy>>, need to go into `.gradle/gradle.properties`.
 
 `gradlew`, `gradlew.bat`::
 A shell script and a Windows batch script for executing the build with the Wrapper.


### PR DESCRIPTION
Fixes #9744.

### Context

This improves the docs to resolve the confusion about configuring a proxy that the wrapper should use, see https://github.com/gradle/gradle/issues/9744.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
