### PR TITLE
Add Assisted Inject to list of annotation processors

### DIFF
--- a/subprojects/docs/src/docs/userguide/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_plugin.adoc
@@ -671,6 +671,10 @@ Many popular annotation processors support incremental annotation processing (se
 | link:https://github.com/mapstruct/mapstruct/issues/1420[Open issue]
 | N/A
 
+| link:https://github.com/square/AssistedInject[Assisted Inject]
+| link:https://github.com/square/AssistedInject/blob/master/CHANGELOG.md#version-050-2019-08-08[0.5.0]
+| N/A
+
 | Realm
 | link:https://github.com/realm/realm-java/issues/5906[Open issue]
 | N/A


### PR DESCRIPTION
### Context
Add information about [Assisted Inject](https://github.com/square/AssistedInject) to list of annotation processors with support of Gradle AP incremental compilation

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- N/A Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- N/A Provide unit tests (under `<subproject>/src/test`) to verify logic
- N/A Update User Guide, DSL Reference, and Javadoc for public-facing changes
- N/A Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
