### PR TITLE
Refactor the UnexportMainSymbol tests to support `_wmain` on Windows

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -53,6 +53,44 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.UnexportMainSymbol",
+            "member": "Class org.gradle.language.nativeplatform.tasks.UnexportMainSymbol",
+            "acceptation": "The class is incubating and was simply moved",
+            "changes": [
+                "Interface has been added"
+            ]
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.UnexportMainSymbol",
+            "member": "Method org.gradle.language.nativeplatform.tasks.UnexportMainSymbol.getObjects()",
+            "acceptation": "The class is incubating and was simply moved",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.UnexportMainSymbol",
+            "member": "Method org.gradle.language.nativeplatform.tasks.UnexportMainSymbol.getOutputDirectory()",
+            "acceptation": "The class is incubating and was simply moved",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.UnexportMainSymbol",
+            "member": "Method org.gradle.language.nativeplatform.tasks.UnexportMainSymbol.getRelocatedObjects()",
+            "acceptation": "The class is incubating and was simply moved",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.UnexportMainSymbol",
+            "member": "Method org.gradle.language.nativeplatform.tasks.UnexportMainSymbol.unexport(org.gradle.work.InputChanges)",
+            "acceptation": "The class is incubating and was simply moved",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.UnexportMainSymbol",
+            "member": "Constructor org.gradle.language.nativeplatform.tasks.UnexportMainSymbol()",
+            "acceptation": "The class is incubating and was simply move",
+            "changes": []
         }
     ]
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -9,8 +9,8 @@ We would like to thank the following community contributors to this release of G
 [Sebastian Schuberth](https://github.com/sschuberth),
 [Andrey Mischenko](https://github.com/gildor),
 [Alex Saveau](https://github.com/SUPERCILEX),
-and [Mike Kobit](https://github.com/mkobit).
-
+[Mike Kobit](https://github.com/mkobit),
+and [Nigel Banks](https://github.com/nigelgbanks).
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/tasks/CppUnexportMainSymbolIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/tasks/CppUnexportMainSymbolIntegrationTest.groovy
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp.tasks
+
+import org.gradle.integtests.fixtures.SourceFile
+import org.gradle.language.nativeplatform.tasks.AbstractUnexportMainSymbolIntegrationTest
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.nativeplatform.fixtures.app.CppGreeter
+import org.gradle.nativeplatform.fixtures.app.CppMultiply
+import org.gradle.nativeplatform.fixtures.app.CppSourceElement
+import org.gradle.nativeplatform.fixtures.app.CppSum
+import org.gradle.nativeplatform.fixtures.app.IncrementalCppElement
+import org.gradle.nativeplatform.fixtures.app.IncrementalElement
+import org.gradle.nativeplatform.fixtures.app.SourceElement
+import org.gradle.nativeplatform.fixtures.app.SourceFileElement
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Issue
+
+class CppUnexportMainSymbolIntegrationTest extends AbstractUnexportMainSymbolIntegrationTest {
+    @RequiresInstalledToolChain(ToolChainRequirement.VISUALCPP)
+    @Issue("https://github.com/gradle/gradle-native/issues/277")
+    def "can relocate Windows specific _wmain symbol"() {
+        makeSingleProject()
+        file("src/main/cpp/main.cpp") << """
+            #include <iostream>
+            
+            int wmain( int argc**, wchar_t *argv[], wchar_t *envp[] ) {
+                std::cout << "hello world!" << std::endl;
+                return 0;
+            }
+        """
+
+        when:
+        succeeds("unexport")
+        then:
+        assertMainSymbolIsNotExported("build/relocated/main.o")
+    }
+
+    @Override
+    protected void makeSingleProject() {
+        settingsFile << "rootProject.name = 'app'"
+        buildFile << """
+            apply plugin: "cpp-application"
+            task unexport(type: UnexportMainSymbol) {
+                outputDirectory = layout.buildDirectory.dir("relocated")
+                objects.from { components.main.developmentBinary.get().objects }
+            }
+        """
+    }
+
+    @Override
+    protected String getDevelopmentBinaryCompileTask() {
+        return ":compileDebugCpp"
+    }
+
+    final List<String> mainSymbols = ["_main", "main", "_wmain", "wmain"]
+
+    protected SourceFileElement mainFile = getMainFile()
+    protected SourceFileElement alternateMainFile = new SourceFileElement() {
+        final SourceFile sourceFile = sourceFile("cpp", "main.cpp", """
+            #include <iostream>
+
+            int main(int argc, char* argv[]) {
+                std::cout << "goodbye world!" << std::endl;
+                return 0;
+            }
+        """)
+    }
+
+    @Override
+    protected SourceFileElement getOtherFile() {
+        return new SourceFileElement() {
+            final SourceFile sourceFile = sourceFile("cpp", "other.cpp", """
+            class Other {};
+        """)
+        }
+    }
+
+    @Override
+    protected IncrementalElement getComponentUnderTest() {
+        return new IncrementalCppElement() {
+            @Override
+            protected List<IncrementalElement.Transform> getIncrementalChanges() {
+                return [modify(mainFile, alternateMainFile)]
+            }
+        }
+    }
+
+    @Override
+    protected SourceElement getComponentWithoutMainUnderTest() {
+        return new CppSourceElement() {
+            final greeter = new CppGreeter()
+            final sum = new CppSum()
+            final multiply = new CppMultiply()
+
+            @Override
+            SourceElement getHeaders() {
+                ofElements(greeter.headers, sum.headers, multiply.headers)
+            }
+
+            @Override
+            SourceElement getSources() {
+                ofElements(greeter.sources, sum.sources, multiply.sources)
+            }
+        }
+    }
+
+    @Override
+    protected SourceElement getComponentWithOtherFileUnderTest() {
+        return SourceElement.ofElements(mainFile, otherFile)
+    }
+
+    @Override
+    protected SourceFileElement getMainFile(String filenameWithoutExtension) {
+        return new SourceFileElement() {
+            final SourceFile sourceFile = sourceFile("cpp", "${filenameWithoutExtension}.cpp", """
+            #include <iostream>
+
+            int main(int argc, char* argv[]) {
+                std::cout << "hello world!" << std::endl;
+                return 0;
+            }
+        """)
+        }
+    }
+}

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/tasks/CppUnexportMainSymbolIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/tasks/CppUnexportMainSymbolIntegrationTest.groovy
@@ -28,8 +28,6 @@ import org.gradle.nativeplatform.fixtures.app.IncrementalCppElement
 import org.gradle.nativeplatform.fixtures.app.IncrementalElement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.fixtures.app.SourceFileElement
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 
 class CppUnexportMainSymbolIntegrationTest extends AbstractUnexportMainSymbolIntegrationTest {
@@ -39,8 +37,8 @@ class CppUnexportMainSymbolIntegrationTest extends AbstractUnexportMainSymbolInt
         makeSingleProject()
         file("src/main/cpp/main.cpp") << """
             #include <iostream>
-            
-            int wmain( int argc**, wchar_t *argv[], wchar_t *envp[] ) {
+
+            int wmain(int argc, wchar_t *argv[], wchar_t *envp[] ) {
                 std::cout << "hello world!" << std::endl;
                 return 0;
             }
@@ -49,7 +47,7 @@ class CppUnexportMainSymbolIntegrationTest extends AbstractUnexportMainSymbolInt
         when:
         succeeds("unexport")
         then:
-        assertMainSymbolIsNotExported("build/relocated/main.o")
+        assertMainSymbolIsNotExported(objectFile("build/relocated/main"))
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/tasks/SwiftUnexportMainSymbolIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/tasks/SwiftUnexportMainSymbolIntegrationTest.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.swift.tasks
+
+import org.gradle.integtests.fixtures.SourceFile
+import org.gradle.language.nativeplatform.tasks.AbstractUnexportMainSymbolIntegrationTest
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.nativeplatform.fixtures.app.IncrementalElement
+import org.gradle.nativeplatform.fixtures.app.IncrementalSwiftElement
+import org.gradle.nativeplatform.fixtures.app.SourceElement
+import org.gradle.nativeplatform.fixtures.app.SourceFileElement
+import org.gradle.nativeplatform.fixtures.app.SwiftLib
+
+@RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
+class SwiftUnexportMainSymbolIntegrationTest extends AbstractUnexportMainSymbolIntegrationTest {
+    @Override
+    protected void makeSingleProject() {
+        settingsFile << "rootProject.name = 'app'"
+        buildFile << """
+            apply plugin: "swift-application"
+            task unexport(type: UnexportMainSymbol) {
+                outputDirectory = layout.buildDirectory.dir("relocated")
+                objects.from { components.main.developmentBinary.get().objects }
+            }
+        """
+    }
+
+    @Override
+    protected String getDevelopmentBinaryCompileTask() {
+        return ":compileDebugSwift"
+    }
+
+    final List<String> mainSymbols = ["_main", "main"]
+
+    protected SourceFileElement mainFile = getMainFile()
+    protected SourceFileElement alternateFile = new SourceFileElement() {
+        final SourceFile sourceFile = sourceFile("swift", "main.swift", 'print("goodbye world!")')
+    }
+
+    @Override
+    protected SourceFileElement getOtherFile() {
+        return new SourceFileElement() {
+            final SourceFile sourceFile = sourceFile("swift", "other.swift", 'class Other {}')
+        }
+    }
+
+    @Override
+    protected IncrementalElement getComponentUnderTest() {
+        return new IncrementalSwiftElement() {
+            @Override
+            protected List<IncrementalElement.Transform> getIncrementalChanges() {
+                return [modify(mainFile, alternateFile)]
+            }
+
+            final String moduleName = "App"
+        }
+    }
+
+    @Override
+    protected SourceElement getComponentWithoutMainUnderTest() {
+        return new SwiftLib()
+    }
+
+    @Override
+    protected SourceElement getComponentWithOtherFileUnderTest() {
+        return SourceElement.ofElements(mainFile, otherFile)
+    }
+
+    @Override
+    protected SourceFileElement getMainFile(String filenameWithoutExtension) {
+        return new SourceFileElement() {
+            final SourceFile sourceFile = sourceFile("swift", "${filenameWithoutExtension}.swift", 'print("hello world!")')
+        }
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/UnexportMainSymbol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.language.swift.tasks;
+package org.gradle.language.nativeplatform.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -105,6 +105,8 @@ public class UnexportMainSymbol extends DefaultTask {
                 final SymbolHider symbolHider = new SymbolHider(object);
                 symbolHider.hideSymbol("main");     // 64 bit
                 symbolHider.hideSymbol("_main");    // 32 bit
+                symbolHider.hideSymbol("wmain");    // 64 bit
+                symbolHider.hideSymbol("_wmain");   // 32 bit
                 symbolHider.saveTo(relocatedObject);
             } catch (IOException e) {
                 throw UncheckedException.throwAsUncheckedException(e);

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/DumpbinBinaryInfo.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/DumpbinBinaryInfo.groovy
@@ -96,7 +96,26 @@ class DumpbinBinaryInfo implements BinaryInfo {
     }
 
     List<BinaryInfo.Symbol> listSymbols() {
-        throw new UnsupportedOperationException("Not yet implemented")
+        def dumpbin = findExe("dumpbin.exe")
+        def process = [dumpbin.absolutePath, '/SYMBOLS', binaryFile.absolutePath].execute(["PATH=$vcPath"], null)
+        def lines = process.inputStream.readLines()
+        return lines.findAll { it.contains(' | ') }.collect { line ->
+            // Looks like:
+            // 000 0105673E ABS    notype       Static       | @comp.id
+            // 001 80000191 ABS    notype       Static       | @feat.00
+            // 002 00000000 SECT1  notype       Static       | .drectve
+            // 005 00000000 SECT2  notype       Static       | .debug$S
+            // 008 00000000 SECT3  notype       Static       | .debug$T
+            // 00B 00000000 SECT4  notype       Static       | .text$mn
+            // 00E 00000000 SECT5  notype       Static       | .debug$S
+            // 011 00000000 UNDEF  notype ()    External     | ?life@@YAHXZ (int __cdecl life(void))
+            // 012 00000000 SECT4  notype ()    External     | _main
+            // 013 00000000 SECT6  notype       Static       | .chks64
+            def tokens = line.split('\\s+')
+            def pipeIndex = tokens.findIndexOf { it == '|' }
+            assert pipeIndex != -1
+            return new BinaryInfo.Symbol(tokens[pipeIndex + 1], tokens[3].charAt(0), line.contains("External"))
+        }
     }
 
     List<BinaryInfo.Symbol> listDebugSymbols() {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
@@ -40,7 +40,7 @@ import org.gradle.language.internal.NativeComponentFactory;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.Dimensions;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
-import org.gradle.language.swift.tasks.UnexportMainSymbol;
+import org.gradle.language.nativeplatform.tasks.UnexportMainSymbol;
 import org.gradle.nativeplatform.TargetMachine;
 import org.gradle.nativeplatform.TargetMachineFactory;
 import org.gradle.nativeplatform.platform.NativePlatform;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -45,7 +45,7 @@ import org.gradle.language.swift.internal.DefaultSwiftBinary;
 import org.gradle.language.swift.internal.DefaultSwiftPlatform;
 import org.gradle.language.swift.plugins.SwiftBasePlugin;
 import org.gradle.language.swift.tasks.SwiftCompile;
-import org.gradle.language.swift.tasks.UnexportMainSymbol;
+import org.gradle.language.nativeplatform.tasks.UnexportMainSymbol;
 import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.nativeplatform.TargetMachine;
 import org.gradle.nativeplatform.TargetMachineFactory;


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-native/issues/277

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle/pull/10095

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fpr-10095)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
