### PR TITLE
Allow init scripts to apply plugins to settings

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/BuildAdapter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildAdapter.java
@@ -28,6 +28,10 @@ public class BuildAdapter implements BuildListener {
     }
 
     @Override
+    public void beforeSettings(Settings settings) {
+    }
+
+    @Override
     public void settingsEvaluated(Settings settings) {
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
@@ -15,6 +15,7 @@
  */
 package org.gradle;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.Gradle;
 
@@ -30,6 +31,15 @@ public interface BuildListener {
      * @param gradle The build which is being started. Never null.
      */
     void buildStarted(Gradle gradle);
+
+    /**
+     * Called when the build settings are about to be loaded and evaluated.
+     *
+     * @param settings The settings. Never null.
+     * @since 5.7
+     */
+    @Incubating
+    default void beforeSettings(Settings settings) {}
 
     /**
      * <p>Called when the build settings have been loaded and evaluated. The settings object is fully configured and is

--- a/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
@@ -36,7 +36,7 @@ public interface BuildListener {
      * Called when the build settings are about to be loaded and evaluated.
      *
      * @param settings The settings. Never null.
-     * @since 5.7
+     * @since 6.0
      */
     @Incubating
     default void beforeSettings(Settings settings) {}

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -191,6 +191,24 @@ public interface Gradle extends PluginAware {
     void buildStarted(Action<? super Gradle> action);
 
     /**
+     * Adds an action to be called before the build settings have been loaded and evaluated.
+     *
+     * @param closure The action to execute.
+     * @since 5.7
+     */
+    @Incubating
+    void beforeSettings(Closure<?> closure);
+
+    /**
+     * Adds an action to be called before the build settings have been loaded and evaluated.
+     *
+     * @param action The action to execute.
+     * @since 5.7
+     */
+    @Incubating
+    void beforeSettings(Action<? super Settings> action);
+
+    /**
      * Adds a closure to be called when the build settings have been loaded and evaluated.
      *
      * The settings object is fully configured and is ready to use to load the build projects. The

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -194,7 +194,7 @@ public interface Gradle extends PluginAware {
      * Adds an action to be called before the build settings have been loaded and evaluated.
      *
      * @param closure The action to execute.
-     * @since 5.7
+     * @since 6.0
      */
     @Incubating
     void beforeSettings(Closure<?> closure);
@@ -203,7 +203,7 @@ public interface Gradle extends PluginAware {
      * Adds an action to be called before the build settings have been loaded and evaluated.
      *
      * @param action The action to execute.
-     * @since 5.7
+     * @since 6.0
      */
     @Incubating
     void beforeSettings(Action<? super Settings> action);

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -558,6 +558,9 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
                 void buildStarted(Gradle gradle) {
                     println 'gradle.addListener(ComboListener) from $source'
                 }
+                void beforeSettings(Settings settings) {
+                    println 'gradle.addListener(ComboListener) from $source'
+                }
                 void settingsEvaluated(Settings settings) {
                     println 'gradle.addListener(ComboListener) from $source'
                 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
@@ -59,6 +59,7 @@ public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
         Map<String, String> properties = propertiesLoader.mergeProperties(Collections.<String, String>emptyMap());
         TextResourceScriptSource settingsScript = new TextResourceScriptSource(textResourceLoader.loadFile("settings file", settingsLocation.getSettingsFile()));
         SettingsInternal settings = settingsFactory.createSettings(gradle, settingsLocation.getSettingsDir(), settingsScript, properties, startParameter, buildRootClassLoaderScope);
+        gradle.getBuildListenerBroadcaster().beforeSettings(settings);
         applySettingsScript(settingsScript, settings);
         LOGGER.debug("Timing: Processing settings took: {}", settingsProcessingClock.getElapsed());
         return settings;

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -324,6 +324,16 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
     }
 
     @Override
+    public void beforeSettings(Closure<?> closure) {
+        buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("beforeSettings", closure));
+    }
+
+    @Override
+    public void beforeSettings(Action<? super Settings> action) {
+        buildListenerBroadcast.add("beforeSettings", action);
+    }
+
+    @Override
     public void settingsEvaluated(Closure closure) {
         buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("settingsEvaluated", closure));
     }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
@@ -291,6 +291,15 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         verifyNoOp()
 
         when:
+        decoratedListener.beforeSettings(settingsEvaluatedArg)
+
+        then:
+        1 * listener.beforeSettings(settingsEvaluatedArg)
+
+        and:
+        verifyNoOp()
+
+        when:
         decoratedListener.projectsLoaded(projectsLoadedArg)
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -272,6 +272,20 @@ class DefaultGradleSpec extends Specification {
         1 * action.execute(_)
     }
 
+    def "broadcasts before settings events to actions"() {
+        given:
+        def action = Mock(Action)
+
+        when:
+        gradle.beforeSettings(action)
+
+        and:
+        gradle.buildListenerBroadcaster.beforeSettings(null)
+
+        then:
+        1 * action.execute(_)
+    }
+
     def "broadcasts projects loaded events to actions"() {
         given:
         def action = Mock(Action)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
@@ -150,10 +150,10 @@ class PluginBuilder {
         file("src/main/resources/META-INF/gradle-plugins")
     }
 
-    private addPluginSource(String id, String className, String impl) {
+    PluginBuilder addPluginSource(String id, String className, String impl) {
         pluginIds[id] = className
-
         groovy("${className}.groovy") << impl
+        this
     }
 
     PluginBuilder addPlugin(String impl, String id = "test-plugin", String className = "TestPlugin") {


### PR DESCRIPTION
Upcoming work will move a key plugin of ours to being settings based instead of project based. This PR makes it practical to continue to use an init script to apply the plugin across “projects” (i.e. in the logical sense), by opening up a callback for accessing the settings object before the settings script is applied.

Documentation, other than API doc, has not been added as this is a rather niche feature. The documentation for the plugin itself will provide a recipe for such usage.

https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Fbefore-settings-lifecycle-callback