### PR TITLE
Improve rendering of artifacts in outgoing variants report

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
@@ -49,7 +49,7 @@ Attributes
     - org.gradle.usage               = java-api
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 Secondary variants (*)
     - Variant : classes
@@ -60,7 +60,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = classes
           - org.gradle.usage               = java-api
        - Artifacts
-          - java-classes-directory at build${File.separator}classes${File.separator}java${File.separator}main
+          - build${File.separator}classes${File.separator}java${File.separator}main (artifactType = java-classes-directory)
 
 --------------------------------------------------
 Variant runtimeElements
@@ -75,7 +75,7 @@ Attributes
     - org.gradle.usage               = java-runtime
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 Secondary variants (*)
     - Variant : classes
@@ -86,7 +86,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = classes
           - org.gradle.usage               = java-runtime
        - Artifacts
-          - java-classes-directory at build${File.separator}classes${File.separator}java${File.separator}main
+          - build${File.separator}classes${File.separator}java${File.separator}main (artifactType = java-classes-directory)
     - Variant : resources
        - Attributes
           - org.gradle.category            = library
@@ -95,7 +95,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = resources
           - org.gradle.usage               = java-runtime
        - Artifacts
-          - java-resources-directory at build${File.separator}resources${File.separator}main
+          - build${File.separator}resources${File.separator}main (artifactType = java-resources-directory)
 """
         and:
         doesNotHaveLegacyVariantsLegend()
@@ -125,7 +125,7 @@ Attributes
     - org.gradle.usage               = java-runtime
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 Secondary variants (*)
     - Variant : classes
@@ -136,7 +136,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = classes
           - org.gradle.usage               = java-runtime
        - Artifacts
-          - java-classes-directory at build${File.separator}classes${File.separator}java${File.separator}main
+          - build${File.separator}classes${File.separator}java${File.separator}main (artifactType = java-classes-directory)
     - Variant : resources
        - Attributes
           - org.gradle.category            = library
@@ -145,7 +145,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = resources
           - org.gradle.usage               = java-runtime
        - Artifacts
-          - java-resources-directory at build${File.separator}resources${File.separator}main
+          - build${File.separator}resources${File.separator}main (artifactType = java-resources-directory)
 """
 
         and:
@@ -196,7 +196,7 @@ Attributes
     - org.gradle.usage               = java-api
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 Secondary variants (*)
     - Variant : classes
@@ -207,7 +207,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = classes
           - org.gradle.usage               = java-api
        - Artifacts
-          - java-classes-directory at build${File.separator}classes${File.separator}java${File.separator}main
+          - build${File.separator}classes${File.separator}java${File.separator}main (artifactType = java-classes-directory)
 
 --------------------------------------------------
 Variant archives (l)
@@ -215,7 +215,7 @@ Variant archives (l)
 Description = Configuration for archive artifacts.
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 --------------------------------------------------
 Variant compile (l)
@@ -233,7 +233,7 @@ Variant default (l)
 Description = Configuration for default artifacts.
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 --------------------------------------------------
 Variant runtime (l)
@@ -241,7 +241,7 @@ Variant runtime (l)
 Description = Runtime dependencies for source set 'main' (deprecated, use 'runtimeOnly' instead).
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 --------------------------------------------------
 Variant runtimeElements
@@ -256,7 +256,7 @@ Attributes
     - org.gradle.usage               = java-runtime
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 
 Secondary variants (*)
     - Variant : classes
@@ -267,7 +267,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = classes
           - org.gradle.usage               = java-runtime
        - Artifacts
-          - java-classes-directory at build${File.separator}classes${File.separator}java${File.separator}main
+          - build${File.separator}classes${File.separator}java${File.separator}main (artifactType = java-classes-directory)
     - Variant : resources
        - Attributes
           - org.gradle.category            = library
@@ -276,7 +276,7 @@ Secondary variants (*)
           - org.gradle.libraryelements     = resources
           - org.gradle.usage               = java-runtime
        - Artifacts
-          - java-resources-directory at build${File.separator}resources${File.separator}main
+          - build${File.separator}resources${File.separator}main (artifactType = java-resources-directory)
 
 --------------------------------------------------
 Variant testCompile (l)
@@ -294,7 +294,7 @@ Variant testRuntime (l)
 Description = Runtime dependencies for source set 'test' (deprecated, use 'testRuntimeOnly' instead).
 
 Artifacts
-    - jar at build${File.separator}libs${File.separator}myLib.jar
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
 """
 
         and:
@@ -322,6 +322,64 @@ Description = Dependencies for source set 'main' (deprecated, use 'implementatio
         and:
         hasLegacyVariantsLegend()
         doesNotHaveSecondaryVariantsLegend()
+    }
+
+    def "reports artifacts without explicit type"() {
+        buildFile << """
+            plugins { id 'java-library' }
+            
+            configurations.runtimeElements.outgoing.variants {
+                classes {
+                   artifact(file("foo"))
+                }
+            }
+        """
+
+        when:
+        run ':outgoingVariants', '--variant', 'runtimeElements'
+
+        then:
+        outputContains """> Task :outgoingVariants
+--------------------------------------------------
+Variant runtimeElements
+--------------------------------------------------
+Description = Elements of runtime for main.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+
+Artifacts
+    - build${File.separator}libs${File.separator}myLib.jar (artifactType = jar)
+
+Secondary variants (*)
+    - Variant : classes
+       - Attributes
+          - org.gradle.category            = library
+          - org.gradle.dependency.bundling = external
+          - org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
+          - org.gradle.libraryelements     = classes
+          - org.gradle.usage               = java-runtime
+       - Artifacts
+          - build${File.separator}classes${File.separator}java${File.separator}main (artifactType = java-classes-directory)
+          - foo
+    - Variant : resources
+       - Attributes
+          - org.gradle.category            = library
+          - org.gradle.dependency.bundling = external
+          - org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
+          - org.gradle.libraryelements     = resources
+          - org.gradle.usage               = java-runtime
+       - Artifacts
+          - build${File.separator}resources${File.separator}main (artifactType = java-resources-directory)
+"""
+
+        and:
+        doesNotHaveLegacyVariantsLegend()
+        hasSecondaryVariantsLegend()
     }
 
     private void hasSecondaryVariantsLegend() {

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/modelingFeatures/crossProjectPublications/advanced/outgoingVariants.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/modelingFeatures/crossProjectPublications/advanced/outgoingVariants.out
@@ -12,7 +12,7 @@ Attributes
     - org.gradle.usage               = java-api
 
 Artifacts
-    - jar at build/libs/producer.jar
+    - build/libs/producer.jar (artifactType = jar)
 
 Secondary variants (*)
     - Variant : classes
@@ -23,7 +23,55 @@ Secondary variants (*)
           - org.gradle.libraryelements     = classes
           - org.gradle.usage               = java-api
        - Artifacts
-          - java-classes-directory at build/classes/java/main
+          - build/classes/java/main (artifactType = java-classes-directory)
+
+--------------------------------------------------
+Variant instrumentedJars
+--------------------------------------------------
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.version         = 11
+    - org.gradle.libraryelements     = instrumented-jar
+    - org.gradle.usage               = java-runtime
+
+Artifacts
+    - build/libs/producer-instrumented.jar (artifactType = jar)
+
+--------------------------------------------------
+Variant runtimeElements
+--------------------------------------------------
+Description = Elements of runtime for main.
+
+Attributes
+    - org.gradle.category            = library
+    - org.gradle.dependency.bundling = external
+    - org.gradle.jvm.version         = 11
+    - org.gradle.libraryelements     = jar
+    - org.gradle.usage               = java-runtime
+
+Artifacts
+    - build/libs/producer.jar (artifactType = jar)
+
+Secondary variants (*)
+    - Variant : classes
+       - Attributes
+          - org.gradle.category            = library
+          - org.gradle.dependency.bundling = external
+          - org.gradle.jvm.version         = 11
+          - org.gradle.libraryelements     = classes
+          - org.gradle.usage               = java-runtime
+       - Artifacts
+          - build/classes/java/main (artifactType = java-classes-directory)
+    - Variant : resources
+       - Attributes
+          - org.gradle.category            = library
+          - org.gradle.dependency.bundling = external
+          - org.gradle.jvm.version         = 11
+          - org.gradle.libraryelements     = resources
+          - org.gradle.usage               = java-runtime
+       - Artifacts
+          - build/resources/main (artifactType = java-resources-directory)
 
 
 (*) Secondary variants are variants created via the Configuration#getOutgoing(): ConfigurationPublications API which also participate in selection, in addition to the configuration itself.


### PR DESCRIPTION
### Context

This commit changes how artifacts are rendered, so that if they
are associated with a type (either explicit or derived), we show
the corresponding `artifactType` attribute.

This helps understanding a bit what can happen in an Android build
where multiple variants may have the same attributes, but only
differ on the artifact type derived from the artifacts carried
by the variant.
