### PR TITLE
Add missing type argument to Exec task

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Exec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Exec.java
@@ -37,7 +37,7 @@ package org.gradle.api.tasks;
  * }
  * </pre>
  */
-public class Exec extends AbstractExecTask {
+public class Exec extends AbstractExecTask<Exec> {
     public Exec() {
         super(Exec.class);
     }


### PR DESCRIPTION
Exec task was accidentally a raw (not typed) AbstractExecTask. Trying to call typed methods from AbstractExecTask (e.g., getCommandLine()) returned List, not List\<String\>.