### PR TITLE
Add inherit dependency version constraints feature

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
@@ -28,4 +28,29 @@ import org.gradle.api.Incubating;
 @Incubating
 public interface DirectDependencyMetadata extends DependencyMetadata<DirectDependencyMetadata> {
 
+    /**
+     * Inherit version constraints with {@link VersionConstraint#isForSubgraph()} from the target module.
+     * For this, the version constraint of this dependency needs to strictly point at one version.
+     *
+     * @since 5.7
+     */
+    @Incubating
+    void inheritConstraints();
+
+    /**
+     * Resets the {@link #isInheriting()} state of this dependency.
+     *
+     * @since 5.7
+     */
+    @Incubating
+    void notInheritConstraints();
+
+    /**
+     * Are the {@link VersionConstraint#isForSubgraph()} dependency constraints of the target module inherited?
+     *
+     * @since 5.7
+     */
+    @Incubating
+    boolean isInheriting();
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -202,4 +202,21 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      */
     @Incubating
     List<Capability> getRequestedCapabilities();
+
+    /**
+     * Inherit version constraints with {@link VersionConstraint#isForSubgraph()} from the target module.
+     * For this, the version constraint of this dependency needs to strictly point at one version.
+     *
+     * @since 5.7
+     */
+    @Incubating
+    void inheritConstraints();
+
+    /**
+     * Are the {@link VersionConstraint#isForSubgraph()} dependency constraints of the target module inherited?
+     *
+     * @since 5.7
+     */
+    @Incubating
+    boolean isInheriting();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -213,6 +213,14 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
     void inheritConstraints();
 
     /**
+     * Resets the {@link #isInheriting()} state of this dependency.
+     *
+     * @since 5.7
+     */
+    @Incubating
+    void notInheritConstraints();
+
+    /**
      * Are the {@link VersionConstraint#isForSubgraph()} dependency constraints of the target module inherited?
      *
      * @since 5.7

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -56,6 +56,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     @Nullable
     private String configuration;
     private boolean transitive = true;
+    private boolean inheriting;
 
     protected AbstractModuleDependency(@Nullable String configuration) {
         this.configuration = configuration;
@@ -225,6 +226,21 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
             return Collections.emptyList();
         }
         return moduleDependencyCapabilities.getRequestedCapabilities();
+    }
+
+    @Override
+    public void inheritConstraints() {
+        this.inheriting = true;
+    }
+
+    @Override
+    public void notInheritConstraints() {
+        this.inheriting = false;
+    }
+
+    @Override
+    public boolean isInheriting() {
+        return this.inheriting;
     }
 
     private void warnAboutInternalApiUse(String thing) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -41,6 +41,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     private final ProjectInternal dependencyProject;
     private final boolean buildProjectDependencies;
     private final ProjectAccessListener projectAccessListener;
+    private boolean inheriting;
 
     public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
         this(dependencyProject, null, projectAccessListener, buildProjectDependencies);
@@ -91,6 +92,16 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
             getTargetConfiguration(), projectAccessListener, buildProjectDependencies);
         copyTo(copiedProjectDependency);
         return copiedProjectDependency;
+    }
+
+    @Override
+    public void inheritConstraints() {
+        this.inheriting = true;
+    }
+
+    @Override
+    public boolean isInheriting() {
+        return this.inheriting;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -41,7 +41,6 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     private final ProjectInternal dependencyProject;
     private final boolean buildProjectDependencies;
     private final ProjectAccessListener projectAccessListener;
-    private boolean inheriting;
 
     public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
         this(dependencyProject, null, projectAccessListener, buildProjectDependencies);
@@ -92,16 +91,6 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
             getTargetConfiguration(), projectAccessListener, buildProjectDependencies);
         copyTo(copiedProjectDependency);
         return copiedProjectDependency;
-    }
-
-    @Override
-    public void inheritConstraints() {
-        this.inheriting = true;
-    }
-
-    @Override
-    public boolean isInheriting() {
-        return this.inheriting;
     }
 
     @Override

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -274,7 +274,7 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             }
         }
         if (platformType == ENFORCED_PLATFORM) {
-            // issue with enforced platform: consumer can not override platform decision
+            // issue with enforced platform: the forced version is always used and the conflict is 'hidden'
             succeeds ':checkDeps'
         } else {
             fails ':checkDeps'
@@ -292,7 +292,8 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
 
     @Unroll
     void "(4) library developer has issues with org:foo:3.1.1 and forces an override of the platform decision with forSubgraph [#platformType]"() {
-        // issue with enforced platform: consumer can not override platform decision
+        // issue with enforced platform: consumer can not override platform decision via constraint
+        //                               (an override via an own forced dependency is possible)
         def expectedFooVersion = platformType == ENFORCED_PLATFORM ? '3.1.1' : '3.2'
 
         updatedRepository(platformType)
@@ -405,7 +406,7 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             }
         }
         if (platformType == ENFORCED_PLATFORM) {
-            // issue with enforced platform: consumer can not override platform decision
+            // issue with enforced platform: the forced version is always used and the conflict is 'hidden'
             succeeds ':checkDeps'
         } else {
             fails ':checkDeps'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve.forsubgraph
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+import org.gradle.test.fixtures.file.TestFile
+
+@RequiredFeatures([
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
+)
+class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        resolve.withStrictReasonsCheck()
+    }
+
+    private TestFile singleLibraryBuildFile() {
+        buildFile << """
+            dependencies {
+                conf('org:platform:1.+') {
+                    inheritConstraints()
+                }
+                conf('org:bar')
+            }
+        """
+    }
+
+    private void initialRepository() {
+        repository {
+            'org:platform:1.0'() {
+                constraint(group: 'org', artifact: 'bar', version: '2.0', forSubgraph: true)
+                constraint(group: 'org', artifact: 'foo', version: '3.0', rejects: ['3.1', '3.2'], forSubgraph: true)
+            }
+            'org:foo' {
+                '3.0'()
+                '3.1'() // bad version
+                '3.2'() // bad version
+            }
+            'org:bar:2.0'() {
+                dependsOn 'org:foo:3.1'
+            }
+        }
+    }
+
+    private void updatedRepository() {
+        initialRepository()
+        repository {
+            'org:platform:1.1'() {
+                constraint(group: 'org', artifact: 'bar', version: '2.0', forSubgraph: true)
+                constraint(group: 'org', artifact: 'foo', version: '3.1.1', rejects: ['3.1', '3.2'], forSubgraph: true)
+            }
+            'org:foo' {
+                '3.1.1'()
+            }
+        }
+    }
+
+    void "(1) all future releases of org:foo:3.0 are bad and the platform enforces 3.0"() {
+        initialRepository()
+        singleLibraryBuildFile()
+
+        when:
+        repositoryInteractions {
+            'org:platform' {
+                expectVersionListing()
+            }
+            'org:platform:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:foo:3.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:platform:1.+', 'org:platform:1.0') {
+                    constraint('org:bar:{require 2.0; subgraph}', 'org:bar:2.0').byConstraint()
+                    constraint('org:foo:{require 3.0; reject 3.1 & 3.2; subgraph}', 'org:foo:3.0').byConstraint()
+                }
+                edge('org:bar', 'org:bar:2.0') {
+                    edge('org:foo:3.1', 'org:foo:3.0').byAncestor()
+                }.byRequest()
+            }
+        }
+    }
+
+    void "(2) org:foo:3.1.1 and platform upgrade 1.1 are release"() {
+        updatedRepository()
+        singleLibraryBuildFile()
+
+        when:
+        repositoryInteractions {
+            'org:platform' {
+                expectVersionListing()
+            }
+            'org:platform:1.1' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:foo:3.1.1' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:platform:1.+', 'org:platform:1.1') {
+                    constraint('org:bar:{require 2.0; subgraph}', 'org:bar:2.0').byConstraint()
+                    constraint('org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}', 'org:foo:3.1.1').byConstraint()
+                }
+                edge('org:bar', 'org:bar:2.0') {
+                    edge('org:foo:3.1', 'org:foo:3.1.1').byAncestor()
+                }.byRequest()
+            }
+        }
+    }
+
+    void "(3) library developer has issues with org:foo:3.1.1 and overrides platform decision with 3.2 which fails due to reject"() {
+        updatedRepository()
+        singleLibraryBuildFile()
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf('org:foo:3.2')
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:platform' {
+                expectVersionListing()
+            }
+            'org:platform:1.1' {
+                expectGetMetadata()
+            }
+            'org:bar:2.0' {
+                expectGetMetadata()
+            }
+            'org:foo:3.1.1' {
+                expectGetMetadata()
+            }
+            'org:foo:3.2' {
+                expectGetMetadata()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
+   Dependency path ':test:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
+   Constraint path ':test:unspecified' --> 'org:platform:1.1' --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}'
+   Constraint path ':test:unspecified' --> 'org:foo:3.2'"""
+    }
+
+    void "(4) library developer has issues with org:foo:3.1.1 and forces an override of the platform decision with forSubgraph"() {
+        updatedRepository()
+        singleLibraryBuildFile()
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf('org:foo:3.2') { 
+                        version { forSubgraph() }
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:platform' {
+                expectVersionListing()
+                expectGetArtifact()
+            }
+            'org:platform:1.1' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:2.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:foo:3.2' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                constraint('org:foo:{require 3.2; subgraph}', 'org:foo:3.2').byConstraint()
+                edge('org:platform:1.+', 'org:platform:1.1') {
+                    constraint('org:bar:{require 2.0; subgraph}', 'org:bar:2.0').byConstraint()
+                    constraint('org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}', 'org:foo:3.2')
+                }
+                edge('org:bar', 'org:bar:2.0') {
+                    edge('org:foo:3.1', 'org:foo:3.2').byAncestor()
+                }.byRequest()
+            }
+        }
+    }
+
+    void "(5) if two libraries are combined without agreeing on an override, the original platform constraint is brought back"() {
+        updatedRepository()
+        settingsFile << "\ninclude 'recklessLibrary', 'secondLibrary'"
+        buildFile << """
+            project(':recklessLibrary') {
+                configurations { conf }
+                dependencies {
+                    conf('org:platform:1.+') {
+                        inheritConstraints()
+                    }
+                    conf('org:bar')
+                    constraints {
+                        conf('org:foo:3.2') { 
+                            version { forSubgraph() } // ignoring platform's reject
+                        }
+                    }
+                }
+            }
+            project(':secondLibrary') {
+                configurations { conf }
+                dependencies {
+                    conf('org:platform:1.+') {
+                        inheritConstraints()
+                    }
+                    conf('org:bar')
+                }
+            }
+            dependencies {
+                conf(project(path: ':recklessLibrary', configuration: 'conf'))
+                conf(project(path: ':secondLibrary', configuration: 'conf'))
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:platform' {
+                expectVersionListing()
+            }
+            'org:platform:1.1' {
+                expectGetMetadata()
+            }
+            'org:bar:2.0' {
+                expectGetMetadata()
+            }
+            'org:foo:3.1.1' {
+                expectGetMetadata()
+            }
+            'org:foo:3.2' {
+                expectGetMetadata()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
+   Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
+   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:platform:1.1' --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}'
+   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:foo:{require 3.2; subgraph}'"""
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -19,33 +19,65 @@ import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
-import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Ignore
+import spock.lang.Unroll
+
+import static org.gradle.integtests.resolve.forsubgraph.InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.PlatformType.MODULE
+import static org.gradle.integtests.resolve.forsubgraph.InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.PlatformType.PLATFORM
+import static org.gradle.integtests.resolve.forsubgraph.InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.PlatformType.LEGACY_PLATFORM
+import static org.gradle.integtests.resolve.forsubgraph.InheritConstraintsInPlatformCentricDevelopmentIntegrationTest.PlatformType.ENFORCED_PLATFORM
 
 @RequiredFeatures([
     @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
 )
 class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends AbstractModuleDependencyResolveTest {
 
+    enum PlatformType {
+        // The recommended way of doing platforms
+        PLATFORM,          // constraints in platform are published with 'forSubgraph', consumer uses 'platform()' dependencies
+        // The recommended way of dealing with existing platforms
+        LEGACY_PLATFORM,   // constraints in platform are published without 'forSubgraph', consumer uses 'platform()' dependencies + component metadata rules to add 'forSubgraph' to published constraints
+        // The discouraged way of dealing with existing platforms
+        ENFORCED_PLATFORM, // constraints in platform are published without 'forSubgraph', consumer uses 'enforcedPlatform()' dependencies (to be deprecated)
+        // Using a normal module as "platform" (i.e. inheriting it's constraints) also works
+        MODULE             // constraints in module are published with 'forSubgraph', consumer uses normal dependencies with 'inheritConstraints()'
+    }
+
     def setup() {
         resolve.withStrictReasonsCheck()
     }
 
-    private TestFile singleLibraryBuildFile() {
+    String platformDependency(platformType, String dependency) {
+        switch (platformType) {
+            case PLATFORM:
+            case LEGACY_PLATFORM:
+                return "conf(platform('$dependency'))"
+            case ENFORCED_PLATFORM:
+                return "conf(enforcedPlatform('$dependency'))"
+            case MODULE:
+                return "conf('$dependency') { inheritConstraints() }"
+        }
+        ""
+    }
+
+    private singleLibraryBuildFile(platformType) {
         buildFile << """
             dependencies {
-                conf('org:platform:1.+') {
-                    inheritConstraints()
-                }
+                ${platformDependency(platformType, 'org:platform:1.+')}
                 conf('org:bar')
             }
         """
     }
 
-    private void initialRepository() {
+    private void initialRepository(platformType) {
         repository {
             'org:platform:1.0'() {
-                constraint(group: 'org', artifact: 'bar', version: '2.0', forSubgraph: true)
-                constraint(group: 'org', artifact: 'foo', version: '3.0', rejects: ['3.1', '3.2'], forSubgraph: true)
+                variant('apiElements') {
+                    attributes = ['org.gradle.category': 'platform']
+                    noArtifacts = true
+                }
+                constraint(group: 'org', artifact: 'bar', version: '2.0', forSubgraph: platformType in [PLATFORM, MODULE])
+                constraint(group: 'org', artifact: 'foo', version: '3.0', rejects: ['3.1', '3.2'], forSubgraph: platformType in [PLATFORM, MODULE])
             }
             'org:foo' {
                 '3.0'()
@@ -56,14 +88,32 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
                 dependsOn 'org:foo:3.1'
             }
         }
+        if (platformType == LEGACY_PLATFORM) {
+            // we use component metadata rules to get behavior similar to 'enforcedPlatform()' for 'platform()'
+            buildFile << """
+                dependencies {
+                    components.withModule('org:platform') { ComponentMetadataDetails details ->
+                        details.withVariant('apiElements') {
+                            withDependencyConstraints {
+                                it.each { it.version { forSubgraph() } }
+                            }
+                        }
+                    }
+                }
+            """
+        }
     }
 
-    private void updatedRepository() {
-        initialRepository()
+    private void updatedRepository(platformType) {
+        initialRepository(platformType)
         repository {
             'org:platform:1.1'() {
-                constraint(group: 'org', artifact: 'bar', version: '2.0', forSubgraph: true)
-                constraint(group: 'org', artifact: 'foo', version: '3.1.1', rejects: ['3.1', '3.2'], forSubgraph: true)
+                variant('apiElements') {
+                    attributes = ['org.gradle.category': 'platform']
+                    noArtifacts = true
+                }
+                constraint(group: 'org', artifact: 'bar', version: '2.0', forSubgraph:  platformType in [PLATFORM, MODULE])
+                constraint(group: 'org', artifact: 'foo', version: '3.1.1', rejects: ['3.1', '3.2'], forSubgraph:  platformType in [PLATFORM, MODULE])
             }
             'org:foo' {
                 '3.1.1'()
@@ -71,9 +121,24 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
         }
     }
 
-    void "(1) all future releases of org:foo:3.0 are bad and the platform enforces 3.0"() {
-        initialRepository()
-        singleLibraryBuildFile()
+    static private String expectSubgraphVersion(platformType, String requiredVersion, String rejectedVersions = '') {
+        String subgraph = platformType == ENFORCED_PLATFORM ? '' : 'subgraph'
+        if (!subgraph.isEmpty() && rejectedVersions.isEmpty()) {
+            return "{require $requiredVersion; $subgraph}"
+        }
+        if (subgraph.isEmpty() && !rejectedVersions.isEmpty()) {
+            return "{require $requiredVersion; reject $rejectedVersions}"
+        }
+        if (!subgraph.isEmpty() && !rejectedVersions.isEmpty()) {
+            return "{require $requiredVersion; reject $rejectedVersions; $subgraph}"
+        }
+        requiredVersion
+    }
+
+    @Unroll
+    void "(1) all future releases of org:foo:3.0 are bad and the platform enforces 3.0 [#platformType]"() {
+        initialRepository(platformType)
+        singleLibraryBuildFile(platformType)
 
         when:
         repositoryInteractions {
@@ -82,7 +147,7 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             }
             'org:platform:1.0' {
                 expectGetMetadata()
-                expectGetArtifact()
+                if (platformType == MODULE) { expectGetArtifact() }
             }
             'org:bar:2.0' {
                 expectGetMetadata()
@@ -99,19 +164,34 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
         resolve.expectGraph {
             root(':', ':test:') {
                 edge('org:platform:1.+', 'org:platform:1.0') {
-                    constraint('org:bar:{require 2.0; subgraph}', 'org:bar:2.0').byConstraint()
-                    constraint('org:foo:{require 3.0; reject 3.1 & 3.2; subgraph}', 'org:foo:3.0').byConstraint()
+                    byRequest()
+                    if (platformType != MODULE) {
+                        configuration(platformType == ENFORCED_PLATFORM ? 'enforcedApiElements' : 'apiElements')
+                        noArtifacts()
+                    }
+                    constraint("org:bar:${expectSubgraphVersion(platformType, '2.0')}", 'org:bar:2.0').byConstraint()
+                    constraint("org:foo:${expectSubgraphVersion(platformType, '3.0', '3.1 & 3.2')}", 'org:foo:3.0').byConstraint()
                 }
                 edge('org:bar', 'org:bar:2.0') {
-                    edge('org:foo:3.1', 'org:foo:3.0').byAncestor()
-                }.byRequest()
+                    byRequest()
+                    edge('org:foo:3.1', 'org:foo:3.0') {
+                        if (platformType != ENFORCED_PLATFORM) { byAncestor() } else { byRequest() }
+                    }
+                }
+            }
+            if (platformType == ENFORCED_PLATFORM) {
+                nodesWithoutRoot.each { it.forced() }
             }
         }
+
+        where:
+        platformType << PlatformType.values()
     }
 
-    void "(2) org:foo:3.1.1 and platform upgrade 1.1 are release"() {
-        updatedRepository()
-        singleLibraryBuildFile()
+    @Unroll
+    void "(2) org:foo:3.1.1 and platform upgrade 1.1 are release [#platformType]"() {
+        updatedRepository(platformType)
+        singleLibraryBuildFile(platformType)
 
         when:
         repositoryInteractions {
@@ -120,7 +200,7 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             }
             'org:platform:1.1' {
                 expectGetMetadata()
-                expectGetArtifact()
+                if (platformType == MODULE) { expectGetArtifact() }
             }
             'org:bar:2.0' {
                 expectGetMetadata()
@@ -137,19 +217,34 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
         resolve.expectGraph {
             root(':', ':test:') {
                 edge('org:platform:1.+', 'org:platform:1.1') {
-                    constraint('org:bar:{require 2.0; subgraph}', 'org:bar:2.0').byConstraint()
-                    constraint('org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}', 'org:foo:3.1.1').byConstraint()
+                    byRequest()
+                    if (platformType != MODULE) {
+                        configuration(platformType == ENFORCED_PLATFORM ? 'enforcedApiElements' : 'apiElements')
+                        noArtifacts()
+                    }
+                    constraint("org:bar:${expectSubgraphVersion(platformType, '2.0')}", 'org:bar:2.0').byConstraint()
+                    constraint("org:foo:${expectSubgraphVersion(platformType, '3.1.1', '3.1 & 3.2')}", 'org:foo:3.1.1').byConstraint()
                 }
                 edge('org:bar', 'org:bar:2.0') {
-                    edge('org:foo:3.1', 'org:foo:3.1.1').byAncestor()
-                }.byRequest()
+                    byRequest()
+                    edge('org:foo:3.1', 'org:foo:3.1.1') {
+                        if (platformType != ENFORCED_PLATFORM) { byAncestor() } else { byRequest() }
+                    }
+                }
+            }
+            if (platformType == ENFORCED_PLATFORM) {
+                nodesWithoutRoot.each { it.forced() }
             }
         }
+
+        where:
+        platformType << PlatformType.values()
     }
 
-    void "(3) library developer has issues with org:foo:3.1.1 and overrides platform decision with 3.2 which fails due to reject"() {
-        updatedRepository()
-        singleLibraryBuildFile()
+    @Unroll
+    void "(3) library developer has issues with org:foo:3.1.1 and overrides platform decision with 3.2 which fails due to reject [#platformType]"() {
+        updatedRepository(platformType)
+        singleLibraryBuildFile(platformType)
         buildFile << """
             dependencies {
                 constraints {
@@ -168,30 +263,44 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             }
             'org:bar:2.0' {
                 expectGetMetadata()
+                if (platformType == ENFORCED_PLATFORM) { expectGetArtifact() }
             }
             'org:foo:3.1.1' {
                 expectGetMetadata()
+                if (platformType == ENFORCED_PLATFORM) { expectGetArtifact() }
             }
             'org:foo:3.2' {
-                expectGetMetadata()
+                if (platformType != ENFORCED_PLATFORM) { expectGetMetadata() }
             }
         }
-        fails ':checkDeps'
-
+        if (platformType == ENFORCED_PLATFORM) {
+            // issue with enforced platform: consumer can not override platform decision
+            succeeds ':checkDeps'
+        } else {
+            fails ':checkDeps'
+        }
         then:
-        failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
+        (platformType == ENFORCED_PLATFORM && !failure) || failure.assertHasCause(
+            """Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
    Constraint path ':test:unspecified' --> 'org:platform:1.1' --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}'
-   Constraint path ':test:unspecified' --> 'org:foo:3.2'"""
+   Constraint path ':test:unspecified' --> 'org:foo:3.2'""")
+
+        where:
+        platformType << PlatformType.values()
     }
 
-    void "(4) library developer has issues with org:foo:3.1.1 and forces an override of the platform decision with forSubgraph"() {
-        updatedRepository()
-        singleLibraryBuildFile()
+    @Unroll
+    void "(4) library developer has issues with org:foo:3.1.1 and forces an override of the platform decision with forSubgraph [#platformType]"() {
+        // issue with enforced platform: consumer can not override platform decision
+        def expectedFooVersion = platformType == ENFORCED_PLATFORM ? '3.1.1' : '3.2'
+
+        updatedRepository(platformType)
+        singleLibraryBuildFile(platformType)
         buildFile << """
             dependencies {
                 constraints {
-                    conf('org:foo:3.2') { 
+                    conf('org:foo:3.2') {
                         version { forSubgraph() }
                     }
                 }
@@ -206,13 +315,13 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             }
             'org:platform:1.1' {
                 expectGetMetadata()
-                expectGetArtifact()
+                if (platformType == MODULE) { expectGetArtifact() }
             }
             'org:bar:2.0' {
                 expectGetMetadata()
                 expectGetArtifact()
             }
-            'org:foo:3.2' {
+            "org:foo:$expectedFooVersion" {
                 expectGetMetadata()
                 expectGetArtifact()
             }
@@ -222,31 +331,41 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:{require 3.2; subgraph}', 'org:foo:3.2').byConstraint()
+                constraint('org:foo:{require 3.2; subgraph}', "org:foo:$expectedFooVersion").byConstraint()
                 edge('org:platform:1.+', 'org:platform:1.1') {
-                    constraint('org:bar:{require 2.0; subgraph}', 'org:bar:2.0').byConstraint()
-                    constraint('org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}', 'org:foo:3.2')
+                    byRequest()
+                    if (platformType != MODULE) {
+                        configuration(platformType == ENFORCED_PLATFORM ? 'enforcedApiElements' : 'apiElements')
+                        noArtifacts()
+                    }
+                    constraint("org:bar:${expectSubgraphVersion(platformType, '2.0')}", 'org:bar:2.0').byConstraint()
+                    constraint("org:foo:${expectSubgraphVersion(platformType, '3.1.1', '3.1 & 3.2')}", "org:foo:$expectedFooVersion").byConstraint()
                 }
                 edge('org:bar', 'org:bar:2.0') {
-                    edge('org:foo:3.1', 'org:foo:3.2').byAncestor()
+                    edge('org:foo:3.1', "org:foo:$expectedFooVersion").byAncestor()
                 }.byRequest()
             }
+            if (platformType == ENFORCED_PLATFORM) {
+                nodesWithoutRoot.each { it.forced() }
+            }
         }
+
+        where:
+        platformType << PlatformType.values()
     }
 
-    void "(5) if two libraries are combined without agreeing on an override, the original platform constraint is brought back"() {
-        updatedRepository()
+    @Unroll
+    void "(5) if two libraries are combined without agreeing on an override, the original platform constraint is brought back [#platformType]"() {
+        updatedRepository(platformType)
         settingsFile << "\ninclude 'recklessLibrary', 'secondLibrary'"
         buildFile << """
             project(':recklessLibrary') {
                 configurations { conf }
                 dependencies {
-                    conf('org:platform:1.+') {
-                        inheritConstraints()
-                    }
+                    ${platformDependency(platformType, 'org:platform:1.+')}
                     conf('org:bar')
                     constraints {
-                        conf('org:foo:3.2') { 
+                        conf('org:foo:3.2') {
                             version { forSubgraph() } // ignoring platform's reject
                         }
                     }
@@ -255,9 +374,7 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             project(':secondLibrary') {
                 configurations { conf }
                 dependencies {
-                    conf('org:platform:1.+') {
-                        inheritConstraints()
-                    }
+                    ${platformDependency(platformType, 'org:platform:1.+')}
                     conf('org:bar')
                 }
             }
@@ -277,20 +394,37 @@ class InheritConstraintsInPlatformCentricDevelopmentIntegrationTest extends Abst
             }
             'org:bar:2.0' {
                 expectGetMetadata()
+                if (platformType == ENFORCED_PLATFORM) { expectGetArtifact() }
             }
             'org:foo:3.1.1' {
                 expectGetMetadata()
+                if (platformType == ENFORCED_PLATFORM) { expectGetArtifact() }
             }
             'org:foo:3.2' {
-                expectGetMetadata()
+                if (platformType != ENFORCED_PLATFORM) { expectGetMetadata() }
             }
         }
-        fails ':checkDeps'
+        if (platformType == ENFORCED_PLATFORM) {
+            // issue with enforced platform: consumer can not override platform decision
+            succeeds ':checkDeps'
+        } else {
+            fails ':checkDeps'
+        }
 
         then:
-        failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
+        (platformType == ENFORCED_PLATFORM && !failure) || failure.assertHasCause(
+            """Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:bar:2.0' --> 'org:foo:3.1'
    Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:platform:1.1' --> 'org:foo:{require 3.1.1; reject 3.1 & 3.2; subgraph}'
-   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:foo:{require 3.2; subgraph}'"""
+   Constraint path ':test:unspecified' --> 'test:recklessLibrary:unspecified' --> 'org:foo:{require 3.2; subgraph}'""")
+
+        where:
+        platformType << PlatformType.values()
+    }
+
+    @Ignore // Having only Unroll tests breaks something in the combination with GradleMetadataResolveRunner
+    void "dummy"() {
+        expect:
+        true
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/forsubgraph/InheritConstraintsIntegrationTest.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve.forsubgraph
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+@RequiredFeatures([
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
+)
+class InheritConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        resolve.withStrictReasonsCheck()
+    }
+
+    void "can downgrade version through platform"() {
+        given:
+        repository {
+            'org:platform:1.0'() {
+                constraint(group: 'org', artifact: 'bar', version: '1.0')
+                constraint(group: 'org', artifact: 'foo', version: '1.0', forSubgraph: true)
+            }
+            'org:foo:1.0'()
+            'org:foo:2.0'()
+            'org:bar:1.0' {
+                dependsOn 'org:foo:2.0'
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:platform:1.0') {
+                    inheritConstraints()
+                }
+                conf('org:bar')
+            }           
+        """
+
+        when:
+        repositoryInteractions {
+            'org:platform:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:foo:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:platform:1.0') {
+                    constraint('org:bar:1.0').byConstraint()
+                    constraint('org:foo:1.0').byConstraint()
+                }
+                edge('org:bar', 'org:bar:1.0') {
+                    edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                }.byRequest()
+            }
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -25,11 +25,13 @@ import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ModuleVersionSelectorStrictSpec;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.ExactVersionSelector;
 
 public abstract class AbstractExternalModuleDependency extends AbstractModuleDependency implements ExternalModuleDependency {
     private final ModuleIdentifier moduleIdentifier;
     private boolean changing;
     private boolean force;
+    private boolean inheriting;
     private final DefaultMutableVersionConstraint versionConstraint;
 
     public AbstractExternalModuleDependency(ModuleIdentifier module, String version, String configuration) {
@@ -112,6 +114,22 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     @Override
     public ModuleIdentifier getModule() {
         return moduleIdentifier;
+    }
+
+    @Override
+    public void inheritConstraints() {
+        this.inheriting = true;
+    }
+
+    @Override
+    public boolean isInheriting() {
+        return this.inheriting;
+    }
+
+    private void assertExactVersion(String versionString) {
+        if (!ExactVersionSelector.isExact(versionString)) {
+            throw new InvalidUserDataException("Subgraph constraints inheritance is not supported for dynamic versions!");
+        }
     }
 
     static ModuleIdentifier assertModuleId(String group, String name) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -25,13 +25,11 @@ import org.gradle.api.artifacts.MutableVersionConstraint;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ModuleVersionSelectorStrictSpec;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.ExactVersionSelector;
 
 public abstract class AbstractExternalModuleDependency extends AbstractModuleDependency implements ExternalModuleDependency {
     private final ModuleIdentifier moduleIdentifier;
     private boolean changing;
     private boolean force;
-    private boolean inheriting;
     private final DefaultMutableVersionConstraint versionConstraint;
 
     public AbstractExternalModuleDependency(ModuleIdentifier module, String version, String configuration) {
@@ -114,22 +112,6 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     @Override
     public ModuleIdentifier getModule() {
         return moduleIdentifier;
-    }
-
-    @Override
-    public void inheritConstraints() {
-        this.inheriting = true;
-    }
-
-    @Override
-    public boolean isInheriting() {
-        return this.inheriting;
-    }
-
-    private void assertExactVersion(String versionString) {
-        if (!ExactVersionSelector.isExact(versionString)) {
-            throw new InvalidUserDataException("Subgraph constraints inheritance is not supported for dynamic versions!");
-        }
     }
 
     static ModuleIdentifier assertModuleId(String group, String name) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -240,8 +240,12 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     @Override
     public Dependency platform(Object notation) {
         Dependency dependency = create(notation);
-        if (dependency instanceof HasConfigurableAttributes) {
-            platformSupport.addPlatformAttribute((HasConfigurableAttributes<Object>) dependency, toCategory(Category.REGULAR_PLATFORM));
+        if (dependency instanceof ModuleDependency) {
+            ModuleDependency moduleDependency = (ModuleDependency) dependency;
+            moduleDependency.inheritConstraints();
+            platformSupport.addPlatformAttribute(moduleDependency, toCategory(Category.REGULAR_PLATFORM));
+        } else if (dependency instanceof HasConfigurableAttributes) {
+            platformSupport.addPlatformAttribute((HasConfigurableAttributes<?>) dependency, toCategory(Category.REGULAR_PLATFORM));
         }
         return dependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -54,7 +54,7 @@ public enum CacheLayout {
         .changedTo(68, "5.0-milestone-1")
         .changedTo(69, "5.0-rc-1")
         .changedTo(71, "5.3-rc-1")
-        .changedTo(72, "5.7-rc-1")
+        .changedTo(73, "5.7-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -219,7 +219,7 @@ public class GradleModuleMetadataParser {
             variant.addFile(file.name, file.uri);
         }
         for (ModuleDependency dependency : dependencies) {
-            variant.addDependency(dependency.group, dependency.module, dependency.versionConstraint, dependency.excludes, dependency.reason, dependency.attributes, dependency.requestedCapabilities);
+            variant.addDependency(dependency.group, dependency.module, dependency.versionConstraint, dependency.excludes, dependency.reason, dependency.attributes, dependency.requestedCapabilities, dependency.inheriting);
         }
         for (ModuleDependencyConstraint dependencyConstraint : dependencyConstraints) {
             variant.addDependencyConstraint(dependencyConstraint.group, dependencyConstraint.module, dependencyConstraint.versionConstraint, dependencyConstraint.reason, dependencyConstraint.attributes);
@@ -262,7 +262,7 @@ public class GradleModuleMetadataParser {
         assertDefined(reader, "version", version);
         reader.endObject();
 
-        return ImmutableList.of(new ModuleDependency(group, module, new DefaultImmutableVersionConstraint(version), ImmutableList.of(), null, ImmutableAttributes.EMPTY, Collections.emptyList()));
+        return ImmutableList.of(new ModuleDependency(group, module, new DefaultImmutableVersionConstraint(version), ImmutableList.of(), null, ImmutableAttributes.EMPTY, Collections.emptyList(), false));
     }
 
     private List<ModuleDependency> consumeDependencies(JsonReader reader) throws IOException {
@@ -276,6 +276,7 @@ public class GradleModuleMetadataParser {
             VersionConstraint version = DefaultImmutableVersionConstraint.of();
             ImmutableList<ExcludeMetadata> excludes = ImmutableList.of();
             List<VariantCapability> requestedCapabilities = ImmutableList.of();
+            boolean inheriting = false;
 
             reader.beginObject();
             while (reader.peek() != END_OBJECT) {
@@ -302,6 +303,9 @@ public class GradleModuleMetadataParser {
                     case "requestedCapabilities":
                         requestedCapabilities = consumeCapabilities(reader);
                         break;
+                    case "inheriting":
+                        inheriting = reader.nextBoolean();
+                        break;
                     default:
                         consumeAny(reader);
                         break;
@@ -311,7 +315,7 @@ public class GradleModuleMetadataParser {
             assertDefined(reader, "module", module);
             reader.endObject();
 
-            dependencies.add(new ModuleDependency(group, module, version, excludes, reason, attributes, requestedCapabilities));
+            dependencies.add(new ModuleDependency(group, module, version, excludes, reason, attributes, requestedCapabilities, inheriting));
         }
         reader.endArray();
         return dependencies;
@@ -550,8 +554,9 @@ public class GradleModuleMetadataParser {
         final String reason;
         final ImmutableAttributes attributes;
         final List<? extends Capability> requestedCapabilities;
+        final boolean inheriting;
 
-        ModuleDependency(String group, String module, VersionConstraint versionConstraint, ImmutableList<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities) {
+        ModuleDependency(String group, String module, VersionConstraint versionConstraint, ImmutableList<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities, boolean inheriting) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
@@ -559,6 +564,7 @@ public class GradleModuleMetadataParser {
             this.reason = reason;
             this.attributes = attributes;
             this.requestedCapabilities = requestedCapabilities;
+            this.inheriting = inheriting;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -303,7 +303,7 @@ public class GradleModuleMetadataParser {
                     case "requestedCapabilities":
                         requestedCapabilities = consumeCapabilities(reader);
                         break;
-                    case "inheriting":
+                    case "inheritConstraints":
                         inheriting = reader.nextBoolean();
                         break;
                     default:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -221,7 +221,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     }
 
     private ModuleDependencyMetadata toDependencyMetadata(ModuleComponentSelector selector) {
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), false, null, false);
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), false, false, null, false);
     }
 
     private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties) throws SAXException, IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/ExactVersionSelector.java
@@ -46,4 +46,7 @@ public class ExactVersionSelector extends AbstractStringVersionSelector {
         return version.isEmpty() || version.equals(candidate);
     }
 
+    public static boolean isExact(String selector) {
+        return selector != null && !VersionRangeSelector.ALL_RANGE.matcher(selector).matches() && !selector.endsWith("+") && !selector.startsWith("latest.");
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -151,6 +151,7 @@ public class ModuleMetadataSerializer {
                 componentSelectorSerializer.write(encoder, dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint(), dependency.getAttributes(), dependency.getRequestedCapabilities());
                 encoder.writeNullableString(dependency.getReason());
                 writeVariantDependencyExcludes(dependency.getExcludes());
+                encoder.writeBoolean(dependency.isInheriting());
             }
         }
 
@@ -458,7 +459,8 @@ public class ModuleMetadataSerializer {
                 ModuleComponentSelector selector = componentSelectorSerializer.read(decoder);
                 String reason = decoder.readNullableString();
                 ImmutableList<ExcludeMetadata> excludes = readVariantDependencyExcludes();
-                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason, (ImmutableAttributes) selector.getAttributes(), selector.getRequestedCapabilities());
+                boolean inheriting = decoder.readBoolean();
+                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason, (ImmutableAttributes) selector.getAttributes(), selector.getRequestedCapabilities(), inheriting);
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -53,7 +53,7 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
             DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of());
         return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
-                Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, dependencyConstraint.getReason());
+                Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, false, dependencyConstraint.getReason());
     }
 
     private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
@@ -54,7 +54,7 @@ public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDep
                 dependency.getAttributes(),
                 dependency.getTargetConfiguration(),
                 convertArtifacts(dependency.getArtifacts()),
-                excludes, force, changing, transitive, false, dependency.getReason());
+                excludes, force, changing, transitive, false, dependency.isInheriting(), dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
@@ -54,7 +54,7 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
             projectDependency.getTargetConfiguration(),
             convertArtifacts(dependency.getArtifacts()),
             excludes,
-            false, false, dependency.isTransitive(), false, dependency.getReason());
+            false, false, dependency.isTransitive(), false, dependency.isInheriting(), dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -95,6 +95,9 @@ public class DependencyGraphBuilder {
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
 
+    final static Spec<EdgeState> INHERITING_DEPENDENCY_SPEC = dependencyState -> dependencyState.getDependencyState().getDependency().isInheriting();
+    final static Spec<EdgeState> NOT_INHERITING_DEPENDENCY_SPEC = dependencyState -> !dependencyState.getDependencyState().getDependency().isInheriting();
+
     public DependencyGraphBuilder(DependencyToComponentIdResolver componentIdResolver,
                                   ComponentMetaDataResolver componentMetaDataResolver,
                                   ResolveContextToComponentResolver resolveContextToComponentResolver,
@@ -178,7 +181,8 @@ public class DependencyGraphBuilder {
                 // Initialize and collect any new outgoing edges of this node
                 dependencies.clear();
                 node.visitOutgoingDependencies(dependencies);
-                resolveEdges(node, dependencies, resolveState, componentIdentifierCache);
+                boolean edgeWasProcessed = resolveEdges(node, dependencies, INHERITING_DEPENDENCY_SPEC, false, resolveState, componentIdentifierCache);
+                resolveEdges(node, dependencies, NOT_INHERITING_DEPENDENCY_SPEC, edgeWasProcessed, resolveState, componentIdentifierCache);
             } else {
                 // We have some batched up conflicts. Resolve the first, and continue traversing the graph
                 if (moduleConflictHandler.hasConflicts()) {
@@ -230,21 +234,34 @@ public class DependencyGraphBuilder {
         });
     }
 
-    private void resolveEdges(final NodeState node,
+    private boolean resolveEdges(final NodeState node,
                               final List<EdgeState> dependencies,
+                              final Spec<EdgeState> dependencyFilter,
+                              final boolean recomputeSelectors,
                               final ResolveState resolveState,
                               final Map<ModuleVersionIdentifier, ComponentIdentifier> componentIdentifierCache) {
         if (dependencies.isEmpty()) {
-            return;
+            return false;
         }
-        performSelectionSerially(dependencies, resolveState);
-        maybeDownloadMetadataInParallel(node, componentIdentifierCache, dependencies);
-        attachToTargetRevisionsSerially(dependencies);
+        if (performSelectionSerially(dependencies, dependencyFilter, resolveState, recomputeSelectors)) {
+            maybeDownloadMetadataInParallel(node, componentIdentifierCache, dependencies, dependencyFilter);
+            attachToTargetRevisionsSerially(dependencies, dependencyFilter);
+            return true;
+        } else {
+            return false;
+        }
 
     }
 
-    private void performSelectionSerially(List<EdgeState> dependencies, ResolveState resolveState) {
+    private boolean performSelectionSerially(List<EdgeState> dependencies, Spec<EdgeState> dependencyFilter, ResolveState resolveState, boolean recomputeSelectors) {
+        boolean processed = false;
         for (EdgeState dependency : dependencies) {
+            if (!dependencyFilter.isSatisfiedBy(dependency)) {
+                continue;
+            }
+            if (recomputeSelectors) {
+                dependency.computeSelector();
+            }
             SelectorState selector = dependency.getSelector();
             ModuleResolveState module = selector.getTargetModule();
 
@@ -254,12 +271,14 @@ public class DependencyGraphBuilder {
             }
 
             module.addUnattachedDependency(dependency);
+            processed = true;
         }
+        return processed;
     }
 
     /**
      * Attempts to resolve a target `ComponentState` for the given dependency.
-     * On successful resolve, a `ComponentState` is constructed for the identifier, recorded as {@link ModuleResolveState#selected},
+     * On successful resolve, a `ComponentState` is constructed for the identifier, recorded as {@link ModuleResolveState#getSelected()},
      * and added to the graph.
      * On resolve failure, the failure is recorded and no `ComponentState` is selected.
      */
@@ -297,9 +316,12 @@ public class DependencyGraphBuilder {
      * Prepares the resolution of edges, either serially or concurrently.
      * It uses a simple heuristic to determine if we should perform concurrent resolution, based on the the number of edges, and whether they have unresolved metadata.
      */
-    private void maybeDownloadMetadataInParallel(NodeState node, Map<ModuleVersionIdentifier, ComponentIdentifier> componentIdentifierCache, List<EdgeState> dependencies) {
+    private void maybeDownloadMetadataInParallel(NodeState node, Map<ModuleVersionIdentifier, ComponentIdentifier> componentIdentifierCache, List<EdgeState> dependencies, Spec<EdgeState> dependencyFilter) {
         List<ComponentState> requiringDownload = null;
         for (EdgeState dependency : dependencies) {
+            if (!dependencyFilter.isSatisfiedBy(dependency)) {
+                continue;
+            }
             ComponentState targetComponent = dependency.getTargetComponent();
             if (targetComponent != null && targetComponent.isSelected() && !targetComponent.alreadyResolved()) {
                 if (!metaDataResolver.isFetchingMetadataCheap(toComponentId(targetComponent.getId(), componentIdentifierCache))) {
@@ -335,12 +357,14 @@ public class DependencyGraphBuilder {
         return identifier;
     }
 
-    private void attachToTargetRevisionsSerially(List<EdgeState> dependencies) {
+    private void attachToTargetRevisionsSerially(List<EdgeState> dependencies, Spec<EdgeState> dependencyFilter) {
         // the following only needs to be done serially to preserve ordering of dependencies in the graph: we have visited the edges
         // but we still didn't add the result to the queue. Doing it from resolve threads would result in non-reproducible graphs, where
         // edges could be added in different order. To avoid this, the addition of new edges is done serially.
         for (EdgeState dependency : dependencies) {
-            dependency.attachToTargetConfigurations();
+            if (dependencyFilter.isSatisfiedBy(dependency)) {
+                dependency.attachToTargetConfigurations();
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -182,6 +182,7 @@ public class DependencyGraphBuilder {
                 dependencies.clear();
                 node.visitOutgoingDependencies(dependencies);
                 boolean edgeWasProcessed = resolveEdges(node, dependencies, INHERITING_DEPENDENCY_SPEC, false, resolveState, componentIdentifierCache);
+                node.collectInheritedSubgraphConstraints(dependencies);
                 resolveEdges(node, dependencies, NOT_INHERITING_DEPENDENCY_SPEC, edgeWasProcessed, resolveState, componentIdentifierCache);
             } else {
                 // We have some batched up conflicts. Resolve the first, and continue traversing the graph

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -86,7 +86,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
             return Collections.singletonList(new LenientPlatformConfigurationMetadata(platformMetadata.getPlatformState(), platformId));
         }
         // the target component exists, so we need to fallback to the traditional selection process
-        return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
+        return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override
@@ -117,6 +117,11 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     @Override
     public boolean isConstraint() {
         return true;
+    }
+
+    @Override
+    public boolean isInheriting() {
+        return false;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -80,6 +80,11 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     }
 
     @Override
+    public ModuleDependencyMetadata withInheritConstraints(boolean inheriting) {
+        return this;
+    }
+
+    @Override
     public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         if (targetComponent instanceof LenientPlatformResolveMetadata) {
             LenientPlatformResolveMetadata platformMetadata = (LenientPlatformResolveMetadata) targetComponent;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -749,10 +749,6 @@ public class NodeState implements DependencyGraphNode {
                 if (constraintsSet == null) {
                     constraintsSet = Sets.newHashSet();
                 }
-                if (constraintsSet.contains(selector.getModuleIdentifier())) {
-                    throw new InvalidUserDataException(
-                        "Dependency " + dependencyState.getModuleIdentifier() + " of " + component.getId() + " defines conflicting forSubgraph constraints");
-                }
                 constraintsSet.add(selector.getModuleIdentifier());
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -859,11 +858,11 @@ public class NodeState implements DependencyGraphNode {
             ComponentState targetComponent = dependencyState.getTargetComponent();
             if (targetComponent != null) { // may be null if the build is about to fail
                 for (NodeState sourceNode : targetComponent.getNodes()) {
+                    if (sourceNode.ownSubgraphConstraints == null) {
+                        // node's dependencies were not yet visited
+                        sourceNode.collectOwnSubgraphConstraints();
+                    }
                     if (singleSubgraphConstraints.isEmpty()) {
-                        if (sourceNode.ownSubgraphConstraints == null) {
-                            // node's dependencies were not yet visited
-                            sourceNode.collectOwnSubgraphConstraints();
-                        }
                         singleSubgraphConstraints = sourceNode.ownSubgraphConstraints;
                     } else {
                         if (collectedConstraints == null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -114,6 +114,6 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
         // TODO: CC make capabilities accessible to rules
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getModule(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes(), ImmutableList.of());
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), details.getReason(), false);
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), false /* FIXME !!*/, details.getReason(), false);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -55,6 +55,8 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     protected abstract boolean isConstraint();
 
+    protected abstract boolean isInheriting(T details);
+
     @Override
     public T get(int index) {
         if (!dependencyMetadataAdapters.containsKey(index)) {
@@ -114,6 +116,6 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
         // TODO: CC make capabilities accessible to rules
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getModule(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes(), ImmutableList.of());
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), false /* FIXME !!*/, details.getReason(), false);
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), isInheriting(details), details.getReason(), false);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
@@ -44,11 +44,11 @@ public abstract class AbstractDependencyMetadataAdapter<T extends DependencyMeta
         this.originalIndex = originalIndex;
     }
 
-    private ModuleDependencyMetadata getOriginalMetadata() {
+    protected ModuleDependencyMetadata getOriginalMetadata() {
         return container.get(originalIndex);
     }
 
-    private void updateMetadata(ModuleDependencyMetadata modifiedMetadata) {
+    protected void updateMetadata(ModuleDependencyMetadata modifiedMetadata) {
         container.set(originalIndex, modifiedMetadata);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
@@ -42,4 +42,9 @@ public class DependencyConstraintsMetadataAdapter extends AbstractDependenciesMe
     protected boolean isConstraint() {
         return true;
     }
+
+    @Override
+    protected boolean isInheriting(DependencyConstraintMetadata details) {
+        return false;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
@@ -41,4 +41,9 @@ public class DirectDependenciesMetadataAdapter extends AbstractDependenciesMetad
     protected boolean isConstraint() {
         return false;
     }
+
+    @Override
+    protected boolean isInheriting(DirectDependencyMetadata details) {
+        return details.isInheriting();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
@@ -27,4 +27,19 @@ public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataA
     public DirectDependencyMetadataAdapter(ImmutableAttributesFactory attributesFactory, List<ModuleDependencyMetadata> container, int originalIndex) {
         super(attributesFactory, container, originalIndex);
     }
+
+    @Override
+    public void inheritConstraints() {
+        updateMetadata(getOriginalMetadata().withInheritConstraints(true));
+    }
+
+    @Override
+    public void notInheritConstraints() {
+        updateMetadata(getOriginalMetadata().withInheritConstraints(false));
+    }
+
+    @Override
+    public boolean isInheriting() {
+        return getOriginalMetadata().isInheriting();
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImpl.java
@@ -20,7 +20,24 @@ import org.gradle.api.artifacts.DirectDependencyMetadata;
 
 public class DirectDependencyMetadataImpl extends AbstractDependencyImpl<DirectDependencyMetadata> implements DirectDependencyMetadata {
 
+    boolean inheriting = false;
+
     public DirectDependencyMetadataImpl(String group, String name, String version) {
         super(group, name, version);
+    }
+
+    @Override
+    public void inheritConstraints() {
+        inheriting = true;
+    }
+
+    @Override
+    public void notInheritConstraints() {
+        inheriting = false;
+    }
+
+    @Override
+    public boolean isInheriting() {
+        return inheriting;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -279,8 +279,8 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
-        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities) {
-            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes, requestedCapabilities));
+        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities, boolean inheriting) {
+            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes, requestedCapabilities, inheriting));
         }
 
         @Override
@@ -360,8 +360,9 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         private final String reason;
         private final ImmutableAttributes attributes;
         private final ImmutableList<Capability> requestedCapabilities;
+        private final boolean inheriting;
 
-        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities) {
+        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities, boolean inheriting) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
@@ -373,6 +374,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
                     .map(c -> new ImmutableCapability(c.getGroup(), c.getName(), c.getVersion()))
                     .collect(Collectors.toList())
             );
+            this.inheriting = inheriting;
         }
 
         @Override
@@ -408,6 +410,11 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         @Override
         public List<Capability> getRequestedCapabilities() {
             return requestedCapabilities;
+        }
+
+        @Override
+        public boolean isInheriting() {
+            return inheriting;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -117,9 +117,10 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         ModuleComponentSelector selector = componentSelectorSerializer.read(decoder);
         List<ExcludeMetadata> excludes = readMavenExcludes(decoder);
         boolean constraint = decoder.readBoolean();
+        boolean inheriting = decoder.readBoolean();
         boolean force = decoder.readBoolean();
         String reason = decoder.readNullableString();
-        return new GradleDependencyMetadata(selector, excludes, constraint, reason, force);
+        return new GradleDependencyMetadata(selector, excludes, constraint, inheriting, reason, force);
     }
 
     protected List<ExcludeMetadata> readMavenExcludes(Decoder decoder) throws IOException {
@@ -171,6 +172,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         List<ExcludeMetadata> excludes = dependencyMetadata.getExcludes();
         writeMavenExcludeRules(encoder, excludes);
         encoder.writeBoolean(dependencyMetadata.isConstraint());
+        encoder.writeBoolean(dependencyMetadata.isInheriting());
         encoder.writeBoolean(dependencyMetadata.isForce());
         encoder.writeNullableString(dependencyMetadata.getReason());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -56,13 +56,14 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes(), dependency.getRequestedCapabilities());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), forcedDependencies));
+            dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.isInheriting(), dependency.getReason(), forcedDependencies));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
             dependencies.add(new GradleDependencyMetadata(
                 DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
+                false,
                 dependencyConstraint.getReason(),
                 forcedDependencies
             ));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -54,6 +54,8 @@ public interface ComponentVariant extends VariantResolveMetadata {
         ImmutableAttributes getAttributes();
 
         List<Capability> getRequestedCapabilities();
+
+        boolean isInheriting();
     }
 
     interface DependencyConstraint {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -172,6 +172,11 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     }
 
     @Override
+    public boolean isInheriting() {
+        return false;
+    }
+
+    @Override
     public String getReason() {
         return reason;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -48,10 +48,11 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     private final String reason;
     private final boolean isTransitive;
     private final boolean isConstraint;
+    private final boolean isInheriting;
 
     private boolean alwaysUseAttributeMatching;
 
-    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching, String reason) {
+    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching, String reason, boolean inheriting) {
         this.configuration = configuration;
         this.componentId = componentId;
         this.dependencyDescriptor = dependencyDescriptor;
@@ -59,6 +60,11 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         this.reason = reason;
         this.isTransitive = dependencyDescriptor.isTransitive();
         this.isConstraint = dependencyDescriptor.isConstraint();
+        this.isInheriting = inheriting;
+    }
+
+    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching, String reason) {
+        this(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, reason, false);
     }
 
     private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching) {
@@ -142,6 +148,14 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, reason);
     }
 
+    @Override
+    public ModuleDependencyMetadata withInheritConstraints(boolean inheriting) {
+        if (this.isInheriting == inheriting) {
+            return this;
+        }
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, reason, inheriting);
+    }
+
     public ConfigurationBoundExternalDependencyMetadata withDescriptor(ExternalDependencyDescriptor descriptor) {
         return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, descriptor, alwaysUseAttributeMatching);
     }
@@ -173,7 +187,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
 
     @Override
     public boolean isInheriting() {
-        return false;
+        return isInheriting;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalDependencyDescriptor.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Represents dependency information as stored in an external descriptor file.
+ * Represents dependency information as stored in an external descriptor file (POM or IVY.XML).
  * This information is able to be transformed into a `ModuleDependencyMetadata` instance.
  */
 public abstract class ExternalDependencyDescriptor {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
@@ -89,6 +89,11 @@ public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadat
     }
 
     @Override
+    public boolean isInheriting() {
+        return delegate.isInheriting();
+    }
+
+    @Override
     public String getReason() {
         return delegate.getReason();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
@@ -54,6 +54,11 @@ public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadat
     }
 
     @Override
+    public ModuleDependencyMetadata withInheritConstraints(boolean inheriting) {
+        return new ForcedDependencyMetadataWrapper(delegate.withInheritConstraints(inheriting));
+    }
+
+    @Override
     public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -41,14 +41,16 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
     private final ModuleComponentSelector selector;
     private final List<ExcludeMetadata> excludes;
     private final boolean constraint;
+    private final boolean inheriting;
     private final String reason;
     private final boolean force;
 
-    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean constraint, String reason, boolean force) {
+    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean constraint, boolean inheriting, String reason, boolean force) {
         this.selector = selector;
         this.excludes = excludes;
         this.reason = reason;
         this.constraint = constraint;
+        this.inheriting = inheriting;
         this.force = force;
     }
 
@@ -62,7 +64,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes(), selector.getRequestedCapabilities()), excludes, constraint, reason, force);
+        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes(), selector.getRequestedCapabilities()), excludes, constraint, inheriting, reason, force);
     }
 
     @Override
@@ -70,13 +72,13 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
         if (Objects.equal(reason, this.reason)) {
             return this;
         }
-        return new GradleDependencyMetadata(selector, excludes, constraint, reason, force);
+        return new GradleDependencyMetadata(selector, excludes, constraint, inheriting, reason, force);
     }
 
     @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
-            return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, constraint, reason, force);
+            return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, constraint, inheriting, reason, force);
         }
         return new DefaultProjectDependencyMetadata((ProjectComponentSelector) target, this);
     }
@@ -115,6 +117,11 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
     }
 
     @Override
+    public boolean isInheriting() {
+        return inheriting;
+    }
+
+    @Override
     public String getReason() {
         return reason;
     }
@@ -131,7 +138,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
 
     @Override
     public ForcingDependencyMetadata forced() {
-        return new GradleDependencyMetadata(selector, excludes, constraint, reason, true);
+        return new GradleDependencyMetadata(selector, excludes, constraint, inheriting, reason, true);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -76,6 +76,14 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
     }
 
     @Override
+    public ModuleDependencyMetadata withInheritConstraints(boolean inheriting) {
+        if (inheriting == this.inheriting) {
+            return this;
+        }
+        return new GradleDependencyMetadata(selector, excludes, constraint, inheriting, reason, force);
+    }
+
+    @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
             return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, constraint, inheriting, reason, force);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -66,13 +66,14 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         for (ComponentVariant.Dependency dependency : dependencies) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes(), dependency.getRequestedCapabilities());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            result.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), force));
+            result.add(new GradleDependencyMetadata(selector, excludes, false, dependency.isInheriting(), dependency.getReason(), force));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : dependencyConstraints) {
             result.add(new GradleDependencyMetadata(
                 DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
+                false,
                 dependencyConstraint.getReason(),
                 force
             ));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadata.java
@@ -31,4 +31,5 @@ public interface ModuleDependencyMetadata extends DependencyMetadata {
     @Override
     ModuleDependencyMetadata withReason(String reason);
 
+    ModuleDependencyMetadata withInheritConstraints(boolean inheriting);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -92,6 +92,11 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
+    public boolean isInheriting() {
+        return delegate.isInheriting();
+    }
+
+    @Override
     public String getReason() {
         return delegate.getReason();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -57,6 +57,14 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
+    public ModuleDependencyMetadata withInheritConstraints(boolean inheriting) {
+        if (delegate instanceof ModuleDependencyMetadata) {
+            return new ModuleDependencyMetadataWrapper(((ModuleDependencyMetadata) delegate).withInheritConstraints(inheriting));
+        }
+        return this;
+    }
+
+    @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         return delegate.withTarget(target);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -26,7 +26,7 @@ import java.util.List;
 public interface MutableComponentVariant {
     void addFile(String name, String uri);
 
-    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities);
+    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities, boolean inheriting);
 
     void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -71,6 +71,11 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     }
 
     @Override
+    public boolean isInheriting() {
+        return delegate.isInheriting();
+    }
+
+    @Override
     public String getReason() {
         return delegate.getReason();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -93,6 +93,11 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
+    public boolean isInheriting() {
+        return delegate.isInheriting();
+    }
+
+    @Override
     public boolean isFromLock() {
         return delegate.isFromLock();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -89,7 +89,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                         : DefaultMutableVersionConstraint.withVersion(lockedVersion);
                     ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(lockedDependency.getGroup(), lockedDependency.getModule()), versionConstraint);
                     result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null,
-                            Collections.<IvyArtifactName>emptyList(),  Collections.<ExcludeMetadata>emptyList(), false, false, false, true, true, getLockReason(strict, lockedVersion)));
+                            Collections.<IvyArtifactName>emptyList(),  Collections.<ExcludeMetadata>emptyList(), false, false, false, true, false, true, getLockReason(strict, lockedVersion)));
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -76,6 +76,11 @@ public interface DependencyMetadata {
     boolean isConstraint();
 
     /**
+     * Is this a dependency that pulls subgraph constraints from the target node up?
+     */
+    boolean isInheriting();
+
+    /**
      * An optional human readable reason why this dependency is used.
      * @return if not null, a description why this dependency is used.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -46,6 +46,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     private final boolean changing;
     private final boolean transitive;
     private final boolean constraint;
+    private final boolean inheriting;
     private final boolean fromLock;
     private final String reason;
 
@@ -60,9 +61,9 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             String dependencyConfiguration,
                                             List<IvyArtifactName> artifactNames,
                                             List<ExcludeMetadata> excludes,
-                                            boolean force, boolean changing, boolean transitive, boolean constraint,
+                                            boolean force, boolean changing, boolean transitive, boolean constraint, boolean inheriting,
                                             String reason) {
-        this(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, false, reason);
+        this(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, inheriting, false, reason);
     }
 
     public LocalComponentDependencyMetadata(ComponentIdentifier componentId,
@@ -74,7 +75,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             List<IvyArtifactName> artifactNames,
                                             List<ExcludeMetadata> excludes,
                                             boolean force, boolean changing, boolean transitive,
-                                            boolean constraint, boolean fromLock,
+                                            boolean constraint, boolean inheriting, boolean fromLock,
                                             String reason) {
         this.componentId = componentId;
         this.selector = selector;
@@ -88,6 +89,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         this.changing = changing;
         this.transitive = transitive;
         this.constraint = constraint;
+        this.inheriting = inheriting;
         this.fromLock = fromLock;
         this.reason = reason;
     }
@@ -185,6 +187,11 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     @Override
+    public boolean isInheriting() {
+        return inheriting;
+    }
+
+    @Override
     public String getReason() {
         return reason;
     }
@@ -224,15 +231,15 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private LocalOriginDependencyMetadata copyWithTarget(ComponentSelector selector) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, inheriting, fromLock, reason);
     }
 
     private LocalOriginDependencyMetadata copyWithReason(String reason) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, inheriting, fromLock, reason);
     }
 
     private LocalOriginDependencyMetadata copyWithForce(boolean force) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, inheriting, fromLock, reason);
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -387,6 +387,32 @@ class DefaultDependencyHandlerTest extends Specification {
         dep2.isInheriting()
     }
 
+    void "platform dependency can be made non-inheriting"() {
+        ModuleDependency dep1 = new DefaultExternalModuleDependency("org", "platform", "")
+        dep1.attributesFactory = AttributeTestUtil.attributesFactory()
+
+        when:
+        dependencyHandler.platform("org:platform") { it.notInheritConstraints() }
+
+        then:
+        1 * dependencyFactory.createDependency("org:platform") >> dep1
+        dep1.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == 'platform'
+        !dep1.isInheriting()
+    }
+
+    void "local platform dependency can be made non-inheriting"() {
+        ModuleDependency dep1 = new DefaultProjectDependency(null, null, false)
+        dep1.attributesFactory = AttributeTestUtil.attributesFactory()
+
+        when:
+        dependencyHandler.platform(dep1) { it.notInheritConstraints() }
+
+        then:
+        1 * dependencyFactory.createDependency(dep1) >> dep1
+        dep1.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == 'platform'
+        !dep1.isInheriting()
+    }
+
     @CompileStatic
     void "can configure ExtensionAware statically"() {
         String dependency = "some:random-dependency:0.1.1"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -24,18 +24,23 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.ExternalDependency
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.attributes.AttributesSchema
+import org.gradle.api.attributes.Category
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.VariantTransformRegistry
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.reflect.TypeOf
 import org.gradle.internal.Factory
+import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
@@ -332,6 +337,54 @@ class DefaultDependencyHandlerTest extends Specification {
 
         then:
         1 * dependencyFactory.createDependency(null)
+    }
+
+    void "platform dependencies are inheriting"() {
+        ModuleDependency dep1 = new DefaultExternalModuleDependency("org", "platform", "")
+        dep1.attributesFactory = AttributeTestUtil.attributesFactory()
+        ModuleDependency dep2 = new DefaultExternalModuleDependency("org", "platform", "")
+        dep2.attributesFactory = AttributeTestUtil.attributesFactory()
+
+        when:
+        dependencyHandler.platform("org:platform")
+
+        then:
+        1 * dependencyFactory.createDependency("org:platform") >> dep1
+        dep1.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == 'platform'
+        dep1.isInheriting()
+        dep1.version == null
+
+        when:
+        dependencyHandler.platform("org:platform") { it.version { it.require('1.0') } }
+
+        then:
+        1 * dependencyFactory.createDependency("org:platform") >> dep2
+        dep2.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == 'platform'
+        dep2.isInheriting()
+        dep2.version == '1.0'
+    }
+
+    void "local platform dependencies are inheriting"() {
+        ModuleDependency dep1 = new DefaultProjectDependency(null, null, false)
+        dep1.attributesFactory = AttributeTestUtil.attributesFactory()
+        ModuleDependency dep2 = new DefaultProjectDependency(null, null, false)
+        dep2.attributesFactory = AttributeTestUtil.attributesFactory()
+
+        when:
+        dependencyHandler.platform(dep1)
+
+        then:
+        1 * dependencyFactory.createDependency(dep1) >> dep1
+        dep1.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == 'platform'
+        dep1.isInheriting()
+
+        when:
+        dependencyHandler.platform(dep2) { }
+
+        then:
+        1 * dependencyFactory.createDependency(dep2) >> dep2
+        dep2.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == 'platform'
+        dep2.isInheriting()
     }
 
     @CompileStatic

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 72
+        expectedVersion = 73
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -226,7 +226,7 @@ class GradleModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant
         1 * variant.addFile("a.zip", "a.zop")
-        1 * variant.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY, [], false)
         1 * metadata.setContentHash(_)
         0 * _
     }
@@ -333,7 +333,7 @@ class GradleModuleMetadataParserTest extends Specification {
                 "attributes": { "usage": "runtime", "packaging": "zip" },
                 "dependencies": [ 
                     { "module": "m3", "group": "g3", "version": { "prefers": "v3" }, "requestedCapabilities":[{"group":"org", "name":"foo", "version":"1.0"}]},
-                    { "module": "m4", "version": { "strictly": "v5" }, "group": "g4"},
+                    { "module": "m4", "inheriting": true, "version": { "strictly": "v5" }, "group": "g4"},
                     { "module": "m5", "version": { "prefers": "v5", "requires": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                     { "module": "m6", "group": "g6", "version": { "strictly": "v6" }, "reason": "v5 is buggy"}
                 ],
@@ -345,15 +345,15 @@ class GradleModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null, ImmutableAttributes.EMPTY, [])
-        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, ImmutableAttributes.EMPTY, [])
-        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY, [])
-        1 * variant1.addDependency("g3", "m3", requiresForSubgraph("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY, [])
+        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null, ImmutableAttributes.EMPTY, [], false)
+        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, ImmutableAttributes.EMPTY, [], false)
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY, [], false)
+        1 * variant1.addDependency("g3", "m3", requiresForSubgraph("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY, [], false)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY, { it[0].group == 'org' && it[0].name == 'foo' && it[0].version == '1.0' })
-        1 * variant2.addDependency("g4", "m4", strictly("v5"), [], null, ImmutableAttributes.EMPTY, [])
-        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null, ImmutableAttributes.EMPTY, [])
-        1 * variant2.addDependency("g6", "m6", strictly("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY, [])
+        1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY, { it[0].group == 'org' && it[0].name == 'foo' && it[0].version == '1.0' }, false)
+        1 * variant2.addDependency("g4", "m4", strictly("v5"), [], null, ImmutableAttributes.EMPTY, [], true)
+        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null, ImmutableAttributes.EMPTY, [], false)
+        1 * variant2.addDependency("g6", "m6", strictly("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY, [], false)
         1 * metadata.setContentHash(_)
         0 * _
     }
@@ -430,7 +430,7 @@ class GradleModuleMetadataParserTest extends Specification {
             {
                 "attributes": { "usage": "runtime", "packaging": "zip" },
                 "dependencyConstraints": [ 
-                    { "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
+                    { "inheriting": true, "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
                     { "version": { "requires": "v2" }, "group": "g2", "module": "m2", "attributes": {"custom": "foo", "other": "bar"} }
                 ],
                 "name": "runtime"
@@ -441,8 +441,8 @@ class GradleModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, attributes(custom: 'foo'), [])
-        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, attributes(custom: 'foo', other: 'bar'), [])
+        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, attributes(custom: 'foo'), [], false)
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, attributes(custom: 'foo', other: 'bar'), [], false)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependencyConstraint("g1", "m1", prefers("v1"), null, attributes(custom: 'foo'))
         1 * variant2.addDependencyConstraint("g2", "m2", requires("v2"), null, attributes(custom: 'foo', other: 'bar'))
@@ -581,9 +581,9 @@ class GradleModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", version("v1"), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant1.addDependency("g1", "m1", version("v1"), [], null, ImmutableAttributes.EMPTY, [], false)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g2", "m2", version("v2"), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant2.addDependency("g2", "m2", version("v2"), [], null, ImmutableAttributes.EMPTY, [], false)
         1 * metadata.setContentHash(_)
         0 * _
     }
@@ -644,7 +644,7 @@ class GradleModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes([:])) >> variant
-        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null, ImmutableAttributes.EMPTY, [])
+        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null, ImmutableAttributes.EMPTY, [], false)
         1 * metadata.setContentHash(_)
         0 * metadata._
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -333,7 +333,7 @@ class GradleModuleMetadataParserTest extends Specification {
                 "attributes": { "usage": "runtime", "packaging": "zip" },
                 "dependencies": [ 
                     { "module": "m3", "group": "g3", "version": { "prefers": "v3" }, "requestedCapabilities":[{"group":"org", "name":"foo", "version":"1.0"}]},
-                    { "module": "m4", "inheriting": true, "version": { "strictly": "v5" }, "group": "g4"},
+                    { "module": "m4", "inheritConstraints": true, "version": { "strictly": "v5" }, "group": "g4"},
                     { "module": "m5", "version": { "prefers": "v5", "requires": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                     { "module": "m6", "group": "g6", "version": { "strictly": "v6" }, "reason": "v5 is buggy"}
                 ],
@@ -430,7 +430,7 @@ class GradleModuleMetadataParserTest extends Specification {
             {
                 "attributes": { "usage": "runtime", "packaging": "zip" },
                 "dependencyConstraints": [ 
-                    { "inheriting": true, "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
+                    { "inheritConstraints": true, "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
                     { "version": { "requires": "v2" }, "group": "g2", "module": "m2", "attributes": {"custom": "foo", "other": "bar"} }
                 ],
                 "name": "runtime"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1103,7 +1103,7 @@ class DependencyGraphBuilderTest extends Specification {
         }
         def dependencyMetaData = new LocalComponentDependencyMetadata(from.id, componentSelector,
                 "default", null, ImmutableAttributes.EMPTY, "default", [] as List<IvyArtifactName>,
-                excludeRules, force, false, transitive, false, null)
+                excludeRules, force, false, transitive, false, false, null)
         dependencyMetaData = new DslOriginDependencyMetadataWrapper(dependencyMetaData, Stub(ModuleDependency) {
             getAttributes() >> ImmutableAttributes.EMPTY
         })

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeStateTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeStateTest.groovy
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
+
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.subgraphconstraints.SubgraphConstraints
+import org.gradle.api.specs.Spec
+import org.gradle.internal.component.model.ConfigurationMetadata
+import org.gradle.internal.component.model.DependencyMetadata
+import spock.lang.Specification
+
+class NodeStateTest extends Specification {
+
+    int idIdx = 0
+    NodeState root = nextNode()
+
+    def "uses empty subgraph constraints object if no subgraph constraints are defined"() {
+        Set<ModuleIdentifier> constraintsSet = []
+
+        when:
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root, false).dependencyState)
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root, false).dependencyState)
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root, false).dependencyState)
+        root.storeOwnConstraints(constraintsSet)
+
+        then:
+        root.ownSubgraphConstraints == SubgraphConstraints.EMPTY
+        root.ownSubgraphConstraints.getModules().isEmpty()
+    }
+
+    def "collects subgraph constraints"() {
+        Set<ModuleIdentifier> constraintsSet = []
+
+        when:
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root).dependencyState)
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root).dependencyState)
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root, false).dependencyState)
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root).dependencyState)
+        root.maybeCollectSubgraphConstraint(constraintsSet, edge(root, false).dependencyState)
+        root.storeOwnConstraints(constraintsSet)
+
+        then:
+        root.ownSubgraphConstraints.getModules().size() == 3
+        root.ownSubgraphConstraints.getModules() == constraintsSet
+    }
+
+    def "uses empty subgraph constraints object if no subgraph constraints are inherited"() {
+        when:
+        def inheritFrom = edge(root, false, null, nextNode(0), true)
+        root.collectInheritedSubgraphConstraints([inheritFrom])
+
+        then:
+        root.inheritedSubgraphConstraints == SubgraphConstraints.EMPTY
+        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == SubgraphConstraints.EMPTY
+    }
+
+    def "collect one inherited subgraph constraint"() {
+        when:
+        def inheritFrom = edge(root, false, null, nextNode(1), true)
+        root.collectInheritedSubgraphConstraints([inheritFrom])
+
+        then:
+        root.inheritedSubgraphConstraints.getModules().size() == 1
+        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints.getModules().size() == 1
+        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == root.inheritedSubgraphConstraints //instance reused
+    }
+
+    def "collects multiple inherited subgraph constraints from one module"() {
+        when:
+        def inheritFrom = edge(root, false, null, nextNode(12), true)
+        root.collectInheritedSubgraphConstraints([inheritFrom])
+
+        then:
+        root.inheritedSubgraphConstraints.getModules().size() == 12
+        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints.getModules().size() == 12
+        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == root.inheritedSubgraphConstraints //instance reused
+    }
+
+    def "collects inherited subgraph constraints from multiple sources"() {
+        when:
+        edge(root, false) // not-inheriting edge
+        def inheritFrom1 = edge(root, false, null, nextNode(1), true)
+        def inheritFrom2 = edge(root, false, null, nextNode(4), true)
+        root.collectInheritedSubgraphConstraints([inheritFrom1, inheritFrom2])
+
+        then:
+        def modulesAll = root.inheritedSubgraphConstraints.getModules()
+        def modules1 = inheritFrom1.targetComponent.nodes[0].ownSubgraphConstraints.getModules()
+        def modules2 = inheritFrom2.targetComponent.nodes[0].ownSubgraphConstraints.getModules()
+
+        modulesAll.size() == 5
+        modules1.size() == 1
+        modules2.size() == 4
+
+        modulesAll == modules1 + modules2
+
+        inheritFrom1.targetComponent.nodes[0].ownSubgraphConstraints != root.inheritedSubgraphConstraints
+        inheritFrom2.targetComponent.nodes[0].ownSubgraphConstraints != root.inheritedSubgraphConstraints
+    }
+
+    def "uses empty subgraph constraints object if there are no ancestor constraints"() {
+        when:
+        def edge = edge(root, false)
+        def childNode = edge.targetComponent.nodes[0]
+        collectOwnSubgraphConstraints(root, [])
+        childNode.collectAncestorsSubgraphConstraints([edge])
+
+        then:
+        root.ownSubgraphConstraints == SubgraphConstraints.EMPTY
+        childNode.ancestorsSubgraphConstraints == SubgraphConstraints.EMPTY
+    }
+
+    def "collects ancestor subgraph constraints from one parent"() {
+        when:
+        def edge = edge(root, false)
+        def childNode = edge.targetComponent.nodes[0]
+        collectOwnSubgraphConstraints(root, ["a", "b", "c", "d"]) // this is always expected to run before running collectAncestorsSubgraphConstraints() on a child
+
+        childNode.collectAncestorsSubgraphConstraints([edge])
+
+        then:
+        root.ownSubgraphConstraints.getModules().size() == 4
+        childNode.ancestorsSubgraphConstraints.getModules().size() == 4
+        childNode.ancestorsSubgraphConstraints == root.ownSubgraphConstraints //instance reused
+    }
+
+    def "uses empty subgraph constraints object if constraints of second parent are empty"() {
+        when:
+        def parent1 = edge(root, false).targetComponent.nodes[0]
+        def parent2 = edge(root, false).targetComponent.nodes[0]
+        collectOwnSubgraphConstraints(parent1, ['a'])
+        collectOwnSubgraphConstraints(parent2, [])
+
+        def childNode = nextNode()
+        def edge1 = edge(parent1, false, null, childNode)
+        def edge2 = edge(parent2, false, null, childNode)
+        childNode.collectAncestorsSubgraphConstraints([edge1, edge2])
+
+        then:
+        childNode.ancestorsSubgraphConstraints == SubgraphConstraints.EMPTY
+        parent1.ownSubgraphConstraints != SubgraphConstraints.EMPTY
+        parent2.ownSubgraphConstraints == SubgraphConstraints.EMPTY
+    }
+
+    def "computes intersection of ancestors"() {
+        when:
+        def parent1Edge = edge(root, false)
+        def parent2Edge = edge(root, false)
+        def parent1 = parent1Edge.targetComponent.nodes[0]
+        def parent2 = parent2Edge.targetComponent.nodes[0]
+        collectOwnSubgraphConstraints(root, ['a']) //root, on all paths
+        collectOwnSubgraphConstraints(parent1, ['b', 'c'])
+        collectOwnSubgraphConstraints(parent2, ['b', 'd'])
+
+        def child = nextNode()
+        def edge1 = edge(parent1, false, null, child)
+        def edge2 = edge(parent2, false, null, child)
+        parent1.collectAncestorsSubgraphConstraints([parent1Edge])
+        parent2.collectAncestorsSubgraphConstraints([parent2Edge])
+        child.collectAncestorsSubgraphConstraints([edge1, edge2])
+
+        then:
+        child.ancestorsSubgraphConstraints.getModules() == moduleSet('a', 'b')
+        parent1.ancestorsSubgraphConstraints == root.ownSubgraphConstraints
+        parent2.ancestorsSubgraphConstraints == root.ownSubgraphConstraints
+    }
+
+    private collectOwnSubgraphConstraints(NodeState node, List<String> children) {
+        Set<ModuleIdentifier> constraintsSet = []
+        for (String child : children) {
+            node.maybeCollectSubgraphConstraint(constraintsSet, edge(node, true, child).dependencyState)
+        }
+        node.storeOwnConstraints(constraintsSet)
+    }
+
+    private EdgeState edge(NodeState from, boolean forSubgraph = true, String name = null, NodeState to = nextNode(), inheriting = false) {
+        String moduleName = name ? name : "${from.nodeId}-${to.nodeId}"
+        EdgeState edgeState = Mock()
+        DependencyState dependencyState = Mock()
+        DependencyMetadata dependencyMetadata = Mock()
+        ModuleComponentSelector selector = Mock()
+        VersionConstraint versionConstraint = Mock()
+        ComponentState componentState = Mock()
+        edgeState.from >> from
+        edgeState.getTargetComponent() >> componentState
+        componentState.nodes >> [to]
+        edgeState.dependencyState >> dependencyState
+        edgeState.dependencyMetadata >> dependencyMetadata
+        dependencyState.dependency >> dependencyMetadata
+        dependencyMetadata.selector >> selector
+        dependencyMetadata.inheriting >> inheriting
+        selector.versionConstraint >> versionConstraint
+        selector.moduleIdentifier >> DefaultModuleIdentifier.newId("org", moduleName)
+        versionConstraint.forSubgraph >> forSubgraph
+        edgeState
+    }
+
+    private NodeState nextNode(int outgoingSubgraph = 0) {
+        def metadata = Stub(ConfigurationMetadata)
+        def resolveState = Stub(ResolveState)
+        def newState = new NodeState(idIdx++, null, Mock(ComponentState), resolveState, metadata)
+        // if outgoing subgraph edges, also include a normal edge to make sure that is filtered out
+        metadata.dependencies >> ((0..<outgoingSubgraph).collect { edge(newState).dependencyMetadata } + (outgoingSubgraph > 0 ? [edge(newState, false).dependencyMetadata] : []))
+        resolveState.moduleExclusions >> Mock(ModuleExclusions)
+        resolveState.edgeFilter >> new Spec<DependencyMetadata>() {
+            boolean isSatisfiedBy(DependencyMetadata element) { true }
+        }
+        newState
+    }
+
+    private static Set moduleSet(String... names) {
+        names.collect { DefaultModuleIdentifier.newId('org', it) }
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeStateTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeStateTest.groovy
@@ -66,9 +66,10 @@ class NodeStateTest extends Specification {
         when:
         def inheritFrom = edge(root, false, null, nextNode(0), true)
         root.collectInheritedSubgraphConstraints([inheritFrom])
+        def inheritedConstraints = root.getInheritedSubgraphConstraints(edge(root, false))
 
         then:
-        root.inheritedSubgraphConstraints == SubgraphConstraints.EMPTY
+        inheritedConstraints == SubgraphConstraints.EMPTY
         inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == SubgraphConstraints.EMPTY
     }
 
@@ -76,22 +77,24 @@ class NodeStateTest extends Specification {
         when:
         def inheritFrom = edge(root, false, null, nextNode(1), true)
         root.collectInheritedSubgraphConstraints([inheritFrom])
+        def inheritedConstraints = root.getInheritedSubgraphConstraints(edge(root, false))
 
         then:
-        root.inheritedSubgraphConstraints.getModules().size() == 1
+        inheritedConstraints.getModules().size() == 1
         inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints.getModules().size() == 1
-        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == root.inheritedSubgraphConstraints //instance reused
+        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == inheritedConstraints //instance reused
     }
 
     def "collects multiple inherited subgraph constraints from one module"() {
         when:
         def inheritFrom = edge(root, false, null, nextNode(12), true)
         root.collectInheritedSubgraphConstraints([inheritFrom])
+        def inheritedConstraints = root.getInheritedSubgraphConstraints(edge(root, false))
 
         then:
-        root.inheritedSubgraphConstraints.getModules().size() == 12
+        inheritedConstraints.getModules().size() == 12
         inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints.getModules().size() == 12
-        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == root.inheritedSubgraphConstraints //instance reused
+        inheritFrom.targetComponent.nodes[0].ownSubgraphConstraints == inheritedConstraints //instance reused
     }
 
     def "collects inherited subgraph constraints from multiple sources"() {
@@ -100,9 +103,10 @@ class NodeStateTest extends Specification {
         def inheritFrom1 = edge(root, false, null, nextNode(1), true)
         def inheritFrom2 = edge(root, false, null, nextNode(4), true)
         root.collectInheritedSubgraphConstraints([inheritFrom1, inheritFrom2])
+        def inheritedConstraints = root.getInheritedSubgraphConstraints(edge(root, false))
 
         then:
-        def modulesAll = root.inheritedSubgraphConstraints.getModules()
+        def modulesAll = inheritedConstraints.getModules()
         def modules1 = inheritFrom1.targetComponent.nodes[0].ownSubgraphConstraints.getModules()
         def modules2 = inheritFrom2.targetComponent.nodes[0].ownSubgraphConstraints.getModules()
 
@@ -112,8 +116,8 @@ class NodeStateTest extends Specification {
 
         modulesAll == modules1 + modules2
 
-        inheritFrom1.targetComponent.nodes[0].ownSubgraphConstraints != root.inheritedSubgraphConstraints
-        inheritFrom2.targetComponent.nodes[0].ownSubgraphConstraints != root.inheritedSubgraphConstraints
+        inheritFrom1.targetComponent.nodes[0].ownSubgraphConstraints != inheritedConstraints
+        inheritFrom2.targetComponent.nodes[0].ownSubgraphConstraints != inheritedConstraints
     }
 
     def "uses empty subgraph constraints object if there are no ancestor constraints"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -156,7 +156,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(DefaultModuleIdentifier.newId(consumerIdentifier.group, consumerIdentifier.name), new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
 
         def configuration = consumer.selectConfigurations(attributes, immutable, schema, [] as Set)[0]
         configuration.dependencies

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnGradleMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnGradleMetadataTest.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver
+
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.internal.component.external.model.GradleDependencyMetadata
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata
+
+class DependenciesMetadataAdapterOnGradleMetadataTest extends DependenciesMetadataAdapterTest {
+
+    @Override
+    ModuleDependencyMetadata newDependency(ModuleComponentSelector requested) {
+        new GradleDependencyMetadata(requested, [], false, false, null, false)
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnIvyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnIvyMetadataTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver
+
+import com.google.common.collect.ArrayListMultimap
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.ExternalDependencyDescriptor
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata
+import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
+
+class DependenciesMetadataAdapterOnIvyMetadataTest extends DependenciesMetadataAdapterTest {
+
+    @Override
+    ModuleDependencyMetadata newDependency(ModuleComponentSelector requested) {
+        ExternalDependencyDescriptor dependencyDescriptor = new IvyDependencyDescriptor(requested, ArrayListMultimap.create())
+        return new ConfigurationBoundExternalDependencyMetadata(null, DefaultModuleComponentIdentifier.newId(requested.moduleIdentifier, requested.version), dependencyDescriptor)
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnPomMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterOnPomMetadataTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver
+
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.internal.component.external.descriptor.MavenScope
+import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.ExternalDependencyDescriptor
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata
+import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyType
+
+class DependenciesMetadataAdapterOnPomMetadataTest extends DependenciesMetadataAdapterTest {
+
+    @Override
+    ModuleDependencyMetadata newDependency(ModuleComponentSelector requested) {
+        ExternalDependencyDescriptor dependencyDescriptor = new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.DEPENDENCY, requested, null, [])
+        return new ConfigurationBoundExternalDependencyMetadata(null, DefaultModuleComponentIdentifier.newId(requested.moduleIdentifier, requested.version), dependencyDescriptor)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -195,7 +195,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
             ModuleComponentSelector requested = newSelector(DefaultModuleIdentifier.newId("org.gradle.test", "module$size"), "1.0")
-            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, null, false) ]
+            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, false, null, false) ]
         }
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.api.internal.artifacts.repositories.resolver
 
+import org.gradle.api.artifacts.DirectDependencyMetadata
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
 import org.gradle.internal.component.external.model.GradleDependencyMetadata
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.util.AttributeTestUtil
@@ -31,7 +33,7 @@ import spock.lang.Specification
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class DependenciesMetadataAdapterTest extends Specification {
-    List<DependencyMetadata> dependenciesMetadata = []
+    List<ModuleDependencyMetadata> dependenciesMetadata = []
     TestDependenciesMetadataAdapter adapter
 
     def setup() {
@@ -64,6 +66,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         when:
         adapter.add("org.gradle.test:module1") {
             it.version { it.require '1.0' }
+            it.inheritConstraints()
         }
 
         then:
@@ -71,6 +74,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].selector.group == "org.gradle.test"
         dependenciesMetadata[0].selector.module == "module1"
         dependenciesMetadata[0].selector.version == "1.0"
+        dependenciesMetadata[0].isInheriting()
     }
 
     def "add via map id with action propagate to the underlying dependency list"() {
@@ -191,6 +195,18 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].selector.attributes.getAttribute(attr) == 'foo'
     }
 
+    def "can modify dependency inheritance state"() {
+        given:
+        fillDependencyList(1)
+
+        when:
+        adapter.get(0).inheritConstraints()
+
+        then:
+        dependenciesMetadata.size() == 1
+        dependenciesMetadata[0].isInheriting()
+    }
+
     private fillDependencyList(int size) {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
@@ -200,7 +216,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)
     }
 
-    class TestDependenciesMetadataAdapter extends AbstractDependenciesMetadataAdapter {
+    class TestDependenciesMetadataAdapter extends AbstractDependenciesMetadataAdapter<DirectDependencyMetadata> {
         TestDependenciesMetadataAdapter(List<DependencyMetadata> dependenciesMetadata) {
             super(AttributeTestUtil.attributesFactory(), dependenciesMetadata, TestUtil.instantiatorFactory().decorateLenient(), DependencyMetadataNotationParser.parser(DirectInstantiator.INSTANCE, DirectDependencyMetadataImpl.class, SimpleMapInterner.notThreadSafe()))
         }
@@ -213,6 +229,11 @@ class DependenciesMetadataAdapterTest extends Specification {
         @Override
         protected boolean isConstraint() {
             return false
+        }
+
+        @Override
+        protected boolean isInheriting(DirectDependencyMetadata details) {
+            return details.isInheriting()
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.notations.DependencyMetadataNotationParser
-import org.gradle.internal.component.external.model.GradleDependencyMetadata
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata
 import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.reflect.DirectInstantiator
@@ -32,9 +31,11 @@ import spock.lang.Specification
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
-class DependenciesMetadataAdapterTest extends Specification {
+abstract class DependenciesMetadataAdapterTest extends Specification {
     List<ModuleDependencyMetadata> dependenciesMetadata = []
     TestDependenciesMetadataAdapter adapter
+
+    abstract ModuleDependencyMetadata newDependency(ModuleComponentSelector requested);
 
     def setup() {
         fillDependencyList(0)
@@ -211,7 +212,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
             ModuleComponentSelector requested = newSelector(DefaultModuleIdentifier.newId("org.gradle.test", "module$size"), "1.0")
-            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, false, null, false) ]
+            dependenciesMetadata += [newDependency(requested)]
         }
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
@@ -76,7 +76,7 @@ class DefaultIvyModuleDescriptorWriterTest extends Specification {
     def addDependencyDescriptor(BuildableLocalConfigurationMetadata metadata, String organisation = "org.test", String moduleName, String revision = "1.0") {
         def dep = new LocalComponentDependencyMetadata(metadata.getComponentId(),
                 DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(organisation, moduleName), new DefaultMutableVersionConstraint(revision)),
-                "runtime", null, ImmutableAttributes.EMPTY, "default", [] as List, [], false, false, true, false, null)
+                "runtime", null, ImmutableAttributes.EMPTY, "default", [] as List, [], false, false, true, false, false, null)
         metadata.addDependency(dep)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -108,7 +108,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
             if (addAllDependenciesAsConstraints()) {
                 defaultVariant.addDependencyConstraint("org.test", name, new DefaultMutableVersionConstraint("1.0"), null, ImmutableAttributes.EMPTY)
             } else {
-                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY, [])
+                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY, [], false)
             }
         }
         metadata
@@ -286,7 +286,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
 
         consumer.selectConfigurations(attributes, immutable, schema, [] as Set)[0]
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -234,10 +234,10 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
 
         given:
         def v1 = metadata.addVariant("api", attributes(usage: "compile"))
-        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [])
-        v1.addDependency("g2", "m2", v("v2"), [], "v2 is tested", ImmutableAttributes.EMPTY, [])
+        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [], false)
+        v1.addDependency("g2", "m2", v("v2"), [], "v2 is tested", ImmutableAttributes.EMPTY, [], true)
         def v2 = metadata.addVariant("runtime", attributes(usage: "runtime"))
-        v2.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [])
+        v2.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [], false)
 
         expect:
         metadata.variants.size() == 2
@@ -245,14 +245,17 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         metadata.variants[0].dependencies[0].group == "g1"
         metadata.variants[0].dependencies[0].module == "m1"
         metadata.variants[0].dependencies[0].versionConstraint.requiredVersion == "v1"
+        !metadata.variants[0].dependencies[0].inheriting
         metadata.variants[0].dependencies[1].group == "g2"
         metadata.variants[0].dependencies[1].module == "m2"
         metadata.variants[0].dependencies[1].versionConstraint.requiredVersion == "v2"
         metadata.variants[0].dependencies[1].reason == "v2 is tested"
+        metadata.variants[0].dependencies[1].inheriting
         metadata.variants[1].dependencies.size() == 1
         metadata.variants[1].dependencies[0].group == "g1"
         metadata.variants[1].dependencies[0].module == "m1"
         metadata.variants[1].dependencies[0].versionConstraint.requiredVersion == "v1"
+        !metadata.variants[1].dependencies[0].inheriting
 
         def immutable = metadata.asImmutable()
         immutable.variants.size() == 2
@@ -285,11 +288,11 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         def v1 = metadata.addVariant("api", attributes1,)
         v1.addFile("f1.jar", "f1.jar")
         v1.addFile("f2.jar", "f2-1.2.jar")
-        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [])
+        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [], false)
         def v2 = metadata.addVariant("runtime", attributes2,)
         v2.addFile("f2", "f2-version.zip")
-        v2.addDependency("g2", "m2", v("v2"), [], null, ImmutableAttributes.EMPTY, [])
-        v2.addDependency("g3", "m3", v("v3"), [], null, ImmutableAttributes.EMPTY, [])
+        v2.addDependency("g2", "m2", v("v2"), [], null, ImmutableAttributes.EMPTY, [], false)
+        v2.addDependency("g3", "m3", v("v3"), [], null, ImmutableAttributes.EMPTY, [], false)
 
         expect:
         def immutable = metadata.asImmutable()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -65,14 +65,14 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     def "returns this when same target requested"() {
         def selector = Stub(ProjectComponentSelector)
-        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, false, null)
 
         expect:
         dep.withTarget(selector).is(dep)
     }
 
     def "selects the target configuration from target component"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         def toConfig = Stub(LocalConfigurationMetadata) {
             isCanBeConsumed() >> true
@@ -88,7 +88,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     @Unroll("selects configuration '#expected' from target component (#scenario)")
     def "selects the target configuration from target component which matches the attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -123,7 +123,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
     }
 
     def "revalidates default configuration if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true, false, false, null)
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
             isCanBeResolved() >> true
@@ -154,7 +154,7 @@ Configuration 'default':
     }
 
     def "revalidates explicit configuration selection if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, 'bar', [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, 'bar', [] as List, [], false, false, true, false, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -194,7 +194,7 @@ Configuration 'bar':
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -264,7 +264,7 @@ Configuration 'bar':
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy using short-hand notation (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy using short-hand notation"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -334,7 +334,7 @@ Configuration 'bar':
 
     def "fails to select target configuration when not present in the target component"() {
         def fromId = Stub(ComponentIdentifier) { getDisplayName() >> "thing a" }
-        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         toComponent.id >> Stub(ComponentIdentifier) { getDisplayName() >> "thing b" }
 
@@ -351,7 +351,7 @@ Configuration 'bar':
 
     def "excludes nothing when no exclude rules provided"() {
         def moduleExclusions = new ModuleExclusions()
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -363,7 +363,7 @@ Configuration 'bar':
         def exclude1 = new DefaultExclude(DefaultModuleIdentifier.newId("group1", "*"))
         def exclude2 = new DefaultExclude(DefaultModuleIdentifier.newId("group2", "*"))
         def moduleExclusions = new ModuleExclusions()
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [exclude1, exclude2], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [exclude1, exclude2], false, false, true, false, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -394,7 +394,7 @@ Configuration 'bar':
 
     @Unroll("can select a compatible attribute value (#scenario)")
     def "can select a compatible attribute value"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
@@ -6,7 +6,7 @@
             "dependencies": [
                 { "group": "g0", "module": "m0" },
                 { "group": "g1", "module": "m1", "version": { "requires": "v1" } },
-                { "version": { "requires": "v1", "prefers": "v2" }, "group": "g2", "module": "m2" },
+                { "version": { "requires": "v1", "prefers": "v2", "forSubgraph": true }, "group": "g2", "module": "m2" },
                 {
                     "group": "g3",
                     "module": "m3",
@@ -27,7 +27,7 @@
                 { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                 { "module": "m6", "version": { "rejects": ["v8"] }, "group": "g6"},
                 { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"},
-                { "module": "m8", "version": { "strictly": "v8" }, "group": "g7"}
+                { "module": "m8", "version": { "strictly": "v8" }, "group": "g7", "inheriting": true}
             ],
             "name": "runtime"
         }

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -131,6 +131,7 @@ This value, nested in `variants`, must contain an array with zero or more elemen
 - `reason`: optional. A explanation why the dependency is used. Can typically be used to explain why a specific version is requested.
 - `attributes`: optional. If set, attributes will override the consumer attributes during dependency resolution for this specific dependency.
 - `requestedCapabilities`: optional. If set, declares the capabilities that the dependency must provide in order to be selected. See `capabilities` above for the format.
+- `inheritConstraints`: optional. If set to `true`, all `forSubgraph` version constraints of the target module will be treated as if they were defined on the variant defining this dependency.
 
 #### `version` value
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -56,6 +56,29 @@ dependencies {
 }
 ```
 
+Subgraph constraints can also be defined in a platform.
+Theses constraints will be _inherited_ when depending on the platform and treated as if they were defined directly.
+
+```groovy
+project(':platform') {
+    dependencies {
+        constraints {
+            api('org.apache.hadoop:hadoop-common:3.2.0') 
+            api('commons-io:commons-io:2.4') {
+                version { forSubgraph() } 
+            }
+        }
+    }
+}
+
+dependencies {
+    // 'commons-io:commons-io:2.4' win over '2.5' because the platform defines the constraint as 'forSubgraph()'
+    implementation(platform(project(':platform')))
+    implementation('org.apache.hadoop:hadoop-common')
+    implementation('commons-io:commons-io')
+}
+```
+
 ## Debug support for forked Java processes
 
 Gradle has now a new DSL element to configure debugging for Java processes.  

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/declaring_dependency_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/declaring_dependency_versions.adoc
@@ -35,6 +35,11 @@ In particular, if you are developing a library that others consume.
 The `forSubgraph` property of a dependency is published in <<publishing.adoc#understanding-gradle-module-md,Gradle Module Metadata>> and honored when your library is consumed, as long as there is no other library requesting the originally declared version to be used.
 More details about dealing with such situations are found in the <<controlling_transitive_dependencies.adoc#, controlling transitive dependencies>> chapter.
 
+You can also _inherit_ the `forSubgraph` constraints defined by another module so that they are applied to all your dependencies as well.
+This is the behavior you typically expect from a _platform_.
+A <<controlling_transitive_dependencies.adoc#using-platform-to-control-transitive-deps,platform dependency>> will enable it automatically.
+You can however activate it for arbitrary dependencies by setting `inheritConstraints()` on the dependency.
+
 [[sec:dynamic_versions_and_changing_modules]]
 == Dealing with versions which change over time
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/controlling_transitive_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/controlling_transitive_dependencies.adoc
@@ -53,6 +53,8 @@ Dependency constraints themselves can also be added transitively.
 [[sharing-dep-versions-between-projects]]
 === Sharing dependency versions between projects
 
+// A dependency to a platform inherits all subgraph constraints of the platform (can be turned off by 'notInheritConstraints()')
+
 [[enforced-platforms]]
 === Enforced platforms
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -163,7 +163,7 @@ class GradleModuleMetadata {
             if (dependencies == null) {
                 dependencies = (values.dependencies ?: []).collect {
                     def exclusions = it.excludes ? it.excludes.collect { "${it.group}:${it.module}" } : []
-                    new Dependency(it.group, it.module, it.version?.requires, it.version?.prefers, it.version?.strictly, it.version?.rejects ?: [], exclusions, it.reason, normalizeForTests(it.attributes))
+                    new Dependency(it.group, it.module, it.version?.requires, it.version?.prefers, it.version?.strictly, it.version?.rejects ?: [], it.version?.forSubgraph, exclusions, it.inheritConstraints, it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencies
@@ -180,7 +180,7 @@ class GradleModuleMetadata {
         List<DependencyConstraint> getDependencyConstraints() {
             if (dependencyConstraints == null) {
                 dependencyConstraints = (values.dependencyConstraints ?: []).collect {
-                    new DependencyConstraint(it.group, it.module, it.version.requires, it.version.prefers, it.version.strictly, it.version.rejects ?: [], it.reason, normalizeForTests(it.attributes))
+                    new DependencyConstraint(it.group, it.module, it.version.requires, it.version.prefers, it.version.strictly, it.version.rejects ?: [], it.version?.forSubgraph, it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencyConstraints
@@ -399,16 +399,18 @@ class GradleModuleMetadata {
         final String prefers
         final String strictly
         final List<String> rejectsVersion
+        final boolean forSubgraph
         final String reason
         final Map<String, String> attributes
 
-        Coords(String group, String module, String version, String prefers = '', String strictly = '', List<String> rejectsVersion = [], String reason = null, Map<String, String> attributes = [:]) {
+        Coords(String group, String module, String version, String prefers = '', String strictly = '', List<String> rejectsVersion = [], Boolean forSubgraph = false, String reason = null, Map<String, String> attributes = [:]) {
             this.group = group
             this.module = module
             this.version = version
             this.prefers = prefers
             this.strictly = strictly
             this.rejectsVersion = rejectsVersion
+            this.forSubgraph = forSubgraph
             this.reason = reason
             this.attributes = attributes
         }
@@ -439,10 +441,12 @@ class GradleModuleMetadata {
     @EqualsAndHashCode
     static class Dependency extends Coords {
         final List<String> excludes
+        final boolean inheritConstraints
 
-        Dependency(String group, String module, String requires, String prefers, String strictly, List<String> rejectedVersions, List<String> excludes, String reason, Map<String, String> attributes) {
-            super(group, module, requires, prefers, strictly, rejectedVersions, reason, attributes)
+        Dependency(String group, String module, String requires, String prefers, String strictly, List<String> rejectedVersions, Boolean forSubgraph, List<String> excludes, Boolean inheritConstraints, String reason, Map<String, String> attributes) {
+            super(group, module, requires, prefers, strictly, rejectedVersions, forSubgraph, reason, attributes)
             this.excludes = excludes*.toString()
+            this.inheritConstraints = inheritConstraints
         }
 
         String toString() {
@@ -456,8 +460,8 @@ class GradleModuleMetadata {
 
     @EqualsAndHashCode
     static class DependencyConstraint extends Coords {
-        DependencyConstraint(String group, String module, String version, String prefers, String strictly, List<String> rejectedVersions, String reason, Map<String, String> attributes) {
-            super(group, module, version, prefers, strictly, rejectedVersions, reason, attributes)
+        DependencyConstraint(String group, String module, String version, String prefers, String strictly, List<String> rejectedVersions, Boolean forSubgraph, String reason, Map<String, String> attributes) {
+            super(group, module, version, prefers, strictly, rejectedVersions, forSubgraph, reason, attributes)
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -30,11 +30,12 @@ class DependencySpec {
     boolean forSubgraph
     List<String> rejects
     List<ExcludeSpec> exclusions = []
+    boolean inheritConstraints
     String reason
     Map<String, Object> attributes
     List<CapabilitySpec> requestedCapabilities = []
 
-    DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, Boolean forSubgraph, List<String> rejects, Collection<Map> excludes, String reason, Map<String, Object> attributes) {
+    DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, Boolean forSubgraph, List<String> rejects, Collection<Map> excludes, Boolean inheritConstraints, String reason, Map<String, Object> attributes) {
         group = g
         module = m
         version = v
@@ -49,6 +50,7 @@ class DependencySpec {
                 new ExcludeSpec(group, module)
             }
         }
+        this.inheritConstraints = inheritConstraints
         this.reason = reason
         this.attributes = attributes
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -89,6 +89,9 @@ class GradleFileModuleAdapter {
                                 }
                                 rejects d.rejects
                             }
+                            if (d.inheritConstraints) {
+                                inheritConstraints d.inheritConstraints
+                            }
                             if (d.reason) {
                                 reason d.reason
                             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -53,11 +53,11 @@ class VariantMetadataSpec {
     }
 
     void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes = [:]) {
-        dependencies << new DependencySpec(group, module, version, null, null, null, null, null, reason, attributes)
+        dependencies << new DependencySpec(group, module, version, null, null, null, null, null, null, reason, attributes)
     }
 
     void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {
-        def spec = new DependencySpec(group, module, version, null, null, null, null, null, null, [:])
+        def spec = new DependencySpec(group, module, version, null, null, null, null, null, null, null, [:])
         config.delegate = spec
         config.resolveStrategy = Closure.DELEGATE_FIRST
         config()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -127,7 +127,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         def variantMetadata = new VariantMetadataSpec(variant, attributes)
         variants.add(variantMetadata)
         configuration(variant) //add variant also as configuration for plain ivy publishing
-        return variantMetadata;
+        return variantMetadata
     }
 
     @Override
@@ -403,6 +403,10 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         }
         GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(organisation, module, revision,
             variants.collect { v ->
+                def artifacts = v.artifacts
+                if (!artifacts && v.useDefaultArtifacts) {
+                    artifacts = defaultArtifacts
+                }
                 new VariantMetadataSpec(
                     v.name,
                     v.attributes,
@@ -412,7 +416,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
                         new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.reason, d.attributes)
                     },
-                    v.artifacts ?: defaultArtifacts,
+                    artifacts,
                     v.capabilities,
                     v.availableAt
                 )

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -411,7 +411,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->
-                        new DependencySpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.exclusions, d.inheritConstraints, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
                         new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.reason, d.attributes)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -131,7 +131,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                               type: attributes.type, scope: attributes.scope, classifier: attributes.classifier,
                               optional: attributes.optional, exclusions: attributes.exclusions, rejects: attributes.rejects,
                               prefers: attributes.prefers, strictly: attributes.strictly, forSubgraph: attributes.forSubgraph,
-                              reason: attributes.reason
+                              inheritConstraints: attributes.inheritConstraints, reason: attributes.reason
         ]
         return this
     }
@@ -464,7 +464,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.exclusions, d.inheritConstraints, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencies.findAll { it.optional }.collect { d ->
                         new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.forSubgraph, d.rejects, d.reason, d.attributes)

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
@@ -25,7 +25,7 @@ import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.ExactVersionSelector;
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyConfiguration;
@@ -295,7 +295,7 @@ public class IvyDescriptorFileGenerator {
     }
 
     private boolean isDynamicVersion(String version) {
-        return VersionRangeSelector.ALL_RANGE.matcher(version).matches() || version.endsWith("+") || version.startsWith("latest.");
+        return !ExactVersionSelector.isExact(version);
     }
 
     private void writeDependencyExclude(ExcludeRule excludeRule, OptionalAttributeXmlWriter xmlWriter) throws IOException {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
@@ -143,4 +143,10 @@ abstract class ClientModuleDelegate : ClientModule {
 
     override fun getReason(): String? =
         delegate.reason
+
+    override fun inheritConstraints() =
+        delegate.inheritConstraints()
+
+    override fun isInheriting() =
+        delegate.isInheriting
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
@@ -147,6 +147,9 @@ abstract class ClientModuleDelegate : ClientModule {
     override fun inheritConstraints() =
         delegate.inheritConstraints()
 
+    override fun notInheritConstraints() =
+        delegate.notInheritConstraints()
+
     override fun isInheriting() =
         delegate.isInheriting
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -555,4 +555,88 @@ class TestCapability implements Capability {
             noMoreDependencies()
         }
     }
+
+    def "publishes component with subgraph version constraints"() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    dependencyConstraints: configurations.implementation.allDependencyConstraints,
+                    attributes: configurations.implementation.attributes))
+
+            dependencies {
+                implementation("org:platform:1.0") {
+                    inheritConstraints()
+                }
+                implementation("org:foo") {
+                    version {
+                        forSubgraph()
+                    }
+                }
+                constraints {
+                    implementation("org:bar") {
+                        version {
+                            forSubgraph()
+                        }
+                    }
+                }
+            }
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from comp
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds 'publish'
+
+        then:
+        def module = mavenRepo.module('group', 'root', '1.0')
+        module.assertPublished()
+        module.parsedModuleMetadata.variants.size() == 1
+        def variant = module.parsedModuleMetadata.variants[0]
+        variant.dependencies.size() == 2
+        variant.dependencyConstraints.size() == 1
+
+        !variant.dependencies[0].forSubgraph
+        variant.dependencies[0].inheritConstraints
+        variant.dependencies[0].group == 'org'
+        variant.dependencies[0].module == 'platform'
+        variant.dependencies[0].version == '1.0'
+        variant.dependencies[0].prefers == null
+        variant.dependencies[0].strictly == null
+        variant.dependencies[0].rejectsVersion == []
+
+        variant.dependencies[1].forSubgraph
+        !variant.dependencies[1].inheritConstraints
+        variant.dependencies[1].group == 'org'
+        variant.dependencies[1].module == 'foo'
+        variant.dependencies[1].version == null
+        variant.dependencies[1].prefers == null
+        variant.dependencies[1].strictly == null
+        variant.dependencies[1].rejectsVersion == []
+
+        variant.dependencyConstraints[0].forSubgraph
+        variant.dependencyConstraints[0].group == 'org'
+        variant.dependencyConstraints[0].module == 'bar'
+        variant.dependencyConstraints[0].version == null
+        variant.dependencyConstraints[0].prefers == null
+        variant.dependencyConstraints[0].strictly == null
+        variant.dependencyConstraints[0].rejectsVersion == []
+    }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -165,7 +165,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
             selector, usageConfigurationName, null, ImmutableAttributes.EMPTY, mappedUsageConfiguration,
                 ImmutableList.<IvyArtifactName>of(),
             EXCLUDE_RULES,
-            false, false, true, false, null);
+            false, false, true, false, false, null);
     }
 
     @Override

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -452,6 +452,12 @@ public class GradleModuleMetadataWriter {
             writeExcludes(moduleDependency, additionalExcludes, jsonWriter);
             writeAttributes(moduleDependency.getAttributes(), jsonWriter);
             writeCapabilities("requestedCapabilities", moduleDependency.getRequestedCapabilities(), jsonWriter);
+
+            boolean inheriting = moduleDependency.isInheriting();
+            if (inheriting) {
+                jsonWriter.name("inheriting");
+                jsonWriter.value(true);
+            }
         }
         String reason = dependency.getReason();
         if (StringUtils.isNotEmpty(reason)) {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -455,7 +455,7 @@ public class GradleModuleMetadataWriter {
 
             boolean inheriting = moduleDependency.isInheriting();
             if (inheriting) {
-                jsonWriter.name("inheriting");
+                jsonWriter.name("inheritConstraints");
                 jsonWriter.value(true);
             }
         }


### PR DESCRIPTION
Implementation of part 2 of #9684.

### Done
- [x] Make sure inherited constraints for the same module are conflict resolved
~Fail if two subgraph constraints for the same module are inherited (but not when there is a non-inherited subgraph constraint for the module that "overrides")~
- [x] more test coverage
- [x] Support in component metadata rules (?)
- [x] Update documentation and release notes
- [x] Update GMM specification