### PR TITLE
Prevent StackOverflowException caused by excessive 'or' via PatternMatcher

### DIFF
--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/pattern/PatternMatcher.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/pattern/PatternMatcher.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.file.pattern;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class PatternMatcher {
     public static final PatternMatcher MATCH_ALL = new PatternMatcher() {
         @Override
@@ -37,21 +40,11 @@ public abstract class PatternMatcher {
     public abstract boolean test(String[] segments, boolean isFile);
 
     public PatternMatcher and(final PatternMatcher other) {
-        return new PatternMatcher() {
-            @Override
-            public boolean test(String[] segments, boolean isFile) {
-                return PatternMatcher.this.test(segments, isFile) && other.test(segments, isFile);
-            }
-        };
+        return new And(PatternMatcher.this, other);
     }
 
     public PatternMatcher or(final PatternMatcher other) {
-        return new PatternMatcher() {
-            @Override
-            public boolean test(String[] segments, boolean isFile) {
-                return PatternMatcher.this.test(segments, isFile) || other.test(segments, isFile);
-            }
-        };
+        return new Or(PatternMatcher.this, other);
     }
 
     public PatternMatcher negate() {
@@ -61,5 +54,55 @@ public abstract class PatternMatcher {
                 return !PatternMatcher.this.test(segments, isFile);
             }
         };
+    }
+
+    private static final class Or extends PatternMatcher {
+        private final List<PatternMatcher> parts = new ArrayList<PatternMatcher>();
+
+        public Or(PatternMatcher patternMatcher, PatternMatcher other) {
+            parts.add(patternMatcher);
+            parts.add(other);
+        }
+
+        @Override
+        public PatternMatcher or(PatternMatcher other) {
+            parts.add(other);
+            return this;
+        }
+
+        @Override
+        public boolean test(String[] segments, boolean isFile) {
+            for (PatternMatcher part : parts) {
+                if (part.test(segments, isFile)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static final class And extends PatternMatcher {
+        private final List<PatternMatcher> parts = new ArrayList<PatternMatcher>();
+
+        public And(PatternMatcher patternMatcher, PatternMatcher other) {
+            parts.add(patternMatcher);
+            parts.add(other);
+        }
+
+        @Override
+        public PatternMatcher and(PatternMatcher other) {
+            parts.add(other);
+            return this;
+        }
+
+        @Override
+        public boolean test(String[] segments, boolean isFile) {
+            for (PatternMatcher part : parts) {
+                if (!part.test(segments, isFile)) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Fixes #10329

### Context
Beside this fixes the java.lang.StackOverflowException described in #10329, it is probably also a slight optimization in the "good case" as it needs way less object instances.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
