### PR TITLE
Write node work graph to the instant execution cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Set;
 
-class ActionNode extends Node {
+public class ActionNode extends Node {
     private final WorkNodeAction action;
 
     public ActionNode(WorkNodeAction action) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -143,13 +143,13 @@ public class DefaultGradleLauncher implements GradleLauncher {
         if (upTo == Stage.TaskGraph) {
             return;
         }
-        instantExecution.saveTaskGraph();
+        instantExecution.saveScheduledWork();
         runWork();
     }
 
     private void doInstantExecution() {
         buildListener.buildStarted(gradle);
-        instantExecution.loadTaskGraph();
+        instantExecution.loadScheduledWork();
         stage = Stage.TaskGraph;
         runWork();
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/InstantExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/InstantExecution.java
@@ -20,7 +20,7 @@ public interface InstantExecution {
 
     boolean canExecuteInstantaneously();
 
-    void saveTaskGraph();
+    void saveScheduledWork();
 
-    void loadTaskGraph();
+    void loadScheduledWork();
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionDependencyResolutionIntegrationTest.groovy
@@ -46,7 +46,10 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         expect:
         instantRun(":resolve")
         outputContains("result = [root.green, a.jar.green, b.jar.green]")
+
         instantRun(":resolve")
+        result.assertTaskOrder(":a:producer", ":resolve")
+        result.assertTaskOrder(":b:producer", ":resolve")
         // For now, scheduled transforms are ignored when writing to the cache
         outputContains("result = [root.green]")
     }
@@ -105,6 +108,7 @@ class InstantExecutionDependencyResolutionIntegrationTest extends AbstractInstan
         instantRun(":resolve")
         outputContains("result = [root.blue.green, a.jar.green, a.blue.green]")
         instantRun(":resolve")
+        result.assertTaskOrder(":a:producer", ":resolve")
         // For now, scheduled transforms are ignored when writing to the cache
         outputContains("result = [root.blue.green, a.blue.green]")
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -108,7 +108,7 @@ class DefaultInstantExecution internal constructor(
         }
     }
 
-    override fun saveTaskGraph() {
+    override fun saveScheduledWork() {
 
         if (!isInstantExecutionEnabled) {
             // No need to hold onto the `ClassLoaderScope` tree
@@ -124,7 +124,7 @@ class DefaultInstantExecution internal constructor(
                 KryoBackedEncoder(stateFileOutputStream()).use { encoder ->
                     writeContextFor(encoder, report).run {
                         runToCompletion {
-                            encodeTaskGraph()
+                            encodeScheduledWork()
                         }
                     }
                 }
@@ -138,7 +138,7 @@ class DefaultInstantExecution internal constructor(
         }
     }
 
-    override fun loadTaskGraph() {
+    override fun loadScheduledWork() {
 
         require(isInstantExecutionEnabled)
 
@@ -150,7 +150,7 @@ class DefaultInstantExecution internal constructor(
             KryoBackedDecoder(stateFileInputStream()).use { decoder ->
                 readContextFor(decoder).run {
                     runToCompletion {
-                        decodeTaskGraph()
+                        decodeScheduledWork()
                     }
                 }
             }
@@ -158,7 +158,7 @@ class DefaultInstantExecution internal constructor(
     }
 
     private
-    suspend fun DefaultWriteContext.encodeTaskGraph() {
+    suspend fun DefaultWriteContext.encodeScheduledWork() {
         val build = host.currentBuild
         writeString(build.rootProject.name)
 
@@ -171,12 +171,12 @@ class DefaultInstantExecution internal constructor(
         writeRelevantProjectsFor(scheduledTasks)
 
         WorkNodeCodec(service(), service()).run {
-            writeWorkOf(scheduledNodes)
+            writeWork(scheduledNodes)
         }
     }
 
     private
-    suspend fun DefaultReadContext.decodeTaskGraph() {
+    suspend fun DefaultReadContext.decodeScheduledWork() {
         val rootProjectName = readString()
         val build = host.createBuild(rootProjectName)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Codec.kt
@@ -40,6 +40,7 @@ interface Codec<T> {
 
 
 interface WriteContext : IsolateContext, Encoder {
+    val sharedIdentities: WriteIdentities
 
     override val isolate: WriteIsolate
 
@@ -55,6 +56,7 @@ typealias Encoding = suspend WriteContext.(value: Any?) -> Unit
 
 
 interface ReadContext : IsolateContext, Decoder {
+    val sharedIdentities: ReadIdentities
 
     override val isolate: ReadIsolate
 
@@ -279,12 +281,17 @@ interface Isolate {
 
 interface WriteIsolate : Isolate {
 
+    /**
+     * Identities of objects that are shared within this isolate only.
+     */
     val identities: WriteIdentities
 }
 
 
 interface ReadIsolate : Isolate {
-
+    /**
+     * Identities of objects that are shared withing this isolate only.
+     */
     val identities: ReadIdentities
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -46,6 +46,7 @@ class DefaultWriteContext(
     val problemHandler: (PropertyProblem) -> Unit
 
 ) : AbstractIsolateContext<WriteIsolate>(), MutableWriteContext, Encoder by encoder {
+    override val sharedIdentities = WriteIdentities()
 
     private
     val beanPropertyWriters = hashMapOf<Class<*>, BeanStateWriter>()
@@ -132,6 +133,7 @@ class DefaultReadContext(
     val beanPropertyReaderFactory: (Class<*>) -> BeanPropertyReader
 
 ) : AbstractIsolateContext<ReadIsolate>(), MutableReadContext, Decoder by decoder {
+    override val sharedIdentities = ReadIdentities()
 
     private
     val beanStateReaders = hashMapOf<Class<*>, BeanStateReader>()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -120,8 +120,8 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
-        bind(ConfigurableFileCollectionCodec(fileSetSerializer, fileCollectionFactory))
-        bind(FileCollectionCodec(fileSetSerializer, fileCollectionFactory))
+        bind(ConfigurableFileCollectionCodec(fileCollectionFactory))
+        bind(FileCollectionCodec(fileCollectionFactory))
 
         // Dependency management types
         bind(ArtifactCollectionCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ConfigurableFileCollectionCodec.kt
@@ -22,17 +22,14 @@ import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.internal.serialize.SetSerializer
-import java.io.File
 
 
 internal
 class ConfigurableFileCollectionCodec(
-    fileSetSerializer: SetSerializer<File>,
     private val fileCollectionFactory: FileCollectionFactory
 ) : Codec<ConfigurableFileCollection> {
     private
-    val codec = FileCollectionCodec(fileSetSerializer, fileCollectionFactory)
+    val codec = FileCollectionCodec(fileCollectionFactory)
 
     override suspend fun WriteContext.encode(value: ConfigurableFileCollection) =
         codec.run { encode(value as FileCollectionInternal) }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -26,13 +26,11 @@ import org.gradle.api.tasks.util.PatternSet
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.internal.serialize.SetSerializer
 import java.io.File
 
 
 internal
 class FileCollectionCodec(
-    private val fileSetSerializer: SetSerializer<File>,
     private val fileCollectionFactory: FileCollectionFactory
 ) : Codec<FileCollectionInternal> {
 
@@ -58,6 +56,7 @@ class FileCollectionCodec(
             if (element is File) {
                 list.add(element)
             }
+            // Otherwise, ignore for now
             list
         })
         else fileCollectionFactory.create(ErrorFileSet(readString()))


### PR DESCRIPTION
### Context

More progress towards supporting artifact transforms applied to project outputs with instant execution. In this PR, write all nodes of the work graph, along with the edges between them, to the cache (previously only task nodes + dependencies were written).

None of the details artifact transformation nodes are written to the cache and these are replaced with a no-op node when read from the cache. So, while the outputs of the nodes are discarded are still being discarded, the producer tasks for the transform inputs are now executed prior to the consuming tasks, and prior to the no-op node that represents the transform execution.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
