### PR TITLE
Fix failed historical performance test

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -100,13 +100,18 @@ abstract class FileContentGenerator {
             if (!isRoot) {
                 return null
             }
-            if (config.subProjects == 0) {
-                return ""
-            }
-            """ 
-            ${(0..config.subProjects - 1).collect { "include(\"project$it\")" }.join("\n")}
 
+            String includedProjects = ""
+            if (config.subProjects != 0) {
+                includedProjects = """ 
+                    ${(0..config.subProjects - 1).collect { "include(\"project$it\")" }.join("\n")}
+                """
+            }
+
+            return includedProjects + """
+            if(org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version('4.6')) {
             ${config.featurePreviews.collect { "enableFeaturePreview(\"$it\")" }.join("\n")}
+            }
             """
         }
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -109,7 +109,7 @@ abstract class FileContentGenerator {
             }
 
             return includedProjects + """
-            if(org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version('4.6')) {
+            if(org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("4.6")) {
             ${config.featurePreviews.collect { "enableFeaturePreview(\"$it\")" }.join("\n")}
             }
             """

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -24,7 +24,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionGradleIntern
     private final static TEST_PROJECT_NAME = 'excludeRuleMergingBuild'
 
     def setup() {
-        runner.minimumVersion = '4.0'
+        runner.minimumVersion = '4.9'
         runner.targetVersions = ["5.7-20190722220035+0000"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
@@ -36,6 +36,9 @@ class JavaABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPer
         runner.tasksToRun = ['assemble']
         runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
         runner.targetVersions = ["5.7-20190722220035+0000"]
+        if (testProject.name().contains("GROOVY")) {
+            runner.minimumVersion = '5.0'
+        }
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
@@ -35,6 +35,10 @@ class JavaNonABIChangePerformanceTest extends AbstractCrossVersionGradleInternal
         runner.tasksToRun = ['assemble']
         runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
         runner.targetVersions = ["5.7-20190722220035+0000"]
+        if (testProject.name().contains("GROOVY")) {
+            runner.minimumVersion = '5.0'
+        }
+
 
         when:
         def result = runner.run()


### PR DESCRIPTION
### Context

There're 4 failed historical performance tests: https://builds.gradle.org/viewLog.html?buildId=25494062&buildTypeId=Gradle_Check_PerformanceHistoricalCoordinator&tab=report_project947_Performance&branch_Gradle_Check_Stage_HistoricalPerformance=master

Two of them are because previously `enableFeaturePreview` was not correctly configured for old Gradle build. This PR fixes them with Gradle version check.

Two of them are because of [this change](https://github.com/gradle/performance-comparisons/commit/c640ae2e31e8c8657e6654791ff02ba26ac95304) using a Gradle 4.6+ API.