### PR TITLE
Throw UnsupportedOperationException on GroovyCompile.compile()

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -144,7 +144,7 @@ public class GroovyCompile extends AbstractCompile {
 
     @Override
     protected void compile() {
-        compile(null);
+        throw new UnsupportedOperationException("This method has been superseded by compile(InputChanges inputChanges)!");
     }
 
     @TaskAction


### PR DESCRIPTION
Since Groovy 5.6 we use compile(InputChanges) method instead.

Let's see if it breaks anything.