### PR TITLE
Remove deprecated `TaskInternal.replaceLogger`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -226,12 +226,6 @@ fun Project.applyKotlinProjectConventions() {
     apply(plugin = "org.gradle.kotlin.kotlin-dsl")
     apply(plugin = "org.gradle.kotlin-dsl.ktlint-convention")
 
-    plugins.withType<KotlinDslPlugin> {
-        configure<KotlinDslPluginOptions> {
-            experimentalWarning.set(false)
-        }
-    }
-
     configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
         // TODO:kotlin-dsl remove precompiled script plugins accessors exclusion from ktlint checks
         filter {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -124,7 +124,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private final TaskStateInternal state;
 
-    private Logger logger = new DefaultContextAwareTaskLogger(BUILD_LOGGER);
+    private final Logger logger = new DefaultContextAwareTaskLogger(BUILD_LOGGER);
 
     private final TaskMutator taskMutator;
     private ObservableList observableActionList;
@@ -462,11 +462,6 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
             loggingManager = new LoggingManagerInternalCompatibilityBridge(services.getFactory(org.gradle.internal.logging.LoggingManagerInternal.class).create());
         }
         return loggingManager;
-    }
-
-    @Override
-    public void replaceLogger(Logger logger) {
-        this.logger = logger;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -89,16 +89,6 @@ public interface TaskInternal extends Task, Configurable<Task> {
     TaskIdentity<?> getTaskIdentity();
 
     /**
-     * Replace this task's logger.
-     *
-     * Callers of {@link #getLogger()} will get the replacement logger after this method invocation.
-     *
-     * @param logger the replacement logger
-     */
-    @Deprecated
-    void replaceLogger(Logger logger);
-
-    /**
      * <p>Gets the shared resources required by this task.</p>
      */
     @Internal

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -21,7 +21,6 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.api.internal.tasks.InputChangesAwareTaskAction;
 import org.gradle.api.internal.tasks.TaskStateInternal;
-import org.gradle.api.logging.Logger;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.internal.Factory;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -524,19 +524,6 @@ class DefaultTaskTest extends AbstractTaskTest {
         then:
         task.actions[0].displayName == "Execute unnamed action"
     }
-
-    def "can replace task logger"() {
-        expect:
-        task.logger instanceof ContextAwareTaskLogger
-        task.logger.delegate == AbstractTask.BUILD_LOGGER
-
-        when:
-        def logger = Mock(Logger)
-        task.replaceLogger(logger)
-
-        then:
-        task.logger == logger
-    }
 }
 
 class TestConvention {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -24,13 +24,11 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.internal.tasks.InputChangesAwareTaskAction
-import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.AbstractTaskTest
 import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.api.tasks.TaskInstantiationException
 import org.gradle.internal.Actions
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger
 import spock.lang.Issue
 
 import java.util.concurrent.Callable

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -29,6 +29,14 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Class org.gradle.api.DefaultTask",
+            "acceptation": "Deprecated method removed in preparation for next major release",
+            "changes": [
+                "org.gradle.api.internal.AbstractTask.replaceLogger(org.gradle.api.logging.Logger)"
+            ]
         }
     ]
 }

--- a/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
@@ -732,14 +732,6 @@ include::sample[dir="kotlinDsl/kotlinDslPlugin",files="buildSrc/build.gradle.kts
 Be aware that the Kotlin DSL Plugin turns on experimental Kotlin compiler features.
 See the <<#sec:kotlin_compiler_arguments>> section below for more information.
 
-By default, the plugin warns about using experimental features of the Kotlin compiler.
-You can silence the warning by setting the `experimentalWarning` property of the `kotlinDslPluginOptions` extension to `false` as follows:
-
-.Disabling the warning about the use of experimental Kotlin compiler features
-====
-include::sample[dir="kotlinDsl/kotlinDslPlugin",files="buildSrc/build.gradle.kts[tags=disable-experimental-warning]"]
-====
-
 [[kotdsl:precompiled_plugins]]
 === Precompiled script plugins
 

--- a/subprojects/docs/src/samples/kotlinDsl/kotlinDslPlugin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/kotlinDsl/kotlinDslPlugin/buildSrc/build.gradle.kts
@@ -1,19 +1,11 @@
 // tag::apply[]
-// tag::disable-experimental-warning[]
 plugins {
     `kotlin-dsl`
 }
 
-// end::disable-experimental-warning[]
 repositories {
     // The org.jetbrains.kotlin.jvm plugin requires a repository
     // where to download the Kotlin compiler dependencies from.
     jcenter()
 }
 // end::apply[]
-
-// tag::disable-experimental-warning[]
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}
-// end::disable-experimental-warning[]

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "1.2.10"
+version = "1.2.11"
 
 base.archivesBaseName = "plugins"
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -1,7 +1,5 @@
 package org.gradle.kotlin.dsl.plugins.dsl
 
-import org.gradle.api.internal.DocumentationRegistry
-
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
@@ -259,51 +257,8 @@ class KotlinDslPluginTest : AbstractPluginTest() {
                 output,
                 not(containsString(KotlinCompilerArguments.samConversionForKotlinFunctions))
             )
-
-            assertThat(
-                output,
-                containsString(experimentalWarningFor(":buildSrc"))
-            )
         }
     }
-
-    @Test
-    fun `can explicitly disable experimental Kotlin compiler features warning`() {
-
-        withBuildExercisingSamConversionForKotlinFunctions(
-            "kotlinDslPluginOptions.experimentalWarning.set(false)"
-        )
-
-        build("test").apply {
-
-            assertThat(
-                output.also(::println),
-                containsMultiLineString("""
-                    STRING
-                    foo
-                    bar
-                """)
-            )
-
-            assertThat(
-                output,
-                not(containsString(KotlinCompilerArguments.samConversionForKotlinFunctions))
-            )
-
-            assertThat(
-                output,
-                not(containsString(experimentalWarningFor(":buildSrc")))
-            )
-        }
-    }
-
-    private
-    fun experimentalWarningFor(projectPath: String) =
-        kotlinDslPluginExperimentalWarning(
-            "project '$projectPath'",
-            DocumentationRegistry().getDocumentationFor("kotlin_dsl", "sec:kotlin-dsl_plugin")
-                .substringBefore("docs.gradle.org") // Dropping the Gradle Version
-        )
 
     private
     fun withBuildExercisingSamConversionForKotlinFunctions(buildSrcScript: String = "") {

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -12,6 +12,7 @@ import org.hamcrest.CoreMatchers.not
 
 import org.junit.Assert.assertThat
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 
@@ -237,6 +238,8 @@ class KotlinDslPluginTest : AbstractPluginTest() {
         result.assertTaskExecuted(":compileKotlin")
     }
 
+    // TODO:kotlin-dsl either unignore or remove
+    @Ignore("Until the Kotlin plugin lets us silence the ATTENTION warning somehow")
     @Test
     fun `by default experimental Kotlin compiler features are enabled and a warning is issued`() {
 

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -19,11 +19,6 @@ package org.gradle.kotlin.dsl.plugins.dsl
 import org.gradle.api.HasImplicitReceiver
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
-
-import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.api.internal.TaskInternal
-import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -31,8 +26,6 @@ import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension
 import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverGradleSubplugin
 
 import org.gradle.kotlin.dsl.*
-
-import org.gradle.kotlin.dsl.support.serviceOf
 
 
 /**
@@ -62,20 +55,10 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
                             KotlinCompilerArguments.samConversionForKotlinFunctions
                         )
                     }
-                    it.applyExperimentalWarning(experimentalWarning.get())
                 }
             }
         }
     }
-}
-
-
-private
-fun KotlinCompile.applyExperimentalWarning(experimentalWarning: Boolean) {
-    replaceLoggerWith(
-        if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger as ContextAwareTaskLogger, project.toString(), project.experimentalWarningLink)
-        else KotlinCompilerWarningSilencingLogger(logger as ContextAwareTaskLogger)
-    )
 }
 
 
@@ -85,50 +68,3 @@ object KotlinCompilerArguments {
     const val newInference = "-XXLanguage:+NewInference"
     const val samConversionForKotlinFunctions = "-XXLanguage:+SamConversionForKotlinFunctions"
 }
-
-
-private
-fun KotlinCompile.replaceLoggerWith(logger: Logger) {
-    (this as TaskInternal).replaceLogger(logger)
-}
-
-
-private
-class KotlinCompilerWarningSubstitutingLogger(
-    private val delegate: ContextAwareTaskLogger,
-    private val target: String,
-    private val link: String
-) : ContextAwareTaskLogger by delegate {
-
-    override fun warn(message: String) {
-        if (message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) delegate.warn(kotlinDslPluginExperimentalWarning(target, link))
-        else delegate.warn(message)
-    }
-}
-
-
-private
-class KotlinCompilerWarningSilencingLogger(
-    private val delegate: ContextAwareTaskLogger
-) : ContextAwareTaskLogger by delegate {
-
-    override fun warn(message: String) {
-        if (!message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) {
-            delegate.warn(message)
-        }
-    }
-}
-
-
-fun kotlinDslPluginExperimentalWarning(target: String, link: String) =
-    "The `kotlin-dsl` plugin applied to $target enables experimental Kotlin compiler features. For more information see $link"
-
-
-private
-val Project.experimentalWarningLink
-    get() = documentationRegistry.getDocumentationFor("kotlin_dsl", "sec:kotlin-dsl_plugin")
-
-
-private
-val Project.documentationRegistry
-    get() = serviceOf<DocumentationRegistry>()

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginOptions.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginOptions.kt
@@ -41,10 +41,11 @@ class KotlinDslPluginOptions internal constructor(objects: ObjectFactory) {
     }
 
     /**
-     * Set to `false` to silence the warning about the `kotlin-dsl` plugin enabling Kotlin compiler experimental features.
+     * No longer supported. Previously, it could be set to `false` to silence the warning about the enabled Kotlin experimental features.
      */
+    @Deprecated("experimentalWarning is no longer supported")
     val experimentalWarning = objects.property<Boolean>().apply {
-        set(true)
+        set(false)
     }
 }
 

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -101,7 +101,7 @@ dependencies {
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
 
-val publishedKotlinDslPluginVersion = "1.2.9" // TODO:kotlin-dsl
+val publishedKotlinDslPluginVersion = "1.2.10" // TODO:kotlin-dsl
 
 tasks {
 


### PR DESCRIPTION
Part of https://github.com/gradle/gradle-private/issues/2475