### PR TITLE
Some refactoring of file collection visiting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -348,6 +348,7 @@ dependencies {
     gradlePlugins(project(":testKit"))
 
     coreRuntimeExtensions(project(":dependencyManagement")) //See: DynamicModulesClassPathProvider.GRADLE_EXTENSION_MODULES
+    coreRuntimeExtensions(project(":instantExecution"))
     coreRuntimeExtensions(project(":pluginUse"))
     coreRuntimeExtensions(project(":workers"))
     coreRuntimeExtensions(project(":kotlinDslProviderPlugins"))

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/ProjectGroups.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/ProjectGroups.kt
@@ -61,7 +61,8 @@ object ProjectGroups {
             rootProject.project("buildProfile"),
             rootProject.project("toolingApiBuilders"),
             rootProject.project("kotlinDslProviderPlugins"),
-            rootProject.project("kotlinDslToolingBuilders")
+            rootProject.project("kotlinDslToolingBuilders"),
+            rootProject.project("instantExecution")
         )
 
     val Project.publicProjects

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -67,7 +67,6 @@ dependencies {
     implementation(library("commons_compress"))
     implementation(library("xmlApis"))
 
-    runtimeOnly(project(":instantExecution"))
     runtimeOnly(project(":docs"))
 
     testImplementation(project(":plugins"))

--- a/subprojects/core/src/main/java/org/gradle/api/execution/internal/DefaultTaskInputsListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/execution/internal/DefaultTaskInputsListener.java
@@ -28,7 +28,7 @@ public class DefaultTaskInputsListener implements TaskInputsListener {
     public void onExecute(TaskInternal taskInternal, FileCollectionInternal fileSystemInputs) {
         if (waiter!=null) {
             FileSystemSubset.Builder fileSystemSubsetBuilder = FileSystemSubset.builder();
-            fileSystemInputs.visitLeafCollections(fileSystemSubsetBuilder);
+            fileSystemInputs.visitStructure(fileSystemSubsetBuilder);
             waiter.watch(fileSystemSubsetBuilder.build());
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -160,7 +160,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         }
 
         @Override
-        public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+        public void visitStructure(FileCollectionStructureVisitor visitor) {
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.tasks.PropertyFileCollection;
 import org.gradle.api.tasks.FileNormalizer;
@@ -134,7 +134,7 @@ public class FileParameterUtils {
             final List<File> roots = Lists.newArrayList();
             final MutableBoolean nonFileRoot = new MutableBoolean();
             FileCollectionInternal outputFileCollection = fileCollectionFactory.resolving(unpackedValue);
-            outputFileCollection.visitLeafCollections(new FileCollectionLeafVisitor() {
+            outputFileCollection.visitStructure(new FileCollectionStructureVisitor() {
                 @Override
                 public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
                     Iterables.addAll(roots, contents);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -136,8 +136,8 @@ public class FileParameterUtils {
             FileCollectionInternal outputFileCollection = fileCollectionFactory.resolving(unpackedValue);
             outputFileCollection.visitLeafCollections(new FileCollectionLeafVisitor() {
                 @Override
-                public void visitCollection(FileCollectionInternal fileCollection) {
-                    Iterables.addAll(roots, fileCollection);
+                public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
+                    Iterables.addAll(roots, contents);
                 }
 
                 @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -53,11 +53,11 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
 
 
     private class FileCollectionLeafVisitorImpl implements FileCollectionLeafVisitor {
-        private final List<FileSystemSnapshot> roots = new ArrayList<FileSystemSnapshot>();
+        private final List<FileSystemSnapshot> roots = new ArrayList<>();
 
         @Override
-        public void visitCollection(FileCollectionInternal fileCollection) {
-            for (File file : fileCollection) {
+        public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
+            for (File file : contents) {
                 roots.add(fileSystemSnapshotter.snapshot(file));
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -20,7 +20,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.file.DefaultFileMetadata;
@@ -46,13 +46,13 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
 
     @Override
     public List<FileSystemSnapshot> snapshot(FileCollection fileCollection) {
-        FileCollectionLeafVisitorImpl visitor = new FileCollectionLeafVisitorImpl();
-        ((FileCollectionInternal) fileCollection).visitLeafCollections(visitor);
+        SnapshotingVisitor visitor = new SnapshotingVisitor();
+        ((FileCollectionInternal) fileCollection).visitStructure(visitor);
         return visitor.getRoots();
     }
 
 
-    private class FileCollectionLeafVisitorImpl implements FileCollectionLeafVisitor {
+    private class SnapshotingVisitor implements FileCollectionStructureVisitor {
         private final List<FileSystemSnapshot> roots = new ArrayList<>();
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -349,7 +349,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -336,8 +336,8 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
-        1 * visitor.visitCollection(collection)
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.visitCollection(FileCollectionInternal.OTHER, collection)
         0 * visitor._
     }
 
@@ -349,7 +349,7 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
         collection.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileCollectionTest.groovy
@@ -330,26 +330,26 @@ class AbstractFileCollectionTest extends FileCollectionSpec {
 
     void visitsSelfAsLeafCollection() {
         def collection = new TestFileCollection()
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
 
         when:
-        collection.visitLeafCollections(visitor)
+        collection.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.Visit
         1 * visitor.visitCollection(FileCollectionInternal.OTHER, collection)
         0 * visitor._
     }
 
     void doesNotVisitSelfWhenVisitorIsNotInterested() {
         def collection = new TestFileCollection()
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
 
         when:
-        collection.visitLeafCollections(visitor)
+        collection.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.NoContents
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -139,7 +139,7 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(tree)
         0 * visitor._
     }
@@ -152,7 +152,7 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -133,26 +133,26 @@ class AbstractFileTreeTest extends Specification {
 
     void "visits self as leaf collection"() {
         def tree = new TestFileTree([])
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
 
         when:
-        tree.visitLeafCollections(visitor)
+        tree.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(tree)
         0 * visitor._
     }
 
     void "does not visit self when visitor is not interested"() {
         def tree = new TestFileTree([])
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
 
         when:
-        tree.visitLeafCollections(visitor)
+        tree.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.NoContents
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/AbstractFileTreeTest.groovy
@@ -152,7 +152,7 @@ class AbstractFileTreeTest extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
         0 * visitor._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionSpec.groovy
@@ -289,9 +289,10 @@ class CompositeFileCollectionSpec extends Specification {
         collection.buildDependencies.getDependencies(task) == [dependency1, dependency2] as LinkedHashSet
     }
 
-    public void "can visit root elements"() {
+    def "can visit root elements"() {
         def child1 = Stub(FileCollectionInternal)
         def child2 = Stub(FileTreeInternal)
+        def source = Stub(FileCollectionInternal.Source)
 
         def tree = new TestCollection() {
             @Override
@@ -306,9 +307,9 @@ class CompositeFileCollectionSpec extends Specification {
         tree.visitLeafCollections(visitor)
 
         then:
-        child1.visitLeafCollections(visitor) >> { FileCollectionLeafVisitor v -> v.visitCollection(child1) }
+        child1.visitLeafCollections(visitor) >> { FileCollectionLeafVisitor v -> v.visitCollection(source, child1) }
         child2.visitLeafCollections(visitor) >> { FileCollectionLeafVisitor v -> v.visitGenericFileTree(child2) }
-        1 * visitor.visitCollection(child1)
+        1 * visitor.visitCollection(source, child1)
         1 * visitor.visitGenericFileTree(child2)
         0 * visitor._
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionSpec.groovy
@@ -301,14 +301,14 @@ class CompositeFileCollectionSpec extends Specification {
                 context.add(child2)
             }
         }
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
 
         when:
-        tree.visitLeafCollections(visitor)
+        tree.visitStructure(visitor)
 
         then:
-        child1.visitLeafCollections(visitor) >> { FileCollectionLeafVisitor v -> v.visitCollection(source, child1) }
-        child2.visitLeafCollections(visitor) >> { FileCollectionLeafVisitor v -> v.visitGenericFileTree(child2) }
+        child1.visitStructure(visitor) >> { FileCollectionStructureVisitor v -> v.visitCollection(source, child1) }
+        child2.visitStructure(visitor) >> { FileCollectionStructureVisitor v -> v.visitGenericFileTree(child2) }
         1 * visitor.visitCollection(source, child1)
         1 * visitor.visitGenericFileTree(child2)
         0 * visitor._

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -285,7 +285,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
 
     static class BrokenVisitor implements FileCollectionLeafVisitor {
         @Override
-        void visitCollection(FileCollectionInternal fileCollection) {
+        void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
             Assert.fail()
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -92,7 +92,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         def collection = factory.empty("some collection")
         collection.files.empty
         collection.buildDependencies.getDependencies(null).empty
-        collection.visitLeafCollections(new BrokenVisitor())
+        collection.visitStructure(new BrokenVisitor())
         collection.toString() == "some collection"
     }
 
@@ -117,7 +117,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         def collection = factory.empty("some collection")
         collection.files.empty
         collection.buildDependencies.getDependencies(null).empty
-        collection.visitLeafCollections(new BrokenVisitor())
+        collection.visitStructure(new BrokenVisitor())
         collection.toString() == "some collection"
     }
 
@@ -126,7 +126,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         def collection = factory.resolving()
         collection.files.empty
         collection.buildDependencies.getDependencies(null).empty
-        collection.visitLeafCollections(new BrokenVisitor())
+        collection.visitStructure(new BrokenVisitor())
         collection.toString() == "file collection"
     }
 
@@ -135,7 +135,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         def collection = factory.resolving("some collection", [])
         collection.files.empty
         collection.buildDependencies.getDependencies(null).empty
-        collection.visitLeafCollections(new BrokenVisitor())
+        collection.visitStructure(new BrokenVisitor())
         collection.toString() == "some collection"
     }
 
@@ -144,7 +144,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         def collection = factory.resolving("some collection")
         collection.files.empty
         collection.buildDependencies.getDependencies(null).empty
-        collection.visitLeafCollections(new BrokenVisitor())
+        collection.visitStructure(new BrokenVisitor())
         collection.toString() == "some collection"
     }
 
@@ -283,7 +283,7 @@ class DefaultFileCollectionFactoryTest extends Specification {
         'URL'       | tmpDir.file('abc').toURI().toURL()
     }
 
-    static class BrokenVisitor implements FileCollectionLeafVisitor {
+    static class BrokenVisitor implements FileCollectionStructureVisitor {
         @Override
         void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
             Assert.fail()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
@@ -142,9 +142,9 @@ class DependencyHandlerApiResolveIntegrationTest extends AbstractIntegrationSpec
         def gradleBaseVersion = GradleVersion.current().baseVersion.version
         def groovyVersion = getGradleGroovyVersion()
         def kotlinVersion = getGradleKotlinVersion()
-        def expectedGradleApiFiles = "gradle-api-${gradleVersion}.jar, groovy-all-${groovyVersion}.jar, kotlin-stdlib-jdk8-${kotlinVersion}.jar, kotlin-stdlib-${kotlinVersion}.jar, kotlin-stdlib-common-${kotlinVersion}.jar, kotlin-stdlib-jdk7-${kotlinVersion}.jar, kotlin-reflect-${kotlinVersion}.jar, gradle-installation-beacon-${gradleBaseVersion}.jar"
+        def expectedGradleApiFiles = "gradle-api-${gradleVersion}.jar, groovy-all-${groovyVersion}.jar, kotlin-stdlib-${kotlinVersion}.jar, kotlin-stdlib-common-${kotlinVersion}.jar, kotlin-stdlib-jdk8-${kotlinVersion}.jar, kotlin-stdlib-jdk7-${kotlinVersion}.jar, kotlin-reflect-${kotlinVersion}.jar, gradle-installation-beacon-${gradleBaseVersion}.jar"
         def expectedGradleApiIds = { id ->
-            "gradle-api-${gradleVersion}.jar ($id), groovy-all-${groovyVersion}.jar ($id), kotlin-stdlib-jdk8-${kotlinVersion}.jar ($id), kotlin-stdlib-${kotlinVersion}.jar ($id), kotlin-stdlib-common-${kotlinVersion}.jar ($id), kotlin-stdlib-jdk7-${kotlinVersion}.jar ($id), kotlin-reflect-${kotlinVersion}.jar ($id), gradle-installation-beacon-${gradleBaseVersion}.jar ($id)"
+            "gradle-api-${gradleVersion}.jar ($id), groovy-all-${groovyVersion}.jar ($id), kotlin-stdlib-${kotlinVersion}.jar ($id), kotlin-stdlib-common-${kotlinVersion}.jar ($id), kotlin-stdlib-jdk8-${kotlinVersion}.jar ($id), kotlin-stdlib-jdk7-${kotlinVersion}.jar ($id), kotlin-reflect-${kotlinVersion}.jar ($id), gradle-installation-beacon-${gradleBaseVersion}.jar ($id)"
         }
         outputContains("gradleApi() files: [$expectedGradleApiFiles]")
         outputContains("gradleApi() ids: [${expectedGradleApiIds("Gradle API")}]")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1244,7 +1244,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-            FileCollectionLeafVisitor.VisitType visitType = visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other);
+            FileCollectionLeafVisitor.VisitType visitType = visitor.prepareForVisit(OTHER);
             if (visitType == FileCollectionLeafVisitor.VisitType.Skip) {
                 return;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -36,7 +36,6 @@ import org.gradle.api.artifacts.DependencyConstraintSet;
 import org.gradle.api.artifacts.DependencyResolutionListener;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ExcludeRule;
-import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.artifacts.ResolutionStrategy;
@@ -84,7 +83,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -1244,19 +1242,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         @Override
         public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-            FileCollectionLeafVisitor.VisitType visitType = visitor.prepareForVisit(OTHER);
-            if (visitType == FileCollectionLeafVisitor.VisitType.Skip) {
-                return;
-            }
-            if (visitType == FileCollectionLeafVisitor.VisitType.Spec) {
-                // This isn't correct - we should visit each of the file collections that are included in the output of resolution, rather than visiting the inputs of resolution
-                for (Dependency dependency : getAllDependencies()) {
-                    if (dependency instanceof FileCollectionDependency) {
-                        FileCollection files = ((FileCollectionDependency) dependency).getFiles();
-                        ((FileCollectionInternal) files).visitLeafCollections(visitor);
-                    }
-                }
-            }
             ResolvedFilesCollectingVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
             visitFiles(collectingVisitor);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -83,7 +83,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
@@ -490,8 +490,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
-    public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        intrinsicFiles.visitLeafCollections(visitor);
+    public void visitStructure(FileCollectionStructureVisitor visitor) {
+        intrinsicFiles.visitStructure(visitor);
     }
 
     @Override
@@ -1241,7 +1241,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
 
         @Override
-        public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+        public void visitStructure(FileCollectionStructureVisitor visitor) {
             ResolvedFilesCollectingVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
             visitFiles(collectingVisitor);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalDependencyFiles;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
 
@@ -51,11 +51,11 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+    public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         if (source instanceof LocalDependencyFiles) {
-            return FileCollectionLeafVisitor.VisitType.NoContents;
+            return FileCollectionStructureVisitor.VisitType.NoContents;
         }
-        return FileCollectionLeafVisitor.VisitType.Visit;
+        return FileCollectionStructureVisitor.VisitType.Visit;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -20,7 +20,9 @@ import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalDependencyFiles;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
@@ -53,13 +55,11 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-        return true;
-    }
-
-    @Override
-    public boolean includeFiles() {
-        return false;
+    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        if (source instanceof LocalDependencyFiles) {
+            return FileCollectionLeafVisitor.VisitType.Skip;
+        }
+        return FileCollectionLeafVisitor.VisitType.Visit;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -51,13 +51,9 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void endVisitCollection(FileCollectionInternal.Source source) {
-    }
-
-    @Override
     public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         if (source instanceof LocalDependencyFiles) {
-            return FileCollectionLeafVisitor.VisitType.Skip;
+            return FileCollectionLeafVisitor.VisitType.NoContents;
         }
         return FileCollectionLeafVisitor.VisitType.Visit;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -51,7 +51,7 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void endVisitCollection() {
+    public void endVisitCollection(FileCollectionInternal.Source source) {
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -307,7 +307,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         @Override
         public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
             if (source instanceof LocalDependencyFiles) {
-                return FileCollectionLeafVisitor.VisitType.Skip;
+                return FileCollectionLeafVisitor.VisitType.NoContents;
             }
             return FileCollectionLeafVisitor.VisitType.Visit;
         }
@@ -320,10 +320,6 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         @Override
         public void visitFailure(Throwable failure) {
             throw UncheckedException.throwAsUncheckedException(failure);
-        }
-
-        @Override
-        public void endVisitCollection(FileCollectionInternal.Source source) {
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -45,7 +45,7 @@ import org.gradle.api.internal.artifacts.transform.ArtifactTransforms;
 import org.gradle.api.internal.artifacts.transform.VariantSelector;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -305,11 +305,11 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
             if (source instanceof LocalDependencyFiles) {
-                return FileCollectionLeafVisitor.VisitType.NoContents;
+                return FileCollectionStructureVisitor.VisitType.NoContents;
             }
-            return FileCollectionLeafVisitor.VisitType.Visit;
+            return FileCollectionStructureVisitor.VisitType.Visit;
         }
 
         @Override
@@ -325,8 +325,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
     private static class LenientFilesAndArtifactResolveVisitor extends LenientArtifactCollectingVisitor {
         @Override
-        public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
-            return FileCollectionLeafVisitor.VisitType.Visit;
+        public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+            return FileCollectionStructureVisitor.VisitType.Visit;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -323,7 +323,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         }
 
         @Override
-        public void endVisitCollection() {
+        public void endVisitCollection(FileCollectionInternal.Source source) {
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -56,7 +56,7 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void endVisitCollection() {
+    public void endVisitCollection(FileCollectionInternal.Source source) {
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -24,6 +24,7 @@ import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
@@ -59,17 +60,12 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-        return true;
+    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        return FileCollectionLeafVisitor.VisitType.Visit;
     }
 
     @Override
     public boolean requireArtifactFiles() {
-        return true;
-    }
-
-    @Override
-    public boolean includeFiles() {
         return true;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -24,8 +24,6 @@ import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult;
-import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
@@ -53,15 +51,6 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
         } catch (Exception t) {
             failures.add(t);
         }
-    }
-
-    @Override
-    public void endVisitCollection(FileCollectionInternal.Source source) {
-    }
-
-    @Override
-    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
-        return FileCollectionLeafVisitor.VisitType.Visit;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalDependencyFiles;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 
@@ -28,7 +29,13 @@ public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisito
 
     @Override
     public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
-        return visitor.prepareForVisit(source);
+        FileCollectionLeafVisitor.VisitType visitType = visitor.prepareForVisit(source);
+        if (visitType == FileCollectionLeafVisitor.VisitType.Spec && source instanceof LocalDependencyFiles) {
+            // This isn't quite right, when the local files are transformed. Should instead collect the inputs of artifact transforms
+            // This collection is visited out of sequence
+            ((LocalDependencyFiles) source).visitSpec(visitor);
+        }
+        return visitType;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 
@@ -26,13 +27,9 @@ public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisito
         this.visitor = visitor;
     }
 
-    public FileCollectionLeafVisitor getVisitor() {
-        return visitor;
-    }
-
     @Override
-    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-        return visitor.prepareForVisit(collectionType) != FileCollectionLeafVisitor.VisitType.Skip;
+    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        return visitor.prepareForVisit(source);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
@@ -17,23 +17,23 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 
 public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisitor {
-    private final FileCollectionLeafVisitor visitor;
+    private final FileCollectionStructureVisitor visitor;
 
-    public ResolvedFileCollectionVisitor(FileCollectionLeafVisitor visitor) {
+    public ResolvedFileCollectionVisitor(FileCollectionStructureVisitor visitor) {
         this.visitor = visitor;
     }
 
     @Override
-    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+    public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         return visitor.prepareForVisit(source);
     }
 
     @Override
     public void visitSpec(FileCollectionInternal spec) {
-        spec.visitLeafCollections(visitor);
+        spec.visitStructure(visitor);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice;
 
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 
 public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisitor {
     private final FileCollectionLeafVisitor visitor;
@@ -33,8 +32,8 @@ public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisito
     }
 
     @Override
-    public void endVisitCollection() {
-        visitor.visitCollection(ImmutableFileCollection.of(getFiles()));
+    public void endVisitCollection(FileCollectionInternal.Source source) {
+        visitor.visitCollection(source, getFiles());
         getFiles().clear();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalDependencyFiles;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 
@@ -29,13 +28,12 @@ public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisito
 
     @Override
     public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
-        FileCollectionLeafVisitor.VisitType visitType = visitor.prepareForVisit(source);
-        if (visitType == FileCollectionLeafVisitor.VisitType.Spec && source instanceof LocalDependencyFiles) {
-            // This isn't quite right, when the local files are transformed. Should instead collect the inputs of artifact transforms
-            // This collection is visited out of sequence
-            ((LocalDependencyFiles) source).visitSpec(visitor);
-        }
-        return visitType;
+        return visitor.prepareForVisit(source);
+    }
+
+    @Override
+    public void visitSpec(FileCollectionInternal spec) {
+        spec.visitLeafCollections(visitor);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -58,7 +58,7 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void endVisitCollection() {
+    public void endVisitCollection(FileCollectionInternal.Source source) {
     }
 
     public Set<File> getFiles() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
@@ -42,18 +43,13 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean includeFiles() {
-        return true;
-    }
-
-    @Override
     public boolean requireArtifactFiles() {
         return true;
     }
 
     @Override
-    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-        return true;
+    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        return FileCollectionLeafVisitor.VisitType.Visit;
     }
 
     @Override
@@ -63,7 +59,6 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
 
     @Override
     public void endVisitCollection() {
-
     }
 
     public Set<File> getFiles() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -20,8 +20,6 @@ import com.google.common.collect.Sets;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
-import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
@@ -48,17 +46,8 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
-        return FileCollectionLeafVisitor.VisitType.Visit;
-    }
-
-    @Override
     public void visitFailure(Throwable failure) {
         failures.add(failure);
-    }
-
-    @Override
-    public void endVisitCollection(FileCollectionInternal.Source source) {
     }
 
     public Set<File> getFiles() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -21,10 +21,10 @@ import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dependencies.SelfResolvingDependencyInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.internal.component.local.model.BuildableLocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
@@ -96,8 +96,8 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         }
 
         @Override
-        public FileCollection getFiles() {
-            return fileDependency.getFiles();
+        public FileCollectionInternal getFiles() {
+            return (FileCollectionInternal) fileDependency.getFiles();
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DownloadArtifactBuildOperationType;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet.AsyncArtifactListener;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.operations.BuildOperationContext;
@@ -110,7 +111,7 @@ class ArtifactBackedResolvedVariant implements ResolvedVariant {
                 visitor.visitFailure(failure);
             } else {
                 visitor.visitArtifact(variantName, variantAttributes, artifact);
-                visitor.endVisitCollection();
+                visitor.endVisitCollection(FileCollectionInternal.OTHER);
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -28,7 +28,9 @@ public interface ArtifactVisitor {
     /**
      * Called prior to scheduling resolution of a set of artifacts.
      */
-    FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source);
+    default FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        return FileCollectionLeafVisitor.VisitType.Visit;
+    }
 
     /**
      * Visits an artifact. Artifacts are resolved but not necessarily available unless {@link #requireArtifactFiles()} returns true.
@@ -48,7 +50,14 @@ public interface ArtifactVisitor {
     void visitFailure(Throwable failure);
 
     /**
+     * Called for a set that may be backed by a file collection, when {@link #prepareForVisit(FileCollectionInternal.Source)} return {@link FileCollectionLeafVisitor.VisitType#Spec}.
+     */
+    default void visitSpec(FileCollectionInternal spec) {
+    }
+
+    /**
      * Called after a set of artifacts has been visited.
      */
-    void endVisitCollection(FileCollectionInternal.Source source);
+    default void endVisitCollection(FileCollectionInternal.Source source) {
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -50,5 +50,5 @@ public interface ArtifactVisitor {
     /**
      * Called after a set of artifacts has been visited.
      */
-    void endVisitCollection();
+    void endVisitCollection(FileCollectionInternal.Source source);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
@@ -25,9 +26,9 @@ import org.gradle.internal.DisplayName;
  */
 public interface ArtifactVisitor {
     /**
-     * Called prior to scheduling resolution of a set of the given type. When {@code false} is returned, the contents of the set is not visited.
+     * Called prior to scheduling resolution of a set of artifacts.
      */
-    boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType);
+    FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source);
 
     /**
      * Visits an artifact. Artifacts are resolved but not necessarily available unless {@link #requireArtifactFiles()} returns true.
@@ -40,11 +41,6 @@ public interface ArtifactVisitor {
      * Returns true here allows the collection to preemptively resolve the files in parallel.
      */
     boolean requireArtifactFiles();
-
-    /**
-     * Should {@link #visitArtifact(DisplayName, AttributeContainer, ResolvableArtifact)} be called for local file dependencies?
-     */
-    boolean includeFiles();
 
     /**
      * Called when some problem occurs visiting some element of the set. Visiting may continue.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.DisplayName;
 
 /**
@@ -28,8 +28,8 @@ public interface ArtifactVisitor {
     /**
      * Called prior to scheduling resolution of a set of artifacts.
      */
-    default FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
-        return FileCollectionLeafVisitor.VisitType.Visit;
+    default FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        return FileCollectionStructureVisitor.VisitType.Visit;
     }
 
     /**
@@ -50,7 +50,7 @@ public interface ArtifactVisitor {
     void visitFailure(Throwable failure);
 
     /**
-     * Called for a set that may be backed by a file collection, when {@link #prepareForVisit(FileCollectionInternal.Source)} return {@link FileCollectionLeafVisitor.VisitType#Spec}.
+     * Called for a set that may be backed by a file collection, when {@link #prepareForVisit(FileCollectionInternal.Source)} return {@link FileCollectionStructureVisitor.VisitType#Spec}.
      */
     default void visitSpec(FileCollectionInternal spec) {
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import org.gradle.api.internal.file.FileCollectionInternal;
+
+public interface LocalDependencyFiles extends FileCollectionInternal.Source {
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 
 public interface LocalDependencyFiles extends FileCollectionInternal.Source {
+    void visitSpec(FileCollectionLeafVisitor visitor);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalDependencyFiles.java
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 
 public interface LocalDependencyFiles extends FileCollectionInternal.Source {
-    void visitSpec(FileCollectionLeafVisitor visitor);
+    void visitSpec(FileCollectionStructureVisitor visitor);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
@@ -43,7 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet {
+public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet, LocalDependencyFiles {
     private static final DisplayName LOCAL_FILE = Describables.of("local file");
 
     private final LocalFileDependencyMetadata dependencyMetadata;
@@ -60,7 +61,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
 
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-        if (!listener.includeFileDependencies()) {
+        if (listener.prepareForVisit(this) == FileCollectionLeafVisitor.VisitType.Skip) {
             return EMPTY_RESULT;
         }
 
@@ -158,11 +159,8 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
 
         @Override
         public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-            if (listener.includeFileDependencies()) {
-                listener.artifactAvailable(artifact);
-                return this;
-            }
-            return EMPTY_RESULT;
+            listener.artifactAvailable(artifact);
+            return this;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -27,7 +27,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
@@ -60,14 +60,14 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
     }
 
     @Override
-    public void visitSpec(FileCollectionLeafVisitor visitor) {
-        dependencyMetadata.getFiles().visitLeafCollections(visitor);
+    public void visitSpec(FileCollectionStructureVisitor visitor) {
+        dependencyMetadata.getFiles().visitStructure(visitor);
     }
 
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-        FileCollectionLeafVisitor.VisitType visitType = listener.prepareForVisit(this);
-        if (visitType == FileCollectionLeafVisitor.VisitType.NoContents) {
+        FileCollectionStructureVisitor.VisitType visitType = listener.prepareForVisit(this);
+        if (visitType == FileCollectionStructureVisitor.VisitType.NoContents) {
             return EMPTY_RESULT;
         }
 
@@ -101,7 +101,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
             selectedArtifacts.add(selector.select(variant));
         }
         Completion result = CompositeResolvedArtifactSet.of(selectedArtifacts.build()).startVisit(actions, listener);
-        if (visitType == FileCollectionLeafVisitor.VisitType.Spec) {
+        if (visitType == FileCollectionStructureVisitor.VisitType.Spec) {
             return visitor -> {
                 result.visit(visitor);
                 visitor.visitSpec(fileCollection);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -60,6 +60,11 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
     }
 
     @Override
+    public void visitSpec(FileCollectionLeafVisitor visitor) {
+        dependencyMetadata.getFiles().visitLeafCollections(visitor);
+    }
+
+    @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
         if (listener.prepareForVisit(this) == FileCollectionLeafVisitor.VisitType.Skip) {
             return EMPTY_RESULT;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.PreResolvedResolvableArtifact;
@@ -26,6 +26,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -41,7 +42,6 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet, LocalDependencyFiles {
@@ -77,7 +77,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
             return new BrokenResolvedArtifactSet(throwable);
         }
 
-        List<ResolvedArtifactSet> selectedArtifacts = Lists.newArrayListWithCapacity(files.size());
+        ImmutableList.Builder<ResolvedArtifactSet> selectedArtifacts = ImmutableList.builderWithExpectedSize(files.size());
         for (File file : files) {
             ComponentArtifactIdentifier artifactIdentifier;
             if (componentIdentifier == null) {
@@ -93,8 +93,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
             SingletonFileResolvedVariant variant = new SingletonFileResolvedVariant(file, artifactIdentifier, LOCAL_FILE, variantAttributes, dependencyMetadata);
             selectedArtifacts.add(selector.select(variant));
         }
-
-        return CompositeResolvedArtifactSet.of(selectedArtifacts).startVisit(actions, listener);
+        return CompositeResolvedArtifactSet.of(selectedArtifacts.build()).startVisit(actions, listener);
     }
 
     @Override
@@ -170,7 +169,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         @Override
         public void visit(ArtifactVisitor visitor) {
             visitor.visitArtifact(variantName, variantAttributes, artifact);
-            visitor.endVisitCollection();
+            visitor.endVisitCollection(FileCollectionInternal.OTHER);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -78,7 +78,7 @@ public abstract class ParallelResolveArtifactSet {
             }
 
             @Override
-            public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+            public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
                 return visitor.prepareForVisit(source);
             }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -77,18 +78,13 @@ public abstract class ParallelResolveArtifactSet {
             }
 
             @Override
-            public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-                return visitor.shouldVisit(collectionType);
+            public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+                return visitor.prepareForVisit(source);
             }
 
             @Override
             public boolean requireArtifactFiles() {
                 return visitor.requireArtifactFiles();
-            }
-
-            @Override
-            public boolean includeFileDependencies() {
-                return visitor.includeFiles();
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -38,10 +39,7 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
      */
     void visitLocalArtifacts(LocalArtifactVisitor listener);
 
-    Completion EMPTY_RESULT = new Completion() {
-        @Override
-        public void visit(ArtifactVisitor visitor) {
-        }
+    Completion EMPTY_RESULT = visitor -> {
     };
 
     ResolvedArtifactSet EMPTY = new ResolvedArtifactSet() {
@@ -72,9 +70,9 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
      */
     interface AsyncArtifactListener {
         /**
-         * Called prior to scheduling resolution of a set of the given type. When {@code false} is returned, the contents of the set is not visited.
+         * Called prior to scheduling resolution of a set of the given type.
          */
-        boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType);
+        FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source);
 
         /**
          * Visits an artifact once its file is available. Only called when {@link #requireArtifactFiles()} returns true. Called from any thread and in any order.
@@ -87,11 +85,6 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
          * Returns true here allows the collection to preemptively resolve the files in parallel.
          */
         boolean requireArtifactFiles();
-
-        /**
-         * Should local file dependency artifacts be included in the result?
-         */
-        boolean includeFileDependencies();
     }
 
     interface LocalArtifactVisitor {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -72,7 +72,7 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
         /**
          * Called prior to scheduling resolution of a set of the given type.
          */
-        FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source);
+        FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source);
 
         /**
          * Visits an artifact once its file is available. Only called when {@link #requireArtifactFiles()} returns true. Called from any thread and in any order.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -62,8 +62,8 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, Con
 
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-        FileCollectionLeafVisitor.VisitType visitType = listener.prepareForVisit(this);
-        if (visitType == FileCollectionLeafVisitor.VisitType.NoContents) {
+        FileCollectionStructureVisitor.VisitType visitType = listener.prepareForVisit(this);
+        if (visitType == FileCollectionStructureVisitor.VisitType.NoContents) {
             return visitor -> visitor.endVisitCollection(ConsumerProvidedResolvedVariant.this);
         }
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * Transformed artifact set that performs the transformation itself when requested.
  */
-public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
+public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, ConsumerProvidedVariantFiles {
     private final ComponentIdentifier componentIdentifier;
     private final ResolvedArtifactSet delegate;
     private final AttributeContainerInternal attributes;
@@ -57,11 +57,11 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
 
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-        if (!listener.shouldVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult)) {
+        if (listener.prepareForVisit(this) == FileCollectionLeafVisitor.VisitType.Skip) {
             return EMPTY_RESULT;
         }
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();
-        Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, listener, actions, artifactResults, getDependenciesResolver(), transformationNodeRegistry));
+        Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, actions, artifactResults, getDependenciesResolver(), transformationNodeRegistry));
         return new TransformCompletion(result, attributes, artifactResults);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -63,10 +63,7 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, Con
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
         FileCollectionLeafVisitor.VisitType visitType = listener.prepareForVisit(this);
-        if (visitType == FileCollectionLeafVisitor.VisitType.Skip) {
-            return EMPTY_RESULT;
-        }
-        if (visitType == FileCollectionLeafVisitor.VisitType.Spec) {
+        if (visitType == FileCollectionLeafVisitor.VisitType.NoContents) {
             return visitor -> visitor.endVisitCollection(ConsumerProvidedResolvedVariant.this);
         }
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -56,9 +56,18 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, Con
     }
 
     @Override
+    public String toString() {
+        return componentIdentifier + " " + attributes;
+    }
+
+    @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-        if (listener.prepareForVisit(this) == FileCollectionLeafVisitor.VisitType.Skip) {
+        FileCollectionLeafVisitor.VisitType visitType = listener.prepareForVisit(this);
+        if (visitType == FileCollectionLeafVisitor.VisitType.Skip) {
             return EMPTY_RESULT;
+        }
+        if (visitType == FileCollectionLeafVisitor.VisitType.Spec) {
+            return visitor -> visitor.endVisitCollection(ConsumerProvidedResolvedVariant.this);
         }
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();
         Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, actions, artifactResults, getDependenciesResolver(), transformationNodeRegistry));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFiles.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFiles.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.internal.file.FileCollectionInternal;
+
+public interface ConsumerProvidedVariantFiles extends FileCollectionInternal.Source {
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -21,6 +21,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.DisplayName;
 
@@ -64,13 +65,8 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-        return visitor.shouldVisit(collectionType);
-    }
-
-    @Override
-    public boolean includeFiles() {
-        return visitor.includeFiles();
+    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        return visitor.prepareForVisit(source);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
@@ -61,7 +61,7 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+    public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         return visitor.prepareForVisit(source);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -48,7 +48,7 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
                     ResolvableArtifact resolvedArtifact = artifact.transformedTo(output);
                     visitor.visitArtifact(variantName, target, resolvedArtifact);
                 }
-                visitor.endVisitCollection();
+                visitor.endVisitCollection(FileCollectionInternal.OTHER);
             },
             failure -> visitor.visitFailure(
                 new TransformException(String.format("Failed to transform %s to match attributes %s.", artifact.getId(), target), failure))
@@ -61,7 +61,7 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void endVisitCollection() {
+    public void endVisitCollection(FileCollectionInternal.Source source) {
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -61,10 +61,6 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void endVisitCollection(FileCollectionInternal.Source source) {
-    }
-
-    @Override
     public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         return visitor.prepareForVisit(source);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
@@ -64,9 +64,9 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     }
 
     @Override
-    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+    public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         // Visit everything
-        return FileCollectionLeafVisitor.VisitType.Visit;
+        return FileCollectionStructureVisitor.VisitType.Visit;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -32,12 +33,10 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     private final ExecutionGraphDependenciesResolver dependenciesResolver;
     private final TransformationNodeRegistry transformationNodeRegistry;
     private final BuildOperationQueue<RunnableBuildOperation> actions;
-    private final ResolvedArtifactSet.AsyncArtifactListener delegate;
     private final Transformation transformation;
 
     TransformingAsyncArtifactListener(
         Transformation transformation,
-        ResolvedArtifactSet.AsyncArtifactListener delegate,
         BuildOperationQueue<RunnableBuildOperation> actions,
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults,
         ExecutionGraphDependenciesResolver dependenciesResolver,
@@ -46,7 +45,6 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
         this.artifactResults = artifactResults;
         this.actions = actions;
         this.transformation = transformation;
-        this.delegate = delegate;
         this.dependenciesResolver = dependenciesResolver;
         this.transformationNodeRegistry = transformationNodeRegistry;
     }
@@ -66,20 +64,15 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     }
 
     @Override
-    public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
+    public FileCollectionLeafVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         // Visit everything
-        return true;
+        return FileCollectionLeafVisitor.VisitType.Visit;
     }
 
     @Override
     public boolean requireArtifactFiles() {
         // Always need the files, as we need to run the transform in order to calculate the output artifacts.
         return true;
-    }
-
-    @Override
-    public boolean includeFileDependencies() {
-        return delegate.includeFileDependencies();
     }
 
     private TransformationResult createTransformationResult(TransformationSubject initialSubject) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalFileDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalFileDependencyMetadata.java
@@ -18,7 +18,7 @@ package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
 
 import javax.annotation.Nullable;
 
@@ -37,5 +37,5 @@ public interface LocalFileDependencyMetadata {
      */
     FileCollectionDependency getSource();
 
-    FileCollection getFiles();
+    FileCollectionInternal getFiles();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 import org.gradle.api.Buildable
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.internal.attributes.AttributeContainerInternal
+import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.internal.Describables
 import org.gradle.internal.operations.TestBuildOperationExecutor
@@ -66,11 +67,11 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         then:
         _ * listener.requireArtifactFiles() >> false
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
-        1 * visitor.endVisitCollection() // each artifact is treated as a separate collection, the entire variant could instead be treated as a collection
+        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER) // each artifact is treated as a separate collection, the entire variant could instead be treated as a collection
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact2)
-        1 * visitor.endVisitCollection()
+        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
 
         when:
@@ -79,7 +80,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         then:
         _ * listener.requireArtifactFiles() >> false
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
-        1 * visitor.endVisitCollection()
+        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
     }
 
@@ -111,11 +112,11 @@ class ArtifactBackedResolvedVariantTest extends Specification {
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
-        1 * visitor.endVisitCollection()
+        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact2)
-        1 * visitor.endVisitCollection()
+        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
 
         when:
@@ -134,7 +135,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
 
         then:
         1 * visitor.visitArtifact(variantDisplayName, variant, artifact1)
-        1 * visitor.endVisitCollection()
+        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -67,7 +67,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         set.startVisit(Stub(BuildOperationQueue), listener).visit(visitor)
 
         then:
-        1 * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.NoContents
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.file.FileCollectionInternal
-import org.gradle.api.internal.file.FileCollectionLeafVisitor
+import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
@@ -67,7 +67,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         set.startVisit(Stub(BuildOperationQueue), listener).visit(visitor)
 
         then:
-        1 * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.NoContents
+        1 * listener.prepareForVisit(_) >> FileCollectionStructureVisitor.VisitType.NoContents
         0 * _
     }
 
@@ -82,7 +82,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
         then:
         _ * dep.componentId >> id
-        _ * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Visit
+        _ * listener.prepareForVisit(_) >> FileCollectionStructureVisitor.VisitType.Visit
         1 * filter.isSatisfiedBy(id) >> false
         0 * _
 
@@ -128,7 +128,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         then:
         _ * dep.componentId >> id
         _ * dep.files >> files
-        _ * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Visit
+        _ * listener.prepareForVisit(_) >> FileCollectionStructureVisitor.VisitType.Visit
         _ * filter.isSatisfiedBy(_) >> true
         1 * files.files >> ([f1, f2] as Set)
         2 * selector.select(_) >> { ResolvedVariantSet variants -> variants.variants.first() }
@@ -214,7 +214,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
         then:
         _ * dep.files >> files
-        _ * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Visit
+        _ * listener.prepareForVisit(_) >> FileCollectionStructureVisitor.VisitType.Visit
         1 * files.files >> { throw failure }
         1 * visitor.visitFailure(failure)
         0 * visitor._

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.file.FileCollectionInternal
+import org.gradle.api.internal.file.FileCollectionLeafVisitor
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
@@ -66,7 +67,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         set.startVisit(Stub(BuildOperationQueue), listener).visit(visitor)
 
         then:
-        1 * listener.includeFileDependencies() >> false
+        1 * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * _
     }
 
@@ -81,7 +82,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
         then:
         _ * dep.componentId >> id
-        _ * listener.includeFileDependencies() >> true
+        _ * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * filter.isSatisfiedBy(id) >> false
         0 * _
 
@@ -127,7 +128,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         then:
         _ * dep.componentId >> id
         _ * dep.files >> files
-        _ * listener.includeFileDependencies() >> true
+        _ * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Visit
         _ * filter.isSatisfiedBy(_) >> true
         1 * files.files >> ([f1, f2] as Set)
         2 * selector.select(_) >> { ResolvedVariantSet variants -> variants.variants.first() }
@@ -213,7 +214,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
         then:
         _ * dep.files >> files
-        _ * listener.includeFileDependencies() >> true
+        _ * listener.prepareForVisit(_) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * files.files >> { throw failure }
         1 * visitor.visitFailure(failure)
         0 * visitor._

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -150,7 +150,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
             assert displayName.displayName == 'local file'
             assert artifact.id == new ComponentFileArtifactIdentifier(id, f2.name)
         }
-        2 * visitor.endVisitCollection() // each file is treated as a separate collection, could potentially be treated as a single collection
+        2 * visitor.endVisitCollection(FileCollectionInternal.OTHER) // each file is treated as a separate collection, could potentially be treated as a single collection
         0 * _
 
         when:
@@ -165,7 +165,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
             assert displayName.displayName == 'local file'
             assert artifact.id == new ComponentFileArtifactIdentifier(id, f2.name)
         }
-        2 * visitor.endVisitCollection()
+        2 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
     }
 
@@ -198,7 +198,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
             assert displayName.displayName == 'local file'
             assert artifact.id == new OpaqueComponentArtifactIdentifier(f2)
         }
-        2 * visitor.endVisitCollection() // each file is treated as a separate collection, could potentially be treated as a single collection
+        2 * visitor.endVisitCollection(FileCollectionInternal.OTHER) // each file is treated as a separate collection, could potentially be treated as a single collection
         0 * visitor._
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.transform
 import com.google.common.collect.ImmutableList
 import org.gradle.api.Buildable
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
-import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
@@ -123,7 +122,6 @@ class DefaultArtifactTransformsTest extends Specification {
         def variant1 = resolvedVariant()
         def variant2 = resolvedVariant()
         def variant1Artifacts = Stub(ResolvedArtifactSet)
-        def id = Stub(ComponentIdentifier)
         def sourceArtifactId = Stub(ComponentArtifactIdentifier)
         def sourceArtifact = Stub(TestArtifact)
         def sourceArtifactFile = new File("thing-1.0.jar")
@@ -133,7 +131,6 @@ class DefaultArtifactTransformsTest extends Specification {
         def variants = [variant1, variant2] as Set
         def transformation = Mock(Transformation)
         CacheableInvocation<TransformationSubject> invocation1 = Mock(CacheableInvocation)
-        CacheableInvocation<TransformationSubject> invocation2 = Mock(CacheableInvocation)
         def listener = Mock(ResolvedArtifactSet.AsyncArtifactListener)
         def visitor = Mock(ArtifactVisitor)
         def targetAttributes = typeAttributes("classes")
@@ -178,7 +175,7 @@ class DefaultArtifactTransformsTest extends Specification {
         1 * invocation1.getCachedResult() >> Optional.empty()
         1 * invocation1.invoke() >> Try.successful(TransformationSubject.initial(sourceArtifactId, sourceArtifactFile).createSubjectFromResult(ImmutableList.of(outFile1, outFile2))) >> invocation1
 
-        1 * listener.shouldVisit(FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult) >> true
+        1 * listener.prepareForVisit({it instanceof ConsumerProvidedVariantFiles}) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile1})
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile2})
         1 * visitor.endVisitCollection()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionLeafVisitor
 import org.gradle.internal.Describables
 import org.gradle.internal.Try
@@ -178,7 +179,7 @@ class DefaultArtifactTransformsTest extends Specification {
         1 * listener.prepareForVisit({it instanceof ConsumerProvidedVariantFiles}) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile1})
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile2})
-        1 * visitor.endVisitCollection()
+        1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * visitor._
         0 * transformation._
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultMutableAttributeContainer
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.FileCollectionInternal
-import org.gradle.api.internal.file.FileCollectionLeafVisitor
+import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.internal.Describables
 import org.gradle.internal.Try
 import org.gradle.internal.component.AmbiguousVariantSelectionException
@@ -176,7 +176,7 @@ class DefaultArtifactTransformsTest extends Specification {
         1 * invocation1.getCachedResult() >> Optional.empty()
         1 * invocation1.invoke() >> Try.successful(TransformationSubject.initial(sourceArtifactId, sourceArtifactFile).createSubjectFromResult(ImmutableList.of(outFile1, outFile2))) >> invocation1
 
-        1 * listener.prepareForVisit({it instanceof ConsumerProvidedVariantFiles}) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * listener.prepareForVisit({it instanceof ConsumerProvidedVariantFiles}) >> FileCollectionStructureVisitor.VisitType.Visit
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile1})
         1 * visitor.visitArtifact(variant1DisplayName, targetAttributes, {it.file == outFile2})
         1 * visitor.endVisitCollection(FileCollectionInternal.OTHER)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -30,7 +30,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
     CacheableInvocation<TransformationSubject> invocation = Mock(CacheableInvocation)
     def operationQueue = Mock(BuildOperationQueue)
     def transformationNodeRegistry = Mock(TransformationNodeRegistry)
-    def listener  = new TransformingAsyncArtifactListener(transformation, null, operationQueue, Maps.newHashMap(), Mock(ExecutionGraphDependenciesResolver), transformationNodeRegistry)
+    def listener  = new TransformingAsyncArtifactListener(transformation, operationQueue, Maps.newHashMap(), Mock(ExecutionGraphDependenciesResolver), transformationNodeRegistry)
     def file = new File("foo")
     def artifactFile = new File("foo-artifact")
     def artifactId = Stub(ComponentArtifactIdentifier)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -115,6 +115,27 @@ class JarProducer extends DefaultTask {
 
     /**
      * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'.
+     * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
+     */
+    void setupBuildWithSimpleColorTransform() {
+        setupBuildWithColorTransformAction()
+        buildFile << """
+            abstract class MakeGreen implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+                
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.name + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+    }
+
+    /**
+     * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'.
      * By default the variant will contain a single file, this can be configured using the supplied {@link Builder}.
      * Caller will need to provide an implementation of 'MakeGreen' transform action
      */

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -44,14 +44,14 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
      * Change this whenever you add or remove a new subproject.
      */
     int getCoreLibJarsCount() {
-        32
+        31
     }
 
     /**
      * Change this if you added or removed dependencies.
      */
     int getThirdPartyLibJarsCount() {
-        182
+        183
     }
 
     int getLibJarsCount() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -277,7 +277,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
         if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.Skip) {
-            visitor.visitCollection(this);
+            visitor.visitCollection(OTHER, this);
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -275,8 +275,8 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
     }
 
     @Override
-    public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.NoContents) {
+    public void visitStructure(FileCollectionStructureVisitor visitor) {
+        if (visitor.prepareForVisit(OTHER) != FileCollectionStructureVisitor.VisitType.NoContents) {
             visitor.visitCollection(OTHER, this);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -276,7 +276,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.Skip) {
             visitor.visitCollection(this);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -276,7 +276,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.NoContents) {
             visitor.visitCollection(OTHER, this);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -168,7 +168,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.NoContents) {
             visitor.visitGenericFileTree(this);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -168,7 +168,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
 
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) != FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.Skip) {
             visitor.visitGenericFileTree(this);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -167,8 +167,8 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     }
 
     @Override
-    public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        if (visitor.prepareForVisit(OTHER) != FileCollectionLeafVisitor.VisitType.NoContents) {
+    public void visitStructure(FileCollectionStructureVisitor visitor) {
+        if (visitor.prepareForVisit(OTHER) != FileCollectionStructureVisitor.VisitType.NoContents) {
             visitor.visitGenericFileTree(this);
         }
     }
@@ -213,9 +213,9 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
         }
 
         @Override
-        public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+        public void visitStructure(FileCollectionStructureVisitor visitor) {
             // TODO: should consider the filter
-            fileTree.visitLeafCollections(visitor);
+            fileTree.visitStructure(visitor);
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -175,9 +175,9 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
     }
 
     @Override
-    public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+    public void visitStructure(FileCollectionStructureVisitor visitor) {
         for (FileCollectionInternal element : getSourceCollections()) {
-            element.visitLeafCollections(visitor);
+            element.visitStructure(visitor);
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -22,20 +22,20 @@ import org.gradle.api.internal.tasks.TaskDependencyContainer;
 
 public interface FileCollectionInternal extends FileCollection, TaskDependencyContainer {
     /**
-     * In a {@link FileCollection} hierarchy visits the leaves of the hierarchy.
+     * Visits the structure of this collection, that is, zero or more atomic sources of files.
      *
-     * <p>The implementation should call the most specific method on {@link FileCollectionLeafVisitor} that it is able to.</p>
+     * <p>The implementation should call the most specific methods on {@link FileCollectionStructureVisitor} that it is able to.</p>
      */
-    void visitLeafCollections(FileCollectionLeafVisitor visitor);
+    void visitStructure(FileCollectionStructureVisitor visitor);
 
     /**
-     * Some representation of the source of some set of files.
+     * Some representation of a source of files.
      */
     interface Source {
     }
 
     /**
-     * A generic source of files.
+     * An opaque source of files.
      */
     Source OTHER = new Source() {
     };

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -27,4 +27,16 @@ public interface FileCollectionInternal extends FileCollection, TaskDependencyCo
      * <p>The implementation should call the most specific method on {@link FileCollectionLeafVisitor} that it is able to.</p>
      */
     void visitLeafCollections(FileCollectionLeafVisitor visitor);
+
+    /**
+     * Some representation of the source of some set of files.
+     */
+    interface Source {
+    }
+
+    /**
+     * A generic source of files.
+     */
+    Source OTHER = new Source() {
+    };
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -54,7 +54,7 @@ public interface FileCollectionLeafVisitor {
     /**
      * Visits a {@link FileCollectionInternal} element that cannot be visited in further detail.
      */
-    void visitCollection(FileCollectionInternal fileCollection);
+    void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents);
 
     /**
      * Visits a {@link FileTreeInternal} that does not represents a directory in the file system.

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -42,9 +42,6 @@ public interface FileCollectionLeafVisitor {
      * <p>Note that this method is not necessarily called immediately before one of the visit methods, as some collections may be
      * resolved in parallel. However, all visiting is performed sequentially and in order.
      *
-     * <p>This method is only intended to be step towards some fine-grained visiting of the contents of a `Configuration` and other collections that may
-     * contain files that are expensive to visit, or task/transform outputs that don't yet exist.
-     *
      * @return how should the collection be visited?
      */
     default VisitType prepareForVisit(FileCollectionInternal.Source source) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -28,11 +28,13 @@ public interface FileCollectionLeafVisitor {
     enum VisitType {
         // Visitor is interested in the contents of the collection
         Visit,
-        // Visitor is not interested in the collection at all
-        Skip,
-        // Visitor is interested in the spec of the collection - that is the files that the collection might include in the future
+        // Visitor is not interested in the contents of the collection, but would like to receive the source and other metadata
+        NoContents,
+        // Visitor is interested in the spec of the collection - that is, the files that the collection <em>might</em> include in the future
         // For most collections, this will be the same as the elements of the collection. However, for a collection that includes
-        // all of the files from a directory, the spec for the collection would be the directory + the patterns it matches files using
+        // all of the files from a directory, the spec for the collection would be the directory + the patterns it matches files with
+        // Or, for a collection that contains some transformation of another collection, the spec for the collection would include the spec
+        // for the original collection
         Spec
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionLeafVisitor.java
@@ -25,10 +25,6 @@ import java.io.File;
  * is called for each element in a file collection that represents a root of a file tree.
  */
 public interface FileCollectionLeafVisitor {
-    enum CollectionType {
-        ArtifactTransformResult, Generated, Other
-    }
-
     enum VisitType {
         // Visitor is interested in the contents of the collection
         Visit,
@@ -41,17 +37,17 @@ public interface FileCollectionLeafVisitor {
     }
 
     /**
-     * Called prior to visiting a file collection of the given type, and allows this visitor to skip the collection.
+     * Called prior to visiting a file collection with the given spec, and allows this visitor to skip the collection.
      *
      * <p>Note that this method is not necessarily called immediately before one of the visit methods, as some collections may be
-     * resolved in parallel. However, all visiting is performed sequentally and in order.
+     * resolved in parallel. However, all visiting is performed sequentially and in order.
      *
      * <p>This method is only intended to be step towards some fine-grained visiting of the contents of a `Configuration` and other collections that may
      * contain files that are expensive to visit, or task/transform outputs that don't yet exist.
      *
      * @return how should the collection be visited?
      */
-    default VisitType prepareForVisit(CollectionType type) {
+    default VisitType prepareForVisit(FileCollectionInternal.Source source) {
         return VisitType.Visit;
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
@@ -21,10 +21,10 @@ import org.gradle.api.tasks.util.PatternSet;
 import java.io.File;
 
 /**
- * Used with {@link FileCollectionInternal#visitLeafCollections(FileCollectionLeafVisitor)} this visitor
- * is called for each element in a file collection that represents a root of a file tree.
+ * Used with {@link FileCollectionInternal#visitStructure(FileCollectionStructureVisitor)} this visitor
+ * is called for each element in a file collection that is an atomic source of files.
  */
-public interface FileCollectionLeafVisitor {
+public interface FileCollectionStructureVisitor {
     enum VisitType {
         // Visitor is interested in the contents of the collection
         Visit,

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
@@ -107,7 +107,7 @@ public class FileSystemSubset {
         public VisitType prepareForVisit(FileCollectionInternal.Source source) {
             if (source instanceof GeneratedFiles) {
                 // Don't watch generated resources
-                return VisitType.Skip;
+                return VisitType.NoContents;
             }
             // Only need the spec for other collections
             return VisitType.Spec;

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
@@ -95,7 +95,7 @@ public class FileSystemSubset {
     }
 
     @ThreadSafe
-    public static class Builder implements FileCollectionLeafVisitor {
+    public static class Builder implements FileCollectionStructureVisitor {
         private final ImmutableSet.Builder<File> files = ImmutableSet.builder();
         private final ImmutableSet.Builder<ImmutableDirectoryTree> trees = ImmutableSet.builder();
         private final Lock lock = new ReentrantLock();

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
@@ -114,20 +114,13 @@ public class FileSystemSubset {
         }
 
         @Override
-        public void visitCollection(FileCollectionInternal fileCollection) {
-            lock.lock();
-            try {
-                for (File file : fileCollection) {
-                    files.add(file.getAbsoluteFile());
-                }
-            } finally {
-                lock.unlock();
-            }
+        public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
+            addFiles(contents);
         }
 
         @Override
         public void visitGenericFileTree(FileTreeInternal fileTree) {
-            visitCollection(fileTree);
+            addFiles(fileTree);
         }
 
         @Override
@@ -145,6 +138,17 @@ public class FileSystemSubset {
             lock.lock();
             try {
                 files.add(file.getAbsoluteFile());
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void addFiles(Iterable<File> contents) {
+            lock.lock();
+            try {
+                for (File file : contents) {
+                    files.add(file.getAbsoluteFile());
+                }
             } finally {
                 lock.unlock();
             }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileSystemSubset.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.internal.file.collections.DirectoryTrees;
+import org.gradle.api.internal.file.collections.GeneratedFiles;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.nativeintegration.services.FileSystems;
@@ -103,8 +104,8 @@ public class FileSystemSubset {
         }
 
         @Override
-        public VisitType prepareForVisit(CollectionType type) {
-            if (type == CollectionType.Generated) {
+        public VisitType prepareForVisit(FileCollectionInternal.Source source) {
+            if (source instanceof GeneratedFiles) {
                 // Don't watch generated resources
                 return VisitType.Skip;
             }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -19,7 +19,7 @@ import org.gradle.api.Buildable;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.AbstractFileTree;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -112,10 +112,10 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
     }
 
     @Override
-    public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
+    public void visitStructure(FileCollectionStructureVisitor visitor) {
         if (tree instanceof GeneratedSingletonFileTree) {
             GeneratedSingletonFileTree singletonFileTree = (GeneratedSingletonFileTree) tree;
-            if (visitor.prepareForVisit(singletonFileTree) == FileCollectionLeafVisitor.VisitType.NoContents) {
+            if (visitor.prepareForVisit(singletonFileTree) == FileCollectionStructureVisitor.VisitType.NoContents) {
                 visitor.visitCollection(singletonFileTree, Collections.emptyList());
             } else {
                 visitor.visitFileTree(singletonFileTree.getFile(), singletonFileTree.getPatterns(), this);
@@ -123,7 +123,7 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
             return;
         }
 
-        if (visitor.prepareForVisit(OTHER) == FileCollectionLeafVisitor.VisitType.NoContents) {
+        if (visitor.prepareForVisit(OTHER) == FileCollectionStructureVisitor.VisitType.NoContents) {
             return;
         }
         if (tree instanceof DirectoryFileTree) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -115,13 +115,15 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
         if (tree instanceof GeneratedSingletonFileTree) {
             GeneratedSingletonFileTree singletonFileTree = (GeneratedSingletonFileTree) tree;
-            if (visitor.prepareForVisit(singletonFileTree) != FileCollectionLeafVisitor.VisitType.Skip) {
+            if (visitor.prepareForVisit(singletonFileTree) == FileCollectionLeafVisitor.VisitType.NoContents) {
+                visitor.visitCollection(singletonFileTree, Collections.emptyList());
+            } else {
                 visitor.visitFileTree(singletonFileTree.getFile(), singletonFileTree.getPatterns(), this);
             }
             return;
         }
 
-        if (visitor.prepareForVisit(OTHER) == FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(OTHER) == FileCollectionLeafVisitor.VisitType.NoContents) {
             return;
         }
         if (tree instanceof DirectoryFileTree) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -114,14 +114,14 @@ public class FileTreeAdapter extends AbstractFileTree implements FileCollectionC
     @Override
     public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
         if (tree instanceof GeneratedSingletonFileTree) {
-            if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Generated) != FileCollectionLeafVisitor.VisitType.Skip) {
-                GeneratedSingletonFileTree singletonFileTree = (GeneratedSingletonFileTree) tree;
+            GeneratedSingletonFileTree singletonFileTree = (GeneratedSingletonFileTree) tree;
+            if (visitor.prepareForVisit(singletonFileTree) != FileCollectionLeafVisitor.VisitType.Skip) {
                 visitor.visitFileTree(singletonFileTree.getFile(), singletonFileTree.getPatterns(), this);
             }
             return;
         }
 
-        if (visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) == FileCollectionLeafVisitor.VisitType.Skip) {
+        if (visitor.prepareForVisit(OTHER) == FileCollectionLeafVisitor.VisitType.Skip) {
             return;
         }
         if (tree instanceof DirectoryFileTree) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedFiles.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedFiles.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.internal.file.FileCollectionInternal;
+
+public interface GeneratedFiles extends FileCollectionInternal.Source {
+}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
 /**
  * A {@link SingletonFileTree} which is composed using a mapping from relative path to file source.
  */
-public class GeneratedSingletonFileTree extends AbstractSingletonFileTree {
+public class GeneratedSingletonFileTree extends AbstractSingletonFileTree implements GeneratedFiles {
     private final Factory<File> tmpDirSource;
     private final FileSystem fileSystem = FileSystems.getDefault();
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.Buildable
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.file.FileCollectionInternal
-import org.gradle.api.internal.file.FileCollectionLeafVisitor
+import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.util.UsesNativeServices
@@ -159,58 +159,58 @@ class FileTreeAdapterTest extends Specification {
     }
 
     def visitsBackingDirectoryTree() {
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
         def directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory()
         def tree = directoryFileTreeFactory.create(new File("dir"))
         def adapter = new FileTreeAdapter(tree)
 
         when:
-        adapter.visitLeafCollections(visitor)
+        adapter.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.Visit
         1 * visitor.visitFileTree(tree.getDir(), tree.getPatterns(), adapter)
         0 * visitor._
     }
 
     def doesNotVisitsBackingDirectoryTreeWhenListenerIsNotInterested() {
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
         def directoryFileTreeFactory = new DefaultDirectoryFileTreeFactory()
         def tree = directoryFileTreeFactory.create(new File("dir"))
         def adapter = new FileTreeAdapter(tree)
 
         when:
-        adapter.visitLeafCollections(visitor)
+        adapter.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.NoContents
         0 * visitor._
     }
 
     def visitsSelfWhenBackingTreeIsNotDirectoryTree() {
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
         def tree = Mock(MinimalFileTree)
         def adapter = new FileTreeAdapter(tree)
 
         when:
-        adapter.visitLeafCollections(visitor)
+        adapter.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(adapter)
         0 * visitor._
     }
 
     def doesNotVisitsSelfWhenListenerIsNotInterested() {
-        def visitor = Mock(FileCollectionLeafVisitor)
+        def visitor = Mock(FileCollectionStructureVisitor)
         def tree = Mock(MinimalFileTree)
         def adapter = new FileTreeAdapter(tree)
 
         when:
-        adapter.visitLeafCollections(visitor)
+        adapter.visitStructure(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionStructureVisitor.VisitType.NoContents
         0 * visitor._
     }
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file.collections
 import org.gradle.api.Buildable
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
+import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionLeafVisitor
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.tasks.util.PatternFilterable
@@ -167,7 +168,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitFileTree(tree.getDir(), tree.getPatterns(), adapter)
         0 * visitor._
     }
@@ -182,7 +183,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 
@@ -195,7 +196,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Visit
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Visit
         1 * visitor.visitGenericFileTree(adapter)
         0 * visitor._
     }
@@ -209,7 +210,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionLeafVisitor.CollectionType.Other) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
         0 * visitor._
     }
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FileTreeAdapterTest.groovy
@@ -183,7 +183,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
         0 * visitor._
     }
 
@@ -210,7 +210,7 @@ class FileTreeAdapterTest extends Specification {
         adapter.visitLeafCollections(visitor)
 
         then:
-        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.Skip
+        1 * visitor.prepareForVisit(FileCollectionInternal.OTHER) >> FileCollectionLeafVisitor.VisitType.NoContents
         0 * visitor._
     }
 

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":modelCore"))
     implementation(project(":fileCollections"))
+    implementation(project(":dependencyManagement"))
 
     implementation(library("groovy"))
     implementation(library("slf4j_api"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
@@ -19,33 +19,52 @@ package org.gradle.instantexecution
 import org.gradle.integtests.resolve.transform.ArtifactTransformTestFixture
 
 class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstantExecutionIntegrationTest implements ArtifactTransformTestFixture {
-    def "task input files can include artifact transform output"() {
-        setupBuildWithColorTransformAction()
+    def setup() {
+        // So that dependency resolution results from previous executions do not interfere
+        requireOwnGradleUserHomeDir()
+    }
+
+    def "task input files can include the output of artifact transforms of project dependencies"() {
         settingsFile << """
             include 'a', 'b'
         """
+        setupBuildWithSimpleColorTransform()
         buildFile << """
             dependencies {
                 implementation project(':a')
                 implementation project(':b')
-            }
-
-            abstract class MakeGreen implements TransformAction<TransformParameters.None> {
-                @InputArtifact
-                abstract Provider<FileSystemLocation> getInputArtifact()
-                
-                void transform(TransformOutputs outputs) {
-                    def input = inputArtifact.get().asFile
-                    println "processing \${input.name}"
-                    def output = outputs.file(input.name + ".green")
-                    output.text = input.text + ".green"
-                }
             }
         """
 
         expect:
         instantRun(":resolve")
         outputContains("result = [a.jar.green, b.jar.green]")
+        instantRun(":resolve")
+        // For now, transforms are ignored when writing to the cache
+        outputContains("result = []")
+    }
+
+    def "task input files can include the output of artifact transforms of external dependencies"() {
+        withColorVariants(mavenRepo.module("group", "thing1", "1.2")).publish()
+        withColorVariants(mavenRepo.module("group", "thing2", "1.2")).publish()
+
+        setupBuildWithSimpleColorTransform()
+        buildFile << """
+            repositories {
+                maven { 
+                    url = uri('${mavenRepo.uri}') 
+                    metadataSources { gradleMetadata() }
+                }
+            } 
+            dependencies {
+                implementation "group:thing1:1.2"
+                implementation "group:thing2:1.2"
+            }
+        """
+
+        expect:
+        instantRun(":resolve")
+        outputContains("result = [thing1-1.2.jar.green, thing2-1.2.jar.green]")
         instantRun(":resolve")
         // For now, transforms are ignored when writing to the cache
         outputContains("result = []")

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFiles
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionLeafVisitor
@@ -62,9 +63,9 @@ private
 class CollectingVisitor : FileCollectionLeafVisitor {
     val files: MutableSet<File> = mutableSetOf()
 
-    override fun prepareForVisit(type: FileCollectionLeafVisitor.CollectionType): FileCollectionLeafVisitor.VisitType {
+    override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionLeafVisitor.VisitType {
         // Ignore scheduled transforms for now
-        return if (type == FileCollectionLeafVisitor.CollectionType.ArtifactTransformResult) {
+        return if (source is ConsumerProvidedVariantFiles) {
             FileCollectionLeafVisitor.VisitType.Skip
         } else {
             FileCollectionLeafVisitor.VisitType.Visit

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -64,31 +64,31 @@ class CollectingVisitor : FileCollectionLeafVisitor {
     val files: MutableSet<File> = mutableSetOf()
 
     override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionLeafVisitor.VisitType {
-        // Ignore scheduled transforms for now
         return if (source is ConsumerProvidedVariantFiles) {
-            FileCollectionLeafVisitor.VisitType.Skip
+            // Visit the spec only for scheduled transforms
+            FileCollectionLeafVisitor.VisitType.Spec
         } else {
             FileCollectionLeafVisitor.VisitType.Visit
         }
     }
 
-    override fun visitCollection(fileCollection: FileCollectionInternal) {
-        files.addAll(fileCollection.files)
+    override fun visitCollection(source: FileCollectionInternal.Source, contents: Iterable<File>) {
+        files.addAll(contents)
     }
 
     override fun visitGenericFileTree(fileTree: FileTreeInternal) {
         // TODO - should serialize a spec for the tree instead of its current elements
-        visitCollection(fileTree)
+        files.addAll(fileTree)
     }
 
     override fun visitFileTree(root: File, patterns: PatternSet, fileTree: FileTreeInternal) {
         // TODO - should serialize a spec for the tree instead of its current elements
-        visitCollection(fileTree)
+        files.addAll(fileTree)
     }
 
     override fun visitFileTreeBackedByFile(file: File, fileTree: FileTreeInternal) {
         // TODO - should serialize a spec for the tree instead of its current elements
-        visitCollection(fileTree)
+        files.addAll(fileTree)
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -19,7 +19,7 @@ package org.gradle.instantexecution.serialization.codecs
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFiles
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
-import org.gradle.api.internal.file.FileCollectionLeafVisitor
+import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.collections.MinimalFileSet
 import org.gradle.api.tasks.util.PatternSet
@@ -39,7 +39,7 @@ class FileCollectionCodec(
     override suspend fun WriteContext.encode(value: FileCollectionInternal) {
         runCatching {
             val visitor = CollectingVisitor()
-            value.visitLeafCollections(visitor)
+            value.visitStructure(visitor)
             visitor.files
         }.apply {
             onSuccess { files ->
@@ -60,15 +60,15 @@ class FileCollectionCodec(
 
 
 private
-class CollectingVisitor : FileCollectionLeafVisitor {
+class CollectingVisitor : FileCollectionStructureVisitor {
     val files: MutableSet<File> = mutableSetOf()
 
-    override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionLeafVisitor.VisitType {
+    override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType {
         return if (source is ConsumerProvidedVariantFiles) {
             // Visit the source only for scheduled transforms
-            FileCollectionLeafVisitor.VisitType.NoContents
+            FileCollectionStructureVisitor.VisitType.NoContents
         } else {
-            FileCollectionLeafVisitor.VisitType.Visit
+            FileCollectionStructureVisitor.VisitType.Visit
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -65,8 +65,8 @@ class CollectingVisitor : FileCollectionLeafVisitor {
 
     override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionLeafVisitor.VisitType {
         return if (source is ConsumerProvidedVariantFiles) {
-            // Visit the spec only for scheduled transforms
-            FileCollectionLeafVisitor.VisitType.Spec
+            // Visit the source only for scheduled transforms
+            FileCollectionLeafVisitor.VisitType.NoContents
         } else {
             FileCollectionLeafVisitor.VisitType.Visit
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -18,7 +18,7 @@ package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.internal.file.DefaultCompositeFileTree
 import org.gradle.api.internal.file.FileCollectionInternal
-import org.gradle.api.internal.file.FileCollectionLeafVisitor
+import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
@@ -50,12 +50,12 @@ class FileTreeCodec(
     private
     fun fileTreeRootsOf(value: FileTreeInternal): LinkedHashSet<File> {
         val visitor = FileTreeVisitor()
-        value.visitLeafCollections(visitor)
+        value.visitStructure(visitor)
         return visitor.roots
     }
 
     private
-    class FileTreeVisitor : FileCollectionLeafVisitor {
+    class FileTreeVisitor : FileCollectionStructureVisitor {
 
         internal
         var roots = LinkedHashSet<File>()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -60,7 +60,7 @@ class FileTreeCodec(
         internal
         var roots = LinkedHashSet<File>()
 
-        override fun visitCollection(fileCollection: FileCollectionInternal) = throw UnsupportedOperationException()
+        override fun visitCollection(source: FileCollectionInternal.Source, contents: Iterable<File>) = throw UnsupportedOperationException()
 
         override fun visitGenericFileTree(fileTree: FileTreeInternal) = throw UnsupportedOperationException()
 

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(project(":buildCache"))
     implementation(project(":persistentCache"))
     implementation(project(":dependencyManagement"))
+    implementation(project(":instantExecution"))
     implementation(project(":jvmServices"))
     implementation(project(":launcher"))
     implementation(project(":internalTesting"))

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.tasks.compile.incremental.recomp;
 import com.google.common.collect.Lists;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.util.RelativePathUtil;
@@ -49,7 +49,7 @@ public class CompilationSourceDirs {
 
     public static List<File> inferSourceRoots(FileTreeInternal sources) {
         SourceRoots visitor = new SourceRoots();
-        sources.visitLeafCollections(visitor);
+        sources.visitStructure(visitor);
         return visitor.canInferSourceRoots ? visitor.sourceRoots : Collections.emptyList();
     }
 
@@ -64,7 +64,7 @@ public class CompilationSourceDirs {
             .findFirst();
     }
 
-    private static class SourceRoots implements FileCollectionLeafVisitor {
+    private static class SourceRoots implements FileCollectionStructureVisitor {
         private boolean canInferSourceRoots = true;
         private List<File> sourceRoots = Lists.newArrayList();
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
@@ -69,8 +69,8 @@ public class CompilationSourceDirs {
         private List<File> sourceRoots = Lists.newArrayList();
 
         @Override
-        public void visitCollection(FileCollectionInternal fileCollection) {
-            cannotInferSourceRoots(fileCollection);
+        public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
+            cannotInferSourceRoots(contents);
         }
 
         @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -123,13 +123,8 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             }
 
             @Override
-            public boolean shouldVisit(FileCollectionLeafVisitor.CollectionType collectionType) {
-                return true;
-            }
-
-            @Override
-            public boolean includeFiles() {
-                return true;
+            public FileCollectionLeafVisitor.VisitType prepareForVisit(Source source) {
+                return FileCollectionLeafVisitor.VisitType.Visit;
             }
 
             @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -45,8 +45,6 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.AbstractFileCollection;
-import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Specs;
@@ -117,15 +115,6 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             @Override
             public void visitFailure(Throwable failure) {
                 throw UncheckedException.throwAsUncheckedException(failure);
-            }
-
-            @Override
-            public void endVisitCollection(FileCollectionInternal.Source source) {
-            }
-
-            @Override
-            public FileCollectionLeafVisitor.VisitType prepareForVisit(Source source) {
-                return FileCollectionLeafVisitor.VisitType.Visit;
             }
 
             @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -45,6 +45,7 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.AbstractFileCollection;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -119,7 +120,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             }
 
             @Override
-            public void endVisitCollection() {
+            public void endVisitCollection(FileCollectionInternal.Source source) {
             }
 
             @Override


### PR DESCRIPTION

### Context

Some further refactoring of file collection visiting, and `Configuration` visiting in particular, to make artifact transform outputs visible to instant execution serialization. The serialization still just ignores these.

The PR also includes some renames and removes a little more special-case handling of local file dependencies (in the visiting).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
