### PR TITLE
Instant execution writes scheduled work nodes to cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -166,7 +166,7 @@ public abstract class Node implements Comparable<Node> {
         return dependencySuccessors;
     }
 
-    protected void addDependencySuccessor(Node toNode) {
+    public void addDependencySuccessor(Node toNode) {
         dependencySuccessors.add(toNode);
         toNode.dependencyPredecessors.add(this);
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -94,6 +94,7 @@ public abstract class TaskNode extends Node {
     public Iterable<Node> getAllSuccessors() {
         return Iterables.concat(getMustSuccessors(), getFinalizingSuccessors(), super.getAllSuccessors());
     }
+
     @Override
     public Iterable<Node> getAllSuccessorsInReverseOrder() {
         return Iterables.concat(

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -29,7 +29,6 @@ import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -140,6 +139,12 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         graphState = GraphState.DIRTY;
 
         LOGGER.debug("Timing: Creating the DAG took " + clock.getElapsed());
+    }
+
+    @Override
+    public void addNodes(Collection<? extends Node> nodes) {
+        executionPlan.addNodes(nodes);
+        graphState = GraphState.DIRTY;
     }
 
     @Override
@@ -290,6 +295,11 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     @Override
+    public List<Node> getScheduledWork() {
+        return executionPlan.getScheduledNodes();
+    }
+
+    @Override
     public Set<Task> getDependencies(Task task) {
         ensurePopulated();
         Node node = executionPlan.getNode(task);
@@ -376,11 +386,6 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
             was necessary, therefore the minimal change solution was implemented.
          */
         return executionPlan.getFilteredTasks();
-    }
-
-    @Override
-    public ProjectInternal getRootProject() {
-        return gradleInternal.getRootProject();
     }
 
     private static class NotifyTaskGraphWhenReady implements RunnableBuildOperation {

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -17,10 +17,11 @@ package org.gradle.execution.taskgraph;
 
 import org.gradle.api.Task;
 import org.gradle.api.execution.TaskExecutionGraph;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.specs.Spec;
+import org.gradle.execution.plan.Node;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
@@ -35,6 +36,11 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
      * are executed before any tasks from a subsequent call to this method are executed.
      */
     void addEntryTasks(Iterable<? extends Task> tasks);
+
+    /**
+     * Adds the given nodes to this graph.
+     */
+    void addNodes(Collection<? extends Node> nodes);
 
     /**
      * Does the work to populate the task graph based on tasks that have been added. Does not fire events.
@@ -63,13 +69,12 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
     Set<Task> getFilteredTasks();
 
     /**
-     * Returns the number of work items in the graph.
+     * Returns the number of work items in this graph.
      */
     int size();
 
     /**
-     * Returns the root project of this graph.
+     * Returns all of the work items in this graph scheduled for execution.
      */
-    ProjectInternal getRootProject();
-
+    List<Node> getScheduledWork();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -549,11 +549,6 @@ class DefaultTaskExecutionGraphSpec extends Specification {
         failures == [failure]
     }
 
-    def "returns root project"() {
-        expect:
-        taskGraph.rootProject == project
-    }
-
     def newTask(String name) {
         def mock = Mock(TaskInternal, name: name)
         _ * mock.name >> name

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
@@ -61,8 +61,8 @@ public class DependencyServices extends AbstractPluginServiceRegistry {
             return new DefaultTransformationNodeRegistry();
         }
 
-        TransformationNodeDependencyResolver createTransformationNodeDependencyResolver(TransformationNodeRegistry transformationNodeRegistry) {
-            return new TransformationNodeDependencyResolver(transformationNodeRegistry);
+        TransformationNodeDependencyResolver createTransformationNodeDependencyResolver() {
+            return new TransformationNodeDependencyResolver();
         }
 
         TransformationNodeExecutor createTransformationNodeExecutor(BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -78,7 +79,15 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet, Con
 
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        context.add(new DefaultTransformationDependency(transformation, delegate, getDependenciesResolver()));
+        Collection<TransformationNode> scheduledNodes = transformationNodeRegistry.getOrCreate(delegate, transformation, getDependenciesResolver());
+        if (!scheduledNodes.isEmpty()) {
+            context.add(new DefaultTransformationDependency(scheduledNodes));
+        }
+    }
+
+    @Override
+    public Collection<TransformationNode> getScheduledNodes() {
+        return transformationNodeRegistry.getOrCreate(delegate, transformation, getDependenciesResolver());
     }
 
     private ExecutionGraphDependenciesResolver getDependenciesResolver() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationDependency.java
@@ -17,54 +17,18 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.NonNullApi;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+
+import java.util.Collection;
 
 @NonNullApi
 public class DefaultTransformationDependency implements TransformationDependency {
-    private final Transformation transformation;
-    private final ResolvedArtifactSet artifacts;
-    private final ExecutionGraphDependenciesResolver dependenciesResolver;
+    private final Collection<TransformationNode> nodes;
 
-    public DefaultTransformationDependency(Transformation transformation, ResolvedArtifactSet artifacts,
-                                           ExecutionGraphDependenciesResolver dependenciesResolver) {
-        this.transformation = transformation;
-        this.artifacts = artifacts;
-        this.dependenciesResolver = dependenciesResolver;
+    public DefaultTransformationDependency(Collection<TransformationNode> nodes) {
+        this.nodes = nodes;
     }
 
-    public Transformation getTransformation() {
-        return transformation;
-    }
-
-    public ResolvedArtifactSet getArtifacts() {
-        return artifacts;
-    }
-
-    public ExecutionGraphDependenciesResolver getDependenciesResolver() {
-        return dependenciesResolver;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        DefaultTransformationDependency that = (DefaultTransformationDependency) o;
-
-        if (!transformation.equals(that.transformation)) {
-            return false;
-        }
-        return artifacts.equals(that.artifacts);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = transformation.hashCode();
-        result = 31 * result + artifacts.hashCode();
-        return result;
+    public Collection<TransformationNode> getNodes() {
+        return nodes;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeDependencyResolver.java
@@ -21,24 +21,15 @@ import org.gradle.api.Task;
 import org.gradle.execution.plan.DependencyResolver;
 import org.gradle.execution.plan.Node;
 
-import java.util.Collection;
-
 /**
  * Resolves dependencies to {@link TransformationNode} objects.
  */
 public class TransformationNodeDependencyResolver implements DependencyResolver {
-    private final TransformationNodeRegistry transformationNodeRegistry;
-
-    public TransformationNodeDependencyResolver(TransformationNodeRegistry transformationNodeRegistry) {
-        this.transformationNodeRegistry = transformationNodeRegistry;
-    }
-
     @Override
     public boolean resolve(Task task, Object node, Action<? super Node> resolveAction) {
         if (node instanceof DefaultTransformationDependency) {
             DefaultTransformationDependency transformation = (DefaultTransformationDependency) node;
-            Collection<TransformationNode> transformations = transformationNodeRegistry.getOrCreate(transformation.getArtifacts(), transformation.getTransformation(), transformation.getDependenciesResolver());
-            for (TransformationNode transformationNode : transformations) {
+            for (TransformationNode transformationNode : transformation.getNodes()) {
                 resolveAction.execute(transformationNode);
             }
             return true;

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
@@ -24,27 +24,34 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         requireOwnGradleUserHomeDir()
     }
 
-    def "task input files can include the output of artifact transforms of project dependencies"() {
+    def "task input files can include the output of artifact transform of project dependencies"() {
         settingsFile << """
             include 'a', 'b'
         """
         setupBuildWithSimpleColorTransform()
         buildFile << """
+            dependencies.artifactTypes {
+                green {
+                    attributes.attribute(color, 'green')
+                }
+            }
             dependencies {
                 implementation project(':a')
+                implementation files('root.green')
                 implementation project(':b')
             }
         """
+        file('root.green') << 'root'
 
         expect:
         instantRun(":resolve")
-        outputContains("result = [a.jar.green, b.jar.green]")
+        outputContains("result = [root.green, a.jar.green, b.jar.green]")
         instantRun(":resolve")
-        // For now, transforms are ignored when writing to the cache
-        outputContains("result = []")
+        // For now, scheduled transforms are ignored when writing to the cache
+        outputContains("result = [root.green]")
     }
 
-    def "task input files can include the output of artifact transforms of external dependencies"() {
+    def "task input files can include the output of artifact transform of external dependencies"() {
         withColorVariants(mavenRepo.module("group", "thing1", "1.2")).publish()
         withColorVariants(mavenRepo.module("group", "thing2", "1.2")).publish()
 
@@ -66,7 +73,39 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         instantRun(":resolve")
         outputContains("result = [thing1-1.2.jar.green, thing2-1.2.jar.green]")
         instantRun(":resolve")
-        // For now, transforms are ignored when writing to the cache
+        // For now, scheduled transforms are ignored when writing to the cache
         outputContains("result = []")
+    }
+
+    def "task input files can include the output of artifact transforms of prebuilt file dependencies"() {
+        settingsFile << """
+            include 'a'
+        """
+        setupBuildWithSimpleColorTransform()
+        buildFile << """
+            dependencies.artifactTypes {
+                blue {
+                    attributes.attribute(color, 'blue')
+                }
+            }
+            dependencies {
+                implementation files('root.blue')
+                implementation project(':a')
+            }
+            project(':a') {
+                dependencies {
+                    implementation files('a.blue')
+                }
+            }
+        """
+        file('root.blue') << 'root'
+        file('a/a.blue') << 'a'
+
+        expect:
+        instantRun(":resolve")
+        outputContains("result = [root.blue.green, a.jar.green, a.blue.green]")
+        instantRun(":resolve")
+        // For now, scheduled transforms are ignored when writing to the cache
+        outputContains("result = [root.blue.green, a.blue.green]")
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
@@ -18,6 +18,7 @@ package org.gradle.instantexecution
 
 import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.execution.plan.Node
 
 
 interface ClassicModeBuild {
@@ -25,7 +26,7 @@ interface ClassicModeBuild {
 
     val rootProject: ProjectInternal
 
-    val scheduledTasks: List<Task>
+    val scheduledWork: List<Node>
 
     fun dependenciesOf(task: Task): Set<Task>
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.execution.plan.Node
 
@@ -27,6 +26,4 @@ interface ClassicModeBuild {
     val rootProject: ProjectInternal
 
     val scheduledWork: List<Node>
-
-    fun dependenciesOf(task: Task): Set<Task>
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -171,7 +171,7 @@ class DefaultInstantExecution internal constructor(
         writeRelevantProjectsFor(scheduledTasks)
 
         WorkNodeCodec(service(), service()).run {
-            writeWorkOf(build, scheduledNodes)
+            writeWorkOf(scheduledNodes)
         }
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
@@ -17,9 +17,9 @@
 package org.gradle.instantexecution
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
+import org.gradle.execution.plan.Node
 
 
 interface InstantExecutionBuild {
@@ -34,5 +34,5 @@ interface InstantExecutionBuild {
 
     fun registerProjects()
 
-    fun scheduleTasks(tasks: Iterable<Task>)
+    fun scheduleNodes(nodes: Collection<Node>)
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -28,6 +28,7 @@ import org.gradle.api.internal.project.IProjectFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
+import org.gradle.execution.plan.Node
 import org.gradle.groovy.scripts.StringScriptSource
 import org.gradle.initialization.BuildLoader
 import org.gradle.initialization.BuildOperatingFiringSettingsPreparer
@@ -102,8 +103,8 @@ class InstantExecutionHost internal constructor(
         override val buildSrc: Boolean
             get() = gradle.parent != null && gradle.publicBuildPath.buildPath.name == BuildSourceBuilder.BUILD_SRC
 
-        override val scheduledTasks: List<Task>
-            get() = gradle.taskGraph.allTasks
+        override val scheduledWork: List<Node>
+            get() = gradle.taskGraph.scheduledWork
 
         override val rootProject: ProjectInternal
             get() = gradle.rootProject
@@ -225,9 +226,9 @@ class InstantExecutionHost internal constructor(
             )
         }
 
-        override fun scheduleTasks(tasks: Iterable<Task>) {
+        override fun scheduleNodes(nodes: Collection<Node>) {
             gradle.taskGraph.run {
-                addEntryTasks(tasks)
+                addNodes(nodes)
                 populate()
             }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.api.Task
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
@@ -108,9 +107,6 @@ class InstantExecutionHost internal constructor(
 
         override val rootProject: ProjectInternal
             get() = gradle.rootProject
-
-        override fun dependenciesOf(task: Task): Set<Task> =
-            gradle.taskGraph.getDependencies(task)
     }
 
     inner class DefaultInstantExecutionBuild(

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -122,7 +122,10 @@ class Codecs(
 
         bind(ConfigurableFileCollectionCodec(fileSetSerializer, fileCollectionFactory))
         bind(FileCollectionCodec(fileSetSerializer, fileCollectionFactory))
+
+        // Dependency management types
         bind(ArtifactCollectionCodec)
+        bind(TransformationNodeCodec)
 
         bind(DefaultCopySpecCodec(fileResolver, instantiator))
         bind(DestinationRootCopySpecCodec(fileResolver))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TransformationNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TransformationNodeCodec.kt
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.transform;
+package org.gradle.instantexecution.serialization.codecs
 
-import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.artifacts.transform.TransformationNode
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
 
-import java.util.Collection;
 
-public interface ConsumerProvidedVariantFiles extends FileCollectionInternal.Source {
-    /**
-     * @return empty list when not scheduled.
-     */
-    Collection<TransformationNode> getScheduledNodes();
+internal
+object TransformationNodeCodec : Codec<TransformationNode> {
+    override suspend fun WriteContext.encode(value: TransformationNode) {
+        // Ignore
+    }
+
+    override suspend fun ReadContext.decode(): TransformationNode? {
+        return null
+    }
 }


### PR DESCRIPTION

### Context

Change instant execution to write the scheduled work nodes rather than scheduled tasks to the instant execution cache. For now, a placeholder is written to the cache for nodes other than task nodes, which means that they are basically ignored when reading from the cache. This PR is simply to change the internal wiring so that the serialization works with nodes rather than tasks. A later PR will start fleshing out the artifact transform and other nodes, and connect the artifact transform nodes back into file collections read from the cache.

In this PR, also short-circuit the task dependency calculation for nodes read from the cache, as this is already recreated from the cached information.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
