### PR TITLE
Let instant execution encode enums explicitly

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionAndroidIntegrationTest.groovy
@@ -21,6 +21,14 @@ import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.test.fixtures.file.TestFile
 
 
+/**
+ * Base Android / Instant execution integration test.
+ *
+ * In order to iterate quickly on changes to AGP:
+ * - change `AGP_VERSION` to `3.6.0-dev`
+ * - change the repository url in `AGP_NIGHTLY_REPOSITORY_DECLARATION` to `file:///path/to/agp-src/out/repo`
+ * - run `./gradlew :publishAndroidGradleLocal` in `/path/to/agp-src/tools`
+ */
 @CompileStatic
 abstract class AbstractInstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -174,7 +174,7 @@ class Codecs(
         bind(ownerService<BuildRequestMetaData>())
         bind(ownerService<WorkerExecutor>())
 
-        bind(EnumCodec())
+        bind(EnumCodec)
 
         bind(SerializableWriteObjectCodec())
         bind(SerializableWriteReplaceCodec())

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -174,6 +174,8 @@ class Codecs(
         bind(ownerService<BuildRequestMetaData>())
         bind(ownerService<WorkerExecutor>())
 
+        bind(EnumCodec())
+
         bind(SerializableWriteObjectCodec())
         bind(SerializableWriteReplaceCodec())
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/EnumCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/EnumCodec.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+
+
+class EnumCodec : EncodingProducer, Decoding {
+
+    private
+    object EnumEncoding : Encoding {
+        override suspend fun WriteContext.encode(value: Any) {
+            writeClass(value::class.java)
+            writeInt((value as Enum<*>).ordinal)
+        }
+    }
+
+    override fun encodingForType(type: Class<*>): Encoding? =
+        EnumEncoding.takeIf { type.isEnum }
+
+    override suspend fun ReadContext.decode(): Any? {
+        val enumClass = readClass()
+        val enumOrdinal = readInt()
+        return enumClass.enumConstants.filterIsInstance(Enum::class.java).first {
+            it.ordinal == enumOrdinal
+        }
+    }
+}


### PR DESCRIPTION
in order to rehydrate instances by lookup instead of the default sneaky instantiation that lead to multiple instances of the same enum value, breaking comparisons, in particular in the AGP `LinkApplicationAndroidResourcesTask` task.

Fixing this broke the Jacoco plugin because an enum comparison now succeeds and triggers a code path with problematic `Project` usages. This PR also fixes the Jacoco plugin by removing `Project` usages from DSL types.