### PR TITLE
Use Deleter to remove output in a number of more cases

### DIFF
--- a/subprojects/antlr/antlr.gradle.kts
+++ b/subprojects/antlr/antlr.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":plugins"))
     implementation(project(":workers"))
+    implementation(project(":files"))
 
     implementation(library("slf4j_api"))
     implementation(library("groovy"))

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -210,7 +210,7 @@ public class AntlrTask extends SourceTask {
         });
         if (cleanRebuild.get()) {
             try {
-                getDeleter().cleanRecursively(outputDirectory, true);
+                getDeleter().ensureEmptyDirectory(outputDirectory, true);
             } catch (IOException ex) {
                 throw new UncheckedIOException(ex);
             }

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.plugins.antlr;
 
-import org.gradle.api.Action;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -36,13 +35,14 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
-import org.gradle.api.tasks.incremental.InputFileDetails;
 import org.gradle.internal.MutableBoolean;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
-import org.gradle.util.GFileUtils;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -59,7 +59,7 @@ public class AntlrTask extends SourceTask {
     private boolean traceLexer;
     private boolean traceParser;
     private boolean traceTreeWalker;
-    private List<String> arguments = new ArrayList<String>();
+    private List<String> arguments = new ArrayList<>();
 
     private FileCollection antlrClasspath;
 
@@ -189,33 +189,31 @@ public class AntlrTask extends SourceTask {
 
     @TaskAction
     public void execute(IncrementalTaskInputs inputs) {
-        final Set<File> grammarFiles = new HashSet<File>();
+        final Set<File> grammarFiles = new HashSet<>();
         final Set<File> sourceFiles = getSource().getFiles();
         final MutableBoolean cleanRebuild = new MutableBoolean();
         inputs.outOfDate(
-            new Action<InputFileDetails>() {
-                @Override
-                public void execute(InputFileDetails details) {
-                    File input = details.getFile();
-                    if (sourceFiles.contains(input)) {
-                        grammarFiles.add(input);
-                    } else {
-                        // classpath change?
-                        cleanRebuild.set(true);
-                    }
-                }
-            }
-        );
-        inputs.removed(new Action<InputFileDetails>() {
-            @Override
-            public void execute(InputFileDetails details) {
-                if (details.isRemoved()) {
+            details -> {
+                File input = details.getFile();
+                if (sourceFiles.contains(input)) {
+                    grammarFiles.add(input);
+                } else {
+                    // classpath change?
                     cleanRebuild.set(true);
                 }
             }
+        );
+        inputs.removed(details -> {
+            if (details.isRemoved()) {
+                cleanRebuild.set(true);
+            }
         });
         if (cleanRebuild.get()) {
-            GFileUtils.cleanDirectory(outputDirectory);
+            try {
+                getDeleter().cleanRecursively(outputDirectory, true);
+            } catch (IOException ex) {
+                throw new UncheckedIOException(ex);
+            }
             grammarFiles.addAll(sourceFiles);
         }
 
@@ -281,5 +279,10 @@ public class AntlrTask extends SourceTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     public FileTree getSource() {
         return super.getSource();
+    }
+
+    @Inject
+    protected Deleter getDeleter() {
+        throw new UnsupportedOperationException("Decorator takes care of injection");
     }
 }

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PackerDirectoryUtil.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PackerDirectoryUtil.java
@@ -27,9 +27,7 @@ public class PackerDirectoryUtil {
     public static void ensureDirectoryForTree(Deleter deleter, TreeType type, File root) throws IOException {
         switch (type) {
             case DIRECTORY:
-                if (!makeDirectory(deleter, root)) {
-                    deleter.cleanRecursively(root, true);
-                }
+                deleter.ensureEmptyDirectory(root, true);
                 break;
             case FILE:
                 if (!makeDirectory(deleter, root.getParentFile())) {

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PackerDirectoryUtil.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PackerDirectoryUtil.java
@@ -18,22 +18,23 @@ package org.gradle.caching.internal.packaging.impl;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.internal.file.TreeType;
+import org.gradle.internal.file.impl.Deleter;
 
 import java.io.File;
 import java.io.IOException;
 
 public class PackerDirectoryUtil {
-    public static void ensureDirectoryForTree(TreeType type, File root) throws IOException {
+    public static void ensureDirectoryForTree(Deleter deleter, TreeType type, File root) throws IOException {
         switch (type) {
             case DIRECTORY:
-                if (!makeDirectory(root)) {
-                    FileUtils.cleanDirectory(root);
+                if (!makeDirectory(deleter, root)) {
+                    deleter.cleanRecursively(root, true);
                 }
                 break;
             case FILE:
-                if (!makeDirectory(root.getParentFile())) {
+                if (!makeDirectory(deleter, root.getParentFile())) {
                     if (root.exists()) {
-                        FileUtils.forceDelete(root);
+                        deleter.deleteRecursively(root, true);
                     }
                 }
                 break;
@@ -42,11 +43,11 @@ public class PackerDirectoryUtil {
         }
     }
 
-    public static boolean makeDirectory(File target) throws IOException {
+    public static boolean makeDirectory(Deleter deleter, File target) throws IOException {
         if (target.isDirectory()) {
             return false;
         } else if (target.isFile()) {
-            FileUtils.forceDelete(target);
+            deleter.delete(target);
         }
         FileUtils.forceMkdir(target);
         return true;

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal.packaging.impl
+
+import org.gradle.api.internal.cache.StringInterner
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.caching.internal.CacheableEntity
+import org.gradle.caching.internal.TestCacheableTree
+import org.gradle.caching.internal.origin.OriginReader
+import org.gradle.caching.internal.origin.OriginWriter
+import org.gradle.internal.file.TreeType
+import org.gradle.internal.file.impl.Deleter
+import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
+import org.gradle.internal.fingerprint.FingerprintingStrategy
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
+import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
+import org.gradle.internal.hash.DefaultStreamHasher
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+import static org.gradle.internal.file.TreeType.DIRECTORY
+import static org.gradle.internal.file.TreeType.FILE
+
+@CleanupTestDirectory
+abstract class AbstractTarBuildCacheEntryPackerSpec extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    def readOrigin = Stub(OriginReader)
+    def writeOrigin = Stub(OriginWriter)
+
+    def fileSystem = createFileSystem()
+    def deleter = createDeleter()
+    def streamHasher = new DefaultStreamHasher()
+    def stringInterner = new StringInterner()
+    def packer = new TarBuildCacheEntryPacker(deleter, fileSystem, streamHasher, stringInterner)
+    def snapshotter = TestFiles.fileSystemSnapshotter()
+
+    abstract protected FileSystem createFileSystem()
+    abstract protected Deleter createDeleter()
+
+    def pack(OutputStream output, OriginWriter writeOrigin = this.writeOrigin, TreeDefinition... treeDefs) {
+        Map<String, CurrentFileCollectionFingerprint> fingerprints = treeDefs.collectEntries { treeDef ->
+            return [(treeDef.tree.name): treeDef.fingerprint()]
+        }
+        packer.pack(entity(treeDefs), fingerprints, output, writeOrigin)
+    }
+
+    def unpack(InputStream input, OriginReader readOrigin = this.readOrigin, TreeDefinition... treeDefs) {
+        packer.unpack(entity(treeDefs), input, readOrigin)
+    }
+
+    def entity(TreeDefinition... treeDefs) {
+        Stub(CacheableEntity) {
+            visitOutputTrees(_ as CacheableEntity.CacheableTreeVisitor) >> { CacheableEntity.CacheableTreeVisitor visitor ->
+                treeDefs.each {
+                    if (it.tree.root != null) {
+                        visitor.visitOutputTree(it.tree.name, it.tree.type, it.tree.root)
+                    }
+                }
+            }
+        }
+    }
+
+    def prop(String name = "test", TreeType type, File output, FingerprintingStrategy fingerprintingStrategy = AbsolutePathFingerprintingStrategy.IGNORE_MISSING) {
+        switch (type) {
+            case FILE:
+                return new TreeDefinition(new TestCacheableTree(name, FILE, output)) {
+                    @Override
+                    CurrentFileCollectionFingerprint fingerprint() {
+                        if (output == null) {
+                            return fingerprintingStrategy.getEmptyFingerprint()
+                        }
+                        return DefaultCurrentFileCollectionFingerprint.from([snapshotter.snapshot(output)], fingerprintingStrategy)
+                    }
+                }
+            case DIRECTORY:
+                return new TreeDefinition(new TestCacheableTree(name, DIRECTORY, output)) {
+                    @Override
+                    CurrentFileCollectionFingerprint fingerprint() {
+                        if (output == null) {
+                            return fingerprintingStrategy.getEmptyFingerprint()
+                        }
+                        return DefaultCurrentFileCollectionFingerprint.from([snapshotter.snapshot(output)], fingerprintingStrategy)
+                    }
+                }
+            default:
+                throw new AssertionError()
+        }
+    }
+
+    protected abstract static class TreeDefinition {
+        final TestCacheableTree tree
+
+        TreeDefinition(TestCacheableTree tree) {
+            this.tree = tree
+        }
+
+        abstract CurrentFileCollectionFingerprint fingerprint()
+    }
+}

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/PackerDirectoryUtilTest.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/PackerDirectoryUtilTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.caching.internal.packaging.impl
 
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -29,13 +30,14 @@ import static org.gradle.internal.file.TreeType.FILE
 class PackerDirectoryUtilTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    def deleter = TestFiles.deleter()
 
     def "parent directory is created for output file"() {
         def targetOutputFile = temporaryFolder.file("build/some-dir/output.txt")
         targetOutputFile << "Some data"
 
         when:
-        ensureDirectoryForTree(FILE, targetOutputFile)
+        ensureDirectoryForTree(deleter, FILE, targetOutputFile)
 
         then:
         targetOutputFile.parentFile.assertIsEmptyDir()
@@ -45,7 +47,7 @@ class PackerDirectoryUtilTest extends Specification {
         def targetOutputDir = temporaryFolder.file("build/output")
 
         when:
-        ensureDirectoryForTree(DIRECTORY, targetOutputDir)
+        ensureDirectoryForTree(deleter, DIRECTORY, targetOutputDir)
 
         then:
         targetOutputDir.assertIsEmptyDir()
@@ -56,7 +58,7 @@ class PackerDirectoryUtilTest extends Specification {
         targetOutputDir.file("sub-dir/data.txt") << "Some data"
 
         when:
-        ensureDirectoryForTree(DIRECTORY, targetOutputDir)
+        ensureDirectoryForTree(deleter, DIRECTORY, targetOutputDir)
 
         then:
         targetOutputDir.assertIsEmptyDir()
@@ -67,7 +69,7 @@ class PackerDirectoryUtilTest extends Specification {
         targetOutputDir << "This should become a directory"
 
         when:
-        ensureDirectoryForTree(DIRECTORY, targetOutputDir)
+        ensureDirectoryForTree(deleter, DIRECTORY, targetOutputDir)
 
         then:
         targetOutputDir.assertIsEmptyDir()
@@ -78,10 +80,9 @@ class PackerDirectoryUtilTest extends Specification {
         targetOutputFile.createDir()
 
         when:
-        ensureDirectoryForTree(FILE, targetOutputFile)
+        ensureDirectoryForTree(deleter, FILE, targetOutputFile)
 
         then:
         targetOutputFile.parentFile.assertIsEmptyDir()
     }
-
 }

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerPermissionTest.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerPermissionTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal.packaging.impl
+
+import org.gradle.internal.file.impl.Deleter
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import spock.lang.Unroll
+
+import static org.gradle.internal.file.TreeType.FILE
+
+class TarBuildCacheEntryPackerPermissionTest extends AbstractTarBuildCacheEntryPackerSpec {
+    @Override
+    protected FileSystem createFileSystem() {
+        Mock(FileSystem)
+    }
+
+    @Override
+    protected Deleter createDeleter() {
+        Mock(Deleter)
+    }
+
+    @Unroll
+    def "can pack single file with file mode #mode"() {
+        def sourceOutputFile = Spy(File, constructorArgs: [temporaryFolder.file("source.txt").absolutePath]) as File
+        sourceOutputFile << "output"
+        def targetOutputFile = Spy(File, constructorArgs: [temporaryFolder.file("target.txt").absolutePath]) as File
+        def output = new ByteArrayOutputStream()
+        def unixMode = Integer.parseInt(mode, 8)
+
+        when:
+        pack output, prop(FILE, sourceOutputFile)
+
+        then:
+        1 * fileSystem.getUnixMode(sourceOutputFile) >> unixMode
+        _ * sourceOutputFile._
+        0 * _
+
+        when:
+        def input = new ByteArrayInputStream(output.toByteArray())
+        unpack input, prop(FILE, targetOutputFile)
+
+        then:
+        targetOutputFile.text == "output"
+        1 * fileSystem.chmod(targetOutputFile, unixMode)
+        _ * targetOutputFile._
+        0 * _
+
+        where:
+        mode << [ "0644", "0755" ]
+    }
+}

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerTest.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerTest.groovy
@@ -16,71 +16,34 @@
 
 package org.gradle.caching.internal.packaging.impl
 
-import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.caching.internal.CacheableEntity
 import org.gradle.caching.internal.TestCacheableTree
 import org.gradle.caching.internal.origin.OriginReader
 import org.gradle.caching.internal.origin.OriginWriter
 import org.gradle.internal.file.TreeType
+import org.gradle.internal.file.impl.Deleter
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.FingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
-import org.gradle.internal.hash.DefaultStreamHasher
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
-import org.gradle.test.fixtures.file.CleanupTestDirectory
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import org.junit.Rule
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.gradle.internal.file.TreeType.DIRECTORY
 import static org.gradle.internal.file.TreeType.FILE
 
-@CleanupTestDirectory
-class TarBuildCacheEntryPackerTest extends Specification {
-    @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
-    def readOrigin = Stub(OriginReader)
-    def writeOrigin = Stub(OriginWriter)
+class TarBuildCacheEntryPackerTest extends AbstractTarBuildCacheEntryPackerSpec {
+    @Override
+    protected FileSystem createFileSystem() {
+        TestFiles.fileSystem()
+    }
 
-    def fileSystem = Mock(FileSystem)
-    def streamHasher = new DefaultStreamHasher()
-    def stringInterner = new StringInterner()
-    def packer = new TarBuildCacheEntryPacker(fileSystem, streamHasher, stringInterner)
-    def snapshotter = TestFiles.fileSystemSnapshotter()
-
-    @Unroll
-    def "can pack single file with file mode #mode"() {
-        def sourceOutputFile = Spy(File, constructorArgs: [temporaryFolder.file("source.txt").absolutePath]) as File
-        sourceOutputFile << "output"
-        def targetOutputFile = Spy(File, constructorArgs: [temporaryFolder.file("target.txt").absolutePath]) as File
-        def output = new ByteArrayOutputStream()
-        def unixMode = Integer.parseInt(mode, 8)
-
-        when:
-        pack output, prop(FILE, sourceOutputFile)
-
-        then:
-        1 * fileSystem.getUnixMode(sourceOutputFile) >> unixMode
-        _ * sourceOutputFile._
-        0 * _
-
-        when:
-        def input = new ByteArrayInputStream(output.toByteArray())
-        unpack input, prop(FILE, targetOutputFile)
-
-        then:
-        targetOutputFile.text == "output"
-        1 * fileSystem.chmod(targetOutputFile, unixMode)
-        _ * targetOutputFile._
-        0 * _
-
-        where:
-        mode << [ "0644", "0755" ]
+    @Override
+    protected Deleter createDeleter() {
+        TestFiles.deleter()
     }
 
     def "can pack directory"() {
@@ -96,9 +59,6 @@ class TarBuildCacheEntryPackerTest extends Specification {
         def packResult = pack output, prop(DIRECTORY, sourceOutputDir)
 
         then:
-        1 * fileSystem.getUnixMode(sourceSubDir) >> 0711
-        1 * fileSystem.getUnixMode(sourceDataFile) >> 0600
-        0 * _
         packResult.entries == 4
 
         when:
@@ -106,11 +66,6 @@ class TarBuildCacheEntryPackerTest extends Specification {
         def result = unpack input, prop(DIRECTORY, targetOutputDir)
 
         then:
-        1 * fileSystem.chmod(targetOutputDir, 0755)
-        1 * fileSystem.chmod(targetSubDir, 0711)
-        1 * fileSystem.chmod(targetDataFile, 0600)
-        0 * _
-        and:
         targetDataFile.text == "output"
         result.entries == 4
     }
@@ -160,12 +115,7 @@ class TarBuildCacheEntryPackerTest extends Specification {
         sourceOutputFile << "output"
         def targetOutputFile = temporaryFolder.file("target.txt")
         def output = new ByteArrayOutputStream()
-        when:
         pack output, prop(FILE, sourceOutputFile)
-
-        then:
-        1 * fileSystem.getUnixMode(sourceOutputFile) >> 0644
-        0 * _
 
         when:
         def input = new ByteArrayInputStream(output.toByteArray())
@@ -173,8 +123,6 @@ class TarBuildCacheEntryPackerTest extends Specification {
 
         then:
         targetOutputFile.text == "output"
-        1 * fileSystem.chmod(targetOutputFile, 0644)
-        0 * _
 
         where:
         type      | treeName
@@ -186,16 +134,11 @@ class TarBuildCacheEntryPackerTest extends Specification {
     @Unroll
     def "can pack tree directory with files having #type characters in name"() {
         def sourceOutputDir = temporaryFolder.file("source").createDir()
-        def sourceOutputFile = sourceOutputDir.file(fileName) << "output"
+        sourceOutputDir.file(fileName) << "output"
         def targetOutputDir = temporaryFolder.file("target")
         def targetOutputFile = targetOutputDir.file(fileName)
         def output = new ByteArrayOutputStream()
-        when:
         pack output, prop(DIRECTORY, sourceOutputDir)
-
-        then:
-        1 * fileSystem.getUnixMode(sourceOutputFile) >> 0644
-        0 * _
 
         when:
         def input = new ByteArrayInputStream(output.toByteArray())
@@ -203,9 +146,6 @@ class TarBuildCacheEntryPackerTest extends Specification {
 
         then:
         targetOutputFile.text == "output"
-        1 * fileSystem.chmod(targetOutputDir, 0755)
-        1 * fileSystem.chmod(targetOutputFile, 0644)
-        0 * _
 
         where:
         type          | fileName
@@ -220,16 +160,11 @@ class TarBuildCacheEntryPackerTest extends Specification {
     @Unroll
     def "can pack trees having #type characters in name"() {
         def sourceOutputDir = temporaryFolder.file("source").createDir()
-        def sourceOutputFile = sourceOutputDir.file("output.txt") << "output"
+        sourceOutputDir.file("output.txt") << "output"
         def targetOutputDir = temporaryFolder.file("target")
         def targetOutputFile = targetOutputDir.file("output.txt")
         def output = new ByteArrayOutputStream()
-        when:
         pack output, prop(treeName, DIRECTORY, sourceOutputDir)
-
-        then:
-        1 * fileSystem.getUnixMode(sourceOutputFile) >> 0644
-        0 * _
 
         when:
         def input = new ByteArrayInputStream(output.toByteArray())
@@ -237,9 +172,6 @@ class TarBuildCacheEntryPackerTest extends Specification {
 
         then:
         targetOutputFile.text == "output"
-        1 * fileSystem.chmod(targetOutputDir, 0755)
-        1 * fileSystem.chmod(targetOutputFile, 0644)
-        0 * _
 
         where:
         type          | treeName
@@ -253,14 +185,14 @@ class TarBuildCacheEntryPackerTest extends Specification {
     }
 
     def "can pack entity with all optional, null trees"() {
-        def output = new ByteArrayOutputStream()
         when:
+        def output = new ByteArrayOutputStream()
         pack output,
             prop("out1", FILE, null),
             prop("out2", DIRECTORY, null)
 
         then:
-        0 * _
+        noExceptionThrown()
 
         when:
         def input = new ByteArrayInputStream(output.toByteArray())
@@ -269,7 +201,7 @@ class TarBuildCacheEntryPackerTest extends Specification {
             prop("out2", DIRECTORY, null)
 
         then:
-        0 * _
+        noExceptionThrown()
     }
 
     def "can pack entity with missing files"() {
@@ -287,7 +219,7 @@ class TarBuildCacheEntryPackerTest extends Specification {
             prop("missingDir", DIRECTORY, missingSourceDir)
 
         then:
-        0 * _
+        noExceptionThrown()
 
         when:
         def input = new ByteArrayInputStream(output.toByteArray())
@@ -296,18 +228,18 @@ class TarBuildCacheEntryPackerTest extends Specification {
             prop("missingDir", DIRECTORY, missingTargetDir)
 
         then:
-        0 * _
+        noExceptionThrown()
     }
 
     def "can pack entity with empty directory"() {
         def sourceDir = temporaryFolder.file("source").createDir()
         def targetDir = temporaryFolder.file("target")
-        def output = new ByteArrayOutputStream()
         when:
+        def output = new ByteArrayOutputStream()
         pack output, prop("empty", DIRECTORY, sourceDir)
 
         then:
-        0 * _
+        noExceptionThrown()
 
         when:
         def input = new ByteArrayInputStream(output.toByteArray())
@@ -315,8 +247,6 @@ class TarBuildCacheEntryPackerTest extends Specification {
 
         then:
         targetDir.assertIsEmptyDir()
-        1 * fileSystem.chmod(targetDir, 0755)
-        0 * _
     }
 
     def pack(OutputStream output, OriginWriter writeOrigin = this.writeOrigin, TreeDefinition... treeDefs) {
@@ -332,7 +262,7 @@ class TarBuildCacheEntryPackerTest extends Specification {
 
     def entity(TreeDefinition... treeDefs) {
         Stub(CacheableEntity) {
-            visitOutputTrees(_) >> { CacheableEntity.CacheableTreeVisitor visitor ->
+            visitOutputTrees(_ as CacheableEntity.CacheableTreeVisitor) >> { CacheableEntity.CacheableTreeVisitor visitor ->
                 treeDefs.each {
                     if (it.tree.root != null) {
                         visitor.visitOutputTree(it.tree.name, it.tree.type, it.tree.root)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -96,7 +96,14 @@ public class DefaultFileOperations implements FileOperations {
         this.resourceHandler = new DefaultResourceHandler(this, new DefaultResourceResolver(fileResolver, fileSystem), temporaryFileProvider, textResourceLoader);
         this.streamHasher = streamHasher;
         this.fileHasher = fileHasher;
-        this.fileCopier = new FileCopier(this.instantiator, fileSystem, this.fileResolver, fileLookup, directoryFileTreeFactory);
+        this.fileCopier = new FileCopier(
+            deleter,
+            directoryFileTreeFactory,
+            fileLookup,
+            fileResolver,
+            fileSystem,
+            instantiator
+        );
         this.fileSystem = fileSystem;
         this.deleter = deleter;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopier.java
@@ -21,24 +21,34 @@ import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.io.File;
 
 public class FileCopier {
-    private final Instantiator instantiator;
-    private final FileSystem fileSystem;
-    private final FileResolver fileResolver;
-    private final FileLookup fileLookup;
+    private final Deleter deleter;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
+    private final FileLookup fileLookup;
+    private final FileResolver fileResolver;
+    private final FileSystem fileSystem;
+    private final Instantiator instantiator;
 
-    public FileCopier(Instantiator instantiator, FileSystem fileSystem, FileResolver fileResolver, FileLookup fileLookup, DirectoryFileTreeFactory directoryFileTreeFactory) {
-        this.instantiator = instantiator;
-        this.fileSystem = fileSystem;
-        this.fileResolver = fileResolver;
-        this.fileLookup = fileLookup;
+    public FileCopier(
+        Deleter deleter,
+        DirectoryFileTreeFactory directoryFileTreeFactory,
+        FileLookup fileLookup,
+        FileResolver fileResolver,
+        FileSystem fileSystem,
+        Instantiator instantiator
+    ) {
+        this.deleter = deleter;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
+        this.fileLookup = fileLookup;
+        this.fileResolver = fileResolver;
+        this.fileSystem = fileSystem;
+        this.instantiator = instantiator;
     }
 
     private DestinationRootCopySpec createCopySpec(Action<? super CopySpec> action) {
@@ -58,7 +68,7 @@ public class FileCopier {
     public WorkResult sync(Action<? super CopySpec> action) {
         DestinationRootCopySpec copySpec = createCopySpec(action);
         File destinationDir = copySpec.getDestinationDir();
-        return doCopy(copySpec, new SyncCopyActionDecorator(destinationDir, getCopyVisitor(destinationDir), directoryFileTreeFactory));
+        return doCopy(copySpec, new SyncCopyActionDecorator(destinationDir, getCopyVisitor(destinationDir), deleter, directoryFileTreeFactory));
     }
 
     private FileCopyAction getCopyVisitor(File destination) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -104,29 +104,23 @@ public class SyncCopyActionDecorator implements CopyAction {
 
         @Override
         public void visitDir(FileVisitDetails dirDetails) {
-            maybeDelete(dirDetails, true);
+            maybeDelete(dirDetails);
         }
 
         @Override
         public void visitFile(FileVisitDetails fileDetails) {
-            maybeDelete(fileDetails, false);
+            maybeDelete(fileDetails);
         }
 
-        private void maybeDelete(FileVisitDetails fileDetails, boolean isDir) {
+        private void maybeDelete(FileVisitDetails fileDetails) {
             RelativePath path = fileDetails.getRelativePath();
             if (!visited.contains(path)) {
                 if (preserveSet.isEmpty() || !preserveSpec.isSatisfiedBy(fileDetails)) {
-                    File file = fileDetails.getFile();
-                    if (isDir) {
-                        try {
-                            deleter.deleteRecursively(file, true);
-                        } catch (IOException ex) {
-                            throw new UncheckedIOException(ex);
-                        }
-                    } else {
-                        deleter.delete(file);
+                    try {
+                        didWork = deleter.deleteRecursively(fileDetails.getFile(), true);
+                    } catch (IOException ex) {
+                        throw new UncheckedIOException(ex);
                     }
-                    didWork = true;
                 }
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SyncCopyActionDecorator.java
@@ -19,7 +19,6 @@ import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.specs.Spec;
@@ -27,10 +26,12 @@ import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.util.GFileUtils;
+import org.gradle.internal.file.impl.Deleter;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,37 +39,42 @@ public class SyncCopyActionDecorator implements CopyAction {
     private final File baseDestDir;
     private final CopyAction delegate;
     private final PatternFilterable preserveSpec;
+    private final Deleter deleter;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
-    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, DirectoryFileTreeFactory directoryFileTreeFactory) {
-        this(baseDestDir, delegate, null, directoryFileTreeFactory);
+    public SyncCopyActionDecorator(
+        File baseDestDir,
+        CopyAction delegate,
+        Deleter deleter,
+        DirectoryFileTreeFactory directoryFileTreeFactory
+    ) {
+        this(baseDestDir, delegate, null, deleter, directoryFileTreeFactory);
     }
 
-    public SyncCopyActionDecorator(File baseDestDir, CopyAction delegate, PatternFilterable preserveSpec, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    public SyncCopyActionDecorator(
+        File baseDestDir,
+        CopyAction delegate,
+        @Nullable PatternFilterable preserveSpec,
+        Deleter deleter,
+        DirectoryFileTreeFactory directoryFileTreeFactory
+    ) {
         this.baseDestDir = baseDestDir;
         this.delegate = delegate;
         this.preserveSpec = preserveSpec;
+        this.deleter = deleter;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
     @Override
     public WorkResult execute(final CopyActionProcessingStream stream) {
-        final Set<RelativePath> visited = new HashSet<RelativePath>();
+        final Set<RelativePath> visited = new HashSet<>();
 
-        WorkResult didWork = delegate.execute(new CopyActionProcessingStream() {
-            @Override
-            public void process(final CopyActionProcessingStreamAction action) {
-                stream.process(new CopyActionProcessingStreamAction() {
-                    @Override
-                    public void processFile(FileCopyDetailsInternal details) {
-                        visited.add(details.getRelativePath());
-                        action.processFile(details);
-                    }
-                });
-            }
-        });
+        WorkResult didWork = delegate.execute(action -> stream.process(details -> {
+            visited.add(details.getRelativePath());
+            action.processFile(details);
+        }));
 
-        SyncCopyActionDecoratorFileVisitor fileVisitor = new SyncCopyActionDecoratorFileVisitor(visited, preserveSpec);
+        SyncCopyActionDecoratorFileVisitor fileVisitor = new SyncCopyActionDecoratorFileVisitor(visited, preserveSpec, deleter);
 
         MinimalFileTree walker = directoryFileTreeFactory.create(baseDestDir).postfix();
         walker.visit(fileVisitor);
@@ -81,10 +87,12 @@ public class SyncCopyActionDecorator implements CopyAction {
         private final Set<RelativePath> visited;
         private final Spec<FileTreeElement> preserveSpec;
         private final PatternSet preserveSet;
+        private final Deleter deleter;
         private boolean didWork;
 
-        private SyncCopyActionDecoratorFileVisitor(Set<RelativePath> visited, @Nullable PatternFilterable preserveSpec) {
+        private SyncCopyActionDecoratorFileVisitor(Set<RelativePath> visited, @Nullable PatternFilterable preserveSpec, Deleter deleter) {
             this.visited = visited;
+            this.deleter = deleter;
             PatternSet preserveSet = new PatternSet();
             if (preserveSpec != null) {
                 preserveSet.include(preserveSpec.getIncludes());
@@ -108,7 +116,16 @@ public class SyncCopyActionDecorator implements CopyAction {
             RelativePath path = fileDetails.getRelativePath();
             if (!visited.contains(path)) {
                 if (preserveSet.isEmpty() || !preserveSpec.isSatisfiedBy(fileDetails)) {
-                    GFileUtils.forceDelete(fileDetails.getFile());
+                    File file = fileDetails.getFile();
+                    if (isDir) {
+                        try {
+                            deleter.deleteRecursively(file, true);
+                        } catch (IOException ex) {
+                            throw new UncheckedIOException(ex);
+                        }
+                    } else {
+                        deleter.delete(file);
+                    }
                     didWork = true;
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
@@ -27,15 +27,17 @@ import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.internal.execution.OutputChangeListener;
 import org.gradle.internal.execution.history.OutputFilesRepository;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.util.GFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -45,22 +47,31 @@ public class CleanupStaleOutputsExecuter implements TaskExecuter {
 
     private final Logger logger = LoggerFactory.getLogger(CleanupStaleOutputsExecuter.class);
     private final BuildOperationExecutor buildOperationExecutor;
+    private final Deleter deleter;
     private final OutputChangeListener outputChangeListener;
     private final TaskExecuter executer;
     private final OutputFilesRepository outputFilesRepository;
     private final BuildOutputCleanupRegistry cleanupRegistry;
 
-    public CleanupStaleOutputsExecuter(BuildOutputCleanupRegistry cleanupRegistry, OutputFilesRepository outputFilesRepository, BuildOperationExecutor buildOperationExecutor, OutputChangeListener outputChangeListener, TaskExecuter executer) {
+    public CleanupStaleOutputsExecuter(
+        BuildOperationExecutor buildOperationExecutor,
+        BuildOutputCleanupRegistry cleanupRegistry,
+        Deleter deleter,
+        OutputChangeListener outputChangeListener,
+        OutputFilesRepository outputFilesRepository,
+        TaskExecuter executer
+    ) {
         this.cleanupRegistry = cleanupRegistry;
         this.buildOperationExecutor = buildOperationExecutor;
+        this.deleter = deleter;
         this.outputChangeListener = outputChangeListener;
         this.executer = executer;
         this.outputFilesRepository = outputFilesRepository;
     }
 
     @Override
-    public TaskExecuterResult execute(final TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
-        final Set<File> filesToDelete = new HashSet<File>();
+    public TaskExecuterResult execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        Set<File> filesToDelete = new HashSet<>();
         TaskProperties properties = context.getTaskProperties();
         for (FilePropertySpec outputFileSpec : properties.getOutputFileProperties()) {
             FileCollection files = outputFileSpec.getPropertyFiles();
@@ -78,7 +89,11 @@ public class CleanupStaleOutputsExecuter implements TaskExecuter {
                     for (File file : filesToDelete) {
                         if (file.exists()) {
                             logger.info("Deleting stale output file: {}", file.getAbsolutePath());
-                            GFileUtils.forceDelete(file);
+                            try {
+                                deleter.deleteRecursively(file, true);
+                            } catch (IOException ex) {
+                                throw new UncheckedIOException("Couldn't delete stale output file", ex);
+                            }
                         }
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Sync.java
@@ -26,8 +26,10 @@ import org.gradle.api.internal.file.copy.FileCopyAction;
 import org.gradle.api.internal.file.copy.SyncCopyActionDecorator;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.reflect.Instantiator;
 
+import javax.inject.Inject;
 import java.io.File;
 
 /**
@@ -73,7 +75,13 @@ public class Sync extends AbstractCopyTask {
         if (destinationDir == null) {
             throw new InvalidUserDataException("No copy destination directory has been specified, use 'into' to specify a target directory.");
         }
-        return new SyncCopyActionDecorator(destinationDir, new FileCopyAction(getFileLookup().getFileResolver(destinationDir)), preserveInDestination, getDirectoryFileTreeFactory());
+        return new SyncCopyActionDecorator(
+            destinationDir,
+            new FileCopyAction(getFileLookup().getFileResolver(destinationDir)),
+            preserveInDestination,
+            getDeleter(),
+            getDirectoryFileTreeFactory()
+        );
     }
 
     @Override
@@ -133,4 +141,8 @@ public class Sync extends AbstractCopyTask {
         return this;
     }
 
+    @Inject
+    protected Deleter getDeleter() {
+        throw new UnsupportedOperationException("Decorator takes care of injection");
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
@@ -32,6 +32,7 @@ import org.gradle.caching.internal.services.BuildCacheControllerFactory.BuildCac
 import org.gradle.caching.internal.services.BuildCacheControllerFactory.RemoteAccessMode;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.internal.SystemProperties;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
@@ -55,8 +56,14 @@ public class BuildCacheServices {
     private static final Path ROOT_BUILD_SRC_PATH = Path.path(":" + BuildSourceBuilder.BUILD_SRC);
     private static final String GRADLE_VERSION_KEY = "gradleVersion";
 
-    BuildCacheEntryPacker createResultPacker(FileSystem fileSystem, StreamHasher fileHasher, StringInterner stringInterner) {
-        return new GZipBuildCacheEntryPacker(new TarBuildCacheEntryPacker(fileSystem, fileHasher, stringInterner));
+    BuildCacheEntryPacker createResultPacker(
+        Deleter deleter,
+        FileSystem fileSystem,
+        StreamHasher fileHasher,
+        StringInterner stringInterner
+    ) {
+        return new GZipBuildCacheEntryPacker(
+            new TarBuildCacheEntryPacker(deleter, fileSystem, fileHasher, stringInterner));
     }
 
     OriginMetadataFactory createOriginMetadataFactory(

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -57,6 +57,7 @@ import org.gradle.internal.file.DefaultReservedFileSystemLocationRegistry;
 import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.file.ReservedFileSystemLocation;
 import org.gradle.internal.file.ReservedFileSystemLocationRegistry;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.fingerprint.FileCollectionSnapshotter;
@@ -99,7 +100,6 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
 
     TaskExecuter createTaskExecuter(TaskExecutionModeResolver repository,
                                     BuildCacheController buildCacheController,
-                                    TaskInputsListener inputsListener,
                                     TaskActionListener actionListener,
                                     OutputChangeListener outputChangeListener,
                                     ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
@@ -118,6 +118,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
                                     TaskListenerInternal taskListenerInternal,
                                     TaskCacheabilityResolver taskCacheabilityResolver,
                                     WorkExecutor<ExecutionRequestContext, CachingResult> workExecutor,
+                                    Deleter deleter,
                                     ListenerManager listenerManager,
                                     ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry,
                                     EmptySourceTaskSkipper emptySourceTaskSkipper
@@ -143,7 +144,14 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
             emptySourceTaskSkipper,
             fileCollectionFactory
         );
-        executer = new CleanupStaleOutputsExecuter(cleanupRegistry, outputFilesRepository, buildOperationExecutor, outputChangeListener, executer);
+        executer = new CleanupStaleOutputsExecuter(
+            buildOperationExecutor,
+            cleanupRegistry,
+            deleter,
+            outputChangeListener,
+            outputFilesRepository,
+            executer
+        );
         executer = new FinalizePropertiesTaskExecuter(executer);
         executer = new ResolveTaskExecutionModeExecuter(repository, fileCollectionFactory, propertyWalker, executer);
         executer = new SkipTaskWithNoActionsExecuter(taskExecutionGraph, executer);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -165,7 +165,7 @@ public class ExecutionGradleServices {
             new TimeoutStep<>(timeoutHandler,
             new CancelExecutionStep<>(cancellationToken,
             new ResolveInputChangesStep<>(
-            new CleanupOutputsStep<>(
+            new CleanupOutputsStep<>(deleter,
             new ExecuteStep<>(
         ))))))))))))))))))))));
         // @formatter:on

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/SyncCopyActionDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/SyncCopyActionDecoratorTest.groovy
@@ -28,7 +28,14 @@ class SyncCopyActionDecoratorTest extends WorkspaceTest {
     FileCopier copier
 
     def setup() {
-        copier = new FileCopier(TestUtil.instantiatorFactory().decorateLenient(), TestFiles.fileSystem(), TestFiles.resolver(testDirectory), TestFiles.fileLookup(), new DefaultDirectoryFileTreeFactory())
+        copier = new FileCopier(
+            TestFiles.deleter(),
+            new DefaultDirectoryFileTreeFactory(),
+            TestFiles.fileLookup(),
+            TestFiles.resolver(testDirectory),
+            TestFiles.fileSystem(),
+            TestUtil.instantiatorFactory().decorateLenient(),
+        )
     }
 
     void deletesExtraFilesFromDestinationDirectoryAtTheEndOfVisit() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -146,6 +146,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def emptySourceTaskSkipper = Stub(EmptySourceTaskSkipper)
     def overlappingOutputDetector = Stub(OverlappingOutputDetector)
     def fileCollectionFactory = new DefaultFileCollectionFactory(new IdentityFileResolver(), null)
+    def deleter = TestFiles.deleter()
 
     // @formatter:off
     def workExecutor = new DefaultWorkExecutor<>(
@@ -161,7 +162,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         new CatchExceptionStep<>(
         new CancelExecutionStep<>(cancellationToken,
         new ResolveInputChangesStep<>(
-        new CleanupOutputsStep<>(
+        new CleanupOutputsStep<>(deleter,
         new ExecuteStep<>(
     )))))))))))))))
     // @formatter:on

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -148,6 +148,7 @@ import org.gradle.internal.execution.steps.StoreExecutionStateStep;
 import org.gradle.internal.execution.steps.TimeoutStep;
 import org.gradle.internal.execution.steps.ValidateStep;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.fingerprint.FileCollectionSnapshotter;
@@ -245,6 +246,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         WorkExecutor<ExecutionRequestContext, CachingResult> createWorkExecutor(
             BuildOperationExecutor buildOperationExecutor,
             ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
+            Deleter deleter,
             ExecutionStateChangeDetector changeDetector,
             ListenerManager listenerManager,
             OverlappingOutputDetector overlappingOutputDetector,
@@ -269,7 +271,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 new CatchExceptionStep<>(
                 new TimeoutStep<>(timeoutHandler,
                 new ResolveInputChangesStep<>(
-                new CleanupOutputsStep<>(
+                new CleanupOutputsStep<>(deleter,
                 new ExecuteStep<>(
             ))))))))))))))));
             // @formatter:on

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/WorkExecutorTestFixture.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/WorkExecutorTestFixture.java
@@ -119,10 +119,11 @@ public class WorkExecutorTestFixture {
             }
 
             @Override
-            public boolean cleanRecursively(File target, boolean followSymlinks) throws IOException {
-                boolean wasDirectory = target.isDirectory();
-                FileUtils.cleanDirectory(target);
-                return wasDirectory;
+            public boolean ensureEmptyDirectory(File target, boolean followSymlinks) throws IOException {
+                File[] children = target.listFiles();
+                FileUtils.forceDelete(target);
+                FileUtils.forceMkdir(target);
+                return children == null || children.length == 0;
             }
 
             @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/WorkExecutorTestFixture.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/WorkExecutorTestFixture.java
@@ -43,6 +43,7 @@ import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.internal.snapshot.impl.DefaultFileSystemMirror;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
 
 public class WorkExecutorTestFixture {
@@ -115,6 +116,13 @@ public class WorkExecutorTestFixture {
             @Override
             public boolean deleteRecursively(File target, boolean followSymlinks) {
                 return FileUtils.deleteQuietly(target);
+            }
+
+            @Override
+            public boolean cleanRecursively(File target, boolean followSymlinks) throws IOException {
+                boolean wasDirectory = target.isDirectory();
+                FileUtils.cleanDirectory(target);
+                return wasDirectory;
             }
 
             @Override

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -133,6 +133,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
 
     def changeDetector = new DefaultExecutionStateChangeDetector()
     def overlappingOutputDetector = new DefaultOverlappingOutputDetector()
+    def deleter = TestFiles.deleter()
 
     WorkExecutor<ExecutionRequestContext, CachingResult> getExecutor() {
         // @formatter:off
@@ -150,7 +151,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
             new CreateOutputsStep<>(
             new CatchExceptionStep<>(
             new ResolveInputChangesStep<>(
-            new CleanupOutputsStep<>(
+            new CleanupOutputsStep<>(deleter,
             new ExecuteStep<>(
         ))))))))))))))))
         // @formatter:on

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CleanupOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CleanupOutputsStep.java
@@ -105,7 +105,7 @@ public class CleanupOutputsStep<C extends InputChangesContext, R extends Result>
                             break;
                         case DIRECTORY:
                             try {
-                                deleter.cleanRecursively(root, true);
+                                deleter.ensureEmptyDirectory(root, true);
                             } catch (IOException ex) {
                                 throw new UncheckedIOException(ex);
                             }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CleanupOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CleanupOutputsStep.java
@@ -24,8 +24,8 @@ import org.gradle.internal.execution.Step;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.impl.OutputsCleaner;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
-import org.gradle.util.GFileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,9 +35,14 @@ import java.util.Set;
 
 public class CleanupOutputsStep<C extends InputChangesContext, R extends Result> implements Step<C, R> {
 
+    private final Deleter deleter;
     private final Step<? super C, ? extends R> delegate;
 
-    public CleanupOutputsStep(Step<? super C, ? extends R> delegate) {
+    public CleanupOutputsStep(
+        Deleter deleter,
+        Step<? super C, ? extends R> delegate
+    ) {
+        this.deleter = deleter;
         this.delegate = delegate;
     }
 
@@ -96,10 +101,14 @@ public class CleanupOutputsStep<C extends InputChangesContext, R extends Result>
                 if (root.exists()) {
                     switch (type) {
                         case FILE:
-                            GFileUtils.forceDelete(root);
+                            deleter.delete(root);
                             break;
                         case DIRECTORY:
-                            GFileUtils.cleanDirectory(root);
+                            try {
+                                deleter.cleanRecursively(root, true);
+                            } catch (IOException ex) {
+                                throw new UncheckedIOException(ex);
+                            }
                             break;
                         default:
                             throw new AssertionError();

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.execution.steps
 
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSortedMap
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.internal.execution.InputChangesContext
 import org.gradle.internal.execution.Result
@@ -36,8 +37,9 @@ class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements Fi
     def afterPreviousExecution = Mock(AfterPreviousExecutionState)
     def beforeExecutionState = Mock(BeforeExecutionState)
     def delegateResult = Mock(Result)
+    def deleter = TestFiles.deleter()
 
-    def step = new CleanupOutputsStep<>(delegate)
+    def step = new CleanupOutputsStep<>(deleter, delegate)
 
     @Override
     protected InputChangesContext createContext() {
@@ -162,7 +164,7 @@ class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements Fi
         1 * delegate.execute(_) >> delegateResult
         0 * _
     }
-    
+
     def "does cleanup outputs when work does not request input changes"() {
         def outputs = new WorkOutputs()
         outputs.createContents()

--- a/subprojects/files/src/main/java/org/gradle/internal/file/impl/DefaultDeleter.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/impl/DefaultDeleter.java
@@ -63,9 +63,17 @@ public class DefaultDeleter implements Deleter {
     }
 
     @Override
-    public boolean cleanRecursively(File root, boolean followSymlinks) throws IOException {
-        if (root.exists() && shouldRemoveContentsOf(root, followSymlinks)) {
+    public boolean ensureEmptyDirectory(File root, boolean followSymlinks) throws IOException {
+        if (root.isDirectory()) {
             return deleteRecursively(root, followSymlinks, true);
+        } else if (root.isFile()) {
+            if (!delete(root)) {
+                throw new IOException("Couldn't delete file: " + root);
+            }
+            if (!root.mkdirs()) {
+                throw new IOException("Couldn't create directory: " + root);
+            }
+            return true;
         } else {
             return false;
         }

--- a/subprojects/files/src/main/java/org/gradle/internal/file/impl/DefaultDeleter.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/impl/DefaultDeleter.java
@@ -64,19 +64,18 @@ public class DefaultDeleter implements Deleter {
 
     @Override
     public boolean ensureEmptyDirectory(File root, boolean followSymlinks) throws IOException {
-        if (root.isDirectory()) {
-            return deleteRecursively(root, followSymlinks, true);
-        } else if (root.isFile()) {
+        if (root.exists()) {
+            if (root.isDirectory()) {
+                return deleteRecursively(root, followSymlinks, true);
+            }
             if (!delete(root)) {
-                throw new IOException("Couldn't delete file: " + root);
+                throw new IOException("Couldn't delete " + root);
             }
-            if (!root.mkdirs()) {
-                throw new IOException("Couldn't create directory: " + root);
-            }
-            return true;
-        } else {
-            return false;
         }
+        if (!root.mkdirs()) {
+            throw new IOException("Couldn't create directory: " + root);
+        }
+        return true;
     }
 
     private boolean deleteRecursively(File root, boolean followSymlinks, boolean keepRootDirectory) throws IOException {

--- a/subprojects/files/src/main/java/org/gradle/internal/file/impl/Deleter.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/impl/Deleter.java
@@ -38,6 +38,20 @@ public interface Deleter {
     boolean deleteRecursively(File target, boolean followSymlinks) throws IOException;
 
     /**
+     * Attempts to clean the given directory recursively, removing all of its contents.
+     *
+     * Does nothing when {@code target} is a regular file.
+     * Follows symlinks pointing to directories when instructed to.
+     *
+     * @return {@code true} if anything was removed, {@code false} if no change was
+     *         attempted (because {@code target} didn't exist).
+     *
+     * @throws IOException when {@code target} cannot be deleted (with detailed error
+     *         message).
+     */
+    boolean cleanRecursively(File target, boolean followSymlinks) throws IOException;
+
+    /**
      * Attempts to delete a single file or an empty directory.
      *
      * Does not follow symlinks.

--- a/subprojects/files/src/main/java/org/gradle/internal/file/impl/Deleter.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/impl/Deleter.java
@@ -38,9 +38,17 @@ public interface Deleter {
     boolean deleteRecursively(File target, boolean followSymlinks) throws IOException;
 
     /**
-     * Attempts to clean the given directory recursively, removing all of its contents.
+     * Makes sure that the given target is an empty directory.
      *
-     * Does nothing when {@code target} is a regular file.
+     * If target is...
+     *
+     * <ul>
+     *     <li>a directory, then its contents are removed recursively,</li>
+     *     <li>a symlink pointing to an existing directory, then the linked directory's contents are removed recursively,</li>
+     *     <li>a file, or a symlink to an existing file, it is deleted and a directory is created in its place,</li>
+     *     <li>non-existent, then a directory is created in its place.</li>
+     * </ul>
+     *
      * Follows symlinks pointing to directories when instructed to.
      *
      * @return {@code true} if anything was removed, {@code false} if no change was
@@ -49,7 +57,7 @@ public interface Deleter {
      * @throws IOException when {@code target} cannot be deleted (with detailed error
      *         message).
      */
-    boolean cleanRecursively(File target, boolean followSymlinks) throws IOException;
+    boolean ensureEmptyDirectory(File target, boolean followSymlinks) throws IOException;
 
     /**
      * Attempts to delete a single file or an empty directory.

--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.internal.file.impl
 
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Specification
@@ -75,6 +76,23 @@ class DefaultDeleterTest extends Specification {
         then:
         dir.assertIsEmptyDir()
         didWork
+    }
+
+
+    @Requires(TestPrecondition.SYMLINKS)
+    def "cleans symlinked target directory"() {
+        def target = tmpDir.createDir("target")
+        def content = target.createFile("content.txt")
+        def link = tmpDir.file("link").tap { Files.createSymbolicLink(it.toPath(), target.toPath()) }
+
+        when:
+        ensureEmptyDirectory(link)
+
+        then:
+        target.assertIsEmptyDir()
+        link.assertIsEmptyDir()
+        Files.readSymbolicLink(link.toPath()) == target.toPath()
+        content.assertDoesNotExist()
     }
 
     def "creates directory in place of file"() {

--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
@@ -90,6 +90,19 @@ class DefaultDeleterTest extends Specification {
         didWork
     }
 
+    def "creates directory if nothing existed before"() {
+        given:
+        TestFile dir = tmpDir.getTestDirectory()
+        def file = dir.file("someFile")
+
+        when:
+        boolean didWork = ensureEmptyDirectory(file)
+
+        then:
+        file.assertIsDir()
+        didWork
+    }
+
     def "didWork is false when nothing has been deleted"() {
         given:
         TestFile dir = tmpDir.file("unknown")

--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
@@ -43,7 +43,7 @@ class DefaultDeleterTest extends Specification {
         dir.file("someFile").createFile()
 
         when:
-        boolean didWork = delete(dir)
+        boolean didWork = deleteRecursively(dir)
 
         then:
         dir.assertDoesNotExist()
@@ -57,37 +57,37 @@ class DefaultDeleterTest extends Specification {
         file.createFile()
 
         when:
-        boolean didWork = delete(file)
+        boolean didWork = deleteRecursively(file)
 
         then:
         file.assertDoesNotExist()
         didWork
     }
 
-    def "cleans directory"() {
+    def "cleans non-empty directory"() {
         given:
         TestFile dir = tmpDir.getTestDirectory()
         dir.file("someFile").createFile()
 
         when:
-        boolean didWork = clean(dir)
+        boolean didWork = ensureEmptyDirectory(dir)
 
         then:
         dir.assertIsEmptyDir()
         didWork
     }
 
-    def "cleans doesn't remove file target"() {
+    def "creates directory in place of file"() {
         given:
         TestFile dir = tmpDir.getTestDirectory()
         def file = dir.file("someFile").createFile()
 
         when:
-        boolean didWork = clean(file)
+        boolean didWork = ensureEmptyDirectory(file)
 
         then:
-        file.assertIsFile()
-        !didWork
+        file.assertIsDir()
+        didWork
     }
 
     def "didWork is false when nothing has been deleted"() {
@@ -96,7 +96,7 @@ class DefaultDeleterTest extends Specification {
         dir.assertDoesNotExist()
 
         when:
-        boolean didWork = delete(dir)
+        boolean didWork = deleteRecursively(dir)
 
         then:
         !didWork
@@ -107,7 +107,7 @@ class DefaultDeleterTest extends Specification {
         TestFile emptyDir = tmpDir.getTestDirectory()
 
         when:
-        boolean didWork = clean(emptyDir)
+        boolean didWork = ensureEmptyDirectory(emptyDir)
 
         then:
         !didWork
@@ -130,7 +130,7 @@ class DefaultDeleterTest extends Specification {
         target = isSymlink ? tmpDir.file("link").tap { Files.createSymbolicLink(delegate.toPath(), target.toPath()) } : target
 
         when:
-        delete(target)
+        deleteRecursively(target)
 
         then:
         def ex = thrown IOException
@@ -159,7 +159,7 @@ class DefaultDeleterTest extends Specification {
         }
 
         when:
-        delete(targetDir)
+        deleteRecursively(targetDir)
 
         then:
         targetDir.assertIsDir()
@@ -192,7 +192,7 @@ class DefaultDeleterTest extends Specification {
         }
 
         when:
-        delete(targetDir)
+        deleteRecursively(targetDir)
 
         then:
         targetDir.assertIsDir()
@@ -225,7 +225,7 @@ class DefaultDeleterTest extends Specification {
         }
 
         when:
-        delete(targetDir)
+        deleteRecursively(targetDir)
 
         then:
         targetDir.assertIsDir()
@@ -261,7 +261,7 @@ class DefaultDeleterTest extends Specification {
         }
 
         when:
-        delete(targetDir)
+        deleteRecursively(targetDir)
 
         then: 'nothing gets deleted'
         targetDir.assertIsDir()
@@ -330,11 +330,11 @@ class DefaultDeleterTest extends Specification {
         FAILURE, CONTINUE
     }
 
-    private boolean delete(File target) {
+    private boolean deleteRecursively(File target) {
         return deleter.deleteRecursively(target, false)
     }
 
-    private boolean clean(File target) {
-        return deleter.cleanRecursively(target, false)
+    private boolean ensureEmptyDirectory(File target) {
+        return deleter.ensureEmptyDirectory(target, false)
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -390,6 +390,8 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails 'syncIt'
+
+        cleanup:
         ins.close()
     }
 

--- a/subprojects/language-groovy/language-groovy.gradle.kts
+++ b/subprojects/language-groovy/language-groovy.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(project(":platformJvm"))
     implementation(project(":languageJvm"))
     implementation(project(":languageJava"))
+    implementation(project(":files"))
 
     implementation(library("slf4j_api"))
     implementation(library("groovy"))
@@ -34,7 +35,7 @@ dependencies {
     testImplementation(testFixtures(project(":launcher")))
 
     testRuntimeOnly(project(":runtimeApiInfo"))
-    
+
     testFixturesApi(testFixtures(project(":languageJvm")))
     testFixturesImplementation(project(":core"))
     testFixturesImplementation(project(":internalTesting"))

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -101,7 +101,7 @@ public class Groovydoc extends SourceTask {
         checkGroovyClasspathNonEmpty(getGroovyClasspath().getFiles());
         File destinationDir = getDestinationDir();
         try {
-            getDeleter().cleanRecursively(destinationDir, true);
+            getDeleter().ensureEmptyDirectory(destinationDir, true);
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.javadoc;
 
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.ClassPathRegistry;
@@ -35,10 +36,12 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.util.GFileUtils;
+import org.gradle.internal.file.impl.Deleter;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,8 +99,13 @@ public class Groovydoc extends SourceTask {
     @TaskAction
     protected void generate() {
         checkGroovyClasspathNonEmpty(getGroovyClasspath().getFiles());
-        GFileUtils.cleanDirectory(getDestinationDir());
-        getAntGroovydoc().execute(getSource(), getDestinationDir(), isUse(), isNoTimestamp(), isNoVersionStamp(), getWindowTitle(),
+        File destinationDir = getDestinationDir();
+        try {
+            getDeleter().cleanRecursively(destinationDir, true);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        getAntGroovydoc().execute(getSource(), destinationDir, isUse(), isNoTimestamp(), isNoVersionStamp(), getWindowTitle(),
                 getDocTitle(), getHeader(), getFooter(), getPathToOverview(), isIncludePrivate(), getLinks(), getGroovyClasspath(),
                 getClasspath(), getProject());
     }
@@ -446,5 +454,10 @@ public class Groovydoc extends SourceTask {
             result = 31 * result + (url != null ? url.hashCode() : 0);
             return result;
         }
+    }
+
+    @Inject
+    protected Deleter getDeleter() {
+        throw new UnsupportedOperationException("Decorator takes care of injection");
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -107,7 +107,7 @@ public class Javadoc extends SourceTask {
     protected void generate() {
         File destinationDir = getDestinationDir();
         try {
-            getDeleter().cleanRecursively(destinationDir, true);
+            getDeleter().ensureEmptyDirectory(destinationDir, true);
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -34,18 +34,20 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.javadoc.internal.JavadocSpec;
 import org.gradle.external.javadoc.MinimalJavadocOptions;
 import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal;
 import org.gradle.jvm.platform.JavaPlatform;
 import org.gradle.jvm.platform.internal.DefaultJavaPlatform;
 import org.gradle.jvm.toolchain.JavaToolChain;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.ConfigureUtil;
-import org.gradle.util.GFileUtils;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -104,7 +106,11 @@ public class Javadoc extends SourceTask {
     @TaskAction
     protected void generate() {
         File destinationDir = getDestinationDir();
-        GFileUtils.cleanDirectory(destinationDir);
+        try {
+            getDeleter().cleanRecursively(destinationDir, true);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
 
         StandardJavadocDocletOptions options = new StandardJavadocDocletOptions((StandardJavadocDocletOptions) getOptions());
 
@@ -353,5 +359,10 @@ public class Javadoc extends SourceTask {
 
     public void setExecutable(@Nullable String executable) {
         this.executable = executable;
+    }
+
+    @Inject
+    protected Deleter getDeleter() {
+        throw new UnsupportedOperationException("Decorator takes care of injection");
     }
 }

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":baseServices"))
     implementation(project(":logging"))
     implementation(project(":processServices"))
+    implementation(project(":files"))
     implementation(project(":coreApi"))
     implementation(project(":modelCore"))
     implementation(project(":core"))
@@ -59,7 +60,7 @@ dependencies {
 
     integTestImplementation(project(":baseServicesGroovy"))
     integTestImplementation(library("jetbrains_annotations"))
-    
+
     integTestRuntimeOnly(project(":toolingApiBuilders"))
     integTestRuntimeOnly(project(":runtimeApiInfo"))
     integTestRuntimeOnly(project(":testingJunitPlatform"))

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -16,7 +16,6 @@
 
 package org.gradle.plugin.devel.tasks;
 
-import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.DirectoryProperty;
@@ -25,9 +24,11 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.file.impl.Deleter;
 import org.gradle.internal.util.PropertiesUtils;
 import org.gradle.plugin.devel.PluginDeclaration;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
@@ -68,9 +69,14 @@ public class GeneratePluginDescriptors extends DefaultTask {
         }
     }
 
+    @Inject
+    protected Deleter getDeleter() {
+        throw new UnsupportedOperationException("Decorator takes care of injection");
+    }
+
     private void clearOutputDirectory(File directoryToClear) {
         try {
-            FileUtils.cleanDirectory(directoryToClear);
+            getDeleter().cleanRecursively(directoryToClear, true);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -76,7 +76,7 @@ public class GeneratePluginDescriptors extends DefaultTask {
 
     private void clearOutputDirectory(File directoryToClear) {
         try {
-            getDeleter().cleanRecursively(directoryToClear, true);
+            getDeleter().ensureEmptyDirectory(directoryToClear, true);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
This takes https://github.com/gradle/gradle/issues/8684 one step close to completion. This PR removes all the usages of `FileUtils.forceDelete()` and `FileUtils.cleanDirectory()`:

- [x] executing non-incrementally
- [x] when loading from cache
- [x] cleaning up stale outputs
- [x] `SyncCopyAction`
- [x] `AntlrTask`
- [x] `Groovydoc`
- [x] `Javadoc`