### PR TITLE
Do not allow setting max worker count after value has been retrieved.

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/DefaultParallelismConfiguration.java
@@ -27,6 +27,7 @@ public class DefaultParallelismConfiguration implements Serializable, Parallelis
 
     private boolean parallelProjectExecution;
     private int maxWorkerCount;
+    private boolean maxWorkerCountRetreived = false;
 
     public DefaultParallelismConfiguration() {
         maxWorkerCount = Runtime.getRuntime().availableProcessors();
@@ -58,6 +59,7 @@ public class DefaultParallelismConfiguration implements Serializable, Parallelis
      */
     @Override
     public int getMaxWorkerCount() {
+        maxWorkerCountRetreived = true;
         return maxWorkerCount;
     }
 
@@ -66,6 +68,9 @@ public class DefaultParallelismConfiguration implements Serializable, Parallelis
      */
     @Override
     public void setMaxWorkerCount(int maxWorkerCount) {
+        if (maxWorkerCountRetreived) {
+            throw new IllegalStateException("Max worker count was already retrieved. Setting the value at this time has no effect.");
+        }
         if (maxWorkerCount < 1) {
             throw new IllegalArgumentException("Max worker count must be > 0");
         } else {

--- a/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -25,7 +25,9 @@ import org.junit.Rule
 import spock.lang.Specification
 
 import static org.gradle.util.Matchers.isSerializable
+import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertThat
+import static org.junit.Assert.fail
 
 class StartParameterTest extends Specification {
     @Rule private TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
@@ -377,5 +379,23 @@ class StartParameterTest extends Specification {
         then:
         parameter.taskNames == []
         parameter.taskRequests == []
+    }
+
+    def 'cannot set max workers after get'() {
+        StartParameter parameter = new StartParameter()
+
+        when:
+        parameter.setMaxWorkerCount(8)
+
+        then:
+        parameter.maxWorkerCount == 8
+
+        try {
+            parameter.setMaxWorkerCount(6)
+            fail()
+        } catch (IllegalStateException e) {
+            assertEquals(e.message, "Max worker count was already retrieved. Setting the value at this time has no effect.")
+
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultParallelismConfigurationManagerTest.groovy
@@ -23,6 +23,9 @@ import org.gradle.internal.concurrent.ParallelismConfigurationListener
 import org.gradle.internal.event.ListenerManager
 import spock.lang.Specification
 
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.fail
+
 
 class DefaultParallelismConfigurationManagerTest extends Specification {
     ParallelismConfigurationListener broadcaster = Mock(ParallelismConfigurationListener)
@@ -58,5 +61,18 @@ class DefaultParallelismConfigurationManagerTest extends Specification {
         expect:
         parallelExecutionManager.parallelismConfiguration.maxWorkerCount == DefaultParallelismConfiguration.DEFAULT.maxWorkerCount
         parallelExecutionManager.parallelismConfiguration.parallelProjectExecutionEnabled == DefaultParallelismConfiguration.DEFAULT.parallelProjectExecutionEnabled
+    }
+
+    def "can only set maxworker count once"() {
+        parallelExecutionManager.parallelismConfiguration.setMaxWorkerCount(2)
+        expect:
+        parallelExecutionManager.parallelismConfiguration.maxWorkerCount == 2
+
+        try {
+            parallelExecutionManager.parallelismConfiguration.setMaxWorkerCount(4)
+            fail()
+        } catch(IllegalStateException e) {
+            assertEquals(e.message, "Max worker count was already retrieved. Setting the value at this time has no effect.")
+        }
     }
 }


### PR DESCRIPTION
### Context
This is likely a programmer error and indicates that the set likely has
no effect.
A user may try to write `gradle.startParameter.setMaxWorkerCount(4)` in a `build.gradle` file without realizing that this has no effect because the value was already retrieved.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
