### PR TITLE
Fix issue with isolation of Properties objects

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractIsolatedMap.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractIsolatedMap.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.internal.Factory;
+import org.gradle.internal.isolation.Isolatable;
+import org.gradle.internal.snapshot.ValueSnapshot;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+abstract public class AbstractIsolatedMap<T extends Map<Object, Object>> extends AbstractMapSnapshot<Isolatable<?>> implements Isolatable<T>, Factory<T> {
+    public AbstractIsolatedMap(ImmutableList<MapEntrySnapshot<Isolatable<?>>> entries) {
+        super(entries);
+    }
+
+    @Override
+    public ValueSnapshot asSnapshot() {
+        ImmutableList.Builder<MapEntrySnapshot<ValueSnapshot>> builder = ImmutableList.builderWithExpectedSize(entries.size());
+        for (MapEntrySnapshot<Isolatable<?>> entry : entries) {
+            builder.add(new MapEntrySnapshot<ValueSnapshot>(entry.getKey().asSnapshot(), entry.getValue().asSnapshot()));
+        }
+        return new MapValueSnapshot(builder.build());
+    }
+
+    @Override
+    public T isolate() {
+        T map = create();
+        for (MapEntrySnapshot<Isolatable<?>> entry : getEntries()) {
+            map.put(entry.getKey().isolate(), entry.getValue().isolate());
+        }
+        return map;
+    }
+
+    @Nullable
+    @Override
+    public <S> S coerce(Class<S> type) {
+        return null;
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedProperties.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedProperties.java
@@ -20,17 +20,16 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.internal.isolation.Isolatable;
 
 import javax.annotation.Nullable;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.Properties;
 
-public class IsolatedMap extends AbstractIsolatedMap<Map<Object, Object>> {
-    public IsolatedMap(ImmutableList<MapEntrySnapshot<Isolatable<?>>> entries) {
+public class IsolatedProperties extends AbstractIsolatedMap<Properties> {
+    public IsolatedProperties(ImmutableList<MapEntrySnapshot<Isolatable<?>>> entries) {
         super(entries);
     }
 
     @Nullable
     @Override
-    public Map<Object, Object> create() {
-        return new LinkedHashMap<>(getEntries().size());
+    public Properties create() {
+        return new Properties();
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -424,6 +424,56 @@ class DefaultValueSnapshotterTest extends Specification {
         snapshotter.snapshot([a: "1", b: "2"]) != snapshotter.snapshot(isolated2)
     }
 
+    Properties properties(Map<String, String> entries) {
+        def properties = new Properties()
+        entries.each { key, value -> properties.setProperty(key, value) }
+        return properties
+    }
+
+    def "creates snapshot for properties"() {
+        expect:
+        def snapshot1 = snapshotter.snapshot(properties([:]))
+        snapshot1 instanceof MapValueSnapshot
+        snapshot1 == snapshotter.snapshot(properties([:]))
+        snapshot1 != snapshotter.snapshot("abc")
+        snapshot1 != snapshotter.snapshot(properties(["a": "123"]))
+
+        def snapshot2 = snapshotter.snapshot(properties(["a": "123"]))
+        snapshot2 instanceof MapValueSnapshot
+        snapshot2 == snapshotter.snapshot(properties([a: "123"]))
+        snapshot2 != snapshotter.snapshot(["123"])
+        snapshot2 != snapshotter.snapshot(properties([:]))
+        snapshot2 != snapshotter.snapshot(properties([a: "123", b: "abc"]))
+        snapshot2 != snapshot1
+    }
+
+    def "creates isolated properties"() {
+        expect:
+        def original1 = properties([:])
+        def isolated1 = snapshotter.isolate(original1)
+        isolated1 instanceof IsolatedProperties
+        def copy1 = isolated1.isolate()
+        copy1 == properties([:])
+        !copy1.is(original1)
+
+        def original2 = properties([a: "123"])
+        def isolated2 = snapshotter.isolate(original2)
+        isolated2 instanceof IsolatedProperties
+        def copy2 = isolated2.isolate()
+        copy2 == properties([a: "123"])
+        !copy2.is(isolated2)
+    }
+
+    def "creates snapshot for isolated properties"() {
+        expect:
+        def isolated1 = snapshotter.isolate(properties([:]))
+        snapshotter.snapshot(properties([:])) == snapshotter.snapshot(isolated1)
+
+        def isolated2 = snapshotter.isolate(properties([a: "123"]))
+        snapshotter.snapshot(properties([a: "123"])) == snapshotter.snapshot(isolated2)
+        snapshotter.snapshot(properties([a: "1", b: "2"])) != snapshotter.snapshot(isolated2)
+    }
+
     enum Type2 {
         TWO, THREE
     }
@@ -1034,6 +1084,27 @@ class DefaultValueSnapshotterTest extends Specification {
         snapshotter.snapshot(map2, snapshot4) == snapshotter.snapshot(map2)
         snapshotter.snapshot(map3, snapshot4) != snapshot4
         snapshotter.snapshot(map3, snapshot4) == snapshotter.snapshot(map3)
+    }
+
+    def "creates snapshot for properties from candidate"() {
+        expect:
+        def snapshot1 = snapshotter.snapshot(properties([:]))
+        snapshotter.snapshot(properties([:]), snapshot1).is(snapshot1)
+
+        snapshotter.snapshot(properties(["12": "123"]), snapshot1) != snapshot1
+
+        snapshotter.snapshot("other", snapshot1) != snapshot1
+        snapshotter.snapshot("other", snapshot1) == snapshotter.snapshot("other")
+        snapshotter.snapshot(new Bean(), snapshot1) != snapshot1
+        snapshotter.snapshot(new Bean(), snapshot1) == snapshotter.snapshot(new Bean())
+
+        def snapshot2 = snapshotter.snapshot(properties(["12": "123"]))
+        snapshotter.snapshot(properties(["12": "123"]), snapshot2).is(snapshot2)
+
+        snapshotter.snapshot(properties(["12": "456"]), snapshot2) != snapshot2
+        snapshotter.snapshot(properties([:]), snapshot2) != snapshot2
+        snapshotter.snapshot(properties(["123": "123"]), snapshot2) != snapshot2
+        snapshotter.snapshot(properties(["12": "123", "10": "123"]), snapshot2) != snapshot2
     }
 
     def "creates snapshot for provider type from candidate"() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
@@ -272,7 +272,12 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
                     @Override
                     void run() {
                         Properties myProps = this.myProps;
-                        myProps.store(outputFile.newWriter(), null)
+                        def writer = outputFile.newWriter()
+                        try {
+                            myProps.store(writer, null)
+                        } finally {
+                            writer.close()
+                        }
                     }
                 }
             }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -242,6 +242,30 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
         isolationMode << ISOLATION_MODES
     }
 
+    def "can provide a Properties object with isolation mode #isolationMode"() {
+        buildFile << """
+            ${parameterWorkAction('Properties', 'println parameters.testParam.collect { it.key + ":" + it.value }.join(",")', true) }
+
+            task runWork(type: ParameterTask) {
+                isolationMode = ${isolationMode}
+                parameters {
+                    testParam = new Properties()
+                    testParam.setProperty("foo", "bar")
+                    testParam.setProperty("bar", "baz")
+                }
+            } 
+        """
+
+        when:
+        succeeds("runWork")
+
+        then:
+        outputContains("bar:baz,foo:bar")
+
+        where:
+        isolationMode << ISOLATION_MODES
+    }
+
     def "can provide file property parameters with isolation mode #isolationMode"() {
         buildFile << """
             ${parameterWorkAction('RegularFileProperty', 'println parameters.testParam.get().getAsFile().name')}

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
@@ -267,6 +267,21 @@ class IsolatableSerializerRegistryTest extends Specification {
         newIsolatables[0].isolate() == map
     }
 
+    def "can serialize/deserialize isolated Properties"() {
+        Properties properties = new Properties()
+        properties.setProperty("foo", "bar")
+        properties.setProperty("baz", "buzz")
+
+        when:
+        serialize(isolatableFactory.isolate(properties))
+
+        and:
+        Isolatable<?>[] newIsolatables = deserialize()
+
+        then:
+        newIsolatables[0].isolate() == properties
+    }
+
     def "can serialize/deserialize isolated Array"() {
         String[] array = ["foo", "bar"]
 


### PR DESCRIPTION
Fixes #10323 

When isolating parameters, a `Properties` object is recognized as a `Map` object and is isolated as an `IsolatedMap`.  However, when we try to get an isolated instance from this, we get a `LinkedHashMap` which then fails to cast to `Properties`.  This adds handling for `Properties` objects to avoid this case, however this is a general problem with these types that we handle specially and a more holistic solution will need to be implemented in future releases.