### PR TITLE
Override getResources in DefaultDeprecatedClassLoader

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultDeprecatedClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultDeprecatedClassLoader.java
@@ -23,6 +23,7 @@ import org.gradle.util.DeprecationLogger;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Enumeration;
 
 public class DefaultDeprecatedClassLoader extends ClassLoader implements DeprecatedClassloader {
 
@@ -46,7 +47,7 @@ public class DefaultDeprecatedClassLoader extends ClassLoader implements Depreca
     @Override
     public URL getResource(String name) {
         URL resource;
-        if(!deprecationFired) {
+        if (!deprecationFired) {
             resource = nonDeprecatedParent.getResource(name);
             if (resource != null) {
                 return resource;
@@ -61,8 +62,26 @@ public class DefaultDeprecatedClassLoader extends ClassLoader implements Depreca
     }
 
     @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        Enumeration<URL> resources;
+        if (!deprecationFired) {
+            resources = nonDeprecatedParent.getResources(name);
+            if (resources.hasMoreElements()) {
+                return resources;
+            }
+        }
+
+        resources = deprecatedUsageLoader.getResources(name);
+        if (resources.hasMoreElements()) {
+            maybeEmitDeprecationWarning();
+        }
+
+        return resources;
+    }
+
+    @Override
     protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        if(!deprecationFired) {
+        if (!deprecationFired) {
             try {
                 return nonDeprecatedParent.loadClass(name);
             } catch (ClassNotFoundException e) {
@@ -74,16 +93,14 @@ public class DefaultDeprecatedClassLoader extends ClassLoader implements Depreca
             maybeEmitDeprecationWarning();
             return deprecatedUsageClass;
         } catch (ClassNotFoundException e) {
-                // Expected
+            // Expected
         }
         throw new ClassNotFoundException(String.format("%s not found.", name));
     }
 
     private void maybeEmitDeprecationWarning() {
-        if (!deprecationFired) {
-            DeprecationLogger.nagUserOfDeprecated(BUILDSRC_IN_SETTINGS_DEPRECATION_WARNING);
-            deprecationFired = true;
-        }
+        DeprecationLogger.nagUserOfDeprecated(BUILDSRC_IN_SETTINGS_DEPRECATION_WARNING);
+        deprecationFired = true;
     }
 
     @Override
@@ -94,13 +111,13 @@ public class DefaultDeprecatedClassLoader extends ClassLoader implements Depreca
 
     @Override
     public void close() throws IOException {
-        if(deprecatedUsageLoader instanceof Closeable){
+        if (deprecatedUsageLoader instanceof Closeable) {
             ((Closeable) deprecatedUsageLoader).close();
         }
 
         // not sure if this is required as its the parent of
         // deprecatedUsageLoader already
-        if(nonDeprecatedParent instanceof Closeable){
+        if (nonDeprecatedParent instanceof Closeable) {
             ((Closeable) nonDeprecatedParent).close();
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultDeprecatedClassLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultDeprecatedClassLoaderTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization
+
+import com.google.common.collect.Iterators
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DefaultDeprecatedClassLoaderTest extends Specification {
+    ClassLoader nonDeprecatedParent = Mock()
+    ClassLoader deprecatedUsageLoader = Mock()
+
+    String resource = 'testResource'
+    URL url1 = new URL('https://a.com')
+    URL url2 = new URL('https://b.com')
+
+    @Subject
+    DefaultDeprecatedClassLoader classLoader = new DefaultDeprecatedClassLoader(deprecatedUsageLoader, nonDeprecatedParent)
+
+    def 'can get resource from nonDeprecatedParent'() {
+        when:
+        1 * nonDeprecatedParent.getResource(resource) >> url1
+        0 * _._
+
+        then:
+        classLoader.getResource(resource) == url1
+    }
+
+    def 'can get resource from deprecatedUsageLoader'() {
+        when:
+        1 * nonDeprecatedParent.getResource(resource) >> null
+        1 * deprecatedUsageLoader.getResource(resource) >> url2
+
+        then:
+        classLoader.getResource(resource) == url2
+    }
+
+    def 'can get resources from nonDeprecatedParent'() {
+        when:
+        1 * nonDeprecatedParent.getResources(resource) >> Iterators.asEnumeration([url1].iterator())
+        0 * _._
+
+        then:
+        classLoader.getResources(resource).nextElement() == url1
+    }
+
+    def 'can get resources from deprecatedUsageLoader'() {
+        when:
+        1 * nonDeprecatedParent.getResources(resource) >> Iterators.asEnumeration([].iterator())
+        1 * deprecatedUsageLoader.getResources(resource) >> Iterators.asEnumeration([url2].iterator())
+
+        then:
+        classLoader.getResources(resource).nextElement() == url2
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/10347

In https://github.com/gradle/gradle/pull/9898 we introduced a `DefaultDeprecatedClassLoader`,
which overrides `getResource()` but not `getResources()`. This causes some issues.
This PR fixes the issue by correctly overriding `getResources()` method.
