### PR TITLE
Let Kotlin DSL IJ script resolver return given Java home

### DIFF
--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -59,6 +59,18 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
+    fun `returns given Java home`() {
+
+        val javaHome = System.getProperty("java.home")
+        val env = arrayOf("gradleJavaHome" to javaHome)
+        assertThat(
+            resolvedScriptDependencies(env = *env)?.javaHome,
+            equalTo(javaHome)
+        )
+    }
+
+
+    @Test
     fun `succeeds on init script`() {
 
         assertSucceeds(withFile("my.init.gradle.kts", """


### PR DESCRIPTION
This is a reinstatement of https://github.com/gradle/gradle/pull/8756 as a fix for https://github.com/gradle/gradle/issues/9299.

This will make IDEs with the IntelliJ Kotlin Plugin 1.3.50 use the correct JVM for TAPI requests. IDEs using previous Kotlin Plugin versions will be given the _Project SDK_ instead of the _Gradle JVM_ breaking the general use case to use a different JVM in _Gradle JVM_ and _Project SDK_, see
https://github.com/gradle/gradle/issues/9195 for more information.

IDEs using Kotlin Plugin >= 1.3.50 will support the general use case to use a different JVM in _Gradle JVM_ and _Project SDK_ properly. And it will be possible to edit `.gradle.kts` files in non-JVM IntelliJ projects, that is without a JVM _Project SDK_, and in non JVM IDEs like Clion, Webstorm etc... Note that more changes on top of this one might be required in such IDEs.

Opened as a draft, required upgrade notes TBD.