### PR TITLE
Reorganize Gradle Module Metadata spec documents

### DIFF
--- a/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -1,4 +1,4 @@
-# Gradle module metadata 1.0 specification
+# Gradle module metadata 1.1 specification
 
 Consumption of Gradle metadata is automatic. However publication needs to be enabled explicitly for any Gradle version prior to Gradle 6.
 
@@ -139,6 +139,7 @@ This value, nested in elements of the `dependencies` or `dependencyConstraints` 
 - `prefers`: optional. The preferred version for this dependency.
 - `strictly`: optional. A strictly enforced version requirement for this dependency.
 - `rejects`: optional. An array of rejected versions for this dependency.
+- `forSubgraph`: optional. If set to `true`, the version constraint applies for each dependency to the corresponding module in the subgraph originating from the containing variant.
 
 #### `excludes` value
 
@@ -172,6 +173,10 @@ This value, nested in `variants`, must contain an array with zero or more elemen
 - `md5`: The MD5 hash of the file content. A hex string.
 
 ### Changelog
+
+#### 1.1
+
+- Adds support for _subgraph version constraints_: `version { forSubgraph = true }`
 
 #### 1.0
 
@@ -251,7 +256,7 @@ This value, nested in `variants`, must contain an array with zero or more elemen
                 { 
                     "group": "some.group", 
                     "module": "other-lib-2", 
-                    "version": { "requires": "1.0" } 
+                    "version": { "requires": "1.0", "forSubgraph": true } 
                 }
             ]
         }

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
@@ -362,7 +362,7 @@ Again, Gradle will first look for an `ivy.xml` file, but if this file contains a
 
 Gradle Module metadata is the last supported format for module metadata.
 This format has specifically been designed for Gradle.
-You can find its https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md[specification] here.
+You can find its https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md[specification] here.
 
 [[sec:supported_metadata_sources]]
 == Supported metadata sources

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/feature_variants.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/feature_variants.adoc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 :maven-optional-deps: https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html[Maven optional dependencies]
-:metadata-file-spec: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+:metadata-file-spec: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
 
 [[feature_variants]]
 = Feature variants and optional dependencies

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/modeling_features.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/modeling_features.adoc
@@ -1,4 +1,4 @@
-:metadata-file-spec: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+:metadata-file-spec: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
 
 [[modeling-features]]
 = Modeling features and their dependencies

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing.adoc
@@ -1,7 +1,7 @@
 [[publishing-components]]
 = Publishing
 
-:metadata-file-spec: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+:metadata-file-spec: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
 
 [[publishing_overview]]
 The vast majority of software projects build something that aims to be consumed in some way. It could be a library that other software projects use or it could be an application for end users. _Publishing_ is the process by which the thing being built is made available to consumers.


### PR DESCRIPTION
* Keep a 1.0 spec
* Add a latest spec, now at 1.1

Proposal is that upon creation of 1.2, latest is copied with a 1.1 name
and then latest is edited to become 1.2.
This enables having a stable link for the latest version and historical
versions in direct access. Maintenance should be minimal as older
version have no reason to change anymore.