### PR TITLE
Remove deprecated `ExtensionContainer.getSchema()`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
@@ -23,7 +23,6 @@ import org.gradle.api.reflect.TypeOf;
 import org.gradle.internal.HasInternalProtocol;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 
 /**
  * Allows adding 'namespaced' DSL extensions to a target object.

--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionContainer.java
@@ -141,15 +141,6 @@ public interface ExtensionContainer {
     <T> T create(String name, Class<T> type, Object... constructionArguments);
 
     /**
-     * Provides access to all known extensions types.
-     *
-     * @return A map of extensions public types, keyed by name
-     * @since 3.5
-     */
-    @Deprecated
-    Map<String, TypeOf<?>> getSchema();
-
-    /**
      * Provides access to the schema of all known extensions.
      *
      * @since 4.5

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/DefaultConvention.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/DefaultConvention.java
@@ -144,15 +144,6 @@ public class DefaultConvention implements Convention, ExtensionContainerInternal
     }
 
     @Override
-    public Map<String, TypeOf<?>> getSchema() {
-        Map<String, TypeOf<?>> map = new HashMap<String, TypeOf<?>>();
-        for (ExtensionsSchema.ExtensionSchema schema : getExtensionsSchema()) {
-            map.put(schema.getName(), schema.getPublicType());
-        }
-        return map;
-    }
-
-    @Override
     public ExtensionsSchema getExtensionsSchema() {
         return extensionsStorage.getSchema();
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/DefaultConventionTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/DefaultConventionTest.groovy
@@ -154,18 +154,22 @@ class DefaultConventionTest {
 
     @Test void honoursHasPublicTypeForAddedExtension() {
         convention.add("pet", new ExtensionWithPublicType())
-        assert convention.schema["pet"] == typeOf(PublicExtensionType)
+        assert publicTypeOf("pet") == typeOf(PublicExtensionType)
     }
 
     @Test void honoursHasPublicTypeForCreatedExtension() {
         convention.create("pet", ExtensionWithPublicType)
-        assert convention.schema["pet"] == typeOf(PublicExtensionType)
+        assert publicTypeOf("pet") == typeOf(PublicExtensionType)
     }
 
     @Test void createWillExposeGivenTypeAsTheSchemaTypeEvenWhenInstantiatorReturnsDecoratedType() {
-        def convention = new DefaultConvention(TestUtil.instantiatorFactory().decorateLenient())
+        convention = new DefaultConvention(TestUtil.instantiatorFactory().decorateLenient())
         assert convention.create("foo", FooExtension).class != FooExtension
-        assert convention.schema["foo"] == typeOf(FooExtension)
+        assert publicTypeOf("foo") == typeOf(FooExtension)
+    }
+
+    private TypeOf<?> publicTypeOf(String extension) {
+        convention.extensionsSchema.find { it.name == extension }.publicType
     }
 
     interface PublicExtensionType {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtensionContainerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtensionContainerTest.groovy
@@ -249,14 +249,15 @@ class ExtensionContainerTest extends Specification {
         container.add "cat", new Thing("gizmo")
         container.add "meo", container.instantiator.newInstance(Thing, "w")
 
+        def schemaMap = container.extensionsSchema.collectEntries { [it.name, it.publicType] }
         expect:
-        container.schema == [ext: typeOf(ExtraPropertiesExtension),
-                             foo: typeOf(Parent),
-                             bar: typeOf(Capability),
-                             boo: typeOf(Child),
-                             baz: new TypeOf<List<String>>() {},
-                             cat: typeOf(Thing),
-                             meo: typeOf(Thing)]
+        schemaMap == [ext: typeOf(ExtraPropertiesExtension),
+                      foo: typeOf(Parent),
+                      bar: typeOf(Capability),
+                      boo: typeOf(Child),
+                      baz: new TypeOf<List<String>>() {},
+                      cat: typeOf(Thing),
+                      meo: typeOf(Thing)]
     }
 
     def "can configure extensions by name"() {
@@ -272,10 +273,13 @@ class ExtensionContainerTest extends Specification {
 }
 
 interface Capability {}
+
 class Impl implements Capability {}
 
 class Parent {}
+
 class Child extends Parent {}
+
 class Thing {
     String name
 


### PR DESCRIPTION
Part of https://github.com/gradle/gradle-private/issues/2475