### PR TITLE
Add generateDeploymentDescriptor boolean to Ear task and EarPluginCon…

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ear.Ear.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ear.Ear.xml
@@ -20,6 +20,10 @@
                 <td>libDirName</td>
                 <td><literal>'lib'</literal></td>
             </tr>
+            <tr>
+                <td>generateDeploymentDescriptor</td>
+                <td><literal>true</literal></td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ear.EarPluginConvention.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ear.EarPluginConvention.xml
@@ -20,6 +20,10 @@
                 <td>deploymentDescriptor</td>
                 <td>A deployment descriptor initialized with sensible defaults</td>
             </tr>
+            <tr>
+                <td>generateDeploymentDescriptor</td>
+                <td><literal>true</literal></td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/userguide/ear_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/ear_plugin.adoc
@@ -76,6 +76,9 @@ The name of the lib directory inside the generated EAR. _Default value: `lib`_.
 `deploymentDescriptor` — link:{javadocPath}/org/gradle/plugins/ear/descriptor/DeploymentDescriptor.html[DeploymentDescriptor]::
 Metadata to generate a deployment descriptor file, e.g. `application.xml`. _Default value: A deployment descriptor with sensible defaults named `application.xml`_. If this file already exists in the `appDirName/META-INF` then the existing file contents will be used and the explicit configuration in the `ear.deploymentDescriptor` will be ignored.
 
+`generateDeploymentDescriptor` — `Boolean`::
+Specifies if deploymentDescriptor should be generated. _Default value: `true`_.
+
 These properties are provided by a link:{groovyDslPath}/org.gradle.plugins.ear.EarPluginConvention.html[EarPluginConvention] convention object.
 
 [[sec:ear_default_settings]]

--- a/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -145,6 +145,22 @@ ear {
         "in specified metaInf folder" | "customMetaInf" | "metaInf { from 'customMetaInf' }"
     }
 
+    void "skips creating application xml"() {
+        buildFile << """
+apply plugin: 'ear'
+ear {
+    generateDeploymentDescriptor = false
+}
+"""
+
+        when:
+        run 'assemble'
+
+        then:
+        def ear = new JarTestFixture(file('build/libs/root.ear'))
+        ear.assertNotContainsFile("META-INF/application.xml")
+    }
+
     @Unroll
     void "uses content found in #location app folder, ignoring descriptor modification"() {
         def applicationXml = """<?xml version="1.0"?>

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -143,6 +143,7 @@ public class EarPlugin implements Plugin<Project> {
             public void execute(Ear ear) {
                 ear.setDescription("Generates a ear archive with all the modules, the application descriptor and the libraries.");
                 ear.setGroup(BasePlugin.BUILD_GROUP);
+                ear.getGenerateDeploymentDescriptor().convention(convention.getGenerateDeploymentDescriptor());
             }
         });
 

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
@@ -17,6 +17,7 @@ package org.gradle.plugins.ear;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 
 /**
@@ -49,6 +50,12 @@ public abstract class EarPluginConvention {
      * Allows changing the library directory in the EAR file. Default is "lib".
      */
     public abstract void libDirName(String libDirName);
+
+    /**
+     * Specifies if the deploymentDescriptor should be generated if it does not exist.
+     * Default is true.
+     */
+    public abstract Property<Boolean> getGenerateDeploymentDescriptor();
 
     /**
      * A custom deployment descriptor configuration.

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ear.internal;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.plugins.ear.EarPluginConvention;
@@ -36,6 +37,7 @@ public class DefaultEarPluginConvention extends EarPluginConvention implements H
     private DeploymentDescriptor deploymentDescriptor;
     private String appDirName;
     private String libDirName;
+    private final Property<Boolean> generateDeploymentDescriptor;
 
     @Inject
     public DefaultEarPluginConvention(ObjectFactory objectFactory) {
@@ -43,6 +45,8 @@ public class DefaultEarPluginConvention extends EarPluginConvention implements H
         deploymentDescriptor = objectFactory.newInstance(DefaultDeploymentDescriptor.class);
         deploymentDescriptor.readFrom("META-INF/application.xml");
         deploymentDescriptor.readFrom(appDirName + "/META-INF/" + deploymentDescriptor.getFileName());
+        generateDeploymentDescriptor = objectFactory.property(Boolean.class);
+        generateDeploymentDescriptor.convention(true);
     }
 
     @Override
@@ -81,6 +85,11 @@ public class DefaultEarPluginConvention extends EarPluginConvention implements H
     @Override
     public void libDirName(String libDirName) {
         this.libDirName = libDirName;
+    }
+
+    @Override
+    public Property<Boolean> getGenerateDeploymentDescriptor() {
+        return generateDeploymentDescriptor;
     }
 
     @Override

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -297,6 +297,16 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         inEar "META-INF/application.xml"
     }
 
+    def supportsSkippingDeploymentDescriptorCreation() {
+        when:
+        project.pluginManager.apply(EarPlugin)
+        project.convention.plugins.ear.generateDeploymentDescriptor = false
+        executeWithDependencies project.tasks[EarPlugin.EAR_TASK_NAME]
+
+        then:
+        notInEar "META-INF/application.xml"
+    }
+
     def avoidsOverwritingDeploymentDescriptor() {
         given:
         project.file("src/main/application/META-INF").mkdirs()


### PR DESCRIPTION
…vention that allows the user to disable application.xml generation.

Signed-off-by: Jesper Utoft <jesper.utoft@systematic.com>

<!--- The issue this PR addresses -->
Fixes #9703 

### Context
<!--- Why do you believe many users will benefit from this change? -->
Maven EAR has this option to skip generating application.xml
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ x ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ x ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ x ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ x ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ x ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ x ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ x ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
