### PR TITLE
Proper transformation of deprecated usage values

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactory.java
@@ -65,7 +65,7 @@ public class DefaultImmutableAttributesFactory implements ImmutableAttributesFac
 
     @Override
     public <T> ImmutableAttributes concat(ImmutableAttributes node, Attribute<T> key, T value) {
-        return doConcatIsolatable(node, key, isolate(value));
+        return concat(node, key, isolate(value));
     }
 
     private <T> Isolatable<T> isolate(T value) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.attributes
 
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.Usage
+import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -270,5 +272,19 @@ class DefaultImmutableAttributesFactoryTest extends Specification {
         e.attribute == OTHER_BAR
         e.leftValue == "bar1"
         e.rightValue == "bar2"
+    }
+
+    def "translates deprecated usage values"() {
+        def result = factory.concat(factory.of(FOO, "foo"), Usage.USAGE_ATTRIBUTE, instantiator.named(Usage, Usage.JAVA_API_JARS))
+
+        expect:
+        result.findEntry(Usage.USAGE_ATTRIBUTE).get().name == "java-api"
+    }
+
+    def "translates deprecated usage values as Isolatable"() {
+        def result = factory.concat(factory.of(FOO, "foo"), Usage.USAGE_ATTRIBUTE, new CoercingStringValueSnapshot("java-runtime-jars", instantiator))
+
+        expect:
+        result.findEntry(Usage.USAGE_ATTRIBUTE).get().toString() == "java-runtime"
     }
 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/UserGuideLinkTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/UserGuideLinkTest.kt
@@ -81,7 +81,7 @@ val linkedPlugins =
         "maven", "maven-publish",
         "microsoft-visual-cpp-compiler",
         "native-component", "native-component-model",
-        "objective-c", "objective-c-lang", "objective-cpp", "objective-cpp-lang", "osgi",
+        "objective-c", "objective-c-lang", "objective-cpp", "objective-cpp-lang",
         "play", "play-application", "play-cofeescript", "play-ide", "play-javascript", "pmd",
         "project-report", "project-reports",
         "reporting-base",


### PR DESCRIPTION
This is a follow up on #10004

It missed one code path for the translation of values, resulting in some
issues for kotlin projects attempting to publish resolved version to
Ivy.