### PR TITLE
Fix NoClassDefFoundError in performance test

### DIFF
--- a/buildSrc/subprojects/performance/performance.gradle.kts
+++ b/buildSrc/subprojects/performance/performance.gradle.kts
@@ -1,10 +1,7 @@
 dependencies {
     api(project(":integrationTesting"))
     implementation(project(":build"))
-    implementation("org.codehaus.groovy.modules.http-builder:http-builder:0.7.2") {
-        // Xerces on the runtime classpath is breaking some of our doc tasks
-        exclude(group = "xerces")
-    }
+    implementation("org.codehaus.groovy.modules.http-builder:http-builder:0.7.2")
     implementation("org.openmbee.junit:junit-xml-parser:1.0.0") {
         // don't need it at runtime
         exclude(module = "lombok")

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -277,7 +277,7 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
                 // Sometimes, TC returns text/html page
                 // https://github.com/gradle/gradle-private/issues/1359
                 System.err.println("""
-Get TeamCity HTML response when accepting application/json:
+Got TeamCity HTML response when accepting application/json:
 
 ${resp.getStatusLine()}
 ${resp.data}


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/1359

The problem is that TC returns a `text/html` HTTP response even when we explicitly set `Accept: application/json`. When this happens, the `NoClassDefFoundError` is expected because we excluded `xerces` [here](https://github.com/gradle/gradle/blob/f8fce64e9f7255fa6fb1c9a04c40903ddbe7fc3e/buildSrc/subprojects/performance/performance.gradle.kts#L6).

@wolfs I re-added the `xerces` back and it seems to be working. Can we keep it?