### PR TITLE
Move some instant execution serialization for several type to separate codecs

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -24,7 +24,6 @@ import org.gradle.initialization.InstantExecution
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
 import org.gradle.instantexecution.serialization.IsolateOwner
-import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.instantexecution.serialization.codecs.BuildOperationListenersCodec
 import org.gradle.instantexecution.serialization.codecs.Codecs
 import org.gradle.instantexecution.serialization.codecs.WorkNodeCodec
@@ -216,8 +215,7 @@ class DefaultInstantExecution internal constructor(
     fun readContextFor(decoder: KryoBackedDecoder) = DefaultReadContext(
         codecs.userTypesCodec,
         decoder,
-        logger,
-        BeanPropertyReader.factoryFor(service())
+        logger
     )
 
     private
@@ -225,6 +223,7 @@ class DefaultInstantExecution internal constructor(
         Codecs(
             directoryFileTreeFactory = service(),
             fileCollectionFactory = service(),
+            filePropertyFactory = service(),
             fileResolver = service(),
             instantiator = service(),
             listenerManager = service(),

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -97,11 +97,7 @@ class DefaultReadContext(
     private
     val decoder: Decoder,
 
-    override val logger: Logger,
-
-    private
-    val beanPropertyReaderFactory: (Class<*>) -> BeanPropertyReader
-
+    override val logger: Logger
 ) : AbstractIsolateContext<ReadIsolate>(codec), ReadContext, Decoder by decoder {
     override val sharedIdentities = ReadIdentities()
 
@@ -134,7 +130,7 @@ class DefaultReadContext(
         get() = getIsolate()
 
     override fun beanStateReaderFor(beanType: Class<*>): BeanStateReader =
-        beanStateReaders.computeIfAbsent(beanType, beanPropertyReaderFactory)
+        beanStateReaders.computeIfAbsent(beanType) { type -> BeanPropertyReader(type) }
 
     override fun readClass(): Class<*> {
         val id = readSmallInt()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -44,8 +44,6 @@ import java.io.File
 import java.io.IOException
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
-import java.util.concurrent.Callable
-import java.util.function.Supplier
 
 
 class BeanPropertyReader(
@@ -133,18 +131,6 @@ class BeanPropertyReader(
                     is BrokenValue -> DefaultProvider { value.rethrow() }
                     else -> Providers.of(value)
                 })
-            }
-            Callable::class.java -> { bean, value ->
-                field.set(bean, Callable { value })
-            }
-            Supplier::class.java -> { bean, value ->
-                field.set(bean, Supplier { value })
-            }
-            Function0::class.java -> { bean, value ->
-                field.set(bean, { value })
-            }
-            Lazy::class.java -> { bean, value ->
-                field.set(bean, lazyOf(value))
             }
             else -> { bean, value ->
                 if (isAssignableTo(type, value)) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -31,8 +31,6 @@ import org.gradle.instantexecution.serialization.codecs.BrokenValue
 import org.gradle.instantexecution.serialization.logPropertyError
 import org.gradle.instantexecution.serialization.logPropertyInfo
 import java.io.IOException
-import java.util.concurrent.Callable
-import java.util.function.Supplier
 
 
 class BeanPropertyWriter(
@@ -66,10 +64,6 @@ class BeanPropertyWriter(
         is Property<*> -> fieldValue.orNull
         is Provider<*> -> unpack(fieldValue)
         is Closure<*> -> fieldValue.dehydrate()
-        is Callable<*> -> fieldValue.call()
-        is Supplier<*> -> fieldValue.get()
-        is Function0<*> -> (fieldValue as (() -> Any?)).invoke()
-        is Lazy<*> -> unpack(fieldValue.value)
         else -> fieldValue
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.instantexecution.serialization.beans
 
-import groovy.lang.Closure
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.provider.Property
@@ -43,7 +42,7 @@ class BeanPropertyWriter(
         writingProperties {
             for (field in relevantFields) {
                 val fieldName = field.name
-                val fieldValue = unpack(field.get(bean), bean, fieldName)
+                val fieldValue = valueOrConvention(field.get(bean), bean, fieldName)
                 writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
             }
         }
@@ -54,8 +53,8 @@ class BeanPropertyWriter(
         conventionMapping.getConventionValue<Any?>(null, fieldName, false)
     }
 
-    fun unpack(fieldValue: Any?, bean: Any, fieldName: String): Any? = when (fieldValue) {
-        is Closure<*> -> fieldValue.dehydrate()
+    private
+    fun valueOrConvention(fieldValue: Any?, bean: Any, fieldName: String): Any? = when (fieldValue) {
         is Property<*> -> {
             if (!fieldValue.isPresent) {
                 // TODO - disallow using convention mapping + property types

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.instantexecution.serialization.beans
 
+import groovy.lang.Closure
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.provider.Property
@@ -26,6 +27,8 @@ import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.logPropertyError
 import org.gradle.instantexecution.serialization.logPropertyInfo
 import java.io.IOException
+import java.util.concurrent.Callable
+import java.util.function.Supplier
 
 
 class BeanPropertyWriter(
@@ -65,6 +68,12 @@ class BeanPropertyWriter(
             }
             fieldValue
         }
+        is Closure<*> -> fieldValue
+        // TODO - do not eagerly evaluate these types
+        is Callable<*> -> fieldValue.call()
+        is Supplier<*> -> fieldValue.get()
+        is Function0<*> -> fieldValue.invoke()
+        is Lazy<*> -> fieldValue.value
         else -> fieldValue ?: conventionalValueOf(bean, fieldName)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -17,17 +17,13 @@
 package org.gradle.instantexecution.serialization.beans
 
 import groovy.lang.Closure
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.instantexecution.InstantExecutionException
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.PropertyKind
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.instantexecution.serialization.codecs.BrokenValue
 import org.gradle.instantexecution.serialization.logPropertyError
 import org.gradle.instantexecution.serialization.logPropertyInfo
 import java.io.IOException
@@ -47,7 +43,7 @@ class BeanPropertyWriter(
         writingProperties {
             for (field in relevantFields) {
                 val fieldName = field.name
-                val fieldValue = unpack(field.get(bean)) ?: unpack(conventionalValueOf(bean, fieldName))
+                val fieldValue = unpack(field.get(bean), bean, fieldName)
                 writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
             }
         }
@@ -58,22 +54,19 @@ class BeanPropertyWriter(
         conventionMapping.getConventionValue<Any?>(null, fieldName, false)
     }
 
-    fun unpack(fieldValue: Any?): Any? = when (fieldValue) {
-        is DirectoryProperty -> fieldValue.asFile.orNull
-        is RegularFileProperty -> fieldValue.asFile.orNull
-        is Property<*> -> fieldValue.orNull
-        is Provider<*> -> unpack(fieldValue)
+    fun unpack(fieldValue: Any?, bean: Any, fieldName: String): Any? = when (fieldValue) {
         is Closure<*> -> fieldValue.dehydrate()
-        else -> fieldValue
-    }
-
-    private
-    fun unpack(fieldValue: Provider<*>): Any? {
-        try {
-            return fieldValue.orNull
-        } catch (e: Exception) {
-            return BrokenValue(e.message ?: "(no message)")
+        is Property<*> -> {
+            if (!fieldValue.isPresent) {
+                // TODO - disallow using convention mapping + property types
+                val convention = conventionalValueOf(bean, fieldName)
+                if (convention != null) {
+                    (fieldValue as Property<Any>).convention(convention)
+                }
+            }
+            fieldValue
         }
+        else -> fieldValue ?: conventionalValueOf(bean, fieldName)
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
@@ -16,15 +16,11 @@
 
 package org.gradle.instantexecution.serialization.beans
 
-import groovy.lang.GroovyObject
-import groovy.lang.MetaClass
-
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.internal.TaskInternal
-
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 
@@ -56,7 +52,6 @@ fun isRelevantDeclaringClass(declaringClass: Class<*>): Boolean =
 private
 val irrelevantDeclaringClasses = setOf(
     Object::class.java,
-    GroovyObject::class.java,
     Task::class.java,
     TaskInternal::class.java,
     DefaultTask::class.java,
@@ -70,10 +65,6 @@ val Class<*>.relevantFields: Sequence<Field>
         .filterNot { field ->
             Modifier.isStatic(field.modifiers)
                 || Modifier.isTransient(field.modifiers)
-                // Ignore the `metaClass` field that Groovy generates
-                || (field.name == "metaClass" && MetaClass::class.java.isAssignableFrom(field.type))
-                // Ignore the `__meta_class__` field that Gradle generates
-                || (field.name == "__meta_class__" && MetaClass::class.java.isAssignableFrom(field.type))
                 // Ignore a lambda field for now
                 || (field.name == "mFolderFilter" && field.declaringClass.name == "com.android.ide.common.resources.DataSet")
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClosureCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ClosureCodec.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import groovy.lang.Closure
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+
+
+object
+ClosureCodec : Codec<Closure<*>> {
+    private
+    val beanCodec = BeanCodec()
+
+    override suspend fun WriteContext.encode(value: Closure<*>) {
+        // TODO - should write the owner, delegate and thisObject, replacing project and script references
+        beanCodec.run { encode(value.dehydrate()) }
+    }
+
+    override suspend fun ReadContext.decode(): Closure<*>? {
+        return beanCodec.run { decode() as Closure<*> }
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -115,6 +115,7 @@ class Codecs(
         bind(PATH_SERIALIZER)
         bind(ClassCodec)
         bind(MethodCodec)
+        bind(GroovyMetaClassCodec)
 
         // Only serialize certain List implementations
         bind(arrayListCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -117,7 +117,6 @@ class Codecs(
         bind(PATH_SERIALIZER)
         bind(ClassCodec)
         bind(MethodCodec)
-        bind(GroovyMetaClassCodec)
 
         // Only serialize certain List implementations
         bind(arrayListCodec)
@@ -153,6 +152,9 @@ class Codecs(
 
         bind(ConfigurableFileCollectionCodec(fileCollectionFactory))
         bind(FileCollectionCodec(fileCollectionFactory))
+
+        bind(ClosureCodec)
+        bind(GroovyMetaClassCodec)
 
         // Dependency management types
         bind(ArtifactCollectionCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformParameterScheme
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileOperations
+import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.project.ProjectStateRegistry
@@ -71,6 +72,7 @@ import kotlin.reflect.KClass
 class Codecs(
     directoryFileTreeFactory: DirectoryFileTreeFactory,
     fileCollectionFactory: FileCollectionFactory,
+    filePropertyFactory: FilePropertyFactory,
     fileResolver: FileResolver,
     instantiator: Instantiator,
     listenerManager: ListenerManager,
@@ -138,6 +140,13 @@ class Codecs(
 
         bind(arrayCodec)
         bind(BrokenValueCodec)
+
+        bind(ListPropertyCodec)
+        bind(MapPropertyCodec)
+        bind(DirectoryPropertyCodec(filePropertyFactory))
+        bind(RegularFilePropertyCodec(filePropertyFactory))
+        bind(PropertyCodec)
+        bind(ProviderCodec)
 
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/GroovyMetaClassCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/GroovyMetaClassCodec.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import groovy.lang.MetaClass
+import org.codehaus.groovy.runtime.InvokerHelper
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+
+
+object
+GroovyMetaClassCodec : Codec<MetaClass> {
+    override suspend fun WriteContext.encode(value: MetaClass) {
+        writeClass(value.theClass)
+    }
+
+    override suspend fun ReadContext.decode(): MetaClass? {
+        return InvokerHelper.getMetaClass(readClass())
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ProviderCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ProviderCodecs.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.file.FilePropertyFactory
+import org.gradle.api.internal.provider.DefaultListProperty
+import org.gradle.api.internal.provider.DefaultMapProperty
+import org.gradle.api.internal.provider.DefaultProperty
+import org.gradle.api.internal.provider.DefaultProvider
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import java.io.File
+
+
+object
+ProviderCodec : Codec<Provider<*>> {
+    override suspend fun WriteContext.encode(value: Provider<*>) {
+        // TODO - should write the provider value type
+        write(unpack(value))
+    }
+
+    override suspend fun ReadContext.decode(): Provider<*>? {
+        val value = read()
+        return when (value) {
+            null -> Providers.notDefined<Any>()
+            is BrokenValue -> DefaultProvider { value.rethrow() }
+            else -> Providers.of(value)
+        }
+    }
+
+    private
+    fun unpack(fieldValue: Provider<*>): Any? {
+        try {
+            return fieldValue.orNull
+        } catch (e: Exception) {
+            return BrokenValue(e.message ?: "(no message)")
+        }
+    }
+}
+
+
+object
+PropertyCodec : Codec<Property<*>> {
+    override suspend fun WriteContext.encode(value: Property<*>) {
+        // TODO - should write the property type
+        write(value.orNull)
+    }
+
+    override suspend fun ReadContext.decode(): Property<*>? {
+        val value = read()
+        return DefaultProperty(Any::class.java).value(value)
+    }
+}
+
+
+class
+DirectoryPropertyCodec(private val filePropertyFactory: FilePropertyFactory) : Codec<DirectoryProperty> {
+    override suspend fun WriteContext.encode(value: DirectoryProperty) {
+        write(value.asFile.orNull)
+    }
+
+    override suspend fun ReadContext.decode(): DirectoryProperty? {
+        val value = read() as File?
+        return filePropertyFactory.newDirectoryProperty().apply { set(value) }
+    }
+}
+
+
+class
+RegularFilePropertyCodec(private val filePropertyFactory: FilePropertyFactory) : Codec<RegularFileProperty> {
+    override suspend fun WriteContext.encode(value: RegularFileProperty) {
+        write(value.asFile.orNull)
+    }
+
+    override suspend fun ReadContext.decode(): RegularFileProperty? {
+        val value = read() as File?
+        return filePropertyFactory.newFileProperty().apply { set(value) }
+    }
+}
+
+
+object
+ListPropertyCodec : Codec<ListProperty<*>> {
+    override suspend fun WriteContext.encode(value: ListProperty<*>) {
+        // TODO - should write the element type
+        write(value.orNull)
+    }
+
+    override suspend fun ReadContext.decode(): ListProperty<*>? {
+        val value = read() as List<*>?
+        return DefaultListProperty(Any::class.java).value(value)
+    }
+}
+
+
+object
+MapPropertyCodec : Codec<MapProperty<*, *>> {
+    override suspend fun WriteContext.encode(value: MapProperty<*, *>) {
+        // TODO - should write the key and value types
+        write(value.orNull)
+    }
+
+    override suspend fun ReadContext.decode(): MapProperty<*, *>? {
+        val value = read() as Map<*, *>?
+        return DefaultMapProperty(Any::class.java, Any::class.java).value(value)
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -168,7 +168,7 @@ suspend fun WriteContext.writeRegisteredPropertiesOf(
 ) = propertyWriter.run {
 
     suspend fun writeProperty(propertyName: String, propertyValue: PropertyValue, kind: PropertyKind): Boolean {
-        val value = unpack(propertyValue.call()) ?: return false
+        val value = propertyValue.call() ?: return false
         return writeNextProperty(propertyName, value, kind)
     }
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/BeanCodecTest.kt
@@ -17,25 +17,19 @@
 package org.gradle.instantexecution.serialization.codecs
 
 import com.nhaarman.mockitokotlin2.mock
-
 import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.instantexecution.runToCompletion
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
 import org.gradle.instantexecution.serialization.IsolateOwner
 import org.gradle.instantexecution.serialization.MutableIsolateContext
-import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.instantexecution.serialization.withIsolate
 import org.gradle.internal.serialize.Encoder
-
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
-
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Test
-
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
@@ -117,14 +111,14 @@ class BeanCodecTest {
         DefaultReadContext(
             codec = codecs().userTypesCodec,
             decoder = KryoBackedDecoder(inputStream),
-            logger = mock(),
-            beanPropertyReaderFactory = BeanPropertyReader.factoryFor(mock())
+            logger = mock()
         )
 
     private
     fun codecs() = Codecs(
         directoryFileTreeFactory = mock(),
         fileCollectionFactory = mock(),
+        filePropertyFactory = mock(),
         fileResolver = mock(),
         instantiator = mock(),
         listenerManager = mock(),


### PR DESCRIPTION

### Context

This PR prepares for handling task properties whose value is calculated from task outputs, by moving the serialization for several types out of the bean serializer and into separate `Codec` implementations.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
