### PR TITLE
Fix execution graph

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ExecutionGraph.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ExecutionGraph.java
@@ -24,13 +24,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public class Graph {
+public class ExecutionGraph {
     // Execution 1,2,3, starting from 1
     int index;
     String title;
     List<Line> data;
 
-    public Graph(int index, Line... lines) {
+    public ExecutionGraph(int index, Line... lines) {
         this.index = index;
         this.title = "Execution " + index + " (ms)";
         this.data = Arrays.asList(lines);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Graph.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Graph.java
@@ -25,13 +25,14 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class Graph {
-    String id;
+    // Execution 1,2,3, starting from 1
+    int index;
     String title;
     List<Line> data;
 
-    public Graph(String id, String title, Line... lines) {
-        this.id = id;
-        this.title = title;
+    public Graph(int index, Line... lines) {
+        this.index = index;
+        this.title = "Execution " + index + " (ms)";
         this.data = Arrays.asList(lines);
     }
 
@@ -39,16 +40,18 @@ public class Graph {
         return JsonOutput.toJson(data);
     }
 
-    String getOptions() {
+    String getTicks() {
         List<List<Object>> ticks = IntStream.range(0, data.get(0).data.size())
             .mapToObj(index -> Arrays.<Object>asList(index, index))
             .collect(Collectors.toList());
-        return JsonOutput.toJson(ImmutableMap.of("xaxis", ImmutableMap.of("ticks", ticks)));
+        return JsonOutput.toJson(ImmutableMap.of("ticks", ticks));
     }
 
     void render(HtmlPageGenerator.MetricsHtml html) {
+        String id = "execution" + index;
         html.h3().text(title).end();
         html.div().id(id).classAttr("chart").end();
-        html.script().raw(String.format("$.plot('#%s', %s, %s)", id, getData(), getOptions())).end();
+        html.dir().id(id + "Legend").end();
+        html.script().raw(String.format("performanceTests.renderGraph(%s, %s, 'execution %d', 'ms', '%s', [])", getData(), getTicks(), index, id)).end();
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Line.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Line.java
@@ -16,17 +16,12 @@
 
 package org.gradle.performance.results;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class Line {
-    private static final Map<String, Object> SHOW_TRUE = ImmutableMap.of("show", true);
-    private static final Map<String, Object> SHOW_FALSE = ImmutableMap.of("show", false);
     String label;
     List<List<Number>> data;
 
@@ -44,21 +39,5 @@ public class Line {
 
     public List<List<Number>> getData() {
         return data;
-    }
-
-    public boolean getStack() {
-        return false;
-    }
-
-    public Map getBars() {
-        return SHOW_FALSE;
-    }
-
-    public Map getLines() {
-        return SHOW_TRUE;
-    }
-
-    public Map getPoints() {
-        return SHOW_TRUE;
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
@@ -24,13 +24,13 @@ import java.util.stream.IntStream;
 import static java.util.stream.Collectors.toList;
 
 public interface PerformanceExecutionGraphRenderer {
-    default List<Graph> getGraphs(PerformanceTestHistory history) {
+    default List<ExecutionGraph> getGraphs(PerformanceTestHistory history) {
         List<PerformanceTestExecution> executions = history.getExecutions()
             .stream()
             .filter(this::sameCommit)
             .filter(this::hasTwoDataLines)
             .collect(toList());
-        return IntStream.range(0, executions.size()).mapToObj(i -> toGraph(executions.get(i), i + 1)).collect(toList());
+        return IntStream.range(0, executions.size()).mapToObj(i -> toExecutionGraph(executions.get(i), i + 1)).collect(toList());
     }
 
     default boolean hasTwoDataLines(PerformanceTestExecution execution) {
@@ -41,11 +41,11 @@ public interface PerformanceExecutionGraphRenderer {
         return !measuredOperations.getTotalTime().isEmpty();
     }
 
-    default Graph toGraph(PerformanceTestExecution execution, int index) {
+    default ExecutionGraph toExecutionGraph(PerformanceTestExecution execution, int index) {
         Line baseline = new Line(execution.getScenarios().stream().filter(this::hasData).findFirst().orElse(new MeasuredOperationList()));
         Line current = new Line(execution.getScenarios().get(execution.getScenarios().size() - 1));
 
-        return new Graph(index, baseline, current);
+        return new ExecutionGraph(index, baseline, current);
     }
 
     default boolean sameCommit(PerformanceTestExecution execution) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
@@ -42,13 +42,10 @@ public interface PerformanceExecutionGraphRenderer {
     }
 
     default Graph toGraph(PerformanceTestExecution execution, int index) {
-        String id = "execution_" + index;
-        String title = "Execution " + index + "(ms)";
-
         Line baseline = new Line(execution.getScenarios().stream().filter(this::hasData).findFirst().orElse(new MeasuredOperationList()));
         Line current = new Line(execution.getScenarios().get(execution.getScenarios().size() - 1));
 
-        return new Graph(id, title, baseline, current);
+        return new Graph(index, baseline, current);
     }
 
     default boolean sameCommit(PerformanceTestExecution execution) {

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
@@ -1,23 +1,23 @@
 (function ($) {
-    var renderCommitIds = function(commits) {
-        return commits.map(function(commit) {
+    const renderCommitIds = function (commits) {
+        return commits.map(function (commit) {
             return commit.substring(0, 7);
         }).join('|');
-    }
+    };
 
-    var plots = [];
+    const plots = [];
 
-    var togglePlot = function(chartId, label) {
-        var plot = plots[chartId];
-        var plotData = plot.getData();
-        $.each(plotData, function(index, value) {
-            if(value.label == label) {
+    const togglePlot = function (chartId, label) {
+        const plot = plots[chartId];
+        const plotData = plot.getData();
+        $.each(plotData, function (index, value) {
+            if (value.label == label) {
                 value.points.show = value.lines.show = !value.lines.show;
             }
         });
         plot.setData(plotData);
         plot.draw();
-    }
+    };
 
     function renderGraphs(allDataJson, charts) {
         charts.forEach(chart => {
@@ -26,7 +26,7 @@
                 {
                     tickFormatter: (index, value) => {
                         if (index === parseInt(index, 10)) { // portable way to check if sth is an integer
-                            var executionLabel = allDataJson.executionLabels[index];
+                            const executionLabel = allDataJson.executionLabels[index];
                             return executionLabel ? executionLabel.date : "";
                         } else {
                             return "";
@@ -46,10 +46,10 @@
         if(!data) {
             return
         }
-        var options = {
+        const options = {
             series: {
-                points: { show: true },
-                lines: { show: true }
+                points: {show: true},
+                lines: {show: true}
             },
             legend: {
                 noColumns: 4,
@@ -57,25 +57,26 @@
                 position: "se",
                 container: $("#" + chartId + "Legend"),
                 labelFormatter:
-                    function(label, series) {
-                        return '<a href="#" class="chart-legend" onClick="performanceTests.togglePlot(\''+chartId+'\', \''+label+'\'); return false;">'+label+'</a>';
+                    function (label, series) {
+                        return '<a href="#" class="chart-legend" onClick="performanceTests.togglePlot(\'' + chartId + '\', \'' + label + '\'); return false;">' + label + '</a>';
                     }
             },
-            grid: { hoverable: true, clickable: true, markings: background },
+            grid: {hoverable: true, clickable: true, markings: background},
             xaxis: xaxis,
-            yaxis: { min: determineMinY(data, unit) }, selection: { mode: 'xy' } };
-        var chart = $.plot('#' + chartId, data, options);
+            yaxis: {min: determineMinY(data, unit)}, selection: {mode: 'xy'}
+        };
+        const chart = $.plot('#' + chartId, data, options);
         plots[chartId] = chart;
         function zoomFunction(plot, reset) {
-            var reset = reset || false;
+            reset = reset || false;
             return function (event, ranges) {
                 $.each(plot.getXAxes(), function(_, axis) {
-                    var opts = axis.options;
+                    const opts = axis.options;
                     opts.min = reset ? null : ranges.xaxis.from;
                     opts.max = reset ? null : ranges.xaxis.to;
                 });
                 $.each(plot.getYAxes(), function(_, axis) {
-                    var opts = axis.options;
+                    const opts = axis.options;
                     opts.min = reset ? 0 : ranges.yaxis.from;
                     opts.max = reset ? null : ranges.yaxis.to;
                 });
@@ -86,14 +87,14 @@
         };
 
         function hoverOnHistoryGraph(event, pos, item) {
-            var executionLabel = executionLabels[item.datapoint[0]];
-            var revLabel;
-            if (item.series.label == executionLabel.branch) {
+            const executionLabel = executionLabels[item.datapoint[0]];
+            let revLabel;
+            if (item.series.label === executionLabel.branch) {
                 revLabel = 'rev: ' + renderCommitIds(executionLabel.commits) + '/' + executionLabel.branch;
             } else {
                 revLabel = 'Version: ' + item.series.label;
             }
-            var text = revLabel + ', date: ' + executionLabel.date + ', ' + label + ': ' + item.datapoint[1] + unit;
+            const text = revLabel + ', date: ' + executionLabel.date + ', ' + label + ': ' + item.datapoint[1] + unit;
             $('#tooltip').html(text).css({top: item.pageY - 20, left: item.pageX + 10}).show();
         }
 
@@ -113,12 +114,12 @@
             .bind("plotclick",
                 function (event, pos, item) {
                     if (!item) {
-                        // not select a plot
+                        // no plot selected
                         return;
                     }
-                    var executionLabel = executionLabels[item.datapoint[0]];
-                    var resultRowId = 'result' + executionLabel.id;
-                    var resultRow = $('#' + resultRowId);
+                    const executionLabel = executionLabels[item.datapoint[0]];
+                    const resultRowId = 'result' + executionLabel.id;
+                    const resultRow = $('#' + resultRowId);
                     if (resultRow) {
                         $('.history tr').css("background-color", "");
                         resultRow.css("background-color", "orange");
@@ -137,9 +138,10 @@
         }
     }
 
-    var createPerformanceGraph = function(jsonFile, charts) {
-        $(function() {
-            $.ajax({ url: jsonFile,
+    const createPerformanceGraph = function (jsonFile, charts) {
+        $(function () {
+            $.ajax({
+                url: jsonFile,
                 dataType: 'json',
                 success: allData => renderGraphs(allData, charts)
             });
@@ -154,7 +156,7 @@
 })($, window);
 
 $(document).ready(function() {
-    var resultRowId = window.location.hash;
+    const resultRowId = window.location.hash;
     if (resultRowId) {
         $(resultRowId).css("background-color","orange");
     }

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/report.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/report.js
@@ -48,16 +48,20 @@ $(document).ready(function () {
     // Add alternate row styles for tables
     $("table").each(function () {
         var counter = 0;
-        $(this).find("tr").each(function () {
-            var e = $(this);
-            if (e.children("th").length > 0) {
-                counter = 0;
-                return;
-            }
-            if (counter % 2 == 0) {
-                e.addClass("table-row-even");
-            }
-            counter++;
-        })
+        var rows = $(this).find("tr");
+        if (rows.length != 1) {
+            rows.each(function () {
+                var e = $(this);
+                if (e.children("th").length > 0) {
+                    counter = 0;
+                    return;
+                }
+                if (counter % 2 == 0) {
+                    e.addClass("table-row-even");
+                }
+                counter++;
+            })
+        }
+
     });
 });


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/2549 by refactoring javascript code. Previously the execution graph is rendered directly by `$.plot`, now it's using the `renderGraph` method so zoom-in/zoom-out are supported.

Demo: https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/25497748:id/report-performance-performance-tests.zip%21/report/tests/clean-assemble-on-largeMonolithicJavaProject-with-remote-https-cache.html?redirectSupported=false
