### PR TITLE
Let Kotlin DSL IJ script resolver pass environment variables

### DIFF
--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -135,6 +135,21 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
+    fun `pass environment`() {
+        assertSucceeds(
+            withBuildScript("""
+                require(System.getProperty("myJvmSysProp") == "systemValue") { "gradleJvmOptions" }
+                require(System.getProperty("myGradleSysProp") == "systemValue") { "gradleOptions system property" }
+                require(findProperty("myGradleProp") == "gradleValue") { "gradleOptions Gradle property" }
+                require(System.getenv("myEnvVar") == "envValue") { "gradleEnvironmentVariables" }
+            """),
+            "gradleJvmOptions" to listOf("-DmyJvmSysProp=systemValue"),
+            "gradleOptions" to listOf("-DmyGradleSysProp=systemValue", "-PmyGradleProp=gradleValue"),
+            "gradleEnvironmentVariables" to mapOf("myEnvVar" to "envValue")
+        )
+    }
+
+    @Test
     fun `report file fatality on TAPI failure`() {
         // thus disabling syntax highlighting
 
@@ -344,9 +359,9 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
         ).get()
 
     private
-    fun assertSucceeds(editedScript: File? = null) {
+    fun assertSucceeds(editedScript: File? = null, vararg env: Pair<String, Any?>) {
 
-        resolvedScriptDependencies(editedScript).apply {
+        resolvedScriptDependencies(editedScript, null, *env).apply {
             assertThat(this, notNullValue())
             this!!.assertContainsBasicDependencies()
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -182,6 +182,7 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
             javaHome = environment.gradleJavaHome,
             options = environment.gradleOptions,
             jvmOptions = environment.gradleJvmOptions,
+            environmentVariables = environment.gradleEnvironmentVariables,
             correlationId = correlationId
         )
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -54,6 +54,7 @@ data class KotlinBuildScriptModelRequest(
     val javaHome: File? = null,
     val options: List<String> = emptyList(),
     val jvmOptions: List<String> = emptyList(),
+    val environmentVariables: Map<String, String> = emptyMap(),
     val correlationId: String = newCorrelationId()
 )
 
@@ -95,6 +96,7 @@ data class FetchParameters(
     val connectorForProject: Function<File, GradleConnector>,
     val options: List<String> = emptyList(),
     val jvmOptions: List<String> = emptyList(),
+    val environmentVariables: Map<String, String> = emptyMap(),
     val correlationId: String = newCorrelationId(),
     val modelBuilderCustomization: ModelBuilderCustomization = {}
 )
@@ -108,6 +110,7 @@ fun KotlinBuildScriptModelRequest.toFetchParametersWith(modelBuilderCustomizatio
         Function { projectDir -> connectorFor(this).forProjectDirectory(projectDir) },
         options,
         jvmOptions,
+        environmentVariables,
         correlationId,
         modelBuilderCustomization
     )
@@ -177,6 +180,7 @@ fun connectionForProjectDir(projectDir: File, parameters: FetchParameters): Proj
 private
 fun ProjectConnection.modelBuilderFor(parameters: FetchParameters) =
     model(KotlinBuildScriptModel::class.java).apply {
+        setEnvironmentVariables(parameters.environmentVariables.takeIf { it.isNotEmpty() })
         setJvmArguments(parameters.jvmOptions + modelSpecificJvmOptions)
         forTasks(kotlinBuildScriptModelTask)
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
@@ -78,7 +78,7 @@ val Environment.gradleJavaHome: File?
 
 
 /**
- * TODO unknown.
+ * Gradle options as configured in IntelliJ.
  */
 internal
 val Environment.gradleOptions: List<String>
@@ -93,6 +93,14 @@ val Environment.gradleJvmOptions: List<String>
     get() = stringList("gradleJvmOptions")
 
 
+/**
+ * Gradle environment variables as configured in IntelliJ.
+ */
+internal
+val Environment.gradleEnvironmentVariables: Map<String, String>
+    get() = stringMap("gradleEnvironmentVariables")
+
+
 private
 fun Environment.path(key: String): File? =
     (get(key) as? String)?.let(::File)
@@ -102,3 +110,9 @@ fun Environment.path(key: String): File? =
 private
 fun Environment.stringList(key: String): List<String> =
     (get(key) as? List<String>) ?: emptyList()
+
+
+@Suppress("unchecked_cast")
+private
+fun Environment.stringMap(key: String) =
+    (get(key) as? Map<String, String>) ?: emptyMap()


### PR DESCRIPTION
This PR lets the Kotlin DSL IJ resolver pass environment variables as configured in IJ to the script dependencies resolution TAPI requests.

This fixes semantic highlighting errors in the `.gradle.kts` editor when relying on IJ configured environment variables. This is a fix for https://github.com/gradle/gradle/issues/9422, see that issue for more details.