### PR TITLE
Add analytic data to performance database

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DataReporter.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DataReporter.java
@@ -14,8 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.performance.results
+package org.gradle.performance.results;
 
-interface DataReporter<T extends PerformanceTestResult> extends Closeable {
-    void report(T results)
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public interface DataReporter<T extends PerformanceTestResult> extends Closeable {
+    void report(T results);
+
+    default String insertStatement(String table, String... columns) {
+        return "insert into " +
+            table +
+            "(" +
+            String.join(", ", columns) +
+            ")" +
+            "values(" +
+            Arrays.stream(columns).map(s -> "?").collect(Collectors.joining(", ")) +
+            ")";
+    }
 }


### PR DESCRIPTION
### Context

As part of https://github.com/gradle/gradle-private/issues/2399, we want to add some extra performance analytic data to perf database so that we can analyze the flakiness with SQL.

This PR adds extra column `currentMedian`/`baselineMedian`/`diffConfidence` to the performance database and calculate them on insertion.