### PR TITLE
Further steps to expose details of artifact transforms to instant execution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/DefaultTaskInputsListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/DefaultTaskInputsListener.java
@@ -28,7 +28,7 @@ public class DefaultTaskInputsListener implements TaskInputsListener {
     public void onExecute(TaskInternal taskInternal, FileCollectionInternal fileSystemInputs) {
         if (waiter!=null) {
             FileSystemSubset.Builder fileSystemSubsetBuilder = FileSystemSubset.builder();
-            fileSystemInputs.registerWatchPoints(fileSystemSubsetBuilder);
+            fileSystemInputs.visitLeafCollections(fileSystemSubsetBuilder);
             waiter.watch(fileSystemSubsetBuilder.build());
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -137,7 +137,7 @@ public class DefaultFileOperations implements FileOperations {
             tarFile = file(tarPath);
             resource = new LocalResourceAdapter(new LocalFileStandInExternalResource(tarFile, fileSystem));
         }
-        TarFileTree tarTree = new TarFileTree(tarFile, new MaybeCompressedFileResource(resource), getExpandDir(), fileSystem, fileSystem, directoryFileTreeFactory, streamHasher, fileHasher);
+        TarFileTree tarTree = new TarFileTree(tarFile, new MaybeCompressedFileResource(resource), getExpandDir(), fileSystem, directoryFileTreeFactory, streamHasher, fileHasher);
         return new FileTreeAdapter(tarTree, fileResolver.getPatternSetFactory());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
@@ -23,7 +23,6 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
-import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.internal.file.collections.ArchiveFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
@@ -150,14 +149,6 @@ public class TarFileTree implements MinimalFileTree, ArchiveFileTree {
 
     private RuntimeException cannotExpand(Exception e) {
         throw new InvalidUserDataException(String.format("Cannot expand %s.", getDisplayName()), e);
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        File backingFile = getBackingFile();
-        if (backingFile != null) {
-            builder.add(backingFile);
-        }
     }
 
     private static class DetailsImpl extends AbstractFileTreeElement implements FileVisitDetails {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/TarFileTree.java
@@ -31,7 +31,6 @@ import org.gradle.api.resources.ResourceException;
 import org.gradle.api.resources.internal.ReadableResourceInternal;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.file.Chmod;
-import org.gradle.internal.file.Stat;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.StreamHasher;
@@ -48,17 +47,15 @@ public class TarFileTree implements MinimalFileTree, ArchiveFileTree {
     private final File tarFile;
     private final ReadableResourceInternal resource;
     private final Chmod chmod;
-    private final Stat stat;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
     private final File tmpDir;
     private final StreamHasher streamHasher;
     private final FileHasher fileHasher;
 
-    public TarFileTree(@Nullable File tarFile, ReadableResourceInternal resource, File tmpDir, Chmod chmod, Stat stat, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher) {
+    public TarFileTree(@Nullable File tarFile, ReadableResourceInternal resource, File tmpDir, Chmod chmod, DirectoryFileTreeFactory directoryFileTreeFactory, StreamHasher streamHasher, FileHasher fileHasher) {
         this.tarFile = tarFile;
         this.resource = resource;
         this.chmod = chmod;
-        this.stat = stat;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
         this.tmpDir = tmpDir;
         this.streamHasher = streamHasher;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
@@ -24,7 +24,6 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
-import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.internal.file.collections.ArchiveFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
@@ -197,10 +196,5 @@ public class ZipFileTree implements MinimalFileTree, ArchiveFileTree {
             }
             return unixMode;
         }
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        builder.add(zipFile);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -336,7 +336,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitCollection(collection)
         0 * visitor._
     }
@@ -349,7 +349,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -336,7 +336,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitCollection(collection)
         0 * visitor._
     }
@@ -349,7 +349,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -139,7 +139,7 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(tree)
         0 * visitor._
     }
@@ -152,7 +152,7 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -139,7 +139,7 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(tree)
         0 * visitor._
     }
@@ -152,7 +152,7 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionSpec.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.Task
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext
 import org.gradle.api.internal.tasks.TaskDependencyContainer
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
-import org.gradle.api.tasks.TaskDependency
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
@@ -316,7 +315,11 @@ class CompositeFileCollectionSpec extends Specification {
 
     def collectionDependsOn(Task... tasks) {
         def collection = Stub(FileCollectionInternal)
-        collection.buildDependencies >> Stub(TaskDependency) { getDependencies(_) >> tasks }
+        collection.visitDependencies(_) >> { TaskDependencyResolveContext context ->
+            for (t in tasks) {
+                context.add(t)
+            }
+        }
         return collection
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultCompositeFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultCompositeFileTreeTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.file
 
 import org.gradle.api.Task
-import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.test.fixtures.file.WorkspaceTest
 import org.gradle.util.UsesNativeServices
 
@@ -76,12 +76,18 @@ class DefaultCompositeFileTreeTest extends WorkspaceTest {
         def tree2 = Stub(FileTreeInternal)
 
         given:
-        tree1.buildDependencies >> Stub(TaskDependency) { getDependencies(_) >> [task1, task2] }
-        tree2.buildDependencies >> Stub(TaskDependency) { getDependencies(_) >> [task2, task3] }
+        tree1.visitDependencies(_) >> { TaskDependencyResolveContext context ->
+            context.add(task1)
+            context.add(task2)
+        }
+        tree2.visitDependencies(_) >> { TaskDependencyResolveContext context ->
+            context.add(task2)
+            context.add(task3)
+        }
 
         expect:
         def composite = new DefaultCompositeFileTree([tree1, tree2])
-        composite.buildDependencies.getDependencies(null) == [task1, task2, task3] as LinkedHashSet
+        composite.buildDependencies.getDependencies(null) as List == [task1, task2, task3]
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/UnionFileCollectionTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.file
 
 import org.gradle.api.Task
-import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
@@ -63,11 +63,17 @@ class UnionFileCollectionTest extends Specification {
         def source2 = Stub(FileCollectionInternal)
 
         given:
-        source1.buildDependencies >> Stub(TaskDependency) { getDependencies(_) >> [task1, task2] }
-        source2.buildDependencies >> Stub(TaskDependency) { getDependencies(_) >> [task2, task3] }
+        source1.visitDependencies(_) >> { TaskDependencyResolveContext context ->
+            context.add(task1)
+            context.add(task2)
+        }
+        source2.visitDependencies(_) >> { TaskDependencyResolveContext context ->
+            context.add(task3)
+            context.add(task2)
+        }
 
         expect:
         def collection = new UnionFileCollection(source1, source2)
-        collection.buildDependencies.getDependencies(null) == [task1, task2, task3] as LinkedHashSet
+        collection.buildDependencies.getDependencies(null) as List == [task1, task2, task3]
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
@@ -52,7 +52,7 @@ public class TarFileTreeTest {
     private final TestFile tarFile = tmpDir.getTestDirectory().file("test.tar");
     private final TestFile rootDir = tmpDir.getTestDirectory().file("root");
     private final TestFile expandDir = tmpDir.getTestDirectory().file("tmp");
-    private final TarFileTree tree = new TarFileTree(tarFile, new MaybeCompressedFileResource(new LocalResourceAdapter(TestFiles.fileRepository().localResource(tarFile))), expandDir, fileSystem(), fileSystem(), directoryFileTreeFactory(), streamHasher(), fileHasher());
+    private final TarFileTree tree = new TarFileTree(tarFile, new MaybeCompressedFileResource(new LocalResourceAdapter(TestFiles.fileRepository().localResource(tarFile))), expandDir, fileSystem(), directoryFileTreeFactory(), streamHasher(), fileHasher());
 
     @Test
     public void displayName() {
@@ -78,7 +78,7 @@ public class TarFileTreeTest {
         rootDir.tgzTo(tgz);
 
         MaybeCompressedFileResource resource = new MaybeCompressedFileResource(new LocalResourceAdapter(TestFiles.fileRepository().localResource(tgz)));
-        TarFileTree tree = new TarFileTree(tgz, resource, expandDir, fileSystem(), fileSystem(), directoryFileTreeFactory(), streamHasher(), fileHasher());
+        TarFileTree tree = new TarFileTree(tgz, resource, expandDir, fileSystem(), directoryFileTreeFactory(), streamHasher(), fileHasher());
 
         assertVisits(tree, toList("subdir/file1.txt", "subdir2/file2.txt"), toList("subdir", "subdir2"));
         assertSetContainsForAllTypes(tree, toList("subdir/file1.txt", "subdir2/file2.txt"));
@@ -93,7 +93,7 @@ public class TarFileTreeTest {
         rootDir.tbzTo(tbz2);
 
         MaybeCompressedFileResource resource = new MaybeCompressedFileResource(new LocalResourceAdapter(TestFiles.fileRepository().localResource(tbz2)));
-        TarFileTree tree = new TarFileTree(tbz2, resource, expandDir, fileSystem(), fileSystem(), directoryFileTreeFactory(), streamHasher(), fileHasher());
+        TarFileTree tree = new TarFileTree(tbz2, resource, expandDir, fileSystem(), directoryFileTreeFactory(), streamHasher(), fileHasher());
 
         assertVisits(tree, toList("subdir/file1.txt", "subdir2/file2.txt"), toList("subdir", "subdir2"));
         assertSetContainsForAllTypes(tree, toList("subdir/file1.txt", "subdir2/file2.txt"));

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
@@ -218,9 +218,7 @@ task checkArtifacts {
                 task checkArtifacts {
                     inputs.files configurations.compile
                     doLast {
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { 
-                            it.buildDependencies.getDependencies(null) 
-                        }*.path.flatten() == [':a:jar']
+                        configurations.compile.resolvedConfiguration.resolvedArtifacts.forEach { println it } 
                     }
                 }
             }
@@ -258,9 +256,7 @@ task checkArtifacts {
                 task checkArtifacts {
                     inputs.files configurations.compile
                     doLast {
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { 
-                            it.buildDependencies.getDependencies(null) 
-                        }*.path.flatten() == [':a:jar']
+                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.each { println it } 
                     }
                 }
             }
@@ -302,9 +298,7 @@ task checkArtifacts {
                 task checkArtifacts {
                     inputs.files configurations.compile
                     doLast {
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { 
-                            it.buildDependencies.getDependencies(null) 
-                        }*.path.flatten() == [':a:classes']
+                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.each { println it } 
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -716,8 +716,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         then:
         failure.assertHasCause("Could not resolve all files for configuration ':app:compile'.")
-        failure.assertHasCause("Failed to transform artifact 'lib1.jar (project :lib)' to match attributes {artifactType=size, usage=api}")
-        failure.assertHasCause("Failed to transform artifact 'lib2.jar (project :lib)' to match attributes {artifactType=size, usage=api}")
+        failure.assertHasCause("Failed to transform lib1.jar (project :lib) to match attributes {artifactType=size, usage=api}")
+        failure.assertHasCause("Failed to transform lib2.jar (project :lib) to match attributes {artifactType=size, usage=api}")
         def outputDir1 = projectOutputDir("lib1.jar", "lib1.jar.txt")
         def outputDir2 = projectOutputDir("lib2.jar", "lib2.jar.txt")
         def outputDir3 = gradleUserHomeOutputDir("lib3.jar", "lib3.jar.txt")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1382,7 +1382,7 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'a.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertHasCause("broken")
 
         and:
@@ -1508,7 +1508,7 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'a.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertHasCause("Execution failed for ToNullTransform: ${file("a.jar").absolutePath}.")
         failure.assertHasCause("Transform returned null result.")
     }
@@ -1537,7 +1537,7 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'a.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertHasCause("Transform output this_file_does_not.exist must exist.")
 
         when:
@@ -1601,7 +1601,7 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'a.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertThatCause(matchesRegexp("Transform ${failureMessage}."))
 
         when:
@@ -1729,7 +1729,7 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'a.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertHasCause("Transform output ${testDirectory.file('other.jar')} must be a part of the input artifact or refer to a relative path.")
     }
 
@@ -1769,7 +1769,7 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'a.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertHasCause("Transform output ${testDirectory.file('other.jar')} must be a part of the input artifact or refer to a relative path.")
     }
 
@@ -1800,7 +1800,7 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'a.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertHasCause("Could not create an instance of type BrokenTransform.")
         failure.assertHasCause("broken")
     }
@@ -1856,10 +1856,10 @@ Found the following transforms:
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
-        failure.assertHasCause("Failed to transform file 'broken.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform broken.jar to match attributes {artifactType=size}")
         failure.assertHasCause("broken: broken.jar")
         failure.assertHasCause("Could not download a.jar (test:a:1.3)")
-        failure.assertHasCause("Failed to transform artifact 'broken.jar (test:broken:2.0)' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform broken.jar (test:broken:2.0) to match attributes {artifactType=size}")
         failure.assertHasCause("broken: broken-2.0.jar")
 
         and:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -359,8 +359,8 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         fails ":resolve"
 
         then:
-        failure.assertHasCause("Failed to transform file 'bad-b.jar' to match attributes {artifactType=size}")
-        failure.assertHasCause("Failed to transform file 'bad-c.jar' to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform bad-b.jar to match attributes {artifactType=size}")
+        failure.assertHasCause("Failed to transform bad-c.jar to match attributes {artifactType=size}")
     }
 
     def "only one transformer execution per workspace"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -723,7 +723,7 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         then:
         failure.assertResolutionFailure(":app:implementation")
         failure.assertHasFailures(1)
-        failure.assertThatCause(CoreMatchers.containsString("Failed to transform artifact 'slf4j-api-1.7.25.jar (org.slf4j:slf4j-api:1.7.25)'"))
+        failure.assertThatCause(CoreMatchers.containsString("Failed to transform slf4j-api-1.7.25.jar (org.slf4j:slf4j-api:1.7.25)"))
 
         assertTransformationsExecuted(
             simpleTransform('common.jar'),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
@@ -26,9 +26,10 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.tasks.FinalizeAction;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.io.File;
@@ -37,28 +38,17 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, ResolvableArti
     private final ModuleVersionIdentifier owner;
     private final IvyArtifactName artifact;
     private final ComponentArtifactIdentifier artifactId;
-    private final TaskDependency buildDependencies;
+    private final TaskDependencyContainer buildDependencies;
     private volatile Factory<File> artifactSource;
-    private final ResolvableArtifact sourceArtifact;
     private volatile File file;
     private volatile Throwable failure;
 
-    public DefaultResolvedArtifact(ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, TaskDependency buildDependencies, Factory<File> artifactSource) {
+    public DefaultResolvedArtifact(ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, TaskDependencyContainer builtBy, Factory<File> artifactSource) {
         this.owner = owner;
         this.artifact = artifact;
         this.artifactId = artifactId;
-        this.buildDependencies = buildDependencies;
-        this.sourceArtifact = null;
+        this.buildDependencies = builtBy;
         this.artifactSource = artifactSource;
-    }
-
-    public DefaultResolvedArtifact(ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, ResolvableArtifact sourceArtifact, File artifactFile) {
-        this.owner = owner;
-        this.artifact = artifact;
-        this.artifactId = artifactId;
-        this.buildDependencies = null;
-        this.sourceArtifact = sourceArtifact;
-        this.file = artifactFile;
     }
 
     @Override
@@ -66,16 +56,7 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, ResolvableArti
         context.add(new FinalizeAction() {
             @Override
             public TaskDependencyContainer getDependencies() {
-                return new TaskDependencyContainer() {
-                    @Override
-                    public void visitDependencies(TaskDependencyResolveContext context) {
-                        if (buildDependencies != null) {
-                            context.add(buildDependencies);
-                        } else if (sourceArtifact != null) {
-                            context.add(sourceArtifact);
-                        }
-                    }
-                };
+                return buildDependencies;
             }
 
             @Override
@@ -117,12 +98,12 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, ResolvableArti
             return false;
         }
         DefaultResolvedArtifact other = (DefaultResolvedArtifact) obj;
-        return other.owner.equals(owner) && other.artifactId.equals(artifactId);
+        return other.artifactId.equals(artifactId);
     }
 
     @Override
     public int hashCode() {
-        return owner.hashCode() ^ artifactId.hashCode();
+        return artifactId.hashCode();
     }
 
     @Override
@@ -148,6 +129,13 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, ResolvableArti
     @Override
     public ResolvedArtifact toPublicView() {
         return this;
+    }
+
+    @Override
+    public ResolvableArtifact transformedTo(File file) {
+        IvyArtifactName artifactName = DefaultIvyArtifactName.forFile(file, getClassifier());
+        ComponentArtifactIdentifier newId = new ComponentFileArtifactIdentifier(artifactId.getComponentIdentifier(), artifactName);
+        return new PreResolvedResolvableArtifact(owner, artifactName, newId, file, buildDependencies);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/PreResolvedResolvableArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/PreResolvedResolvableArtifact.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedModuleVersion;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.DefaultResolvedModuleVersion;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.IvyArtifactName;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+public class PreResolvedResolvableArtifact implements ResolvableArtifact, ResolvedArtifact {
+    private final ModuleVersionIdentifier owner;
+    private final IvyArtifactName artifact;
+    private final ComponentArtifactIdentifier artifactId;
+    private final File file;
+    private final TaskDependencyContainer builtBy;
+
+    public PreResolvedResolvableArtifact(@Nullable ModuleVersionIdentifier owner, IvyArtifactName artifact, ComponentArtifactIdentifier artifactId, File file, TaskDependencyContainer builtBy) {
+        this.owner = owner;
+        this.artifact = artifact;
+        this.artifactId = artifactId;
+        this.file = file;
+        this.builtBy = builtBy;
+    }
+
+    @Override
+    public ComponentArtifactIdentifier getId() {
+        return artifactId;
+    }
+
+    @Override
+    public File getFile() {
+        return file;
+    }
+
+    @Override
+    public ResolvedArtifact toPublicView() {
+        return this;
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        builtBy.visitDependencies(context);
+    }
+
+    @Override
+    public boolean isResolveSynchronously() {
+        return true;
+    }
+
+    @Override
+    public ResolvedModuleVersion getModuleVersion() {
+        if (owner == null) {
+            // Local file dependencies do not have an owner
+            throw new UnsupportedOperationException();
+        }
+        return new DefaultResolvedModuleVersion(owner);
+    }
+
+    @Override
+    public ResolvableArtifact transformedTo(File file) {
+        IvyArtifactName artifactName = DefaultIvyArtifactName.forFile(file, getClassifier());
+        ComponentArtifactIdentifier newId = new ComponentFileArtifactIdentifier(artifactId.getComponentIdentifier(), artifactName);
+        return new PreResolvedResolvableArtifact(owner, artifactName, newId, file, builtBy);
+    }
+
+    @Override
+    public String getName() {
+        return artifact.getName();
+    }
+
+    @Override
+    public String getType() {
+        return artifact.getType();
+    }
+
+    @Override
+    public String getExtension() {
+        return artifact.getType();
+    }
+
+    @Nullable
+    @Override
+    public String getClassifier() {
+        return artifact.getClassifier();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -26,7 +25,6 @@ import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
 
-import java.io.File;
 import java.util.Set;
 
 public class ArtifactCollectingVisitor implements ArtifactVisitor {
@@ -63,11 +61,6 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     @Override
     public boolean requireArtifactFiles() {
         return false;
-    }
-
-    @Override
-    public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-        throw new UnsupportedOperationException();
     }
 
     public Set<ResolvedArtifact> getArtifacts() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -49,7 +49,11 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+    public void endVisitCollection() {
+    }
+
+    @Override
+    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
         return true;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
@@ -324,22 +323,12 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         public void visitFailure(Throwable failure) {
             throw UncheckedException.throwAsUncheckedException(failure);
         }
-
-        @Override
-        public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-            throw new UnsupportedOperationException();
-        }
     }
 
     private static class LenientFilesAndArtifactResolveVisitor extends LenientArtifactCollectingVisitor {
         @Override
         public boolean includeFiles() {
             return true;
-        }
-
-        @Override
-        public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-            files.add(file);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -305,7 +305,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
             return true;
         }
 
@@ -322,6 +322,10 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         @Override
         public void visitFailure(Throwable failure) {
             throw UncheckedException.throwAsUncheckedException(failure);
+        }
+
+        @Override
+        public void endVisitCollection() {
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -69,13 +69,6 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
         return true;
     }
 
-    @Override
-    public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-        if (seenArtifacts.add(artifactIdentifier)) {
-            artifacts.add(new DefaultResolvedArtifactResult(artifactIdentifier, variantAttributes, variantName, Artifact.class, file));
-        }
-    }
-
     public Set<ResolvedArtifactResult> getArtifacts() {
         return artifacts;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -55,7 +55,11 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+    public void endVisitCollection() {
+    }
+
+    @Override
+    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
         return true;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice;
+
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
+
+public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisitor {
+    private final FileCollectionLeafVisitor visitor;
+
+    public ResolvedFileCollectionVisitor(FileCollectionLeafVisitor visitor) {
+        this.visitor = visitor;
+    }
+
+    public FileCollectionLeafVisitor getVisitor() {
+        return visitor;
+    }
+
+    @Override
+    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        return visitor.prepareForVisit(collectionType) != FileCollectionLeafVisitor.VisitType.Skip;
+    }
+
+    @Override
+    public void endVisitCollection() {
+        visitor.visitCollection(ImmutableFileCollection.of(getFiles()));
+        getFiles().clear();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.Sets;
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -44,7 +43,7 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     @Override
     public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
         try {
-            File file = artifact.getFile(); // triggering file resolve
+            File file = artifact.getFile(); // maybe triggering file resolve
             this.files.add(file);
         } catch (Exception t) {
             failures.add(t);
@@ -69,11 +68,6 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     @Override
     public boolean includeFiles() {
         return true;
-    }
-
-    @Override
-    public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-        this.files.add(file);
     }
 
     public Set<File> getFiles() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -30,15 +30,6 @@ import java.util.Set;
 public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     private final Set<File> files = Sets.newLinkedHashSet();
     private final Set<Throwable> failures = Sets.newLinkedHashSet();
-    private final boolean visitScheduledTransforms;
-
-    public ResolvedFilesCollectingVisitor() {
-        this(true);
-    }
-
-    public ResolvedFilesCollectingVisitor(boolean visitScheduledTransforms) {
-        this.visitScheduledTransforms = visitScheduledTransforms;
-    }
 
     @Override
     public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
@@ -51,12 +42,17 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-        return collectionType != FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult || visitScheduledTransforms;
+    public boolean includeFiles() {
+        return true;
     }
 
     @Override
     public boolean requireArtifactFiles() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
         return true;
     }
 
@@ -66,8 +62,8 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean includeFiles() {
-        return true;
+    public void endVisitCollection() {
+
     }
 
     public Set<File> getFiles() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -110,6 +110,7 @@ class ArtifactBackedResolvedVariant implements ResolvedVariant {
                 visitor.visitFailure(failure);
             } else {
                 visitor.visitArtifact(variantName, variantAttributes, artifact);
+                visitor.endVisitCollection();
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -16,12 +16,9 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
-
-import java.io.File;
 
 /**
  * A visitor over the contents of a {@link ResolvedArtifactSet}.
@@ -42,14 +39,9 @@ public interface ArtifactVisitor {
     boolean requireArtifactFiles();
 
     /**
-     * Should {@link #visitFile(ComponentArtifactIdentifier, DisplayName, AttributeContainer, File)} be called?
+     * Should {@link #visitArtifact(DisplayName, AttributeContainer, ResolvableArtifact)} be called for local file dependencies?
      */
     boolean includeFiles();
-
-    /**
-     * Visits a file. Should be considered an artifact but is separate as a migration step.
-     */
-    void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file);
 
     /**
      * Called when some problem occurs visiting some element of the set. Visiting may continue.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -21,10 +21,13 @@ import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
 /**
- * A visitor over the contents of a {@link ResolvedArtifactSet}.
+ * A visitor over the contents of a {@link ResolvedArtifactSet}. A {@link ResolvedArtifactSet} may contain zero or more sets of files, each set containing zero or more artifacts.
  */
 public interface ArtifactVisitor {
-    boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType);
+    /**
+     * Called prior to scheduling resolution of a set of the given type. When {@code false} is returned, the contents of the set is not visited.
+     */
+    boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType);
 
     /**
      * Visits an artifact. Artifacts are resolved but not necessarily available unless {@link #requireArtifactFiles()} returns true.
@@ -47,4 +50,9 @@ public interface ArtifactVisitor {
      * Called when some problem occurs visiting some element of the set. Visiting may continue.
      */
     void visitFailure(Throwable failure);
+
+    /**
+     * Called after a set of artifacts has been visited.
+     */
+    void endVisitCollection();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -107,7 +107,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
             ResolvableArtifact resolvedArtifact = allResolvedArtifacts.get(artifact.getId());
             if (resolvedArtifact == null) {
                 Factory<File> artifactSource = new LazyArtifactSource(artifact, moduleSource, artifactResolver);
-                resolvedArtifact = new DefaultResolvedArtifact(ownerId, artifactName, artifact.getId(), artifact.getBuildDependencies(), artifactSource);
+                resolvedArtifact = new DefaultResolvedArtifact(ownerId, artifactName, artifact.getId(), context -> context.add(artifact.getBuildDependencies()), artifactSource);
                 allResolvedArtifacts.put(artifact.getId(), resolvedArtifact);
             }
             resolvedArtifacts.add(resolvedArtifact);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -172,6 +172,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         @Override
         public void visit(ArtifactVisitor visitor) {
             visitor.visitArtifact(variantName, variantAttributes, artifact);
+            visitor.endVisitCollection();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
@@ -22,8 +22,6 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
-import java.io.File;
-
 /**
  * A wrapper that prepares artifacts in parallel when visiting the delegate.
  * This is done by collecting all artifacts to prepare and/or visit in a first step.
@@ -91,11 +89,6 @@ public abstract class ParallelResolveArtifactSet {
             @Override
             public boolean includeFileDependencies() {
                 return visitor.includeFiles();
-            }
-
-            @Override
-            public void fileAvailable(File file) {
-                // Don't care, collect the files later (in the correct order)
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
@@ -77,8 +77,8 @@ public abstract class ParallelResolveArtifactSet {
             }
 
             @Override
-            public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-                return visitor.startVisit(collectionType);
+            public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+                return visitor.shouldVisit(collectionType);
             }
 
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvableArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvableArtifact.java
@@ -38,5 +38,7 @@ public interface ResolvableArtifact extends TaskDependencyContainer {
      */
     File getFile();
 
+    ResolvableArtifact transformedTo(File file);
+
     ResolvedArtifact toPublicView();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -22,8 +22,6 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
-import java.io.File;
-
 /**
  * A container for a set of files or artifacts. May or may not be immutable, and may require building and further resolution.
  */
@@ -88,15 +86,9 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
         boolean requireArtifactFiles();
 
         /**
-         * Should file dependency artifacts be included in the result?
+         * Should local file dependency artifacts be included in the result?
          */
         boolean includeFileDependencies();
-
-        /**
-         * Visits a file. Only called when {@link #includeFileDependencies()} returns true. Should be considered an artifact but is separate as a migration step.
-         * Called from any thread and in any order.
-         */
-        void fileAvailable(File file);
     }
 
     interface LocalArtifactVisitor {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -71,7 +71,10 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
      * A listener that is notified as artifacts are made available while visiting the contents of a set. Implementations must be thread safe as they are notified from multiple threads concurrently.
      */
     interface AsyncArtifactListener {
-        boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType);
+        /**
+         * Called prior to scheduling resolution of a set of the given type. When {@code false} is returned, the contents of the set is not visited.
+         */
+        boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType);
 
         /**
          * Visits an artifact once its file is available. Only called when {@link #requireArtifactFiles()} returns true. Called from any thread and in any order.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
-import java.io.File;
 import java.util.Map;
 
 /**
@@ -62,9 +61,8 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
             return EMPTY_RESULT;
         }
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();
-        Map<File, TransformationResult> fileResults = Maps.newConcurrentMap();
-        Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, listener, actions, artifactResults, fileResults, getDependenciesResolver(), transformationNodeRegistry));
-        return new TransformCompletion(result, attributes, artifactResults, fileResults);
+        Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, listener, actions, artifactResults, getDependenciesResolver(), transformationNodeRegistry));
+        return new TransformCompletion(result, attributes, artifactResults);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -57,7 +57,7 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
 
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-        if (!listener.startVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult)) {
+        if (!listener.shouldVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult)) {
             return EMPTY_RESULT;
         }
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformCompletion.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformCompletion.java
@@ -21,24 +21,21 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 
-import java.io.File;
 import java.util.Map;
 
 public class TransformCompletion implements ResolvedArtifactSet.Completion {
     private final AttributeContainerInternal attributes;
     private final ResolvedArtifactSet.Completion delegate;
     private final Map<ComponentArtifactIdentifier, TransformationResult> artifactResults;
-    private final Map<File, TransformationResult> fileResults;
 
-    public TransformCompletion(ResolvedArtifactSet.Completion delegate, AttributeContainerInternal attributes, Map<ComponentArtifactIdentifier, TransformationResult> artifactResults, Map<File, TransformationResult> fileResults) {
+    public TransformCompletion(ResolvedArtifactSet.Completion delegate, AttributeContainerInternal attributes, Map<ComponentArtifactIdentifier, TransformationResult> artifactResults) {
         this.delegate = delegate;
         this.attributes = attributes;
         this.artifactResults = artifactResults;
-        this.fileResults = fileResults;
     }
 
     @Override
     public void visit(ArtifactVisitor visitor) {
-        delegate.visit(new TransformingArtifactVisitor(visitor, attributes, artifactResults, fileResults));
+        delegate.visit(new TransformingArtifactVisitor(visitor, attributes, artifactResults));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -47,6 +47,7 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
                     ResolvableArtifact resolvedArtifact = artifact.transformedTo(output);
                     visitor.visitArtifact(variantName, target, resolvedArtifact);
                 }
+                visitor.endVisitCollection();
             },
             failure -> visitor.visitFailure(
                 new TransformException(String.format("Failed to transform %s to match attributes %s.", artifact.getId(), target), failure))
@@ -59,8 +60,12 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-        return visitor.startVisit(collectionType);
+    public void endVisitCollection() {
+    }
+
+    @Override
+    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+        return visitor.shouldVisit(collectionType);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -16,18 +16,13 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.artifacts.DefaultResolvedArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
-import org.gradle.internal.component.model.DefaultIvyArtifactName;
-import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.io.File;
 import java.util.Map;
@@ -36,13 +31,11 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     private final ArtifactVisitor visitor;
     private final AttributeContainerInternal target;
     private final Map<ComponentArtifactIdentifier, TransformationResult> artifactResults;
-    private final Map<File, TransformationResult> fileResults;
 
-    TransformingArtifactVisitor(ArtifactVisitor visitor, AttributeContainerInternal target, Map<ComponentArtifactIdentifier, TransformationResult> artifactResults, Map<File, TransformationResult> fileResults) {
+    TransformingArtifactVisitor(ArtifactVisitor visitor, AttributeContainerInternal target, Map<ComponentArtifactIdentifier, TransformationResult> artifactResults) {
         this.visitor = visitor;
         this.target = target;
         this.artifactResults = artifactResults;
-        this.fileResults = fileResults;
     }
 
     @Override
@@ -50,17 +43,13 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
         TransformationResult result = artifactResults.get(artifact.getId());
         result.getTransformedSubject().ifSuccessfulOrElse(
             transformedSubject -> {
-                ResolvedArtifact sourceArtifact = artifact.toPublicView();
                 for (File output : transformedSubject.getFiles()) {
-                    IvyArtifactName artifactName = DefaultIvyArtifactName.forFile(output, sourceArtifact.getClassifier());
-                    ComponentArtifactIdentifier newId = new ComponentFileArtifactIdentifier(sourceArtifact.getId().getComponentIdentifier(), artifactName);
-                    DefaultResolvedArtifact resolvedArtifact = new DefaultResolvedArtifact(sourceArtifact.getModuleVersion().getId(), artifactName, newId, artifact, output);
+                    ResolvableArtifact resolvedArtifact = artifact.transformedTo(output);
                     visitor.visitArtifact(variantName, target, resolvedArtifact);
                 }
             },
             failure -> visitor.visitFailure(
-                new TransformException(String.format("Failed to transform artifact '%s' to match attributes %s.",
-                    artifact.getId(), target), failure))
+                new TransformException(String.format("Failed to transform %s to match attributes %s.", artifact.getId(), target), failure))
         );
     }
 
@@ -82,19 +71,5 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     @Override
     public boolean requireArtifactFiles() {
         return visitor.requireArtifactFiles();
-    }
-
-    @Override
-    public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-        TransformationResult result = fileResults.get(file);
-        result.getTransformedSubject().ifSuccessfulOrElse(
-            transformedSubject -> {
-                for (File outputFile : transformedSubject.getFiles()) {
-                    visitor.visitFile(new ComponentFileArtifactIdentifier(artifactIdentifier.getComponentIdentifier(), outputFile.getName()), variantName, target, outputFile);
-                }
-            },
-            failure -> visitor.visitFailure(new TransformException(String.format("Failed to transform file '%s' to match attributes %s",
-                file.getName(), target), failure))
-        );
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 
 class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArtifactListener {
     private final Map<ComponentArtifactIdentifier, TransformationResult> artifactResults;
-    private final Map<File, TransformationResult> fileResults;
     private final ExecutionGraphDependenciesResolver dependenciesResolver;
     private final TransformationNodeRegistry transformationNodeRegistry;
     private final BuildOperationQueue<RunnableBuildOperation> actions;
@@ -41,7 +40,6 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
         ResolvedArtifactSet.AsyncArtifactListener delegate,
         BuildOperationQueue<RunnableBuildOperation> actions,
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults,
-        Map<File, TransformationResult> fileResults,
         ExecutionGraphDependenciesResolver dependenciesResolver,
         TransformationNodeRegistry transformationNodeRegistry
     ) {
@@ -49,7 +47,6 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
         this.actions = actions;
         this.transformation = transformation;
         this.delegate = delegate;
-        this.fileResults = fileResults;
         this.dependenciesResolver = dependenciesResolver;
         this.transformationNodeRegistry = transformationNodeRegistry;
     }
@@ -83,13 +80,6 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     @Override
     public boolean includeFileDependencies() {
         return delegate.includeFileDependencies();
-    }
-
-    @Override
-    public void fileAvailable(File file) {
-        TransformationSubject initialSubject = TransformationSubject.initial(file);
-        TransformationResult transformationResult = createTransformationResult(initialSubject);
-        fileResults.put(file, transformationResult);
     }
 
     private TransformationResult createTransformationResult(TransformationSubject initialSubject) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -66,7 +66,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     }
 
     @Override
-    public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
         // Visit everything
         return true;
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedArtifactTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedArtifactTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
-import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.internal.tasks.TaskDependencyContainer
 import org.gradle.internal.Factory
 import org.gradle.internal.component.model.IvyArtifactName
 import org.gradle.util.Matchers
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class DefaultResolvedArtifactTest extends Specification {
 
-    def "artifacts are equal when module and artifact identifier are equal"() {
+    def "artifacts are equal when artifact identifier is equal"() {
         def dependency = dep("group", "module1", "1.2")
         def dependencySameModule = dep("group", "module1", "1.2")
         def dependency2 = dep("group", "module2", "1-beta")
@@ -32,16 +32,16 @@ class DefaultResolvedArtifactTest extends Specification {
         def ivyArt = Stub(IvyArtifactName)
         def artifactId = Stub(ComponentArtifactIdentifier)
         def otherArtifactId = Stub(ComponentArtifactIdentifier)
-        def buildDependencies = Stub(TaskDependency)
+        def buildDependencies = Stub(TaskDependencyContainer)
 
         def artifact = new DefaultResolvedArtifact(dependency, ivyArt, artifactId, buildDependencies, artifactSource)
-        def equalArtifact = new DefaultResolvedArtifact(dependencySameModule, Stub(IvyArtifactName), artifactId, Stub(TaskDependency), Stub(Factory))
+        def equalArtifact = new DefaultResolvedArtifact(dependencySameModule, Stub(IvyArtifactName), artifactId, Stub(TaskDependencyContainer), Stub(Factory))
         def differentModule = new DefaultResolvedArtifact(dependency2, ivyArt, artifactId, buildDependencies, artifactSource)
         def differentId = new DefaultResolvedArtifact(dependency, ivyArt, otherArtifactId, buildDependencies, artifactSource)
 
         expect:
         artifact Matchers.strictlyEqual(equalArtifact)
-        artifact != differentModule
+        artifact Matchers.strictlyEqual(differentModule)
         artifact != differentId
     }
 
@@ -50,7 +50,7 @@ class DefaultResolvedArtifactTest extends Specification {
         def artifactSource = Mock(Factory)
         def ivyArt = Stub(IvyArtifactName)
         def artifactId = Stub(ComponentArtifactIdentifier)
-        def buildDependencies = Stub(TaskDependency)
+        def buildDependencies = Stub(TaskDependencyContainer)
         def file = new File("result")
 
         when:
@@ -83,7 +83,7 @@ class DefaultResolvedArtifactTest extends Specification {
         def artifactSource = Mock(Factory)
         def ivyArt = Stub(IvyArtifactName)
         def artifactId = Stub(ComponentArtifactIdentifier)
-        def buildDependencies = Stub(TaskDependency)
+        def buildDependencies = Stub(TaskDependencyContainer)
         def failure = new RuntimeException()
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolvedDependencyTest.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.tasks.TaskDependency
+import org.gradle.api.internal.tasks.TaskDependencyContainer
 import org.gradle.internal.Factory
 import org.gradle.internal.component.model.IvyArtifactName
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -41,7 +41,7 @@ class DefaultResolvedDependencyTest extends Specification {
         String someVersion = "someVersion"
         String someConfiguration = "someConfiguration"
         DefaultResolvedDependency resolvedDependency = new DefaultResolvedDependency(newId(someGroup, someName, someVersion, someConfiguration), buildOperationProcessor)
-        
+
         then:
         resolvedDependency.name == someGroup + ":" + someName + ":" + someVersion
         resolvedDependency.moduleGroup == someGroup
@@ -209,8 +209,6 @@ class DefaultResolvedDependencyTest extends Specification {
         final Factory artifactSource = Mock() {
             create() >> new File("pathTo" + name)
         }
-        return new DefaultResolvedArtifact(id, artifactStub, Mock(ComponentArtifactIdentifier), Mock(TaskDependency), artifactSource)
+        return new DefaultResolvedArtifact(id, artifactStub, Mock(ComponentArtifactIdentifier), Mock(TaskDependencyContainer), artifactSource)
     }
-
-
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/TestArtifactSet.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/TestArtifactSet.java
@@ -102,6 +102,11 @@ public class TestArtifactSet implements ResolvedArtifactSet {
         }
 
         @Override
+        public ResolvableArtifact transformedTo(File file) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public ResolvedArtifact toPublicView() {
             return artifact;
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -49,6 +49,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult
@@ -474,7 +475,13 @@ class DefaultConfigurationSpec extends Specification {
         def visitedArtifactSet = Stub(VisitedArtifactSet)
 
         _ * visitedArtifactSet.select(_, _, _, _) >> Stub(SelectedArtifactSet) {
-            visitArtifacts(_, _) >> { ArtifactVisitor visitor, boolean l -> files.each { visitor.visitFile(null, null, null, it) } }
+            visitArtifacts(_, _) >> { ArtifactVisitor visitor, boolean l ->
+                files.each {
+                    def artifact = Stub(ResolvableArtifact)
+                    _ * artifact.file >> it
+                    visitor.visitArtifact(null, null, artifact)
+                }
+            }
         }
 
         _ * localComponentsResult.resolvedProjectConfigurations >> Collections.emptySet()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -66,9 +66,11 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         then:
         _ * listener.requireArtifactFiles() >> false
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * visitor.endVisitCollection() // each artifact is treated as a separate collection, the entire variant could instead be treated as a collection
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact2)
+        1 * visitor.endVisitCollection()
         0 * _
 
         when:
@@ -77,6 +79,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         then:
         _ * listener.requireArtifactFiles() >> false
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * visitor.endVisitCollection()
         0 * _
     }
 
@@ -108,9 +111,11 @@ class ArtifactBackedResolvedVariantTest extends Specification {
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * visitor.endVisitCollection()
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact2)
+        1 * visitor.endVisitCollection()
         0 * _
 
         when:
@@ -129,6 +134,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * visitor.endVisitCollection()
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -18,12 +18,14 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.file.FileCollection
+import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
+import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
+import org.gradle.internal.DisplayName
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
@@ -41,7 +43,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
     def "has build dependencies"() {
         def fileBuildDependencies = Stub(TaskDependency)
-        def files = Stub(FileCollection)
+        def files = Stub(FileCollectionInternal)
         def visitor = Mock(TaskDependencyResolveContext)
 
         given:
@@ -95,7 +97,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         def f2 = new File("a.dll")
         def listener = Mock(ResolvedArtifactSet.AsyncArtifactListener)
         def visitor = Mock(ArtifactVisitor)
-        def files = Mock(FileCollection)
+        def files = Mock(FileCollectionInternal)
 
         when:
         set.startVisit(Stub(BuildOperationQueue), listener).visit(visitor)
@@ -115,7 +117,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         def id = Stub(ComponentIdentifier)
         def listener = Mock(ResolvedArtifactSet.AsyncArtifactListener)
         def visitor = Mock(ArtifactVisitor)
-        def files = Mock(FileCollection)
+        def files = Mock(FileCollectionInternal)
         def attrs1 = attributesFactory.of(Attribute.of('attr', String), 'value1')
         def attrs2 = attributesFactory.of(Attribute.of('attr', String), 'value2')
 
@@ -129,8 +131,8 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         _ * filter.isSatisfiedBy(_) >> true
         1 * files.files >> ([f1, f2] as Set)
         2 * selector.select(_) >> { ResolvedVariantSet variants -> variants.variants.first() }
-        1 * listener.fileAvailable(f1)
-        1 * listener.fileAvailable(f2)
+        1 * listener.artifactAvailable({ it.file == f1 })
+        1 * listener.artifactAvailable({ it.file == f2 })
         1 * artifactTypeRegistry.mapAttributesFor(f1) >> attrs1
         1 * artifactTypeRegistry.mapAttributesFor(f2) >> attrs2
         0 * _
@@ -139,16 +141,28 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         result.visit(visitor)
 
         then:
-        1 * visitor.visitFile(new ComponentFileArtifactIdentifier(id, f1.name), { it.displayName == 'local file' }, attrs1, f1)
-        1 * visitor.visitFile(new ComponentFileArtifactIdentifier(id, f2.name), { it.displayName == 'local file' }, attrs2, f2)
+        1 * visitor.visitArtifact(_, attrs1, { it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+            assert displayName.displayName == 'local file'
+            assert artifact.id == new ComponentFileArtifactIdentifier(id, f1.name)
+        }
+        1 * visitor.visitArtifact(_, attrs2, { it.file == f2 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+            assert displayName.displayName == 'local file'
+            assert artifact.id == new ComponentFileArtifactIdentifier(id, f2.name)
+        }
         0 * _
 
         when:
         result.visit(visitor)
 
         then:
-        1 * visitor.visitFile(new ComponentFileArtifactIdentifier(id, f1.name), { it.displayName == 'local file' }, attrs1, f1)
-        1 * visitor.visitFile(new ComponentFileArtifactIdentifier(id, f2.name), { it.displayName == 'local file' }, attrs2, f2)
+        1 * visitor.visitArtifact(_, attrs1, { it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+            assert displayName.displayName == 'local file'
+            assert artifact.id == new ComponentFileArtifactIdentifier(id, f1.name)
+        }
+        1 * visitor.visitArtifact(_, attrs2, { it.file == f2 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+            assert displayName.displayName == 'local file'
+            assert artifact.id == new ComponentFileArtifactIdentifier(id, f2.name)
+        }
         0 * _
     }
 
@@ -157,7 +171,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         def f2 = new File("a.dll")
         def listener = Mock(ResolvedArtifactSet.AsyncArtifactListener)
         def visitor = Mock(ArtifactVisitor)
-        def files = Mock(FileCollection)
+        def files = Mock(FileCollectionInternal)
         def attrs1 = attributesFactory.of(Attribute.of('attr', String), 'value1')
         def attrs2 = attributesFactory.of(Attribute.of('attr', String), 'value2')
 
@@ -173,15 +187,21 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         1 * artifactTypeRegistry.mapAttributesFor(f2) >> attrs2
         1 * files.files >> ([f1, f2] as Set)
         2 * selector.select(_) >> { ResolvedVariantSet variants -> variants.variants.first() }
-        1 * visitor.visitFile(new OpaqueComponentArtifactIdentifier(f1), { it.displayName == 'local file' }, attrs1, f1)
-        1 * visitor.visitFile(new OpaqueComponentArtifactIdentifier(f2), { it.displayName == 'local file' }, attrs2, f2)
+        1 * visitor.visitArtifact(_, attrs1, {it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+            assert displayName.displayName == 'local file'
+            assert artifact.id == new OpaqueComponentArtifactIdentifier(f1)
+        }
+        1 * visitor.visitArtifact(_, attrs2, {it.file == f2 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+            assert displayName.displayName == 'local file'
+            assert artifact.id == new OpaqueComponentArtifactIdentifier(f2)
+        }
         0 * visitor._
     }
 
     def "reports failure to list files"() {
         def listener = Mock(ResolvedArtifactSet.AsyncArtifactListener)
         def visitor = Mock(ArtifactVisitor)
-        def files = Mock(FileCollection)
+        def files = Mock(FileCollectionInternal)
         def failure = new RuntimeException()
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -149,6 +149,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
             assert displayName.displayName == 'local file'
             assert artifact.id == new ComponentFileArtifactIdentifier(id, f2.name)
         }
+        2 * visitor.endVisitCollection() // each file is treated as a separate collection, could potentially be treated as a single collection
         0 * _
 
         when:
@@ -163,6 +164,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
             assert displayName.displayName == 'local file'
             assert artifact.id == new ComponentFileArtifactIdentifier(id, f2.name)
         }
+        2 * visitor.endVisitCollection()
         0 * _
     }
 
@@ -195,6 +197,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
             assert displayName.displayName == 'local file'
             assert artifact.id == new OpaqueComponentArtifactIdentifier(f2)
         }
+        2 * visitor.endVisitCollection() // each file is treated as a separate collection, could potentially be treated as a single collection
         0 * visitor._
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -178,9 +178,10 @@ class DefaultArtifactTransformsTest extends Specification {
         1 * invocation1.getCachedResult() >> Optional.empty()
         1 * invocation1.invoke() >> Try.successful(TransformationSubject.initial(sourceArtifactId, sourceArtifactFile).createSubjectFromResult(ImmutableList.of(outFile1, outFile2))) >> invocation1
 
-        1 * listener.startVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult) >> true
+        1 * listener.shouldVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult) >> true
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile1})
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile2})
+        1 * visitor.endVisitCollection()
         0 * visitor._
         0 * transformation._
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -24,14 +24,13 @@ import org.gradle.internal.Try
 import org.gradle.internal.operations.BuildOperation
 import org.gradle.internal.operations.BuildOperationQueue
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class TransformingAsyncArtifactListenerTest extends Specification {
     def transformation = Mock(Transformation)
     CacheableInvocation<TransformationSubject> invocation = Mock(CacheableInvocation)
     def operationQueue = Mock(BuildOperationQueue)
     def transformationNodeRegistry = Mock(TransformationNodeRegistry)
-    def listener  = new TransformingAsyncArtifactListener(transformation, null, operationQueue, Maps.newHashMap(), Maps.newHashMap(), Mock(ExecutionGraphDependenciesResolver), transformationNodeRegistry)
+    def listener  = new TransformingAsyncArtifactListener(transformation, null, operationQueue, Maps.newHashMap(), Mock(ExecutionGraphDependenciesResolver), transformationNodeRegistry)
     def file = new File("foo")
     def artifactFile = new File("foo-artifact")
     def artifactId = Stub(ComponentArtifactIdentifier)
@@ -41,37 +40,25 @@ class TransformingAsyncArtifactListenerTest extends Specification {
     }
     def node = Mock(TransformationNode)
 
-    @Unroll
-    def "adds expensive #type transformations to the build operation queue"() {
+    def "adds expensive artifact transformations to the build operation queue"() {
         when:
-        listener."${type}Available"(this."${type}")
+        listener.artifactAvailable(artifact)
 
         then:
-        if (type == 'artifact') {
-            1 * transformationNodeRegistry.getIfExecuted(artifactId, transformation) >> Optional.empty()
-        }
+        1 * transformationNodeRegistry.getIfExecuted(artifactId, transformation) >> Optional.empty()
         1 * transformation.createInvocation(_, _, _) >> invocation
         1 * invocation.getCachedResult() >> Optional.empty()
         1 * operationQueue.add(_ as BuildOperation)
-
-        where:
-        type << ['file', 'artifact']
     }
 
-    @Unroll
-    def "runs cheap #type transformations immediately when not scheduled"() {
+    def "runs cheap artifact transformations immediately when not scheduled"() {
         when:
-        listener."${type}Available"(this."${type}")
+        listener.artifactAvailable(artifact)
 
         then:
-        if (type == 'artifact') {
-            1 * transformationNodeRegistry.getIfExecuted(artifactId, transformation) >> Optional.empty()
-        }
-        1 * transformation.createInvocation({ it.files == [this."${type == 'file' ? 'file' : 'artifactFile'}"] }, _ as ExecutionGraphDependenciesResolver, _) >> invocation
+        1 * transformationNodeRegistry.getIfExecuted(artifactId, transformation) >> Optional.empty()
+        1 * transformation.createInvocation({ it.files == [this.artifactFile] }, _ as ExecutionGraphDependenciesResolver, _) >> invocation
         1 * invocation.getCachedResult() >> Optional.of(Try.successful(TransformationSubject.initial(file)))
-
-        where:
-        type << ['file', 'artifact']
     }
 
     def "re-uses scheduled artifact transformation result"() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -276,15 +276,8 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other)) {
+        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
             visitor.visitCollection(this);
-        }
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        for (File file : this) {
-            builder.add(file);
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -276,7 +276,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
             visitor.visitCollection(this);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.ResolvableFileCollectionResolveContext;
 import org.gradle.api.internal.provider.AbstractProviderWithValue;
 import org.gradle.api.internal.tasks.AbstractTaskDependency;
-import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
@@ -46,7 +45,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-public abstract class AbstractFileCollection implements FileCollectionInternal, TaskDependencyContainer {
+public abstract class AbstractFileCollection implements FileCollectionInternal {
     /**
      * Returns the display name of this file collection. Used in log and error messages.
      *

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -168,7 +168,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
             visitor.visitGenericFileTree(this);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -168,7 +168,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other)) {
+        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
             visitor.visitGenericFileTree(this);
         }
     }
@@ -216,12 +216,6 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
         public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
             // TODO: should consider the filter
             fileTree.visitLeafCollections(visitor);
-        }
-
-        @Override
-        public void registerWatchPoints(FileSystemSubset.Builder builder) {
-            // TODO: we aren't considering the filter
-            fileTree.registerWatchPoints(builder);
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -175,13 +175,6 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
     }
 
     @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        for (FileCollectionInternal files : getSourceCollections()) {
-            files.registerWatchPoints(builder);
-        }
-    }
-
-    @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
         for (FileCollectionInternal element : getSourceCollections()) {
             element.visitLeafCollections(visitor);

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -18,8 +18,9 @@ package org.gradle.api.internal.file;
 
 
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
 
-public interface FileCollectionInternal extends FileCollection {
+public interface FileCollectionInternal extends FileCollection, TaskDependencyContainer {
 
     /**
      * Adds a logical description of the potential contents of this collection to the builder.

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -21,19 +21,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 
 public interface FileCollectionInternal extends FileCollection, TaskDependencyContainer {
-
-    /**
-     * Adds a logical description of the potential contents of this collection to the builder.
-     * <p>
-     * That is, registers a description of the parts of the file system that can influence the actual contents of the collection.
-     * <p>
-     * It is not required that an absolutely accurate description is added.
-     * For example, the description added to the builder may not consider all kinds of filtering that the file collection actually applies.
-     *
-     * @param builder the receiver of the description.
-     */
-    void registerWatchPoints(FileSystemSubset.Builder builder);
-
     /**
      * In a {@link FileCollection} hierarchy visits the leaves of the hierarchy.
      *

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -43,12 +43,15 @@ public interface FileCollectionLeafVisitor {
     /**
      * Called prior to visiting a file collection of the given type, and allows this visitor to skip the collection.
      *
-     * This is only intended to be step towards some fine-grained visiting of the contents of a `Configuration` and other collections that may
+     * <p>Note that this method is not necessarily called immediately before one of the visit methods, as some collections may be
+     * resolved in parallel. However, all visiting is performed sequentally and in order.
+     *
+     * <p>This method is only intended to be step towards some fine-grained visiting of the contents of a `Configuration` and other collections that may
      * contain files that are expensive to visit, or task/transform outputs that don't yet exist.
      *
-     * @return true to indicate that the collection should be visited, false to indicate it should be skipped.
+     * @return how should the collection be visited?
      */
-    default VisitType beforeVisit(CollectionType type) {
+    default VisitType prepareForVisit(CollectionType type) {
         return VisitType.Visit;
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -26,7 +26,7 @@ import java.io.File;
  */
 public interface FileCollectionLeafVisitor {
     enum CollectionType {
-        ArtifactTransformResult, Other
+        ArtifactTransformResult, Generated, Other
     }
 
     enum VisitType {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -29,6 +29,17 @@ public interface FileCollectionLeafVisitor {
         ArtifactTransformResult, Other
     }
 
+    enum VisitType {
+        // Visitor is interested in the contents of the collection
+        Visit,
+        // Visitor is not interested in the collection at all
+        Skip,
+        // Visitor is interested in the spec of the collection - that is the files that the collection might include in the future
+        // For most collections, this will be the same as the elements of the collection. However, for a collection that includes
+        // all of the files from a directory, the spec for the collection would be the directory + the patterns it matches files using
+        Spec
+    }
+
     /**
      * Called prior to visiting a file collection of the given type, and allows this visitor to skip the collection.
      *
@@ -37,8 +48,8 @@ public interface FileCollectionLeafVisitor {
      *
      * @return true to indicate that the collection should be visited, false to indicate it should be skipped.
      */
-    default boolean beforeVisit(CollectionType type) {
-        return true;
+    default VisitType beforeVisit(CollectionType type) {
+        return VisitType.Visit;
     }
 
     /**

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
@@ -104,6 +104,11 @@ public class FileSystemSubset {
 
         @Override
         public VisitType prepareForVisit(CollectionType type) {
+            if (type == CollectionType.Generated) {
+                // Don't watch generated resources
+                return VisitType.Skip;
+            }
+            // Only need the spec for other collections
             return VisitType.Spec;
         }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
@@ -103,7 +103,7 @@ public class FileSystemSubset {
         }
 
         @Override
-        public VisitType beforeVisit(CollectionType type) {
+        public VisitType prepareForVisit(CollectionType type) {
             return VisitType.Spec;
         }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultSingletonFileTree.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.file.collections;
 
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.internal.file.DefaultFileVisitDetails;
-import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
@@ -46,11 +45,6 @@ public class DefaultSingletonFileTree extends AbstractSingletonFileTree {
     @Override
     protected FileVisitDetails createFileVisitDetails() {
         return new DefaultFileVisitDetails(file, fileSystem, fileSystem);
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        builder.add(file);
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -24,7 +24,6 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.file.ReproducibleFileVisitor;
 import org.gradle.api.internal.file.DefaultFileVisitDetails;
-import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -106,11 +105,6 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
     @Override
     public boolean contains(File file) {
         return DirectoryTrees.contains(fileSystem, this, file) && file.isFile();
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        builder.add(this);
     }
 
     @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -20,7 +20,6 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.AbstractFileTree;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
-import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -57,11 +56,6 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
     @Override
     public void visitContents(FileCollectionResolveContext context) {
         context.add(tree);
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        tree.registerWatchPoints(builder);
     }
 
     @Override
@@ -119,7 +113,7 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (!visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other)) {
+        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) == FileCollectionLeafVisitor.VisitType.Skip) {
             return;
         }
         if (tree instanceof DirectoryFileTree) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -113,6 +113,14 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+        if (tree instanceof GeneratedSingletonFileTree) {
+            if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Generated) != FileCollectionLeafVisitor.VisitType.Skip) {
+                GeneratedSingletonFileTree singletonFileTree = (GeneratedSingletonFileTree) tree;
+                visitor.visitFileTree(singletonFileTree.getFile(), singletonFileTree.getPatterns(), this);
+            }
+            return;
+        }
+
         if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) == FileCollectionLeafVisitor.VisitType.Skip) {
             return;
         }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -113,7 +113,7 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) == FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) == FileCollectionLeafVisitor.VisitType.Skip) {
             return;
         }
         if (tree instanceof DirectoryFileTree) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
-import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
@@ -194,9 +193,5 @@ public class GeneratedSingletonFileTree extends AbstractSingletonFileTree {
             return new RelativePath(true, fileName);
         }
 
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/MinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/MinimalFileTree.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.file.collections;
 
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.internal.file.FileSystemSubset;
 
 /**
  * A minimal file tree implementation. An implementation can optionally also implement the following interfaces:
@@ -32,6 +31,4 @@ public interface MinimalFileTree extends MinimalFileCollection {
      * Visits the elements of this tree, in depth-first prefix order.
      */
     void visit(FileVisitor visitor);
-
-    void registerWatchPoints(FileSystemSubset.Builder builder);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
@@ -21,7 +21,6 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.DefaultFileVisitDetails;
-import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.internal.file.pattern.PatternStep;
 import org.gradle.api.internal.file.pattern.PatternStepFactory;
 import org.gradle.api.specs.Spec;
@@ -133,10 +132,5 @@ public class SingleIncludePatternFileTree implements MinimalFileTree {
     @Override
     public String getDisplayName() {
         return "directory '" + baseDir + "' include '" + includePattern + "'";
-    }
-
-    @Override
-    public void registerWatchPoints(FileSystemSubset.Builder builder) {
-        builder.add(baseDir, new PatternSet().include(includePattern).exclude(excludeSpec));
     }
 }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -21,8 +21,8 @@ import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionSpec
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.internal.tasks.TaskResolver
-import org.gradle.api.tasks.TaskDependency
 
 import java.util.concurrent.Callable
 
@@ -346,7 +346,6 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         def fileCollectionMock = Mock(FileCollectionInternal)
         def taskA = Mock(Task)
         def taskB = Mock(Task)
-        def dependency = Mock(TaskDependency)
 
         when:
         collection.from(fileCollectionMock)
@@ -356,8 +355,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         _ * fileResolver.resolve("f") >> new File("f")
-        _ * fileCollectionMock.getBuildDependencies() >> dependency
-        _ * dependency.getDependencies(null) >> ([taskA] as Set)
+        _ * fileCollectionMock.visitDependencies(_) >> { TaskDependencyResolveContext context -> context.add(taskA) }
         _ * taskResolver.resolveTask("b") >> taskB
         dependencies == [taskA, taskB] as Set<? extends Task>
     }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -167,7 +167,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitFileTree(tree.getDir(), tree.getPatterns(), adapter)
         0 * visitor._
     }
@@ -182,7 +182,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 
@@ -195,7 +195,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> true
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(adapter)
         0 * visitor._
     }
@@ -209,7 +209,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> false
+        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -167,7 +167,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitFileTree(tree.getDir(), tree.getPatterns(), adapter)
         0 * visitor._
     }
@@ -182,7 +182,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 
@@ -195,7 +195,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(adapter)
         0 * visitor._
     }
@@ -209,7 +209,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.beforeVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
@@ -18,6 +18,7 @@ package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
@@ -27,15 +28,17 @@ import java.io.File
 
 internal
 class ConfigurableFileCollectionCodec(
-    private val fileSetSerializer: SetSerializer<File>,
+    fileSetSerializer: SetSerializer<File>,
     private val fileCollectionFactory: FileCollectionFactory
 ) : Codec<ConfigurableFileCollection> {
+    private
+    val codec = FileCollectionCodec(fileSetSerializer, fileCollectionFactory)
 
     override suspend fun WriteContext.encode(value: ConfigurableFileCollection) =
-        fileSetSerializer.write(this, value.files)
+        codec.run { encode(value as FileCollectionInternal) }
 
     override suspend fun ReadContext.decode(): ConfigurableFileCollection =
         fileCollectionFactory.configurableFiles().also {
-            it.setFrom(fileSetSerializer.read(this))
+            it.from(codec.run { decode() })
         }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -62,12 +62,12 @@ private
 class CollectingVisitor : FileCollectionLeafVisitor {
     val files: MutableSet<File> = mutableSetOf()
 
-    override fun beforeVisit(type: FileCollectionLeafVisitor.CollectionType): FileCollectionLeafVisitor.VisitType {
+    override fun prepareForVisit(type: FileCollectionLeafVisitor.CollectionType): FileCollectionLeafVisitor.VisitType {
         // Ignore scheduled transforms for now
         return if (type == FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult) {
             FileCollectionLeafVisitor.VisitType.Skip
         } else {
-            FileCollectionLeafVisitor.VisitType.Spec
+            FileCollectionLeafVisitor.VisitType.Visit
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -62,9 +62,13 @@ private
 class CollectingVisitor : FileCollectionLeafVisitor {
     val files: MutableSet<File> = mutableSetOf()
 
-    override fun beforeVisit(type: FileCollectionLeafVisitor.CollectionType): Boolean {
+    override fun beforeVisit(type: FileCollectionLeafVisitor.CollectionType): FileCollectionLeafVisitor.VisitType {
         // Ignore scheduled transforms for now
-        return type != FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult
+        return if (type == FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult) {
+            FileCollectionLeafVisitor.VisitType.Skip
+        } else {
+            FileCollectionLeafVisitor.VisitType.Spec
+        }
     }
 
     override fun visitCollection(fileCollection: FileCollectionInternal) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -19,7 +19,6 @@ package org.gradle.jvm.internal;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributeContainer;
@@ -132,11 +131,6 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             @Override
             public boolean requireArtifactFiles() {
                 return true;
-            }
-
-            @Override
-            public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-                result.add(file);
             }
         });
         return result;

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -119,7 +119,11 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             }
 
             @Override
-            public boolean startVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+            public void endVisitCollection() {
+            }
+
+            @Override
+            public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
                 return true;
             }
 


### PR DESCRIPTION

### Context

This PR makes further changes to `FileCollection` visiting, and `Configuration` visiting in particular, to give the visitor a little more insight into the structure of the file collection. This will be further refactored in some later PRs.

This PR includes some simplifications:

- Merged the visiting of artifact resolution results, so that artifacts from local file dependencies and artifacts from component variants are all visited the same way.
- Merged the `registerWatchPoints()` method into `visitLeafCollections()`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
