### PR TITLE
Deduplicate sign task inputs

### DIFF
--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsIntegrationSpec.groovy
@@ -79,4 +79,30 @@ class SigningConfigurationsIntegrationSpec extends SigningIntegrationSpec {
         and:
         file("build", "libs", "sign-1.0.jar.asc").text
     }
+
+    def "duplicated inputs are handled"() {
+        given:
+        buildFile << """
+            signing {
+                ${signingConfiguration()}
+                sign configurations.archives
+            }
+
+            ${keyInfo.addAsPropertiesScript()}
+
+            artifacts {
+                // depend directly on 'jar' task in addition to dependency through 'archives'
+                archives jar  
+            }
+        """
+
+        when:
+        run "buildSignatures"
+
+        then:
+        executedAndNotSkipped ":signArchives"
+
+        and:
+        file("build", "libs", "sign-1.0.jar.asc").text
+    }
 }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -369,6 +369,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
 
             publishing.publications.mavenJava.artifacts = [] 
             publishing.publications.mavenJava.artifact(sourceJar)
+            generateMetadataFileForMavenJavaPublication.enabled = false
         """
 
         when:

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -84,7 +84,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     public Map<String, File> getOutputFiles() {
         SingleMessageLogger.nagUserOfDiscontinuedMethod("Sign.getOutputFiles()",
             "Please use Sign.getSignatures() and Signature.getFile() instead.");
-        return signatures.stream().collect(toMap(Signature::toKey, Signature::getFile));
+        return signaturesForExsitingFiles().stream().collect(toMap(Signature::toKey, Signature::getFile));
     }
 
     /**
@@ -224,7 +224,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
             throw new InvalidUserDataException("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory");
         }
 
-        for (Signature signature : signatures) {
+        for (Signature signature : signaturesForExsitingFiles()) {
             signature.generate();
         }
     }
@@ -244,7 +244,11 @@ public class Sign extends DefaultTask implements SignatureSpec {
     @Nested
     @Incubating
     public Map<String, Signature> getSignaturesByKey() {
-        return signatures.stream().collect(toMap(Signature::toKey, identity()));
+        return signaturesForExsitingFiles().stream().collect(toMap(Signature::toKey, identity()));
+    }
+
+    private DomainObjectSet<Signature> signaturesForExsitingFiles() {
+        return signatures.matching(signature -> signature.getToSign().exists());
     }
 
     /**

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -84,7 +84,8 @@ public class Sign extends DefaultTask implements SignatureSpec {
     public Map<String, File> getOutputFiles() {
         SingleMessageLogger.nagUserOfDiscontinuedMethod("Sign.getOutputFiles()",
             "Please use Sign.getSignatures() and Signature.getFile() instead.");
-        return signaturesForExsitingFiles().stream().collect(toMap(Signature::toKey, Signature::getFile));
+        // will be removed in 6.0
+        return sanitizedSignatures().entrySet().stream().collect(toMap(Map.Entry::getKey, entry -> entry.getValue().getFile()));
     }
 
     /**
@@ -224,7 +225,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
             throw new InvalidUserDataException("Cannot perform signing task \'" + getPath() + "\' because it has no configured signatory");
         }
 
-        for (Signature signature : signaturesForExsitingFiles()) {
+        for (Signature signature : sanitizedSignatures().values()) {
             signature.generate();
         }
     }
@@ -244,11 +245,14 @@ public class Sign extends DefaultTask implements SignatureSpec {
     @Nested
     @Incubating
     public Map<String, Signature> getSignaturesByKey() {
-        return signaturesForExsitingFiles().stream().collect(toMap(Signature::toKey, identity()));
+        return sanitizedSignatures();
     }
 
-    private DomainObjectSet<Signature> signaturesForExsitingFiles() {
-        return signatures.matching(signature -> signature.getToSign().exists());
+    /**
+     * Returns signatures mapped by their key with duplicated and non-existing inputs removed.
+     */
+    private Map<String, Signature> sanitizedSignatures() {
+        return signatures.matching(signature -> signature.getToSign().exists()).stream().collect(toMap(Signature::toKey, identity(), (signature, duplicate) -> signature));
     }
 
     /**
@@ -259,10 +263,11 @@ public class Sign extends DefaultTask implements SignatureSpec {
      */
     @Internal
     public Signature getSingleSignature() {
-        if (signatures.size() == 1) {
-            return signatures.iterator().next();
+        Map<String, Signature> sanitizedSignatures = sanitizedSignatures();
+        if (sanitizedSignatures.size() == 1) {
+            return sanitizedSignatures.values().iterator().next();
         }
-        throw new IllegalStateException("Expected %s to contain exactly one signature, however, it contains " + signatures.size() + " signatures.");
+        throw new IllegalStateException("Expected %s to contain exactly one signature, however, it contains " + sanitizedSignatures.size() + " signatures.");
     }
 
     @Inject


### PR DESCRIPTION
See: #10302

This includes a fix to ignore inputs where the files are missing (for example, because a task was disabled). This fix was already on master but is very much related and it might also be part of the regression.