### PR TITLE
Fail on unpack failure

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/Try.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Try.java
@@ -84,6 +84,8 @@ public abstract class Try<T> {
      * If the represented operation was successful, returns the result of applying the given
      * {@code Try}-bearing mapping function to the value, otherwise returns
      * the {@code Try} representing the original failure.
+     *
+     * Exceptions thrown by the given function are propagated.
      */
     public abstract <U> Try<U> flatMap(Function<? super T, Try<U>> f);
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Try.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Try.java
@@ -21,11 +21,19 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * An object to represent the result of an operation that can potentially fail.
+ * The object either holds the result of a successful execution, or an exception encountered during a failed one.
+ */
 public abstract class Try<T> {
 
     private Try() {
     }
 
+    /**
+     * Construct a {@code Try} by executing the given operation.
+     * The returned object will either hold the result or the exception thrown during the operation.
+     */
     public static <U> Try<U> ofFailable(Callable<U> failable) {
         try {
             return Try.successful(failable.call());
@@ -34,40 +42,86 @@ public abstract class Try<T> {
         }
     }
 
-    public static <U> Try<U> successful(U u) {
-        return new Success<U>(u);
+    /**
+     * Construct a {@code Try} representing a successful execution.
+     * The returned object will hold the given result.
+     */
+    public static <U> Try<U> successful(U result) {
+        return new Success<U>(result);
     }
 
-    public static <U> Try<U> failure(Throwable e) {
-        return new Failure<U>(e);
+    /**
+     * Construct a {@code Try} representing a failed execution.
+     * The returned object will hold the given failure.
+     */
+    public static <U> Try<U> failure(Throwable failure) {
+        return new Failure<U>(failure);
     }
 
+    /**
+     * Returns whether this {@code Try} represents a successful execution.
+     */
     public abstract boolean isSuccessful();
 
+    /**
+     * Return the result if the represented operation was successful.
+     * Throws the original failure otherwise (wrapped in an {@link UncheckedException} if necessary).
+     */
     public abstract T get();
 
-    public abstract T orElseMapFailure(Function<Throwable, T> f);
+    /**
+     * Return the result if the represented operation was successful or return the result of the given function.
+     * In the latter case the failure is passed to the function.
+     */
+    public abstract T getOrMapFailure(Function<Throwable, T> f);
 
+    /**
+     * Returns the failure for a failed result, or {@link Optional#empty()} otherwise.
+     */
     public abstract Optional<Throwable> getFailure();
 
+    /**
+     * If the represented operation was successful, returns the result of applying the given
+     * {@code Try}-bearing mapping function to the value, otherwise returns
+     * the {@code Try} representing the original failure.
+     */
     public abstract <U> Try<U> flatMap(Function<? super T, Try<U>> f);
 
-    public <U> Try<U> map(final Function<? super T, U> f) {
-        return flatMap(new Function<T, Try<U>>() {
-            @Override
-            public Try<U> apply(T input) {
-                return Try.successful(f.apply(input));
-            }
-        });
-    }
+    /**
+     * If the represented operation was successful, returns the result of applying the given
+     * mapping function to the value, otherwise returns
+     * the {@code Try} representing the original failure.
+     *
+     * This is similar to {@link #tryMap(Function)} but propagates any exception the given function throws.
+     */
+    public abstract <U> Try<U> map(Function<? super T, U> f);
 
+    /**
+     * If the represented operation was successful, returns the result of applying the given
+     * mapping function to the value, otherwise returns
+     * the {@code Try} representing the original failure.
+     *
+     * This is similar to {@link #map(Function)} but converts any exception the given function
+     * throws into a failed {@code Try}.
+     */
+    public abstract <U> Try<U> tryMap(Function<? super T, U> f);
+
+    /**
+     * If the represented operation was successful, returns the original result,
+     * otherwise returns the given mapping function applied to the failure.
+     */
     public abstract Try<T> mapFailure(Function<Throwable, Throwable> f);
 
+    /**
+     * Calls the given consumer with the result iff the represented operation was successful.
+     */
     public abstract void ifSuccessful(Consumer<T> consumer);
 
+    /**
+     * Calls {successConsumer} with the result if the represented operation was successful,
+     * otherwise calls {failureConsumer} with the failure.
+     */
     public abstract void ifSuccessfulOrElse(Consumer<? super T> successConsumer, Consumer<? super Throwable> failureConsumer);
-
-    public abstract <R> R getSuccessfulOrElse(Function<? super T, ? extends R> successFunction, Function<? super Throwable, ? extends R> failureFunction);
 
     private static final class Success<T> extends Try<T> {
         private final T value;
@@ -87,7 +141,7 @@ public abstract class Try<T> {
         }
 
         @Override
-        public T orElseMapFailure(Function<Throwable, T> f) {
+        public T getOrMapFailure(Function<Throwable, T> f) {
             return value;
         }
 
@@ -98,11 +152,22 @@ public abstract class Try<T> {
 
         @Override
         public <U> Try<U> flatMap(Function<? super T, Try<U>> f) {
-            try {
-                return f.apply(value);
-            } catch (Exception e) {
-                return Try.failure(e);
-            }
+            return f.apply(value);
+        }
+
+        @Override
+        public <U> Try<U> map(Function<? super T, U> f) {
+            return Try.successful(f.apply(value));
+        }
+
+        @Override
+        public <U> Try<U> tryMap(final Function<? super T, U> f) {
+            return Try.ofFailable(new Callable<U>() {
+                @Override
+                public U call() {
+                    return f.apply(value);
+                }
+            });
         }
 
         @Override
@@ -118,11 +183,6 @@ public abstract class Try<T> {
         @Override
         public void ifSuccessfulOrElse(Consumer<? super T> successConsumer, Consumer<? super Throwable> failureConsumer) {
             successConsumer.accept(value);
-        }
-
-        @Override
-        public <R> R getSuccessfulOrElse(Function<? super T, ? extends R> successFunction, Function<? super Throwable, ? extends R> failureFunction) {
-            return successFunction.apply(value);
         }
 
         @Override
@@ -163,7 +223,7 @@ public abstract class Try<T> {
         }
 
         @Override
-        public T orElseMapFailure(Function<Throwable, T> f) {
+        public T getOrMapFailure(Function<Throwable, T> f) {
             return f.apply(failure);
         }
 
@@ -174,7 +234,17 @@ public abstract class Try<T> {
 
         @Override
         public <U> Try<U> flatMap(Function<? super T, Try<U>> f) {
-            return Try.failure(failure);
+            return Cast.uncheckedNonnullCast(this);
+        }
+
+        @Override
+        public <U> Try<U> map(Function<? super T, U> f) {
+            return Cast.uncheckedNonnullCast(this);
+        }
+
+        @Override
+        public <U> Try<U> tryMap(Function<? super T, U> f) {
+            return Cast.uncheckedNonnullCast(this);
         }
 
         @Override
@@ -189,11 +259,6 @@ public abstract class Try<T> {
         @Override
         public void ifSuccessfulOrElse(Consumer<? super T> successConsumer, Consumer<? super Throwable> failureConsumer) {
             failureConsumer.accept(failure);
-        }
-
-        @Override
-        public <R> R getSuccessfulOrElse(Function<? super T, ? extends R> successFunction, Function<? super Throwable, ? extends R> failureFunction) {
-            return failureFunction.apply(failure);
         }
 
         @Override

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/BuildCacheBuildOperationsIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/BuildCacheBuildOperationsIntegrationTest.groovy
@@ -243,8 +243,7 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         }
 
         when:
-        executer.withStackTraceChecksDisabled()
-        succeeds("clean", "t")
+        fails("clean", "t")
 
         then:
         def failedUnpackOp = operations.only(BuildCacheArchiveUnpackBuildOperationType)

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultBuildCacheController.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closer;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.UncheckedIOException;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.BuildCacheService;
 import org.gradle.caching.internal.controller.operations.PackOperationDetails;
@@ -52,6 +51,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Optional;
 
 public class DefaultBuildCacheController implements BuildCacheController {

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadataFactory.java
@@ -104,7 +104,7 @@ public class OriginMetadataFactory {
                 String executionTimeAsString = properties.getProperty(EXECUTION_TIME_KEY);
 
                 if (originBuildInvocationId == null || executionTimeAsString == null) {
-                    throw new IllegalStateException("Cached result format error, corrupted origin metadata.");
+                    throw new IllegalStateException("Cached result format error, corrupted origin metadata");
                 }
 
                 long originalExecutionTime = Long.parseLong(executionTimeAsString);

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
@@ -22,12 +22,9 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
-import spock.lang.Unroll
 
 import java.util.function.Consumer
 import java.util.function.Predicate
-
-import static org.gradle.api.tasks.LocalStateFixture.defineTaskWithLocalState
 
 class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
 
@@ -107,7 +104,6 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         output =~ /org.gradle.api.GradleException: Could not pack tree 'output'/
     }
 
-
     def "corrupt archive loaded from remote cache is not copied into local cache"() {
         when:
         file("input.txt") << "data"
@@ -134,23 +130,11 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         localCache.listCacheFiles()*.delete()
 
         then:
-        executer.withStackTraceChecksDisabled()
-        succeeds("clean", "customTask")
-        output =~ /Build cache entry .+ from remote build cache is invalid/
-        output =~ /java.util.zip.ZipException: Not in GZIP format/
+        fails("clean", "customTask")
+        failure.assertHasCause("Failed to load cache entry for task ':customTask'")
 
         and:
-        localCache.listCacheFiles().size() == 1
-        localCache.listCacheFiles().first().text != "corrupt"
-
-        when:
-        settingsFile << """
-            buildCache.remote.enabled = false
-        """
-
-        then:
-        succeeds("clean", "customTask")
-        executed(":customTask")
+        localCache.listCacheFiles().empty
     }
 
     def "corrupt archive loaded from local cache is purged"() {
@@ -177,22 +161,22 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         localCache.listCacheFiles().first().bytes = localCache.listCacheFiles().first().bytes[0..-100]
 
         then:
-        executer.withStackTraceChecksDisabled()
-        succeeds("clean", "customTask")
-        output =~ /Failed to load cache entry for task ':customTask', cleaning outputs and falling back to \(non-incremental\) execution/
-        output =~ /Build cache entry .+ from local build cache is invalid/
-        output =~ /java.io.EOFException: Unexpected end of ZLIB input stream/
-
-        and:
-        localCache.listCacheFiles().size() == 1
+        fails("clean", "customTask")
+        failure.assertHasCause("Failed to load cache entry for task ':customTask'")
+        errorOutput.contains("Caused by: java.io.UncheckedIOException: java.io.EOFException: Unexpected end of ZLIB input stream")
         localCache.listCacheFailedFiles().size() == 1
 
         and:
-        succeeds("clean", "customTask")
-        executed(":customTask")
+        localCache.listCacheFiles().empty
+
+        when:
+        file("build").deleteDir()
+
+        then:
+        succeeds("customTask")
     }
 
-    def "corrupted cache provides useful error message"() {
+    def "corrupted cache artifact metadata provides useful error message"() {
         when:
         buildFile << """
             @CacheableTask
@@ -215,72 +199,13 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         cleanBuildDir()
 
         and:
-        executer.withStackTraceChecksDisabled()
         corruptMetadata({ metadata -> metadata.text = "corrupt" })
-        succeeds("cacheable")
+        fails("cacheable")
 
         then:
-        output =~ /Cached result format error, corrupted origin metadata\./
+        errorOutput.contains("Caused by: java.lang.IllegalStateException: Cached result format error, corrupted origin metadata")
         localCache.listCacheFailedFiles().size() == 1
-
-        when:
-        file("build").deleteDir()
-
-        then:
-        succeeds("cacheable")
     }
-
-    def "failed unpack does not disable caching for later tasks"() {
-        buildFile << """
-            @CacheableTask
-            class CustomTask extends DefaultTask {
-                @Input String title
-                @OutputDirectory File outputDir
-                @TaskAction
-                void generate() {
-                    new File(outputDir, "output").text = "OK"
-                }
-            }
-
-            task firstTask(type: CustomTask) {
-                title = "first"
-                outputDir = new File(temporaryDir, 'first')
-            }
-            task secondTask(type: CustomTask) {
-                mustRunAfter firstTask
-                title = "second"
-                outputDir = new File(temporaryDir, 'second')
-            }
-        """
-
-        when:
-        succeeds "firstTask", "secondTask"
-        executedAndNotSkipped ":firstTask", ":secondTask"
-
-        then:
-        localCache.listCacheFiles().size() == 2
-
-        when:
-        cleanBuildDir()
-        executer.withStackTraceChecksDisabled()
-        corruptMetadata({ metadata -> metadata.text = "corrupt" }, { metadata -> metadata.text.contains ":firstTask" })
-        succeeds "firstTask", "secondTask"
-
-        then:
-        output =~ /Cached result format error, corrupted origin metadata\./
-        localCache.listCacheFiles().size() == 2
-        localCache.listCacheFailedFiles().size() == 1
-        executedAndNotSkipped ":firstTask"
-        skipped ":secondTask"
-
-        when:
-        file("build").deleteDir()
-
-        then:
-        succeeds "firstTask", "secondTask"
-        skipped ":firstTask", ":secondTask"
-    }
-
 
     def "failed pack does not disable caching for later tasks"() {
         buildFile << """
@@ -322,65 +247,6 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         then:
         executedAndNotSkipped ":firstTask"
         skipped ":secondTask"
-    }
-
-    def "corrupted cache disables incremental execution"() {
-        when:
-        buildFile << """
-            @CacheableTask
-            class CustomTask extends DefaultTask {
-                @OutputDirectory File outputDir = new File(temporaryDir, 'output')
-                @TaskAction
-                void generate(IncrementalTaskInputs inputs) {
-                    println "> Incremental: \${inputs.incremental}"
-                    new File(outputDir, "output").text = "OK"
-                }
-            }
-
-            task cacheable(type: CustomTask)
-        """
-        succeeds("cacheable")
-
-        then:
-        localCache.listCacheFiles().size() == 1
-
-        when:
-        cleanBuildDir()
-
-        and:
-        executer.withStackTraceChecksDisabled()
-        corruptMetadata({ metadata -> metadata.text = "corrupt" })
-        succeeds("cacheable")
-
-        then:
-        output =~ /Cached result format error, corrupted origin metadata\./
-        output =~ /> Incremental: false/
-        localCache.listCacheFailedFiles().size() == 1
-    }
-
-    @Unroll
-    def "local state declared via #api API is destroyed when task fails to load from cache"() {
-        def localStateFile = file("local-state.json")
-        buildFile << defineTaskWithLocalState(useRuntimeApi)
-
-        when:
-        succeeds "customTask"
-        then:
-        executedAndNotSkipped ":customTask"
-        localStateFile.assertIsFile()
-
-        when:
-        cleanBuildDir()
-        executer.withStackTraceChecksDisabled()
-        corruptMetadata({ metadata -> metadata.text = "corrupt" })
-        succeeds "customTask", "-PassertNoLocalState"
-        then:
-        executedAndNotSkipped ":customTask"
-        localCache.listCacheFailedFiles().size() == 1
-
-        where:
-        useRuntimeApi << [true, false]
-        api = useRuntimeApi ? "runtime" : "annotation"
     }
 
     @Requires(TestPrecondition.SYMLINKS)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -579,8 +579,8 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
                 doLast {
                     delete('build')
                     ${
-                        actual == "file" ?
-                            "mkdir('build'); file('build/output').text = file('input.txt').text"
+                        actual == "file"
+                            ? "mkdir('build'); file('build/output').text = file('input.txt').text"
                             : "mkdir('build/output'); file('build/output/output.txt').text = file('input.txt').text"
                     }
                 }
@@ -588,11 +588,11 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         """
 
         when:
-        executer.withStackTraceChecksDisabled()
-        withBuildCache().run "customTask"
+        withBuildCache().fails "customTask"
         then:
+        failureHasCause("Failed to store cache entry for task ':customTask'")
         def expectedMessage = message.replace("PATH", file("build/output").path)
-        output.contains "Could not pack tree 'output': $expectedMessage"
+        errorOutput.contains "Could not pack tree 'output': $expectedMessage"
 
         where:
         expected | actual | message

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -197,7 +197,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             public boolean executedIncrementally() {
                 return result.getOutcome()
                     .map(executionOutcome -> executionOutcome == ExecutionOutcome.EXECUTED_INCREMENTALLY)
-                    .orElseMapFailure(throwable -> false);
+                    .getOrMapFailure(throwable -> false);
             }
 
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/CacheableInvocation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/CacheableInvocation.java
@@ -69,8 +69,8 @@ public interface CacheableInvocation<T> {
     default <U> CacheableInvocation<U> flatMap(Function<? super T, CacheableInvocation<U>> mapper) {
         return getCachedResult()
             .map(cachedResult -> cachedResult
-                .map(mapper)
-                .orElseMapFailure(failure -> cached(Try.failure(failure)))
+                .tryMap(mapper)
+                .getOrMapFailure(failure -> cached(Try.failure(failure)))
             ).orElseGet(() ->
                 nonCached(() ->
                     invoke().flatMap(intermediateResult -> mapper.apply(intermediateResult).invoke())

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -209,7 +209,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
                     });
 
                     return outcome.getOutcome()
-                        .map(outcome1 -> execution.loadResultsFile())
+                        .tryMap(outcome1 -> execution.loadResultsFile())
                         .mapFailure(failure -> new TransformException(String.format("Execution failed for %s.", execution.getDisplayName()), failure));
                 });
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -190,7 +190,7 @@ public abstract class TransformationNode extends Node {
                 protected String describeSubject() {
                     return previousTransformationNode.getTransformedSubject()
                         .map(subject -> subject.getDisplayName())
-                        .orElseMapFailure(failure -> failure.getMessage());
+                        .getOrMapFailure(failure -> failure.getMessage());
                 }
             });
         }

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -53,6 +53,15 @@ Calls to `BuildCacheConfiguration.local(Class)` with anything other than `Direct
 Use `getLocal()` and `local(Action)` instead.
 These methods now assume the local build cache type to be `DirectoryBuildCache`.
 
+==== Failing to pack or unpack cached results will now fail the build
+
+In the past when Gradle encountered a problem while packaging the results of a cached task, it would ignore the problem and try to continue running the build.
+Similarly, having encountered a corrupt cached artifact during unpacking Gradle would try to remove whatever was already unpacked of the output and re-execute the task to make sure the build had a chance to succeed.
+
+While this behavior could be helpful to maintain executing build no matter what, hiding the problems this way can lead to reduced cache performance.
+In Gradle 6.0 we are switching to failing fast, and both pack and unpack errors will result the build to fail.
+Doing so allows these problems to be surfaced more easily.
+
 ==== `@Nullable` annotation is gone
 
 The `org.gradle.api.Nullable` annotation type has been removed. Use `javax.annotation.Nullable` from JSR-305 instead.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CacheStep.java
@@ -105,7 +105,7 @@ public class CacheStep implements Step<IncrementalChangesContext, CurrentSnapsho
                 })
                 .orElseGet(() -> executeAndStoreInCache(cacheKey, context))
             )
-            .orElseMapFailure(loadFailure -> {
+            .getOrMapFailure(loadFailure -> {
                 throw new GradleException(
                     String.format("Failed to load cache entry for %s",
                         work.getDisplayName()),

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CacheStep.java
@@ -19,7 +19,6 @@ package org.gradle.internal.execution.steps;
 import com.google.common.collect.ImmutableSortedMap;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.GradleException;
-import org.gradle.api.UncheckedIOException;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.command.BuildCacheCommandFactory;
 import org.gradle.caching.internal.command.BuildCacheCommandFactory.LoadMetadata;
@@ -38,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Optional;
 
 public class CacheStep implements Step<IncrementalChangesContext, CurrentSnapshotResult> {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CacheStep.java
@@ -18,7 +18,6 @@ package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableSortedMap;
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.GradleException;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.command.BuildCacheCommandFactory;
 import org.gradle.caching.internal.command.BuildCacheCommandFactory.LoadMetadata;
@@ -106,7 +105,7 @@ public class CacheStep implements Step<IncrementalChangesContext, CurrentSnapsho
                 .orElseGet(() -> executeAndStoreInCache(cacheKey, context))
             )
             .getOrMapFailure(loadFailure -> {
-                throw new GradleException(
+                throw new RuntimeException(
                     String.format("Failed to load cache entry for %s",
                         work.getDisplayName()),
                     loadFailure
@@ -151,7 +150,10 @@ public class CacheStep implements Step<IncrementalChangesContext, CurrentSnapsho
                     work.getDisplayName(), cacheKey.getHashCode());
             }
         } catch (Exception e) {
-            LOGGER.warn("Failed to store cache entry {}", cacheKey.getDisplayName(), e);
+            throw new RuntimeException(
+                String.format("Failed to store cache entry for %s",
+                    work.getDisplayName()),
+                e);
         }
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CacheStepTest.groovy
@@ -31,8 +31,6 @@ import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 import org.gradle.internal.execution.caching.CachingState
-import org.gradle.internal.execution.history.changes.ExecutionStateChanges
-import spock.lang.Shared
 
 class CacheStepTest extends StepSpec<IncrementalChangesContext> implements FingerprinterFixture {
     def buildCacheController = Mock(BuildCacheController)
@@ -41,7 +39,6 @@ class CacheStepTest extends StepSpec<IncrementalChangesContext> implements Finge
     def cacheKey = Stub(BuildCacheKey)
     def cachingState = Mock(CachingState)
     def loadMetadata = Mock(BuildCacheCommandFactory.LoadMetadata)
-    @Shared def rebuildChanges = Mock(ExecutionStateChanges)
     def localStateFile = file("local-state.txt") << "local state"
 
     def step = new CacheStep(buildCacheController, buildCacheCommandFactory, delegate)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CacheStepTest.groovy
@@ -175,12 +175,16 @@ class CacheStepTest extends StepSpec<IncrementalChangesContext> implements Finge
         0 * _
     }
 
-    def "does not fail when cache backend throws exception while storing cached result"() {
+    def "fails when cache backend throws exception while storing cached result"() {
+        def failure = new RuntimeException("store failure")
+
         when:
-        def result = step.execute(context)
+        step.execute(context)
 
         then:
-        result == delegateResult
+        def ex = thrown Exception
+        ex.message == "Failed to store cache entry for job ':test'"
+        ex.cause == failure
 
         interaction { withValidCacheKey() }
 
@@ -192,7 +196,7 @@ class CacheStepTest extends StepSpec<IncrementalChangesContext> implements Finge
         1 * delegateResult.outcome >> Try.successful(ExecutionOutcome.EXECUTED_NON_INCREMENTALLY)
 
         then:
-        interaction { outputStored { throw new RuntimeException("store failure") } }
+        interaction { outputStored { throw failure } }
         0 * _
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CacheStepTest.groovy
@@ -32,9 +32,7 @@ import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 import org.gradle.internal.execution.caching.CachingState
 import org.gradle.internal.execution.history.changes.ExecutionStateChanges
-import org.gradle.internal.file.TreeType
 import spock.lang.Shared
-import spock.lang.Unroll
 
 class CacheStepTest extends StepSpec<IncrementalChangesContext> implements FingerprinterFixture {
     def buildCacheController = Mock(BuildCacheController)
@@ -106,16 +104,18 @@ class CacheStepTest extends StepSpec<IncrementalChangesContext> implements Finge
         0 * _
     }
 
-    @Unroll
-    def "executes work #description non-incrementally and stores after unpack failure"() {
+    def "fails after unpack failure"() {
+        def failure = new RuntimeException("unpack failure")
         def loadedOutputFile = file("output.txt")
         def loadedOutputDir = file("output")
 
         when:
-        def result = step.execute(context)
+        step.execute(context)
 
         then:
-        result == delegateResult
+        def ex = thrown Exception
+        ex.message == "Failed to load cache entry for job ':test'"
+        ex.cause == failure
 
         interaction { withValidCacheKey() }
 
@@ -126,61 +126,10 @@ class CacheStepTest extends StepSpec<IncrementalChangesContext> implements Finge
             loadedOutputFile << "output"
             loadedOutputDir.mkdirs()
             loadedOutputDir.file("output.txt") << "output"
-            throw new RuntimeException("unpack failure")
+            throw failure
         }
 
         then:
-        _ * work.visitOutputProperties(_) >> { UnitOfWork.OutputPropertyVisitor visitor ->
-            visitor.visitOutputProperty("outputFile", TreeType.FILE, ImmutableList.of(loadedOutputFile))
-            visitor.visitOutputProperty("outputDir", TreeType.DIRECTORY, ImmutableList.of(loadedOutputDir))
-            visitor.visitOutputProperty("missingOutputFile", TreeType.FILE, ImmutableList.of(file("missing.txt")))
-            visitor.visitOutputProperty("missingOutputDir", TreeType.DIRECTORY, ImmutableList.of(file("missing")))
-        }
-        loadedOutputFile.assertDoesNotExist()
-        loadedOutputDir.assertIsEmptyDir()
-        interaction { localStateIsRemoved() }
-
-        then:
-        _ * context.changes >> Optional.ofNullable(changes)
-        1 * delegate.execute(_) >> { IncrementalChangesContext delegateContext ->
-            assert delegateContext != context
-            check(delegateContext)
-            delegateResult
-        }
-        1 * delegateResult.outcome >> Try.successful(ExecutionOutcome.EXECUTED_NON_INCREMENTALLY)
-
-        then:
-        interaction { outputStored {} }
-        0 * _
-
-        where:
-        description       | check                                                                                        | changes
-        "without changes" | { IncrementalChangesContext context -> assert !context.getChanges().present }                | null
-        "with changes"    | { IncrementalChangesContext context -> assert context.getChanges().get() == rebuildChanges } | Mock(ExecutionStateChanges) {
-            1 * withEnforcedRebuild("Outputs removed due to failed load from cache") >> rebuildChanges
-        }
-    }
-
-    def "propagates non-recoverable unpack failure"() {
-        when:
-        step.execute(context)
-
-        then:
-        def ex = thrown Exception
-        ex.message == "cleanup failure"
-
-        interaction { withValidCacheKey() }
-
-        then:
-        _ * work.allowedToLoadFromCache >> true
-        1 * buildCacheCommandFactory.createLoad(cacheKey, work) >> loadCommand
-        1 * buildCacheController.load(loadCommand) >> { throw new RuntimeException("unpack failure") }
-
-        then:
-        _ * work.visitOutputProperties(_) >> {
-            throw new RuntimeException("cleanup failure")
-        }
-        interaction { localStateIsRemoved() }
         0 * _
     }
 


### PR DESCRIPTION
Previously we used to try a complicated dance to continue even if unpacking a cached result failed. We did this because wanted to avoid a corrupted cache entry breaking a build. However, with real-world usage it looks like hiding these problems causes more grief, and adds quite some complexity to the process. So we are removing this mitigation now.

<!--- The issue this PR addresses -->
Fixes #9033
