### PR TITLE
Integration test Santa Tracker with Instant Execution

### DIFF
--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -96,7 +96,7 @@ tasks {
         dependsOn(santaTrackerKotlin)
     }
 
-    register<Delete>("cleanTemplates") {
+    register<Delete>("cleanRemoteProjects") {
         delete(santaTrackerJava.get().outputDirectory)
         delete(santaTrackerKotlin.get().outputDirectory)
     }

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -1,5 +1,8 @@
 import build.futureKotlin
+import org.gradle.gradlebuild.BuildEnvironment
+import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
+import org.gradle.testing.performance.generator.tasks.RemoteProject
 
 plugins {
     `kotlin-library`
@@ -58,3 +61,43 @@ gradlebuildJava {
     moduleType = ModuleType.CORE
 }
 
+
+tasks {
+
+    /**
+     * Santa Tracker git URI.
+     *
+     * Note that you can change it to `file:///path/to/your/santa-tracker-clone/.git`
+     * if you need to iterate quickly on changes to Santa Tracker.
+     */
+    val gitUri = "https://github.com/gradle/santa-tracker-android.git"
+
+    val javaBranch = "agp-3.6.0-java"
+    val kotlinBranch = "agp-3.6.0"
+
+    val santaTrackerJava by registering(RemoteProject::class) {
+        remoteUri.set(gitUri)
+        branch.set(javaBranch)
+    }
+
+    val santaTrackerKotlin by registering(RemoteProject::class) {
+        remoteUri.set(gitUri)
+        branch.set(kotlinBranch)
+    }
+
+    if (BuildEnvironment.isCiServer) {
+        withType<RemoteProject>().configureEach {
+            outputs.upToDateWhen { false }
+        }
+    }
+
+    withType<IntegrationTest>().configureEach {
+        dependsOn(santaTrackerJava)
+        dependsOn(santaTrackerKotlin)
+    }
+
+    register<Delete>("cleanTemplates") {
+        delete(santaTrackerJava.get().outputDirectory)
+        delete(santaTrackerKotlin.get().outputDirectory)
+    }
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -31,8 +31,8 @@ class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionInt
     def setup() {
         AndroidHome.assumeIsSet()
         executer.noDeprecationChecks()
+        executer.withRepositoryMirrors()
         executer.beforeExecute {
-            withRepositoryMirrors()
             inDirectory(file("android-3.6-mini"))
         }
         instantExecution = newInstantExecutionFixture()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -17,11 +17,10 @@
 package org.gradle.instantexecution
 
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.integtests.fixtures.android.AndroidHome
 import org.junit.Rule
 
 
-class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionAndroidIntegrationTest {
 
     @Rule
     TestResources resources = new TestResources(temporaryFolder, "builds")
@@ -29,12 +28,15 @@ class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionInt
     def instantExecution
 
     def setup() {
-        AndroidHome.assumeIsSet()
         executer.noDeprecationChecks()
         executer.withRepositoryMirrors()
+
+        def rootDir = file("android-3.6-mini")
         executer.beforeExecute {
-            inDirectory(file("android-3.6-mini"))
+            inDirectory(rootDir)
         }
+        withAgpNightly(rootDir.file("build.gradle"))
+
         instantExecution = newInstantExecutionFixture()
     }
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import groovy.transform.CompileStatic
+import org.gradle.integtests.fixtures.android.AndroidHome
+import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Unroll
+
+import static org.gradle.instantexecution.fixtures.InstantExecutionAndroidFixture.AGP_NIGHTLY_REPOSITORY_INIT_SCRIPT
+import static org.gradle.instantexecution.fixtures.InstantExecutionAndroidFixture.AGP_VERSION
+import static org.gradle.instantexecution.fixtures.InstantExecutionAndroidFixture.replaceAgpVersion
+
+
+/**
+ * Integration test Santa Tracker android app against AGP nightly.
+ */
+class InstantExecutionSantaTrackerIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+
+    def setup() {
+        AndroidHome.assumeIsSet()
+        executer.noDeprecationChecks()
+        executer.withRepositoryMirrors()
+    }
+
+    @Unroll
+    def "assembleDebug --dry-run on Santa Tracker #flavor"() {
+
+        given:
+        copyTemplate(template)
+        withAgpNightly()
+
+        when:
+        instantRun ':santa-tracker:assembleDebug', '--dry-run', '--no-build-cache'
+
+        then:
+        instantRun ':santa-tracker:assembleDebug', '--dry-run', '--no-build-cache'
+
+        where:
+        flavor | template
+        'Java' | "santaTrackerJava"
+        // 'Kotlin' | "santaTrackerKotlin" // TODO:instant-execution Instant execution state could not be cached.
+    }
+
+    def "supported tasks up-to-date on Santa Tracker Java"() {
+
+        given:
+        copyTemplate("santaTrackerJava")
+        withAgpNightly()
+
+        and:
+        def tasks = TASKS_TO_ASSEMBLE_DEBUG_JAVA + ['--no-build-cache'] - [
+            // unsupported tasks
+            ":santa-tracker:processDevelopmentDebugResources",
+            ":santa-tracker:compileDevelopmentDebugJavaWithJavac",
+            ":santa-tracker:compileDevelopmentDebugSources",
+            ":santa-tracker:dexBuilderDevelopmentDebug",
+            ":santa-tracker:mergeProjectDexDevelopmentDebug",
+            ":santa-tracker:packageDevelopmentDebug",
+            ":santa-tracker:assembleDevelopmentDebug",
+            ":santa-tracker:assembleDebug",
+        ]
+
+        when:
+        instantRun(*tasks)
+
+        then:
+        instantRun(*tasks)
+    }
+
+    def "supported tasks clean build on Santa Tracker Java"() {
+
+        given:
+        copyTemplate("santaTrackerJava")
+        withAgpNightly()
+
+        and:
+        def libs = [':common', ':dasherdancer', ':doodles', ':presentquest', ':rocketsleigh', ':snowdown', ':village']
+        def tasks = TASKS_TO_ASSEMBLE_DEBUG_JAVA + ['--no-build-cache'] - [
+            // unsupported library tasks
+            ':compileDebugLibraryResources',
+            ':extractDeepLinksDebug',
+            ':mergeDebugShaders',
+            ':compileDebugShaders',
+            ':generateDebugAssets',
+            ':packageDebugAssets',
+            ':processDebugJavaRes',
+            ':bundleLibResDebug',
+            ':bundleLibRuntimeDebug',
+            ':createFullJarDebug',
+            ':mergeDebugJniLibFolders',
+            ':mergeDebugNativeLibs',
+            ':stripDebugDebugSymbols',
+            ':copyDebugJniLibsProjectOnly',
+        ].collectMany { task -> libs.collect { lib -> "$lib$task" } } - [
+            // unsupported application tasks
+            ":santa-tracker:processDevelopmentDebugResources",
+            ":santa-tracker:compileDevelopmentDebugJavaWithJavac",
+            ":santa-tracker:compileDevelopmentDebugSources",
+            ":santa-tracker:dexBuilderDevelopmentDebug",
+            ":santa-tracker:mergeProjectDexDevelopmentDebug",
+            ":santa-tracker:packageDevelopmentDebug",
+            ":santa-tracker:assembleDevelopmentDebug",
+            ":santa-tracker:assembleDebug",
+        ]
+
+        when:
+        instantRun(*tasks)
+
+        and:
+        instantRun 'clean'
+
+        then:
+        instantRun(*tasks)
+    }
+
+    @CompileStatic
+    private void copyTemplate(String template) {
+        new TestFile(new File("build/$template")).copyTo(testDirectory)
+    }
+
+    @CompileStatic
+    private void withAgpNightly() {
+
+        println "> Using AGP nightly ${AGP_VERSION}"
+
+        // Inject AGP nightly repository
+        def init = file("gradle/agp-nightly.init.gradle") << AGP_NIGHTLY_REPOSITORY_INIT_SCRIPT
+        executer.beforeExecute {
+            withArgument("-I")
+            withArgument(init.path)
+        }
+
+        // Inject AGP nightly version
+        buildFile.text = replaceAgpVersion(buildFile.text)
+    }
+
+    static final List<String> TASKS_TO_ASSEMBLE_DEBUG_JAVA = [
+        ':common:preBuild',
+        ':common:preDebugBuild',
+        ':common:compileDebugAidl',
+        ':common:compileDebugRenderscript',
+        ':common:checkDebugManifest',
+        ':common:generateDebugBuildConfig',
+        ':common:generateDebugResValues',
+        ':common:generateDebugResources',
+        ':common:packageDebugResources',
+        ':common:parseDebugLocalResources',
+        ':common:processDebugManifest',
+        ':common:generateDebugRFile',
+        ':common:javaPreCompileDebug',
+        ':common:compileDebugJavaWithJavac',
+        ':common:bundleLibCompileDebug',
+        ':dasherdancer:preBuild',
+        ':dasherdancer:preDebugBuild',
+        ':dasherdancer:compileDebugAidl',
+        ':common:packageDebugRenderscript',
+        ':dasherdancer:compileDebugRenderscript',
+        ':dasherdancer:checkDebugManifest',
+        ':dasherdancer:generateDebugBuildConfig',
+        ':dasherdancer:generateDebugResValues',
+        ':dasherdancer:generateDebugResources',
+        ':dasherdancer:packageDebugResources',
+        ':dasherdancer:parseDebugLocalResources',
+        ':dasherdancer:processDebugManifest',
+        ':dasherdancer:generateDebugRFile',
+        ':dasherdancer:javaPreCompileDebug',
+        ':dasherdancer:compileDebugJavaWithJavac',
+        ':dasherdancer:bundleLibCompileDebug',
+        ':doodles:preBuild',
+        ':doodles:preDebugBuild',
+        ':doodles:compileDebugAidl',
+        ':doodles:compileDebugRenderscript',
+        ':doodles:checkDebugManifest',
+        ':doodles:generateDebugBuildConfig',
+        ':doodles:generateDebugResValues',
+        ':doodles:generateDebugResources',
+        ':doodles:packageDebugResources',
+        ':doodles:parseDebugLocalResources',
+        ':doodles:processDebugManifest',
+        ':doodles:generateDebugRFile',
+        ':doodles:javaPreCompileDebug',
+        ':doodles:compileDebugJavaWithJavac',
+        ':doodles:bundleLibCompileDebug',
+        ':presentquest:preBuild',
+        ':presentquest:preDebugBuild',
+        ':presentquest:compileDebugAidl',
+        ':presentquest:compileDebugRenderscript',
+        ':presentquest:checkDebugManifest',
+        ':presentquest:generateDebugBuildConfig',
+        ':presentquest:generateDebugResValues',
+        ':presentquest:generateDebugResources',
+        ':presentquest:packageDebugResources',
+        ':presentquest:parseDebugLocalResources',
+        ':presentquest:processDebugManifest',
+        ':presentquest:generateDebugRFile',
+        ':presentquest:javaPreCompileDebug',
+        ':presentquest:compileDebugJavaWithJavac',
+        ':presentquest:bundleLibCompileDebug',
+        ':rocketsleigh:preBuild',
+        ':rocketsleigh:preDebugBuild',
+        ':rocketsleigh:compileDebugAidl',
+        ':rocketsleigh:compileDebugRenderscript',
+        ':rocketsleigh:checkDebugManifest',
+        ':rocketsleigh:generateDebugBuildConfig',
+        ':rocketsleigh:generateDebugResValues',
+        ':rocketsleigh:generateDebugResources',
+        ':rocketsleigh:packageDebugResources',
+        ':rocketsleigh:parseDebugLocalResources',
+        ':rocketsleigh:processDebugManifest',
+        ':rocketsleigh:generateDebugRFile',
+        ':rocketsleigh:javaPreCompileDebug',
+        ':rocketsleigh:compileDebugJavaWithJavac',
+        ':rocketsleigh:bundleLibCompileDebug',
+        ':santa-tracker:preBuild',
+        ':santa-tracker:preDevelopmentDebugBuild',
+        ':village:preBuild',
+        ':village:preDebugBuild',
+        ':village:compileDebugAidl',
+        ':santa-tracker:compileDevelopmentDebugAidl',
+        ':dasherdancer:packageDebugRenderscript',
+        ':doodles:packageDebugRenderscript',
+        ':presentquest:packageDebugRenderscript',
+        ':rocketsleigh:packageDebugRenderscript',
+        ':village:packageDebugRenderscript',
+        ':santa-tracker:compileDevelopmentDebugRenderscript',
+        ':santa-tracker:checkDevelopmentDebugManifest',
+        ':santa-tracker:generateDevelopmentDebugBuildConfig',
+        ':village:compileDebugRenderscript',
+        ':village:checkDebugManifest',
+        ':village:generateDebugBuildConfig',
+        ':village:generateDebugResValues',
+        ':village:generateDebugResources',
+        ':village:packageDebugResources',
+        ':village:parseDebugLocalResources',
+        ':village:processDebugManifest',
+        ':village:generateDebugRFile',
+        ':village:javaPreCompileDebug',
+        ':village:compileDebugJavaWithJavac',
+        ':village:bundleLibCompileDebug',
+        ':santa-tracker:javaPreCompileDevelopmentDebug',
+        ':common:compileDebugLibraryResources',
+        ':dasherdancer:compileDebugLibraryResources',
+        ':doodles:compileDebugLibraryResources',
+        ':presentquest:compileDebugLibraryResources',
+        ':rocketsleigh:compileDebugLibraryResources',
+        ':santa-tracker:mainApkListPersistenceDevelopmentDebug',
+        ':santa-tracker:generateDevelopmentDebugResValues',
+        ':santa-tracker:generateDevelopmentDebugResources',
+        ':santa-tracker:mergeDevelopmentDebugResources',
+        ':common:extractDeepLinksDebug',
+        ':dasherdancer:extractDeepLinksDebug',
+        ':doodles:extractDeepLinksDebug',
+        ':presentquest:extractDeepLinksDebug',
+        ':rocketsleigh:extractDeepLinksDebug',
+        ':santa-tracker:createDevelopmentDebugCompatibleScreenManifests',
+        ':santa-tracker:extractDeepLinksDevelopmentDebug',
+        ':village:extractDeepLinksDebug',
+        ':santa-tracker:processDevelopmentDebugManifest',
+        ':village:compileDebugLibraryResources',
+        ':santa-tracker:processDevelopmentDebugResources',
+        ':santa-tracker:compileDevelopmentDebugJavaWithJavac',
+        ':santa-tracker:compileDevelopmentDebugSources',
+        ':common:mergeDebugShaders',
+        ':common:compileDebugShaders',
+        ':common:generateDebugAssets',
+        ':common:packageDebugAssets',
+        ':dasherdancer:mergeDebugShaders',
+        ':dasherdancer:compileDebugShaders',
+        ':dasherdancer:generateDebugAssets',
+        ':dasherdancer:packageDebugAssets',
+        ':doodles:mergeDebugShaders',
+        ':doodles:compileDebugShaders',
+        ':doodles:generateDebugAssets',
+        ':doodles:packageDebugAssets',
+        ':presentquest:mergeDebugShaders',
+        ':presentquest:compileDebugShaders',
+        ':presentquest:generateDebugAssets',
+        ':presentquest:packageDebugAssets',
+        ':rocketsleigh:mergeDebugShaders',
+        ':rocketsleigh:compileDebugShaders',
+        ':rocketsleigh:generateDebugAssets',
+        ':rocketsleigh:packageDebugAssets',
+        ':santa-tracker:mergeDevelopmentDebugShaders',
+        ':santa-tracker:compileDevelopmentDebugShaders',
+        ':santa-tracker:generateDevelopmentDebugAssets',
+        ':village:mergeDebugShaders',
+        ':village:compileDebugShaders',
+        ':village:generateDebugAssets',
+        ':village:packageDebugAssets',
+        ':santa-tracker:mergeDevelopmentDebugAssets',
+        ':common:processDebugJavaRes',
+        ':common:bundleLibResDebug',
+        ':dasherdancer:processDebugJavaRes',
+        ':dasherdancer:bundleLibResDebug',
+        ':doodles:processDebugJavaRes',
+        ':doodles:bundleLibResDebug',
+        ':presentquest:processDebugJavaRes',
+        ':presentquest:bundleLibResDebug',
+        ':rocketsleigh:processDebugJavaRes',
+        ':rocketsleigh:bundleLibResDebug',
+        ':santa-tracker:processDevelopmentDebugJavaRes',
+        ':village:processDebugJavaRes',
+        ':village:bundleLibResDebug',
+        ':santa-tracker:mergeDevelopmentDebugJavaResource',
+        ':santa-tracker:checkDevelopmentDebugDuplicateClasses',
+        ':santa-tracker:mergeExtDexDevelopmentDebug',
+        ':village:bundleLibRuntimeDebug',
+        ':village:createFullJarDebug',
+        ':dasherdancer:bundleLibRuntimeDebug',
+        ':dasherdancer:createFullJarDebug',
+        ':rocketsleigh:bundleLibRuntimeDebug',
+        ':rocketsleigh:createFullJarDebug',
+        ':doodles:bundleLibRuntimeDebug',
+        ':doodles:createFullJarDebug',
+        ':presentquest:bundleLibRuntimeDebug',
+        ':presentquest:createFullJarDebug',
+        ':common:bundleLibRuntimeDebug',
+        ':common:createFullJarDebug',
+        ':santa-tracker:mergeLibDexDevelopmentDebug',
+        ':santa-tracker:dexBuilderDevelopmentDebug',
+        ':santa-tracker:mergeProjectDexDevelopmentDebug',
+        ':santa-tracker:validateSigningDevelopmentDebug',
+        ':santa-tracker:signingConfigWriterDevelopmentDebug',
+        ':common:mergeDebugJniLibFolders',
+        ':common:mergeDebugNativeLibs',
+        ':common:stripDebugDebugSymbols',
+        ':common:copyDebugJniLibsProjectOnly',
+        ':dasherdancer:mergeDebugJniLibFolders',
+        ':dasherdancer:mergeDebugNativeLibs',
+        ':dasherdancer:stripDebugDebugSymbols',
+        ':dasherdancer:copyDebugJniLibsProjectOnly',
+        ':doodles:mergeDebugJniLibFolders',
+        ':doodles:mergeDebugNativeLibs',
+        ':doodles:stripDebugDebugSymbols',
+        ':doodles:copyDebugJniLibsProjectOnly',
+        ':presentquest:mergeDebugJniLibFolders',
+        ':presentquest:mergeDebugNativeLibs',
+        ':presentquest:stripDebugDebugSymbols',
+        ':presentquest:copyDebugJniLibsProjectOnly',
+        ':rocketsleigh:mergeDebugJniLibFolders',
+        ':rocketsleigh:mergeDebugNativeLibs',
+        ':rocketsleigh:stripDebugDebugSymbols',
+        ':rocketsleigh:copyDebugJniLibsProjectOnly',
+        ':santa-tracker:mergeDevelopmentDebugJniLibFolders',
+        ':village:mergeDebugJniLibFolders',
+        ':village:mergeDebugNativeLibs',
+        ':village:stripDebugDebugSymbols',
+        ':village:copyDebugJniLibsProjectOnly',
+        ':santa-tracker:mergeDevelopmentDebugNativeLibs',
+        ':santa-tracker:stripDevelopmentDebugDebugSymbols',
+        ':santa-tracker:packageDevelopmentDebug',
+        ':santa-tracker:assembleDevelopmentDebug',
+        ':santa-tracker:assembleDebug',
+    ]
+}

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/fixtures/InstantExecutionAndroidFixture.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/fixtures/InstantExecutionAndroidFixture.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.fixtures
+
+import groovy.transform.CompileStatic
+
+
+@CompileStatic
+class InstantExecutionAndroidFixture {
+
+    static final String AGP_VERSION = "3.6.0-20190820155739+0200"
+
+    static final String AGP_NIGHTLY_REPOSITORY_DECLARATION = '''
+        maven {
+            name = 'agp-nightlies'
+            url = 'https://repo.gradle.org/gradle/ext-snapshots-local/'
+        }
+    '''
+
+    static final String AGP_NIGHTLY_REPOSITORY_INIT_SCRIPT = """
+        allprojects {
+            buildscript {
+                repositories {
+                    $AGP_NIGHTLY_REPOSITORY_DECLARATION
+                }
+            }
+            repositories {
+                $AGP_NIGHTLY_REPOSITORY_DECLARATION
+            }
+        }
+    """
+
+    static String replaceAgpVersion(String scriptText) {
+        return scriptText.replaceAll(
+            "(['\"]com.android.tools.build:gradle:).+(['\"])",
+            "${'$'}1$AGP_VERSION${'$'}2"
+        )
+    }
+}

--- a/subprojects/instant-execution/src/integTest/resources/org/gradle/instantexecution/builds/android-3.6-mini/build.gradle
+++ b/subprojects/instant-execution/src/integTest/resources/org/gradle/instantexecution/builds/android-3.6-mini/build.gradle
@@ -2,12 +2,11 @@
 
 buildscript {
     repositories {
-        maven { url = "https://repo.gradle.org/gradle/ext-snapshots-local/" }
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-20190820155739+0200'
+        classpath 'com.android.tools.build:gradle:3.6.0-alpha6'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,7 +15,6 @@ buildscript {
 
 allprojects {
     repositories {
-        maven { url = "https://repo.gradle.org/gradle/ext-snapshots-local/" }
         google()
         jcenter()
     }


### PR DESCRIPTION
Covering
- `assembleDebug --dry-run`
- supported tasks in up-to-date builds
- supported tasks in clean builds

For the Java branch only for now as instant execution is currently broken with the Kotlin one.