### PR TITLE
Remove AbstractCompile.compile()

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -45,6 +45,14 @@
             "changes": [
                 "Class is now abstract"
             ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.AbstractCompile",
+            "member": "Method org.gradle.api.tasks.compile.AbstractCompile.compile()",
+            "acceptation": "method shouldn't be used",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -133,6 +133,12 @@ Additionally, the following deprecated functionality now results in an error:
 - Replacing a registered (unrealized) task with an incompatible type. A compatible type is the same type or a sub-type of the registered type.
 - Replacing a task that has never been registered.
 
+==== `AbstractCompile.compile()` is gone
+
+The abstrace method `compile()` is no longer declared by `AbstractCompile`.
+Tasks extending `AbstractCompile` can implement their own `@TaskAction` method with the name of their choosing.
+They are also free to add a `@TaskAction` method with an `InputChanges` parameter without having to implement a parameter-less one as well.
+
 ==== Updates to bundled Gradle dependencies
 
 - Groovy has been updated to http://groovy-lang.org/changelogs/changelog-2.5.8.html[Groovy 2.5.8].

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -143,11 +143,6 @@ public class GroovyCompile extends AbstractCompile {
         return getFeaturePreviews().isFeatureEnabled(GROOVY_COMPILATION_AVOIDANCE);
     }
 
-    @Override
-    protected void compile() {
-        throw new UnsupportedOperationException("This method has been superseded by compile(InputChanges inputChanges)!");
-    }
-
     @TaskAction
     protected void compile(InputChanges inputChanges) {
         checkGroovyClasspathIsNonEmpty();

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/AbstractCompile.java
@@ -38,8 +38,6 @@ public abstract class AbstractCompile extends SourceTask {
         this.destinationDir = getProject().getObjects().property(File.class);
     }
 
-    protected abstract void compile();
-
     /**
      * Returns the classpath to use to compile the source files.
      *

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -97,9 +97,8 @@ public abstract class AbstractScalaCompile extends AbstractCompile {
 
     abstract protected org.gradle.language.base.internal.compile.Compiler<ScalaJavaJointCompileSpec> getCompiler(ScalaJavaJointCompileSpec spec);
 
-    @Override
     @TaskAction
-    protected void compile() {
+    public void compile() {
         ScalaJavaJointCompileSpec spec = createSpec();
         configureIncrementalCompilation(spec);
         Compiler<ScalaJavaJointCompileSpec> compiler = getCompiler(spec);


### PR DESCRIPTION
The method is not useful, and incremental compiler tasks were only throwing a UnsupportedOperationException anyway.

This shouldn't break any implementing task during runtime. Compilation would break but can be fixed easily by removing the `@Override` annotation.

<!--- The issue this PR addresses -->
Fixes #10228
