### PR TITLE
Disable some https test on JDK12

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsProxyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsProxyResolveIntegrationTest.groovy
@@ -19,8 +19,12 @@ package org.gradle.integtests.resolve.http
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
+// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
+@Requires(TestPrecondition.JDK11_OR_EARLIER)
 class HttpsProxyResolveIntegrationTest extends AbstractProxyResolveIntegrationTest {
     @Override
     MavenHttpRepository getRepo() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyHttpsLegacyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyHttpsLegacyPublishIntegrationTest.groovy
@@ -20,8 +20,12 @@ import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
+// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
+@Requires(TestPrecondition.JDK11_OR_EARLIER)
 class IvyHttpsLegacyPublishIntegrationTest extends AbstractIvyRemoteLegacyPublishIntegrationTest {
     TestKeyStore keyStore
     @Rule RepositoryHttpServer server = new RepositoryHttpServer(temporaryFolder)

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpsIntegTest.groovy
@@ -22,8 +22,12 @@ import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.IvyHttpModule
 import org.gradle.test.fixtures.server.http.IvyHttpRepository
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
+// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
+@Requires(TestPrecondition.JDK11_OR_EARLIER)
 class IvyPublishHttpsIntegTest extends AbstractIvyPublishIntegTest {
     TestKeyStore keyStore
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpsIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpsIntegTest.groovy
@@ -21,8 +21,12 @@ import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
+// Remove when https://bugs.openjdk.java.net/browse/JDK-8219658 is fixed in JDK 12
+@Requires(TestPrecondition.JDK11_OR_EARLIER)
 class MavenPublishHttpsIntegTest extends AbstractMavenPublishIntegTest {
     TestKeyStore keyStore
 


### PR DESCRIPTION
Each test method takes about 5 minutes because of
https://bugs.openjdk.java.net/browse/JDK-8219658.

The bug may be fixed JDK 12.02, so maybe we should upgrade
to this version at some point.
