### PR TITLE
Remove some deprecated DomainObject* constructors

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -29,7 +29,6 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.metaobject.ConfigureDelegate;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.ConfigureUtil;
-import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 
@@ -44,25 +43,6 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
 
     protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(type, instantiator, Named.Namer.forType(type), callbackActionDecorator);
-    }
-
-    /**
-     * This internal constructor is used by 'nebula.plugin-plugin' which we test as part of our ci pipeline.
-     * */
-    @Deprecated
-    protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
-        this(type, instantiator, namer, CollectionCallbackActionDecorator.NOOP);
-        DeprecationLogger.nagUserOfDeprecated("Internal API constructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator, Namer<? extends T>)", "Don't use internal API");
-    }
-
-
-    /**
-     * This internal constructor is used by the 'com.eriwen.gradle.css' and 'com.eriwen.gradle.js' plugin which we test as part of our ci pipeline.
-     * */
-    @Deprecated
-    protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
-        this(type, instantiator, CollectionCallbackActionDecorator.NOOP);
-        DeprecationLogger.nagUserOfDeprecated("Internal API constructor FactoryNamedDomainObjectContainerConstructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator)", "Don't use internal API");
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
@@ -20,7 +20,6 @@ import org.gradle.api.*;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.core.NamedEntityInstantiator;
-import org.gradle.util.DeprecationLogger;
 
 import java.util.Set;
 
@@ -31,15 +30,6 @@ public class DefaultPolymorphicDomainObjectContainer<T> extends AbstractPolymorp
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {
         super(type, instantiator, namer, callbackDecorator);
         namedEntityInstantiator = new DefaultPolymorphicNamedEntityInstantiator<T>(type, "this container");
-    }
-
-    /**
-     * This internal constructor is used by the 'nebula.lint' plugin which we test as part of our ci pipeline.
-     * */
-    @Deprecated
-    public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator) {
-        this(type, instantiator, Named.Namer.forType(type), CollectionCallbackActionDecorator.NOOP);
-        DeprecationLogger.nagUserOfDeprecated("Internal API constructor DefaultPolymorphicDomainObjectContainer(Class<T>, Instantiator)");
     }
 
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackDecorator) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JavaScriptPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JavaScriptPluginsSmokeTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.smoketests
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Ignore
 
-@Ignore("Ignored until a new version of the plugin is released.  See https://github.com/eriwen/gradle-js-plugin/pull/174.")
+@Ignore("Ignored until a new version of the plugins are released.  See https://github.com/eriwen/gradle-js-plugin/pull/174 and https://github.com/eriwen/gradle-css-plugin/pull/54.")
 class JavaScriptPluginsSmokeTest extends AbstractSmokeTest {
 
     def 'js plugin'() {


### PR DESCRIPTION
There are still some constructors being used by android plugin 3.4.1 that we can't deprecate yet.  This cleans up a few that are either already cleaned up (nebula plugins) or that have pending releases (js/css plugins).