### PR TITLE
Am/ie/small fixes ii

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/PropertyAssociationTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/PropertyAssociationTaskFactory.java
@@ -47,7 +47,11 @@ public class PropertyAssociationTaskFactory implements ITaskFactory {
     @Override
     public <S extends Task> S create(TaskIdentity<S> taskIdentity, @Nullable Object[] constructorArgs) {
         final S task = delegate.create(taskIdentity, constructorArgs);
-        TaskPropertyUtils.visitProperties(propertyWalker, (TaskInternal) task, new Listener(task));
+        if (constructorArgs != null) {
+            // Do not attach property objects when recreating from cache, they're not really needed
+            // TODO:instant-execution - separate construction from property attachment, so that tasks can be recreated from cache and then have properties attached
+            TaskPropertyUtils.visitProperties(propertyWalker, (TaskInternal) task, new Listener(task));
+        }
         return task;
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.provider.DefaultListProperty
 import org.gradle.api.internal.provider.DefaultMapProperty
 import org.gradle.api.internal.provider.DefaultProperty
+import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -33,6 +34,7 @@ import org.gradle.instantexecution.serialization.IsolateContext
 import org.gradle.instantexecution.serialization.PropertyKind
 import org.gradle.instantexecution.serialization.PropertyTrace
 import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.codecs.BrokenValue
 import org.gradle.instantexecution.serialization.logPropertyInfo
 import org.gradle.instantexecution.serialization.logPropertyWarning
 import org.gradle.instantexecution.serialization.withPropertyTrace
@@ -99,7 +101,6 @@ class BeanPropertyReader(
 
     private
     fun setterFor(field: Field): ReadContext.(Any, Any?) -> Unit =
-
         when (val type = field.type) {
             DirectoryProperty::class.java -> { bean, value ->
                 field.set(bean, filePropertyFactory.newDirectoryProperty().apply {
@@ -129,6 +130,7 @@ class BeanPropertyReader(
             Provider::class.java -> { bean, value ->
                 field.set(bean, when (value) {
                     null -> Providers.notDefined()
+                    is BrokenValue -> DefaultProvider { value.rethrow() }
                     else -> Providers.of(value)
                 })
             }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
@@ -74,6 +74,8 @@ val Class<*>.relevantFields: Sequence<Field>
                 || (field.name == "metaClass" && MetaClass::class.java.isAssignableFrom(field.type))
                 // Ignore the `__meta_class__` field that Gradle generates
                 || (field.name == "__meta_class__" && MetaClass::class.java.isAssignableFrom(field.type))
+                // Ignore a lambda field for now
+                || (field.name == "mFolderFilter" && field.declaringClass.name == "com.android.ide.common.resources.DataSet")
         }
         .filter { field ->
             field.declaringClass != AbstractTask::class.java || field.name == "actions"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValue.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValue.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+
+class BrokenValue(val message: String) {
+    fun rethrow(): Nothing {
+        throw RuntimeException(message)
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValueCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValueCodec.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+
+
+object BrokenValueCodec : Codec<BrokenValue> {
+    override suspend fun WriteContext.encode(value: BrokenValue) {
+        writeString(value.message)
+    }
+
+    override suspend fun ReadContext.decode(): BrokenValue? {
+        return BrokenValue(readString())
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -62,6 +62,7 @@ import org.gradle.internal.serialize.SetSerializer
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.process.internal.ExecActionFactory
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.gradle.workers.WorkerExecutor
 import org.gradle.workers.internal.IsolatableSerializerRegistry
 import kotlin.reflect.KClass
 
@@ -133,6 +134,7 @@ class Codecs(
         bind(ImmutableMapCodec)
 
         bind(arrayCodec)
+        bind(BrokenValueCodec)
 
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
@@ -160,6 +162,7 @@ class Codecs(
         bind(ownerService<ExecActionFactory>())
         bind(ownerService<BuildOperationListenerManager>())
         bind(ownerService<BuildRequestMetaData>())
+        bind(ownerService<WorkerExecutor>())
 
         // This protects the BeanCodec against StackOverflowErrors but
         // we can still get them for the other codecs, for instance,

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/PluginAuthorServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/PluginAuthorServices.java
@@ -25,10 +25,10 @@ import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 public class PluginAuthorServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerGlobalServices(ServiceRegistration registration) {
-        registration.addProvider(new GlobalcopeServices());
+        registration.addProvider(new GlobalScopeServices());
     }
 
-    private static class GlobalcopeServices {
+    private static class GlobalScopeServices {
         SoftwareComponentFactory createSoftwareComponentFactory() {
             return new DefaultSoftwareComponentFactory();
         }


### PR DESCRIPTION

### Context

A collection of fixes to instant execution:

- Serialize references to `WorkerExecutor`.
- Serialize broken `Provider<T>` instances, similar to broken `FileCollection` instances.
- Fix deserializing tasks implemented in Kotlin and with a property of type `Property` and with an output file annotation attached.
- A work around for the Android plugin, pending support for serialization of Java lambdas.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
