### PR TITLE
Instant execution supports `Provider` instances whose value is a mapped task output

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ServiceRegistration.java
@@ -28,11 +28,9 @@ public interface ServiceRegistration {
     <T> void add(Class<T> serviceType, T serviceInstance);
 
     /**
-     * Adds a service to this registry.
+     * Adds a service to this registry. The implementation class should have a single public constructor, and this constructor can take services to be injected as parameters.
      *
-     * Note: currently no dependencies are injected into the implementation.
-     *
-     * @param serviceType The service implementation to make visible. This class should have a public no-args constructor.
+     * @param serviceType The service implementation to make visible.
      */
     void add(Class<?> serviceType);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
@@ -20,6 +20,9 @@ import org.gradle.api.Incubating;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 
+import javax.annotation.Nullable;
+import java.io.File;
+
 /**
  * Represents some configurable directory location, whose value is mutable.
  *
@@ -49,6 +52,18 @@ public interface DirectoryProperty extends FileSystemLocationProperty<Directory>
      */
     @Override
     DirectoryProperty value(Provider<? extends Directory> provider);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    DirectoryProperty fileValue(@Nullable File file);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    DirectoryProperty fileProvider(Provider<File> provider);
 
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemLocationProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemLocationProperty.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 
 /**
- * Represents some element of the file system. A file system element has two parts: its location and its content. A file system element, or more accurately, its content, may be the output of a task
+ * Represents some element of the file system. A file system element has two parts: its location and its content. A file system element's content, may be the output of a task
  * or tasks. This property object keeps track of both the location and the task or tasks that produce the content of the element.
  *
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.</p>
@@ -40,9 +40,30 @@ public interface FileSystemLocationProperty<T extends FileSystemLocation> extend
     Provider<File> getAsFile();
 
     /**
-     * Sets the location of this file, using a {@link File} instance.
+     * Sets the location of this file, using a {@link File} instance. {@link File} instances with relative paths are resolved relative to the project directory of the project
+     * that owns this property instance.
      */
     void set(@Nullable File file);
+
+    /**
+     * Sets the location of this file, using a {@link File} instance. {@link File} instances with relative paths are resolved relative to the project directory of the project
+     * that owns this property instance.
+     *
+     * <p>This method is the same as {@link #set(File)} but allows method chaining.</p>
+     *
+     * @return this
+     * @since 5.7
+     */
+    FileSystemLocationProperty<T> fileValue(@Nullable File file);
+
+    /**
+     * Sets the location of this file, using a {@link File} {@link Provider} instance. {@link File} instances with relative paths are resolved relative to the project directory of the project
+     * that owns this property instance.
+     *
+     * @return this
+     * @since 5.7
+     */
+    FileSystemLocationProperty<T> fileProvider(Provider<File> provider);
 
     /**
      * Returns the location of the file system element, and discards details of the task that produces its content. This allows the location, or a value derived from it, to be used as an input to some other task without implying any dependency on the producing task. This should only be used when the task does, in fact, not use the content of this file system element.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemLocationProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemLocationProperty.java
@@ -52,7 +52,7 @@ public interface FileSystemLocationProperty<T extends FileSystemLocation> extend
      * <p>This method is the same as {@link #set(File)} but allows method chaining.</p>
      *
      * @return this
-     * @since 5.7
+     * @since 6.0
      */
     FileSystemLocationProperty<T> fileValue(@Nullable File file);
 
@@ -61,7 +61,7 @@ public interface FileSystemLocationProperty<T extends FileSystemLocation> extend
      * that owns this property instance.
      *
      * @return this
-     * @since 5.7
+     * @since 6.0
      */
     FileSystemLocationProperty<T> fileProvider(Provider<File> provider);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
@@ -20,6 +20,9 @@ import org.gradle.api.Incubating;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 
+import javax.annotation.Nullable;
+import java.io.File;
+
 /**
  * Represents some configurable regular file location, whose value is mutable.
  *
@@ -44,6 +47,18 @@ public interface RegularFileProperty extends FileSystemLocationProperty<RegularF
      */
     @Override
     RegularFileProperty value(Provider<? extends RegularFile> provider);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    RegularFileProperty fileValue(@Nullable File file);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    RegularFileProperty fileProvider(Provider<File> provider);
 
     /**
      * {@inheritDoc}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -900,4 +900,57 @@ The following types/formats are supported:
         file("out.txt").text == "17"
     }
 
+    def "collection input property containing value of mapped task output implies dependency on the task"() {
+        taskTypeWithOutputFileProperty()
+        taskTypeWithInputListProperty()
+        buildFile << """
+            def a = tasks.create("a", FileProducer) {
+                output = file("a.txt")
+                content = "12"
+            }
+            def b = tasks.create("b", FileProducer) {
+                output = file("b.txt")
+                content = "0"
+            }
+            tasks.register("c", InputTask) {
+                inValue = a.output.map { it.asFile.text as Integer }.map { [it, it+3] }
+                inValue.add(b.output.map { it.asFile.text as Integer })
+                outFile = file("out.txt")
+            }
+        """
+
+        when:
+        run("c")
+
+        then:
+        result.assertTasksExecuted(":a", ":b", ":c")
+        file("out.txt").text == "22,25,10"
+    }
+
+    def "map input property containing value of mapped task output implies dependency on the task"() {
+        taskTypeWithOutputFileProperty()
+        taskTypeWithInputMapProperty()
+        buildFile << """
+            def a = tasks.create("a", FileProducer) {
+                output = file("a.txt")
+                content = "12"
+            }
+            def b = tasks.create("b", FileProducer) {
+                output = file("b.txt")
+                content = "0"
+            }
+            tasks.register("c", InputTask) {
+                inValue = a.output.map { it.asFile.text as Integer }.map { [a1: it, a2: it+3] }
+                inValue.put("b", b.output.map { it.asFile.text as Integer })
+                outFile = file("out.txt")
+            }
+        """
+
+        when:
+        run("c")
+
+        then:
+        result.assertTasksExecuted(":a", ":b", ":c")
+        file("out.txt").text == "a1=22,a2=25,b=10"
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -98,7 +98,7 @@ public class DefaultProjectLayout extends DefaultFilePropertyFactory implements 
     public Provider<RegularFile> file(Provider<File> provider) {
         return new AbstractMappingProvider<RegularFile, File>(RegularFile.class, Providers.internal(provider)) {
             @Override
-            protected RegularFile map(File file) {
+            protected RegularFile mapValue(File file) {
                 return new FixedFile(projectDir.fileResolver.resolve(file));
             }
         };

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -120,6 +120,36 @@ trait TasksWithInputsAndOutputs {
         """
     }
 
+    def taskTypeWithInputListProperty() {
+        buildFile << """
+            class InputTask extends DefaultTask {
+                @Input
+                final ListProperty<Integer> inValue = project.objects.listProperty(Integer)
+                @OutputFile
+                final RegularFileProperty outFile = project.objects.fileProperty()
+                @TaskAction
+                def go() {
+                    outFile.get().asFile.text = inValue.get().collect { it + 10 }.join(",")
+                }
+            }
+        """
+    }
+
+    def taskTypeWithInputMapProperty() {
+        buildFile << """
+            class InputTask extends DefaultTask {
+                @Input
+                final MapProperty<String, Integer> inValue = project.objects.mapProperty(String, Integer)
+                @OutputFile
+                final RegularFileProperty outFile = project.objects.fileProperty()
+                @TaskAction
+                def go() {
+                    outFile.get().asFile.text = inValue.get().collect { k, v -> "\$k=\${v + 10}" }.join(",")
+                }
+            }
+        """
+    }
+
     def taskTypeWithInputFileProperty() {
         buildFile << """
             class InputFileTask extends DefaultTask {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -96,6 +96,12 @@ To avoid these errors, Gradle has been employing workarounds in some but not all
 From now on Gradle uses these workarounds every time it removes file hierarchies.
 The two most important cases that are now covered are cleaning stale output files of a task, and removing previous outputs before loading fresh ones from the build cache.
 
+## Features for plugin authors
+
+### File and directory property methods
+
+TBD - Added `fileValue()` and `fileProvider()` methods.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -234,7 +234,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
     }
 
-    static class DefaultRegularFileVar extends AbstractFileVar<RegularFile, RegularFileProperty> implements RegularFileProperty, Managed {
+    public static class DefaultRegularFileVar extends AbstractFileVar<RegularFile, RegularFileProperty> implements RegularFileProperty, Managed {
         private final PathToFileResolver fileResolver;
 
         DefaultRegularFileVar(PathToFileResolver fileResolver) {
@@ -273,7 +273,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
     }
 
-    static class DefaultDirectoryVar extends AbstractFileVar<Directory, DirectoryProperty> implements DirectoryProperty, Managed {
+    public static class DefaultDirectoryVar extends AbstractFileVar<Directory, DirectoryProperty> implements DirectoryProperty, Managed {
         private final FileResolver resolver;
 
         DefaultDirectoryVar(FileResolver resolver) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -144,7 +144,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        protected RegularFile map(CharSequence path) {
+        protected RegularFile mapValue(CharSequence path) {
             return new FixedFile(resolver.resolve(path));
         }
     }
@@ -267,7 +267,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        protected Directory map(CharSequence path) {
+        protected Directory mapValue(CharSequence path) {
             File dir = resolver.resolve(path);
             return new FixedDirectory(dir, resolver.newResolver(dir));
         }
@@ -317,7 +317,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         public Provider<Directory> dir(final String path) {
             return new AbstractMappingProvider<Directory, Directory>(Directory.class, this) {
                 @Override
-                protected Directory map(Directory dir) {
+                protected Directory mapValue(Directory dir) {
                     return dir.dir(path);
                 }
             };
@@ -337,7 +337,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         public Provider<RegularFile> file(final String path) {
             return new AbstractMappingProvider<RegularFile, Directory>(RegularFile.class, this) {
                 @Override
-                protected RegularFile map(Directory dir) {
+                protected RegularFile mapValue(Directory dir) {
                     return dir.file(path);
                 }
             };
@@ -360,7 +360,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        protected File map(FileSystemLocation provider) {
+        protected File mapValue(FileSystemLocation provider) {
             return provider.getAsFile();
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.state.Managed;
 
@@ -148,10 +149,17 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
     }
 
-    static abstract class AbstractFileVar<T extends FileSystemLocation> extends DefaultProperty<T> implements FileSystemLocationProperty<T> {
+    static abstract class AbstractFileVar<T extends FileSystemLocation, THIS extends FileSystemLocationProperty<T>> extends DefaultProperty<T> implements FileSystemLocationProperty<T> {
 
         public AbstractFileVar(Class<T> type) {
             super(type);
+        }
+
+        protected abstract T fromFile(File file);
+
+        @Override
+        public Provider<File> getAsFile() {
+            return new ToFileProvider(this);
         }
 
         @Override
@@ -161,6 +169,51 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
             } else {
                 super.setFromAnyValue(object);
             }
+        }
+
+        @Override
+        public THIS value(T value) {
+            super.value(value);
+            return Cast.uncheckedNonnullCast(this);
+        }
+
+        @Override
+        public THIS value(Provider<? extends T> provider) {
+            super.value(provider);
+            return Cast.uncheckedNonnullCast(this);
+        }
+
+        @Override
+        public void set(File file) {
+            if (file == null) {
+                set((T) null);
+                return;
+            }
+            set(fromFile(file));
+        }
+
+        @Override
+        public THIS fileValue(@Nullable File file) {
+            set(file);
+            return Cast.uncheckedNonnullCast(this);
+        }
+
+        @Override
+        public THIS fileProvider(Provider<File> provider) {
+            set(provider.map(file -> fromFile(file)));
+            return Cast.uncheckedNonnullCast(this);
+        }
+
+        @Override
+        public THIS convention(T value) {
+            super.convention(value);
+            return Cast.uncheckedNonnullCast(this);
+        }
+
+        @Override
+        public THIS convention(Provider<? extends T> valueProvider) {
+            super.convention(valueProvider);
+            return Cast.uncheckedNonnullCast(this);
         }
 
         @Override
@@ -181,7 +234,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
     }
 
-    static class DefaultRegularFileVar extends AbstractFileVar<RegularFile> implements RegularFileProperty, Managed {
+    static class DefaultRegularFileVar extends AbstractFileVar<RegularFile, RegularFileProperty> implements RegularFileProperty, Managed {
         private final PathToFileResolver fileResolver;
 
         DefaultRegularFileVar(PathToFileResolver fileResolver) {
@@ -195,46 +248,13 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
 
         @Override
-        public Provider<File> getAsFile() {
-            return new ToFileProvider(this);
-        }
-
-        @Override
         public int getFactoryId() {
             return ManagedFactories.RegularFilePropertyManagedFactory.FACTORY_ID;
         }
 
         @Override
-        public void set(File file) {
-            if (file == null) {
-                set((RegularFile) null);
-                return;
-            }
-            set(new FixedFile(fileResolver.resolve(file)));
-        }
-
-        @Override
-        public RegularFileProperty value(RegularFile value) {
-            super.value(value);
-            return this;
-        }
-
-        @Override
-        public RegularFileProperty value(Provider<? extends RegularFile> provider) {
-            super.value(provider);
-            return this;
-        }
-
-        @Override
-        public RegularFileProperty convention(RegularFile value) {
-            super.convention(value);
-            return this;
-        }
-
-        @Override
-        public RegularFileProperty convention(Provider<? extends RegularFile> valueProvider) {
-            super.convention(valueProvider);
-            return this;
+        protected RegularFile fromFile(File file) {
+            return new FixedFile(fileResolver.resolve(file));
         }
     }
 
@@ -253,7 +273,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         }
     }
 
-    static class DefaultDirectoryVar extends AbstractFileVar<Directory> implements DirectoryProperty, Managed {
+    static class DefaultDirectoryVar extends AbstractFileVar<Directory, DirectoryProperty> implements DirectoryProperty, Managed {
         private final FileResolver resolver;
 
         DefaultDirectoryVar(FileResolver resolver) {
@@ -282,48 +302,15 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
             return resolver.resolveFilesAsTree(this);
         }
 
-        @Override
-        public Provider<File> getAsFile() {
-            return new ToFileProvider(this);
-        }
-
         void resolveAndSet(Object value) {
             File resolved = resolver.resolve(value);
             set(new FixedDirectory(resolved, resolver.newResolver(resolved)));
         }
 
         @Override
-        public void set(File dir) {
-            if (dir == null) {
-                set((Directory) null);
-                return;
-            }
+        protected Directory fromFile(File dir) {
             File resolved = resolver.resolve(dir);
-            set(new FixedDirectory(resolved, resolver.newResolver(resolved)));
-        }
-
-        @Override
-        public DirectoryProperty value(Directory value) {
-            super.value(value);
-            return this;
-        }
-
-        @Override
-        public DirectoryProperty value(Provider<? extends Directory> provider) {
-            super.value(provider);
-            return this;
-        }
-
-        @Override
-        public DirectoryProperty convention(Directory value) {
-            super.convention(value);
-            return this;
-        }
-
-        @Override
-        public DirectoryProperty convention(Provider<? extends Directory> valueProvider) {
-            super.convention(valueProvider);
-            return this;
+            return new FixedDirectory(resolved, resolver.newResolver(resolved));
         }
 
         @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file
 
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.internal.provider.PropertySpec
+import org.gradle.api.internal.provider.Providers
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 
@@ -32,7 +33,7 @@ abstract class FileSystemPropertySpec<T extends FileSystemLocation> extends Prop
         baseDir.set(tmpDir.testDirectory)
     }
 
-    def "can set value using file"() {
+    def "can set value using absolute file"() {
         given:
         def file = tmpDir.file("thing")
         def prop = providerWithNoValue()
@@ -40,6 +41,36 @@ abstract class FileSystemPropertySpec<T extends FileSystemLocation> extends Prop
 
         expect:
         prop.get().asFile == file
+    }
+
+    def "can set value using relative file"() {
+        given:
+        def file = new File("thing")
+        def prop = providerWithNoValue()
+        prop.set(file)
+
+        expect:
+        prop.get().asFile == tmpDir.file("thing")
+    }
+
+    def "can set value using absolute file provider"() {
+        given:
+        def file = tmpDir.file("thing")
+        def prop = providerWithNoValue()
+        prop.fileProvider(Providers.of(file))
+
+        expect:
+        prop.get().asFile == file
+    }
+
+    def "can set value using relative file provider"() {
+        given:
+        def file = new File("thing")
+        def prop = providerWithNoValue()
+        prop.fileProvider(Providers.of(file))
+
+        expect:
+        prop.get().asFile == tmpDir.file("thing")
     }
 
     def "cannot set value using file when finalized"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -610,6 +610,8 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         "RegularFileProperty"         | "objects.fileProperty()"              | "null"           | "null"
         "ListProperty<String>"        | "objects.listProperty(String)"        | "[]"             | "[]"
         "ListProperty<String>"        | "objects.listProperty(String)"        | "['abc']"        | ['abc']
+        "SetProperty<String>"         | "objects.setProperty(String)"         | "[]"             | "[]"
+        "SetProperty<String>"         | "objects.setProperty(String)"         | "['abc']"        | ['abc']
         "MapProperty<String, String>" | "objects.mapProperty(String, String)" | "[:]"            | [:]
         "MapProperty<String, String>" | "objects.mapProperty(String, String)" | "['abc': 'def']" | ['abc': 'def']
     }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -263,6 +263,8 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
     @Unroll
     def "restores task fields whose value is instance of #type"() {
         buildFile << """
+            import java.util.concurrent.*
+
             class SomeBean {
                 ${type} value 
             }
@@ -299,41 +301,42 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         outputContains("bean.value = ${output}")
 
         where:
-        type                             | reference                                                     | output
-        String.name                      | "'value'"                                                     | "value"
-        String.name                      | "null"                                                        | "null"
-        Boolean.name                     | "true"                                                        | "true"
-        boolean.name                     | "true"                                                        | "true"
-        Character.name                   | "'a'"                                                         | "a"
-        char.name                        | "'a'"                                                         | "a"
-        Byte.name                        | "12"                                                          | "12"
-        byte.name                        | "12"                                                          | "12"
-        Short.name                       | "12"                                                          | "12"
-        short.name                       | "12"                                                          | "12"
-        Integer.name                     | "12"                                                          | "12"
-        int.name                         | "12"                                                          | "12"
-        Long.name                        | "12"                                                          | "12"
-        long.name                        | "12"                                                          | "12"
-        Float.name                       | "12.1"                                                        | "12.1"
-        float.name                       | "12.1"                                                        | "12.1"
-        Double.name                      | "12.1"                                                        | "12.1"
-        double.name                      | "12.1"                                                        | "12.1"
-        Class.name                       | "SomeBean"                                                    | "class SomeBean"
-        "SomeEnum"                       | "SomeEnum.Two"                                                | "Two"
-        "SomeEnum[]"                     | "[SomeEnum.Two] as SomeEnum[]"                                | "[Two]"
-        "List<String>"                   | "['a', 'b', 'c']"                                             | "[a, b, c]"
-        "ArrayList<String>"              | "['a', 'b', 'c'] as ArrayList"                                | "[a, b, c]"
-        "LinkedList<String>"             | "['a', 'b', 'c'] as LinkedList"                               | "[a, b, c]"
-        "Set<String>"                    | "['a', 'b', 'c'] as Set"                                      | "[a, b, c]"
-        "HashSet<String>"                | "['a', 'b', 'c'] as HashSet"                                  | "[a, b, c]"
-        "LinkedHashSet<String>"          | "['a', 'b', 'c'] as LinkedHashSet"                            | "[a, b, c]"
-        "TreeSet<String>"                | "['a', 'b', 'c'] as TreeSet"                                  | "[a, b, c]"
-        "EnumSet<SomeEnum>"              | "EnumSet.of(SomeEnum.Two)"                                    | "[Two]"
-        "Map<String, Integer>"           | "[a: 1, b: 2]"                                                | "[a:1, b:2]"
-        "HashMap<String, Integer>"       | "new HashMap([a: 1, b: 2])"                                   | "[a:1, b:2]"
-        "LinkedHashMap<String, Integer>" | "new LinkedHashMap([a: 1, b: 2])"                             | "[a:1, b:2]"
-        "TreeMap<String, Integer>"       | "new TreeMap([a: 1, b: 2])"                                   | "[a:1, b:2]"
-        "EnumMap<SomeEnum, String>"      | "new EnumMap([(SomeEnum.One): 'one', (SomeEnum.Two): 'two'])" | "[One:one, Two:two]"
+        type                                 | reference                                                     | output
+        String.name                          | "'value'"                                                     | "value"
+        String.name                          | "null"                                                        | "null"
+        Boolean.name                         | "true"                                                        | "true"
+        boolean.name                         | "true"                                                        | "true"
+        Character.name                       | "'a'"                                                         | "a"
+        char.name                            | "'a'"                                                         | "a"
+        Byte.name                            | "12"                                                          | "12"
+        byte.name                            | "12"                                                          | "12"
+        Short.name                           | "12"                                                          | "12"
+        short.name                           | "12"                                                          | "12"
+        Integer.name                         | "12"                                                          | "12"
+        int.name                             | "12"                                                          | "12"
+        Long.name                            | "12"                                                          | "12"
+        long.name                            | "12"                                                          | "12"
+        Float.name                           | "12.1"                                                        | "12.1"
+        float.name                           | "12.1"                                                        | "12.1"
+        Double.name                          | "12.1"                                                        | "12.1"
+        double.name                          | "12.1"                                                        | "12.1"
+        Class.name                           | "SomeBean"                                                    | "class SomeBean"
+        "SomeEnum"                           | "SomeEnum.Two"                                                | "Two"
+        "SomeEnum[]"                         | "[SomeEnum.Two] as SomeEnum[]"                                | "[Two]"
+        "List<String>"                       | "['a', 'b', 'c']"                                             | "[a, b, c]"
+        "ArrayList<String>"                  | "['a', 'b', 'c'] as ArrayList"                                | "[a, b, c]"
+        "LinkedList<String>"                 | "['a', 'b', 'c'] as LinkedList"                               | "[a, b, c]"
+        "Set<String>"                        | "['a', 'b', 'c'] as Set"                                      | "[a, b, c]"
+        "HashSet<String>"                    | "['a', 'b', 'c'] as HashSet"                                  | "[a, b, c]"
+        "LinkedHashSet<String>"              | "['a', 'b', 'c'] as LinkedHashSet"                            | "[a, b, c]"
+        "TreeSet<String>"                    | "['a', 'b', 'c'] as TreeSet"                                  | "[a, b, c]"
+        "EnumSet<SomeEnum>"                  | "EnumSet.of(SomeEnum.Two)"                                    | "[Two]"
+        "Map<String, Integer>"               | "[a: 1, b: 2]"                                                | "[a:1, b:2]"
+        "HashMap<String, Integer>"           | "new HashMap([a: 1, b: 2])"                                   | "[a:1, b:2]"
+        "LinkedHashMap<String, Integer>"     | "new LinkedHashMap([a: 1, b: 2])"                             | "[a:1, b:2]"
+        "TreeMap<String, Integer>"           | "new TreeMap([a: 1, b: 2])"                                   | "[a:1, b:2]"
+        "ConcurrentHashMap<String, Integer>" | "new ConcurrentHashMap([a: 1, b: 2])"                         | "[a:1, b:2]"
+        "EnumMap<SomeEnum, String>"          | "new EnumMap([(SomeEnum.One): 'one', (SomeEnum.Two): 'two'])" | "[One:one, Two:two]"
     }
 
     @Unroll

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
@@ -29,7 +29,7 @@ class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecution
                 outFile = layout.buildDirectory.file("out.txt")
             }
             task transformer(type: InputTask) {
-                inValue = producer.outFile.map { it.asFile.text as Integer }
+                inValue = producer.outFile.map { f -> f.asFile.text as Integer }.map { i -> i + 2 }
                 outFile = file("out.txt")
             } 
         """
@@ -43,7 +43,7 @@ class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecution
 
         then:
         result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
-        output.text == "22"
+        output.text == "24"
 
         when:
         input.text = "4"
@@ -52,7 +52,7 @@ class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecution
         then:
         instantExecution.assertStateLoaded()
         result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
-        output.text == "14"
+        output.text == "16"
 
         when:
         input.text = "10"
@@ -61,6 +61,6 @@ class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecution
         then:
         instantExecution.assertStateLoaded()
         result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
-        output.text == "20"
+        output.text == "22"
     }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.tasks.TasksWithInputsAndOutputs
+
+class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecutionIntegrationTest implements TasksWithInputsAndOutputs {
+    def "task can consume the mapped output of another task"() {
+        taskTypeWithInputFileProperty()
+        taskTypeWithInputProperty()
+
+        buildFile << """
+            task producer(type: InputFileTask) {
+                inFile = file("in.txt")
+                outFile = layout.buildDirectory.file("out.txt")
+            }
+            task transformer(type: InputTask) {
+                inValue = producer.outFile.map { it.asFile.text as Integer }
+                outFile = file("out.txt")
+            } 
+        """
+        def input = file("in.txt")
+        def output = file("out.txt")
+        def instantExecution = newInstantExecutionFixture()
+
+        when:
+        input.text = "12"
+        instantRun(":transformer")
+
+        then:
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "22"
+
+        when:
+        input.text = "4"
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "14"
+
+        when:
+        input.text = "10"
+        instantRun(":transformer")
+
+        then:
+        instantExecution.assertStateLoaded()
+        result.assertTasksExecutedAndNotSkipped(":producer", ":transformer")
+        output.text == "20"
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValue.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValue.kt
@@ -17,8 +17,8 @@
 package org.gradle.instantexecution.serialization.codecs
 
 
-class BrokenValue(val message: String) {
+class BrokenValue(val failure: Throwable) {
     fun rethrow(): Nothing {
-        throw RuntimeException(message)
+        throw failure
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -126,6 +126,7 @@ class Codecs(
         bind(linkedHashMapCodec)
         bind(hashMapCodec)
         bind(treeMapCodec)
+        bind(concurrentHashMapCodec)
         bind(ImmutableMapCodec)
 
         bind(arrayCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -106,7 +106,6 @@ class Codecs(
         bind(BYTE_SERIALIZER)
         bind(FLOAT_SERIALIZER)
         bind(DOUBLE_SERIALIZER)
-        bind(FileTreeCodec(fileSetSerializer, directoryFileTreeFactory))
         bind(FILE_SERIALIZER)
         bind(PATH_SERIALIZER)
         bind(ClassCodec)
@@ -142,6 +141,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
+        bind(FileTreeCodec(fileSetSerializer, directoryFileTreeFactory))
         bind(ConfigurableFileCollectionCodec(fileCollectionFactory))
         bind(FileCollectionCodec(fileCollectionFactory))
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -132,6 +132,7 @@ class Codecs(
         bind(BrokenValueCodec)
 
         bind(ListPropertyCodec)
+        bind(SetPropertyCodec)
         bind(MapPropertyCodec)
         bind(DirectoryPropertyCodec(filePropertyFactory))
         bind(RegularFilePropertyCodec(filePropertyFactory))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
@@ -27,6 +27,7 @@ import org.gradle.instantexecution.serialization.writeMap
 import java.util.LinkedList
 import java.util.TreeMap
 import java.util.TreeSet
+import java.util.concurrent.ConcurrentHashMap
 
 
 internal
@@ -71,6 +72,10 @@ val hashMapCodec: Codec<HashMap<Any?, Any?>> = mapCodec { HashMap<Any?, Any?>(it
 
 internal
 val linkedHashMapCodec: Codec<LinkedHashMap<Any?, Any?>> = mapCodec { LinkedHashMap<Any?, Any?>(it) }
+
+
+internal
+val concurrentHashMapCodec: Codec<ConcurrentHashMap<Any?, Any?>> = mapCodec { ConcurrentHashMap<Any?, Any?>(it) }
 
 
 internal

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -45,7 +45,7 @@ class FileCollectionCodec(
                 write(elements)
             }
             onFailure { ex ->
-                write(BrokenValue(ex.message ?: "(no message)"))
+                write(BrokenValue(ex))
             }
         }
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Message.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/Message.java
@@ -16,15 +16,13 @@
 
 package org.gradle.internal.serialize;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 
 public abstract class Message {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Message.class);
-
     /**
      * Serialize the <code>message</code> onto the provided <code>outputStream</code>, replacing all {@link Throwable}s in the object graph with a placeholder object that can be read back by {@link
      * #receive(java.io.InputStream, ClassLoader)}.

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -120,6 +120,16 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
     }
 
     @Override
+    public boolean isContentProducedByTask() {
+        return super.isContentProducedByTask() || value.isContentProducedByTask();
+    }
+
+    @Override
+    public boolean isValueProducedByTask() {
+        return value.isValueProducedByTask();
+    }
+
+    @Override
     public boolean isPresent() {
         beforeRead();
         return value.present();
@@ -300,6 +310,16 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                 return right.maybeVisitBuildDependencies(context);
             }
             return false;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return left.isContentProducedByTask() || right.isContentProducedByTask();
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return left.isValueProducedByTask() || right.isValueProducedByTask();
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -111,6 +111,28 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         return elementType;
     }
 
+    /**
+     * Unpacks this property into a list of element providers.
+     */
+    public List<ProviderInternal<? extends Iterable<? extends T>>> getProviders() {
+        List<ProviderInternal<? extends Iterable<? extends T>>> sources = new ArrayList<>();
+        value.visit(sources);
+        return sources;
+    }
+
+    /**
+     * Sets the value of this property the given list of element providers.
+     */
+    public void providers(List<ProviderInternal<? extends Iterable<? extends T>>> providers) {
+        if (!beforeMutate()) {
+            return;
+        }
+        value = defaultValue;
+        for (ProviderInternal<? extends Iterable<? extends T>> provider : providers) {
+            value = new PlusCollector<>(value, new ElementsFromCollectionProvider<>(provider));
+        }
+    }
+
     @Override
     public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
         if (super.maybeVisitBuildDependencies(context)) {
@@ -302,6 +324,12 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                 return right.maybeCollectInto(collector, dest);
             }
             return false;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+            left.visit(sources);
+            right.visit(sources);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
@@ -57,19 +57,19 @@ public abstract class AbstractMappingProvider<OUT, IN> extends AbstractMinimalPr
 
     @Override
     public OUT get() {
-        return map(provider.get());
+        return mapValue(provider.get());
     }
 
     @Override
     public OUT getOrNull() {
         IN value = provider.getOrNull();
         if (value != null) {
-            return map(value);
+            return mapValue(value);
         }
         return null;
     }
 
-    protected abstract OUT map(IN v);
+    protected abstract OUT mapValue(IN v);
 
     @Override
     public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
@@ -35,6 +35,21 @@ public abstract class AbstractMappingProvider<OUT, IN> extends AbstractMinimalPr
         return type;
     }
 
+    public ProviderInternal<? extends IN> getProvider() {
+        return provider;
+    }
+
+    @Override
+    public boolean isValueProducedByTask() {
+        // Need the content in order to transform the value
+        return provider.isContentProducedByTask();
+    }
+
+    @Override
+    public boolean isContentProducedByTask() {
+        return provider.isContentProducedByTask();
+    }
+
     @Override
     public boolean isPresent() {
         return provider.isPresent();

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -69,6 +69,16 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     }
 
     @Override
+    public boolean isValueProducedByTask() {
+        return false;
+    }
+
+    @Override
+    public boolean isContentProducedByTask() {
+        return false;
+    }
+
+    @Override
     public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
         return false;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -76,10 +76,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Override
     public ProviderInternal<T> withFinalValue() {
         T value = getOrNull();
-        if (value == null) {
-            return Providers.notDefined();
-        }
-        return Providers.of(value);
+        return Providers.ofNullable(value);
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -39,6 +39,11 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     }
 
     @Override
+    public boolean isContentProducedByTask() {
+        return producer != null;
+    }
+
+    @Override
     public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
         if (producer != null) {
             context.add(producer);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -30,4 +30,8 @@ public interface Collector<T> {
     int size();
 
     boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context);
+
+    boolean isContentProducedByTask();
+
+    boolean isValueProducedByTask();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface Collector<T> {
     boolean present();
@@ -28,6 +29,8 @@ public interface Collector<T> {
     boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> dest);
 
     int size();
+
+    void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources);
 
     boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context);
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -50,6 +50,16 @@ public class Collectors {
         }
 
         @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return false;
+        }
+
+        @Override
         public int size() {
             return 0;
         }
@@ -80,6 +90,16 @@ public class Collectors {
 
         @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+            return false;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
             return false;
         }
 
@@ -145,6 +165,16 @@ public class Collectors {
         }
 
         @Override
+        public boolean isContentProducedByTask() {
+            return providerOfElement.isContentProducedByTask();
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return providerOfElement.isValueProducedByTask();
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -192,6 +222,16 @@ public class Collectors {
 
         @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+            return false;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
             return false;
         }
 
@@ -252,6 +292,16 @@ public class Collectors {
         }
 
         @Override
+        public boolean isContentProducedByTask() {
+            return provider.isContentProducedByTask();
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return provider.isValueProducedByTask();
+        }
+
+        @Override
         public boolean isProvidedBy(Provider<?> provider) {
             return Objects.equal(provider, provider);
         }
@@ -305,6 +355,16 @@ public class Collectors {
         }
 
         @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return false;
+        }
+
+        @Override
         public int size() {
             return 0;
         }
@@ -337,6 +397,16 @@ public class Collectors {
 
         @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+            return false;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
             return false;
         }
 
@@ -389,6 +459,16 @@ public class Collectors {
         @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return delegate.maybeVisitBuildDependencies(context);
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return delegate.isContentProducedByTask();
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return delegate.isValueProducedByTask();
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -17,12 +17,14 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.List;
 
 public class Collectors {
     public interface ProvidedCollector<T> extends Collector<T> {
@@ -42,6 +44,10 @@ public class Collectors {
 
         @Override
         public void collectInto(ValueCollector<Object> collector, Collection<Object> collection) {
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends Object>>> sources) {
         }
 
         @Override
@@ -86,6 +92,11 @@ public class Collectors {
         public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> collection) {
             collector.add(element, collection);
             return true;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+            sources.add(Providers.of(ImmutableList.of(element)));
         }
 
         @Override
@@ -160,6 +171,11 @@ public class Collectors {
         }
 
         @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+            sources.add(providerOfElement.map(e -> ImmutableList.of(e)));
+        }
+
+        @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return providerOfElement.maybeVisitBuildDependencies(context);
         }
@@ -218,6 +234,11 @@ public class Collectors {
         public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> collection) {
             collector.addAll(value, collection);
             return true;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+            sources.add(Providers.of(value));
         }
 
         @Override
@@ -287,6 +308,11 @@ public class Collectors {
         }
 
         @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+            sources.add(provider);
+        }
+
+        @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return provider.maybeVisitBuildDependencies(context);
         }
@@ -350,6 +376,10 @@ public class Collectors {
         }
 
         @Override
+        public void visit(List<ProviderInternal<? extends Iterable<?>>> sources) {
+        }
+
+        @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return true;
         }
@@ -393,6 +423,11 @@ public class Collectors {
         public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> dest) {
             collectInto(collector, dest);
             return true;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+            sources.add(Providers.of(ImmutableList.copyOf(value)));
         }
 
         @Override
@@ -454,6 +489,11 @@ public class Collectors {
         @Override
         public boolean isProvidedBy(Provider<?> provider) {
             return delegate instanceof ProvidedCollector && ((ProvidedCollector<T>)delegate).isProvidedBy(provider);
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Iterable<? extends T>>> sources) {
+            delegate.visit(sources);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -307,6 +307,24 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
         }
     }
 
+    @Override
+    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+        if (super.maybeVisitBuildDependencies(context)) {
+            return true;
+        }
+        return value.maybeVisitBuildDependencies(context);
+    }
+
+    @Override
+    public boolean isContentProducedByTask() {
+        return super.isContentProducedByTask() || value.isContentProducedByTask();
+    }
+
+    @Override
+    public boolean isValueProducedByTask() {
+        return value.isValueProducedByTask();
+    }
+
     private class KeySetProvider extends AbstractReadOnlyProvider<Set<K>> {
 
         @Nullable
@@ -384,6 +402,16 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
                 return right.maybeVisitBuildDependencies(context);
             }
             return false;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return left.isContentProducedByTask() || right.isContentProducedByTask();
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return left.isValueProducedByTask() || right.isContentProducedByTask();
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -97,6 +97,11 @@ public class DefaultProperty<T> extends AbstractProperty<T> implements Property<
         return this;
     }
 
+    public Property<T> provider(Provider<? extends T> provider) {
+        set(provider);
+        return this;
+    }
+
     @Override
     public void set(Provider<? extends T> provider) {
         if (!beforeMutate()) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -97,7 +97,11 @@ public class DefaultProperty<T> extends AbstractProperty<T> implements Property<
         return this;
     }
 
-    public Property<T> provider(Provider<? extends T> provider) {
+    public ProviderInternal<? extends T> getProvider() {
+        return provider;
+    }
+
+    public DefaultProperty<T> provider(Provider<? extends T> provider) {
         set(provider);
         return this;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -59,6 +59,16 @@ public class DefaultProperty<T> extends AbstractProperty<T> implements Property<
     }
 
     @Override
+    public boolean isContentProducedByTask() {
+        return super.isContentProducedByTask() || provider.isContentProducedByTask();
+    }
+
+    @Override
+    public boolean isValueProducedByTask() {
+        return provider.isValueProducedByTask();
+    }
+
+    @Override
     public void setFromAnyValue(Object object) {
         if (object instanceof Provider) {
             set((Provider<T>) object);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -38,11 +38,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            if (state == null) {
-                return type.cast(Providers.notDefined());
-            } else {
-                return type.cast(Providers.of(state));
-            }
+            return type.cast(Providers.ofNullable(state));
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
@@ -34,4 +34,8 @@ public interface MapCollector<K, V> {
     boolean maybeCollectKeysInto(ValueCollector<K> collector, Collection<K> dest);
 
     boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context);
+
+    boolean isContentProducedByTask();
+
+    boolean isValueProducedByTask();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public interface MapCollector<K, V> {
@@ -32,6 +33,8 @@ public interface MapCollector<K, V> {
     void collectKeysInto(ValueCollector<K> collector, Collection<K> dest);
 
     boolean maybeCollectKeysInto(ValueCollector<K> collector, Collection<K> dest);
+
+    void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources);
 
     boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context);
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -53,6 +53,16 @@ public class MapCollectors {
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return true;
         }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return false;
+        }
     }
 
     public static class SingleEntry<K, V> implements MapCollector<K, V> {
@@ -94,6 +104,16 @@ public class MapCollectors {
 
         @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+            return false;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
             return false;
         }
 
@@ -169,6 +189,16 @@ public class MapCollectors {
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return providerOfValue.maybeVisitBuildDependencies(context);
         }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return providerOfValue.isContentProducedByTask();
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return providerOfValue.isValueProducedByTask();
+        }
     }
 
     public static class EntriesFromMap<K, V> implements MapCollector<K, V> {
@@ -208,6 +238,16 @@ public class MapCollectors {
 
         @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+            return false;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
             return false;
         }
     }
@@ -261,6 +301,16 @@ public class MapCollectors {
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return providerOfEntries.maybeVisitBuildDependencies(context);
         }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return providerOfEntries.isContentProducedByTask();
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return providerOfEntries.isValueProducedByTask();
+        }
     }
 
     public static class NoValue implements MapCollector<Object, Object> {
@@ -293,6 +343,16 @@ public class MapCollectors {
         @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return true;
+        }
+
+        @Override
+        public boolean isContentProducedByTask() {
+            return false;
+        }
+
+        @Override
+        public boolean isValueProducedByTask() {
+            return false;
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -17,9 +17,11 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class MapCollectors {
@@ -47,6 +49,10 @@ public class MapCollectors {
         @Override
         public boolean maybeCollectKeysInto(ValueCollector<Object> collector, Collection<Object> dest) {
             return true;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Map<?, ?>>> sources) {
         }
 
         @Override
@@ -100,6 +106,11 @@ public class MapCollectors {
         public boolean maybeCollectKeysInto(ValueCollector<K> collector, Collection<K> dest) {
             collectKeysInto(collector, dest);
             return true;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
+            sources.add(Providers.of(ImmutableMap.of(key, value)));
         }
 
         @Override
@@ -186,6 +197,11 @@ public class MapCollectors {
         }
 
         @Override
+        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
+            sources.add(providerOfValue.map(v -> ImmutableMap.of(key, v)));
+        }
+
+        @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return providerOfValue.maybeVisitBuildDependencies(context);
         }
@@ -234,6 +250,11 @@ public class MapCollectors {
         public boolean maybeCollectKeysInto(ValueCollector<K> collector, Collection<K> dest) {
             collectKeysInto(collector, dest);
             return true;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
+            sources.add(Providers.of(entries));
         }
 
         @Override
@@ -298,6 +319,11 @@ public class MapCollectors {
         }
 
         @Override
+        public void visit(List<ProviderInternal<? extends Map<? extends K, ? extends V>>> sources) {
+            sources.add(providerOfEntries);
+        }
+
+        @Override
         public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
             return providerOfEntries.maybeVisitBuildDependencies(context);
         }
@@ -338,6 +364,10 @@ public class MapCollectors {
         @Override
         public boolean maybeCollectKeysInto(ValueCollector<Object> collector, Collection<Object> dest) {
             return false;
+        }
+
+        @Override
+        public void visit(List<ProviderInternal<? extends Map<?, ?>>> sources) {
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -33,7 +33,21 @@ public interface ProviderInternal<T> extends Provider<T>, TaskDependencyContaine
     Class<T> getType();
 
     /**
+     * Returns true when the <em>value</em> of this provider is produced by a task.
+     *
+     * <p>Note that a task producing the value of this provider is not the same as a task producing the <em>content</em> of
+     * the value of this provider.
+     */
+    boolean isValueProducedByTask();
+
+    /**
+     * Returns true when the <em>content</em> of the value of this provider is produced by a task.
+     */
+    boolean isContentProducedByTask();
+
+    /**
      * Visits the build dependencies of this provider, if possible.
+     *
      * @return true if the dependencies have been added (possibly none), false if the build dependencies are unknown.
      */
     boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
@@ -99,6 +99,14 @@ public class Providers {
         return Cast.uncheckedCast(value);
     }
 
+    public static <T> ProviderInternal<T> ofNullable(@Nullable T value) {
+        if (value == null) {
+            return notDefined();
+        } else {
+            return of(value);
+        }
+    }
+
     public static class FixedValueProvider<T> extends AbstractProviderWithValue<T> {
         private final T value;
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -31,7 +31,7 @@ public class TransformBackedProvider<OUT, IN> extends AbstractMappingProvider<OU
     }
 
     @Override
-    protected OUT map(IN v) {
+    protected OUT mapValue(IN v) {
         OUT result = transformer.transform(v);
         if (result == null) {
             throw new IllegalStateException(Providers.NULL_TRANSFORMER_RESULT);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/TransformBackedProvider.java
@@ -18,12 +18,16 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
 
-class TransformBackedProvider<OUT, IN> extends AbstractMappingProvider<OUT, IN> {
+public class TransformBackedProvider<OUT, IN> extends AbstractMappingProvider<OUT, IN> {
     private final Transformer<? extends OUT, ? super IN> transformer;
 
     public TransformBackedProvider(Transformer<? extends OUT, ? super IN> transformer, ProviderInternal<? extends IN> provider) {
         super(null, provider);
         this.transformer = transformer;
+    }
+
+    public Transformer<? extends OUT, ? super IN> getTransformer() {
+        return transformer;
     }
 
     @Override


### PR DESCRIPTION

### Context

This PR adds some support for `Provider` instances whose value is a mapped task output, and so cannot be evaluated eagerly when the instant execution cache is written. For these `Providers`, serialize the transformation and run it when the provider value is queried at execution time.

Also adds `fileValue()` and `fileProvider()` methods to `RegularFileProperty` and `DirectoryProperty` to allow the value to be set using a `File` or `Provider<File>`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
