### PR TITLE
Subgraph constraints improvements

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
@@ -84,6 +84,14 @@ public interface MutableVersionConstraint extends VersionConstraint {
     void forSubgraph();
 
     /**
+     * Reset the {@link #forSubgraph()} state of this version constraint.
+     *
+     * @since 5.7
+     */
+    @Incubating
+    void notForSubgraph();
+
+    /**
      * Sets the version as strict.
      * <p>
      * Any version not matched by this version notation will be excluded. This is the strongest version declaration.

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsFeatureInteractionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsFeatureInteractionIntegrationTest.groovy
@@ -75,8 +75,8 @@ class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends Abstra
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:bar:1.0') {
-                    module('org:baz:1.0').byRequest()
-                    module('org:foo:1.0') {
+                    edge('org:baz:{require 1.0; subgraph}', 'org:baz:1.0').byRequest()
+                    edge('org:foo:{require 1.0; subgraph}', 'org:foo:1.0') {
                         edge('org:baz:2.0', 'org:baz:1.0').byAncestor()
                     }
                 }
@@ -186,7 +186,7 @@ class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:1.0').byConstraint()
+                constraint('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byConstraint()
                 module('org:bar:1.0') {
                     edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
                 }
@@ -232,7 +232,7 @@ class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:bar:1.0', 'org:bar:2.0').byConstraint()
+                constraint('org:bar:{require 1.0; subgraph}', 'org:bar:2.0').byConstraint()
                 project(':foo', 'test:foo:') {
                     configuration = 'conf'
                     module('org:bar:2.0').byRequest().forced()
@@ -280,7 +280,7 @@ class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:bar:1.0', 'org:bar:2.0').byConstraint()
+                constraint('org:bar:{require 1.0; subgraph}', 'org:bar:2.0').byConstraint()
                 project(':foo', 'test:foo:') {
                     configuration = 'conf'
                     module('org:bar:2.0').byRequest().forced()
@@ -328,7 +328,7 @@ class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                module('org:foo:1.0').byRequest()
+                edge('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byRequest()
                 module('org:bar:1.0') {
                     edge('org:old:2.0', 'org:foo:1.0').selectedByRule("better foo than old").byAncestor()
                 }
@@ -378,7 +378,7 @@ class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:1.0', 'org:foo:0.11').byConstraint()
+                constraint('org:foo:{require 1.0; subgraph}', 'org:foo:0.11').byConstraint()
                 module('org:bar:1.0') {
                     edge('org:foo:2.0', 'org:foo:0.11').byRequest().selectedByRule('because I can')
                 }
@@ -431,7 +431,7 @@ class SubgraphVersionConstraintsFeatureInteractionIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org:foo:1.0', 'org:new:1.0').byRequest().selectedByRule()
+                edge('org:foo:{require 1.0; subgraph}', 'org:new:1.0').byRequest().selectedByRule()
                 module('org:bar:1.0') {
                     module('org:foo:2.0')
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/SubgraphVersionConstraintsIntegrationTest.groovy
@@ -61,7 +61,7 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                module('org:foo:1.0').byRequest()
+                edge('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byRequest()
                 module('org:bar:1.0') {
                     edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
                 }
@@ -106,7 +106,7 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:1.0').byConstraint()
+                constraint('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byConstraint()
                 module('org:bar:1.0') {
                     edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
                 }
@@ -165,10 +165,10 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
                         edge('org:c:3.0', 'org:c:1.0').byAncestor()
                     }
                     if (publishedConstraintsSupported) {
-                        constraint('org:c:2.0', 'org:c:1.0')
+                        constraint('org:c:{require 2.0; subgraph}', 'org:c:1.0')
                     }
                 }
-                constraint('org:c:1.0').byConstraint()
+                constraint('org:c:{require 1.0; subgraph}', 'org:c:1.0').byConstraint()
             }
         }
     }
@@ -223,10 +223,10 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
                         edge('org:c:2.0', 'org:c:1.0').byAncestor()
                     }
                     if (publishedConstraintsSupported) {
-                        constraint('org:c:1.0')
+                        constraint('org:c:{require 1.0; subgraph}', 'org:c:1.0')
                     }
                 }
-                constraint('org:c:1.0').byConstraint()
+                constraint('org:c:{require 1.0; subgraph}', 'org:c:1.0').byConstraint()
             }
         }
     }
@@ -278,11 +278,14 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
                     module('org:b:1.0') {
                         module('org:c:2.0')
                     }
-                    edge('org:c:1.0', 'org:c:2.0').byConflictResolution("between versions 2.0 and 1.0").with {
-                        if (subgraphConstraintsSupported) { it.byAncestor() }
+                    if (subgraphConstraintsSupported) {
+                        edge('org:c:{require 1.0; subgraph}', 'org:c:2.0').byAncestor()
+                    } else {
+                        edge('org:c:1.0', 'org:c:2.0')
                     }
+
                 }
-                module('org:c:2.0').byRequest()
+                module('org:c:2.0').byRequest().byConflictResolution("between versions 2.0 and 1.0")
             }
         }
     }
@@ -337,10 +340,12 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
             root(':', ':test:') {
                 module('org:a:1.0') {
                     module('org:b:1.0') {
-                        edge('org:c:2.0', cResult)
+                        edge('org:c:2.0', cResult).byRequest()
                     }
-                    edge('org:c:1.0', cResult).byRequest().with {
-                        if (cResult == 'org:c:1.0') { it.byAncestor() } else { it.byConflictResolution("between versions 2.0 and 1.0") }
+                    if (cResult == 'org:c:1.0') {
+                        edge('org:c:{require 1.0; subgraph}', cResult).byAncestor()
+                    } else {
+                        edge('org:c:1.0', cResult).byConflictResolution("between versions 2.0 and 1.0")
                     }
                 }
             }
@@ -469,7 +474,7 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:1.0').byConstraint()
+                constraint('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byConstraint()
                 module('org:bar:1.0') {
                     edge("org:foo:$publishedFooDependencyVersion", 'org:foo:1.0').byAncestor()
                 }
@@ -515,7 +520,7 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:1.0').byConstraint()
+                constraint('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byConstraint()
                 module('org:bar:1.0') {
                     edge("org:foo:[2.0,3.0)", 'org:foo:1.0').byAncestor()
                 }
@@ -562,7 +567,7 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:1.0', 'project :foo', 'org:foo:1.0').byConstraint()
+                constraint('org:foo:{require 1.0; subgraph}', 'project :foo', 'org:foo:1.0').byConstraint()
                 module('org:bar:1.0') {
                     edge('org:foo:2.0', 'project :foo', 'org:foo:1.0') {}.byAncestor()
                 }
@@ -656,7 +661,7 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
                     module('org:bar:1.0') {
                         module('org:foo:2.0').byRequest()
                     }
-                    constraint('org:foo:1.0', 'org:foo:2.0').byConstraint().byConflictResolution("between versions 2.0 and 1.0")
+                    constraint('org:foo:{require 1.0; subgraph}', 'org:foo:2.0').byConstraint().byConflictResolution("between versions 2.0 and 1.0")
                 }
                 module('org:x2:1.0') {
                     module('org:bar:1.0')
@@ -723,12 +728,12 @@ class SubgraphVersionConstraintsIntegrationTest extends AbstractModuleDependency
                     module('org:bar:1.0') {
                         edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
                     }
-                    constraint('org:foo:1.0').byConstraint()
+                    constraint('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byConstraint()
                 }
                 module('org:x2:1.0') {
                     module('org:bar:1.0')
                 }
-                constraint('org:foo:1.0').byConstraint()
+                constraint('org:foo:{require 1.0; subgraph}', 'org:foo:1.0').byConstraint()
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -102,7 +102,8 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
         return (getPreferredVersion().isEmpty() || getRequiredVersion().equals(getPreferredVersion()))
                 && getStrictVersion().isEmpty()
                 && getRejectedVersions().isEmpty()
-                && getBranch() == null;
+                && getBranch() == null
+                && !isForSubgraph();
     }
 
     private String rejectedVersionsString() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -110,6 +110,11 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     }
 
     @Override
+    public void notForSubgraph() {
+        forSubgraph = false;
+    }
+
+    @Override
     public String getStrictVersion() {
         return strictVersion;
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -190,7 +190,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.getRejectedVersions() == ['+']
     }
 
-    def "calling forSubgraph modifies only the isForSubgraph detail"() {
+    def "calling forSubgraph or notForSubgraph modifies only the isForSubgraph detail"() {
         when:
         def version = new DefaultMutableVersionConstraint('1.0')
         version.reject('1.0.1', '1.0.2')
@@ -202,6 +202,16 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.strictVersion == ''
         version.rejectedVersions == ['1.0.1', '1.0.2']
         version.forSubgraph
+
+        when:
+        version.notForSubgraph()
+
+        then:
+        version.requiredVersion == '1.0'
+        version.preferredVersion == ''
+        version.strictVersion == ''
+        version.rejectedVersions == ['1.0.1', '1.0.2']
+        !version.forSubgraph
     }
 
 }


### PR DESCRIPTION
Follow up work for #10097.

- [x] fix ancestor collection
- [x] clarify and fix substitution behavior (substitute first, then collect)
- [x] Always print `subgraph` property if `true` in `VersionConstraint.toString()`
(currently only done when constraint is "rich")
- [x] Add a `VersionConstraint.notForSubgraph()` to be used in component metadata rules.