### PR TITLE
Fix comments in the generated build.gradle file

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GroovyApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GroovyApplicationProjectInitDescriptor.java
@@ -38,10 +38,10 @@ public class GroovyApplicationProjectInitDescriptor extends GroovyProjectInitDes
     protected void configureBuildScript(InitSettings settings, BuildScriptBuilder buildScriptBuilder) {
         buildScriptBuilder
             .plugin(
-                "Apply the application plugin to add support for building a CLI application",
+                "Apply the application plugin to add support for building a CLI application.",
                 "application")
             .block(null, "application", b -> {
-                b.propertyAssignment("Define the main class for the application", "mainClassName", withPackage(settings, "App"));
+                b.propertyAssignment("Define the main class for the application.", "mainClassName", withPackage(settings, "App"));
             });
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaApplicationProjectInitDescriptor.java
@@ -43,12 +43,12 @@ public class JavaApplicationProjectInitDescriptor extends JavaProjectInitDescrip
         super.configureBuildScript(settings, buildScriptBuilder);
         buildScriptBuilder
             .plugin(
-                "Apply the application plugin to add support for building a CLI application",
+                "Apply the application plugin to add support for building a CLI application.",
                 "application")
             .implementationDependency("This dependency is used by the application.",
                 "com.google.guava:guava:" + libraryVersionProvider.getVersion("guava"))
             .block(null, "application", b -> {
-                b.propertyAssignment("Define the main class for the application", "mainClassName", withPackage(settings, "App"));
+                b.propertyAssignment("Define the main class for the application.", "mainClassName", withPackage(settings, "App"));
             });
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
@@ -65,7 +65,7 @@ public class KotlinApplicationProjectInitDescriptor extends JvmProjectInitDescri
             .fileComment("This generated file contains a sample Kotlin application project to get you started.")
             .plugin("Apply the application plugin to add support for building a CLI application.", "application")
             .block(null, "application", b -> {
-                b.propertyAssignment("Define the main class for the application", "mainClassName", withPackage(settings, "AppKt"));
+                b.propertyAssignment("Define the main class for the application.", "mainClassName", withPackage(settings, "AppKt"));
             });
 
         TemplateOperation kotlinSourceTemplate = templateFactory.fromSourceTemplate("kotlinapp/App.kt.template", "main");


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
When I did `gradle init` and initialized a kotlin application project, I found that comments in `build.gradle` are not unified. Some ended with a period and some did without it. I fixed them.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
