### PR TITLE
Ensure that no-isolation workers run with the classloader of the submitting thread

### DIFF
--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.workers.fixtures.WorkerExecutorFixture
+import spock.lang.Unroll
+
+class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpec {
+    WorkerExecutorFixture fixture = new WorkerExecutorFixture(temporaryFolder)
+    def plugin = testDirectory.createDir("plugin")
+    def build1 = testDirectory.createDir("build1")
+
+    @Unroll
+    def "can use worker api with composite builds using #pluginId"() {
+        settingsFile << """
+            includeBuild "plugin"
+            includeBuild "build1"
+        """
+
+        withFileHelperInPluginBuild()
+        withLegacyRunnableAndTaskInPluginBuild()
+        withTypedWorkerPluginInPluginBuild()
+
+        build1.file("build.gradle") << """
+            buildscript {
+                repositories {
+                    ${jcenterRepository()}
+                }
+
+                dependencies {
+                    classpath "org.apache.commons:commons-math:2.2"
+                }
+            }
+
+            plugins {
+                id "java"
+                id "org.gradle.test.${pluginId}"
+            }
+
+            group = "org.gradle.test"
+            version = "1.0"
+
+            jar {
+                from runWork
+            }
+        """
+
+        buildFile << """
+            plugins {
+                id "java"
+                id "org.gradle.test.${pluginId}"
+            }
+       
+            dependencies {
+                compile "org.gradle.test:build1:1.0"
+            }
+
+            runWork.dependsOn compileJava
+        """
+
+        expect:
+        succeeds("runWork")
+
+        where:
+        pluginId << [ 'legacy-worker-plugin', 'typed-worker-plugin' ]
+    }
+
+    private void withLegacyRunnableAndTaskInPluginBuild() {
+        plugin.file("src/main/java/LegacyParameter.java") << """
+            import java.io.File;
+            import java.io.Serializable;
+            
+            public class LegacyParameter implements Serializable {
+                private final File outputFile;
+                
+                public LegacyParameter(File outputFile) {
+                    this.outputFile = outputFile;
+                }
+                
+                public File getOutputFile() {
+                    return this.outputFile;
+               }
+            }
+        """
+
+        plugin.file('src/main/java/LegacyRunnable.java') << """
+            import javax.inject.Inject;
+            import java.io.File;
+            import org.gradle.test.FileHelper;
+            
+            public class LegacyRunnable implements Runnable {
+                private File outputFile;
+                
+                @Inject
+                public LegacyRunnable(LegacyParameter parameter) {
+                    this.outputFile = parameter.getOutputFile();
+                }
+                
+                public void run() {
+                    FileHelper.write("foo", outputFile);
+                }
+            }
+        """
+
+        plugin.file('src/main/java/LegacyWorkerTask.java') << """
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.Action;
+            import org.gradle.api.tasks.*;
+            import org.gradle.workers.*;
+            import javax.inject.Inject;
+            import java.io.File;
+            
+            public class LegacyWorkerTask extends DefaultTask {
+                private final WorkerExecutor workerExecutor;
+                private File outputFile;
+                
+                @Inject
+                public LegacyWorkerTask(WorkerExecutor workerExecutor) {
+                    this.workerExecutor = workerExecutor;
+                } 
+                
+                @TaskAction
+                public void runWork() {
+                    workerExecutor.submit(LegacyRunnable.class, new Action<WorkerConfiguration>() {
+                        public void execute(WorkerConfiguration config) {
+                            config.setIsolationMode(IsolationMode.NONE);
+                            config.params(new LegacyParameter(outputFile));
+                        }
+                    });
+                }
+                
+                @OutputFile
+                File getOutputFile() {
+                    return outputFile;
+                }
+                
+                void setOutputFile(File outputFile) {
+                    this.outputFile = outputFile;
+                }
+            }
+        """
+
+        plugin.file("src/main/java/LegacyWorkerPlugin.java") << """
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import java.io.File;
+            
+            public class LegacyWorkerPlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    project.getTasks().create("runWork", LegacyWorkerTask.class)
+                        .setOutputFile(new File(project.getBuildDir(), "workOutput"));
+                }
+            }
+        """
+
+        plugin.file("build.gradle") << """
+            apply plugin: "java-gradle-plugin"
+            
+            gradlePlugin {
+                plugins {
+                    LegacyWorkerPlugin {
+                        id = "org.gradle.test.legacy-worker-plugin"
+                        implementationClass = "LegacyWorkerPlugin"
+                    }
+                }
+            }
+        """
+    }
+
+    private void withTypedWorkerPluginInPluginBuild() {
+        plugin.file("src/main/java/TypedParameter.java") << """
+            import org.gradle.workers.WorkParameters;
+            import org.gradle.api.file.RegularFileProperty;
+            
+            public interface TypedParameter extends WorkParameters {
+                RegularFileProperty getOutputFile();
+            }
+        """
+
+        plugin.file("src/main/java/TypedWorkAction.java") << """
+            import org.gradle.workers.WorkAction;
+            import org.gradle.test.FileHelper;
+            
+            abstract public class TypedWorkAction implements WorkAction<TypedParameter> {
+                public void execute() {
+                    FileHelper.write("foo", getParameters().getOutputFile().getAsFile().get());
+                }
+            }
+        """
+
+        plugin.file("src/main/java/TypedWorkerTask.java") << """
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.Action;
+            import org.gradle.api.file.RegularFileProperty;
+            import org.gradle.api.tasks.*;
+            import org.gradle.workers.*;
+            import javax.inject.Inject;
+            import java.io.File;
+            
+            public class TypedWorkerTask extends DefaultTask {
+                private final WorkerExecutor workerExecutor;
+                private RegularFileProperty outputFile;
+                
+                @Inject
+                public TypedWorkerTask(WorkerExecutor workerExecutor) {
+                    this.workerExecutor = workerExecutor;
+                    this.outputFile = getProject().getObjects().fileProperty();
+                } 
+                
+                @TaskAction
+                public void runWork() {
+                    workerExecutor.noIsolation().submit(TypedWorkAction.class, new Action<TypedParameter>() {
+                        public void execute(TypedParameter parameters) {
+                            parameters.getOutputFile().set(outputFile);
+                        }
+                    });
+                }
+                
+                @OutputFile
+                RegularFileProperty getOutputFile() {
+                    return outputFile;
+                }
+            }
+        """
+
+        plugin.file("src/main/java/TypedWorkerPlugin.java") << """
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import java.io.File;
+            
+            public class TypedWorkerPlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    project.getTasks().create("runWork", TypedWorkerTask.class)
+                        .getOutputFile().set(new File(project.getBuildDir(), "workOutput"));
+                }
+            }
+        """
+
+        plugin.file("build.gradle") << """
+            apply plugin: "java-gradle-plugin"
+            
+            gradlePlugin {
+                plugins {
+                    TypedWorkerPlugin {
+                        id = "org.gradle.test.typed-worker-plugin"
+                        implementationClass = "TypedWorkerPlugin"
+                    }
+                }
+            }
+        """
+    }
+
+    private void withFileHelperInPluginBuild() {
+        plugin.file("src/main/java/org/gradle/test/FileHelper.java") << fixture.fileHelperClass
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -42,12 +42,8 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
 
         lib.file("build.gradle") << """
             buildscript {
-                repositories {
-                    ${jcenterRepository()}
-                }
-
                 dependencies {
-                    classpath "org.apache.commons:commons-math:2.2"
+                    classpath files('foo.jar')
                 }
             }
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -24,21 +24,23 @@ import spock.lang.Unroll
 class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpec {
     WorkerExecutorFixture fixture = new WorkerExecutorFixture(temporaryFolder)
     def plugin = testDirectory.createDir("plugin")
-    def build1 = testDirectory.createDir("build1")
+    def lib = testDirectory.createDir("lib")
 
     @Unroll
     @Issue("https://github.com/gradle/gradle/issues/10317")
     def "can use worker api with composite builds using #pluginId"() {
         settingsFile << """
+            rootProject.name = "app"
+            
             includeBuild "plugin"
-            includeBuild "build1"
+            includeBuild "lib"
         """
 
         withFileHelperInPluginBuild()
         withLegacyWorkerPluginInPluginBuild()
         withTypedWorkerPluginInPluginBuild()
 
-        build1.file("build.gradle") << """
+        lib.file("build.gradle") << """
             buildscript {
                 repositories {
                     ${jcenterRepository()}
@@ -69,7 +71,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             }
        
             dependencies {
-                compile "org.gradle.test:build1:1.0"
+                compile "org.gradle.test:lib:1.0"
             }
 
             runWork.dependsOn compileJava
@@ -80,7 +82,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
 
         and:
         file("build/workOutput").text == "foo"
-        build1.file("build/workOutput").text == "foo"
+        lib.file("build/workOutput").text == "foo"
 
         where:
         pluginId << [ 'legacy-worker-plugin', 'typed-worker-plugin' ]

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -55,6 +55,9 @@ class WorkerExecutorFixture {
     }
 
     def prepareTaskTypeUsingWorker() {
+        withParameterClassInBuildSrc()
+        withFileHelperClassInBuildSrc()
+
         buildFile << """
             import org.gradle.workers.*
             $taskTypeUsingWorker
@@ -62,9 +65,6 @@ class WorkerExecutorFixture {
     }
 
     String getTaskTypeUsingWorker() {
-        withParameterClassInBuildSrc()
-        withFileHelperClassInBuildSrc()
-
         return """
             import javax.inject.Inject
             import org.gradle.other.Foo
@@ -241,7 +241,7 @@ class WorkerExecutorFixture {
             import java.io.FileWriter;
             
             public class FileHelper {
-                static void write(String id, File outputFile) {
+                public static void write(String id, File outputFile) {
                     PrintWriter out = null;
                     try {
                         outputFile.getParentFile().mkdirs();

--- a/subprojects/workers/workers.gradle.kts
+++ b/subprojects/workers/workers.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     integTestRuntimeOnly(project(":kotlinDsl"))
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
     integTestRuntimeOnly(project(":apiMetadata"))
+    integTestRuntimeOnly(project(":testKit"))
 
     integTestImplementation(project(":jvmServices"))
     integTestImplementation(project(":internalIntegTesting"))


### PR DESCRIPTION
This fixes a problem where, in a composite build, a worker can get a context
classloader set to a classloader from another project, which causes a class
mismatch when we attempt to re-hydrate a legacy runnable class in AdapterWorkAction.

We now ensure that the context classloader for no-isolation workers get set
to the context classloader of the thread that submitted the work.

Fixes #10317 