### PR TITLE
Autodetect TestFramework if none is configured explicitly

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -207,6 +207,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         tasks.withType<Test>().configureEach {
             maxParallelForks = project.maxParallelForks
 
+            useJUnit()
+
             configureJvmForTest()
 
             doFirst {

--- a/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
+++ b/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AntlrPluginIntegrationTest.groovy
@@ -23,14 +23,19 @@ class AntlrPluginIntegrationTest extends WellBehavedPluginTest {
         return "build"
     }
 
+    def setup() {
+        buildFile << """
+            ${jcenterRepository()}
+        """
+    }
+
     def "can handle grammar in nested folders"(){
         given:
         buildFile << """
             apply plugin: "java"
             apply plugin: "antlr"
-
-            ${jcenterRepository()}
         """
+
         and:
 
         file("src/main/antlr/org/acme/TestGrammar.g") << """ class TestGrammar extends Parser;
@@ -56,7 +61,6 @@ class AntlrPluginIntegrationTest extends WellBehavedPluginTest {
         file("build/generated-src/antlr/main/TestGrammar.smap").exists()
         file("build/generated-src/antlr/main/TestGrammarTokenTypes.java").exists()
         file("build/generated-src/antlr/main/TestGrammarTokenTypes.txt").exists()
-
     }
 
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaProjectInitDescriptor.java
@@ -91,11 +91,8 @@ public abstract class JavaProjectInitDescriptor extends JvmProjectInitDescriptor
             case TESTNG:
                 buildScriptBuilder
                     .testImplementationDependency(
-                        "Use TestNG framework, also requires calling test.useTestNG() below",
-                        "org.testng:testng:" + libraryVersionProvider.getVersion("testng"))
-                    .taskMethodInvocation(
-                        "Use TestNG for unit tests",
-                        "test", "Test", "useTestNG");
+                        "Use TestNG framework",
+                        "org.testng:testng:" + libraryVersionProvider.getVersion("testng"));
                 break;
             case JUNIT_JUPITER:
                 buildScriptBuilder
@@ -105,9 +102,6 @@ public abstract class JavaProjectInitDescriptor extends JvmProjectInitDescriptor
                     ).testRuntimeOnlyDependency(
                     "Use JUnit Jupiter Engine for testing.",
                     "org.junit.jupiter:junit-jupiter-engine:" + libraryVersionProvider.getVersion("junit-jupiter")
-                ).taskMethodInvocation(
-                    "Use junit platform for unit tests",
-                    "test", "Test", "useJUnitPlatform"
                 );
                 break;
             default:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -199,6 +199,10 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
                 implementation gradleApi()
                 implementation localGroovy()
             }
+
+            test {
+                useJUnit()
+            }
         """
     }
 

--- a/subprojects/docs/src/docs/userguide/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/java_testing.adoc
@@ -289,9 +289,9 @@ Unlike its predecessor, JUnit 5 is modularized and composed of several modules:
 The JUnit Platform serves as a foundation for launching testing frameworks on the JVM. JUnit Jupiter is the combination of the new http://junit.org/junit5/docs/current/user-guide/#writing-tests[programming model]
  and http://junit.org/junit5/docs/current/user-guide/#extensions[extension model] for writing tests and extensions in JUnit 5. JUnit Vintage provides a `TestEngine` for running JUnit 3 and JUnit 4 based tests on the platform.
 
-The following code enables JUnit Platform support in `build.gradle`:
+Gradle detects whether the JUnit Platform is on the classpath of the `Test` task and automatically enables its built-in JUnit Platform support. If you don't want to rely on the autodetection or configure it explicitly, you can enable it in your buildscript:
 
-.Enabling JUnit Platform to run your tests
+.Explicitly enabling JUnit Platform to run your tests
 ====
 include::sample[dir="testing/junitplatform/jupiter/groovy",files="build.gradle[tags=enabling-junit-platform]"]
 include::sample[dir="testing/junitplatform/jupiter/kotlin",files="build.gradle.kts[tags=enabling-junit-platform]"]

--- a/subprojects/docs/src/docs/userguide/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/java_testing.adoc
@@ -289,7 +289,7 @@ Unlike its predecessor, JUnit 5 is modularized and composed of several modules:
 The JUnit Platform serves as a foundation for launching testing frameworks on the JVM. JUnit Jupiter is the combination of the new http://junit.org/junit5/docs/current/user-guide/#writing-tests[programming model]
  and http://junit.org/junit5/docs/current/user-guide/#extensions[extension model] for writing tests and extensions in JUnit 5. JUnit Vintage provides a `TestEngine` for running JUnit 3 and JUnit 4 based tests on the platform.
 
-Gradle detects whether the JUnit Platform is on the classpath of the `Test` task and automatically enables its built-in JUnit Platform support. If you don't want to rely on the autodetection or configure it explicitly, you can enable it in your buildscript:
+Gradle can automatically detect if the JUnit Platform can be used with a `Test` task. If you don't want to rely on the auto-detection or need to explicitly configure it, you can enable JUnit Platform support in your buildscript:
 
 .Explicitly enabling JUnit Platform to run your tests
 ====

--- a/subprojects/docs/src/samples/testing/junitplatform/mix/groovy/build.gradle
+++ b/subprojects/docs/src/samples/testing/junitplatform/mix/groovy/build.gradle
@@ -29,7 +29,3 @@ dependencies {
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.1.0'
 }
 // end::vintage-dependencies[]
-
-test {
-    useJUnitPlatform()
-}

--- a/subprojects/docs/src/samples/testing/junitplatform/mix/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/testing/junitplatform/mix/kotlin/build.gradle.kts
@@ -14,7 +14,3 @@ dependencies {
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.1.0")
 }
 // end::vintage-dependencies[]
-
-tasks.test {
-    useJUnitPlatform()
-}

--- a/subprojects/docs/src/samples/testing/testng/java-passing/build.gradle
+++ b/subprojects/docs/src/samples/testing/testng/java-passing/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 test {
-   useTestNG(){
+   useTestNG {
        useDefaultListeners = true
    }
 }

--- a/subprojects/docs/src/samples/testing/testng/suitexmlbuilder/build.gradle
+++ b/subprojects/docs/src/samples/testing/testng/suitexmlbuilder/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 test {
-	useTestNG() {
+	useTestNG {
         suiteXmlBuilder().suite(name: 'testing-testng') {
             test (name : 'testing-testng', annotations : 'JDK', verbose:'1') {
                 classes([:]) {

--- a/subprojects/docs/src/samples/userguide/java/basic/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/java/basic/groovy/build.gradle
@@ -24,8 +24,6 @@ dependencies {
 }
 
 test {
-    useJUnit()
-
     maxHeapSize = '1G'
 }
 // end::java-basic-test-config[]

--- a/subprojects/docs/src/samples/userguide/java/basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/java/basic/kotlin/build.gradle.kts
@@ -27,8 +27,6 @@ dependencies {
 }
 
 tasks.test {
-    useJUnit()
-
     maxHeapSize = "1G"
 }
 // end::java-basic-test-config[]

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
@@ -43,6 +43,7 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         task.binResultsDir = task.project.file('build/test-results')
         task.reports.junitXml.destination = task.project.file('build/test-results')
         task.testClassesDirs = task.project.layout.files()
+        task.classpath = task.project.layout.files()
         completion = task.project.services.get(WorkerLeaseRegistry).getWorkerLease().start()
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -85,7 +85,6 @@ class TestTest extends AbstractConventionTaskTest {
 
     def "test default settings"() {
         expect:
-        test.getTestFramework() instanceof JUnitTestFramework
         test.getTestClassesDirs() == null
         test.getClasspath() == null
         test.getReports().getJunitXml().getDestination() == null

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestFrameworkAutoDetectionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestFrameworkAutoDetectionIntegrationTest.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.testing.fixture.JUnitCoverage
+import org.gradle.testing.fixture.TestNGCoverage
+
+class TestFrameworkAutoDetectionIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id("java")
+            }
+            repositories {
+                ${mavenCentralRepository()} 
+            }
+        """
+    }
+
+    def "uses JUnit Platform if junit-platform-engine is on the classpath"() {
+        given:
+        buildFile << """
+            dependencies {
+                testImplementation('junit:junit:${JUnitCoverage.JUNIT_4_LATEST}')
+                testImplementation('org.testng:testng:${TestNGCoverage.NEWEST}')
+                testImplementation('org.junit.jupiter:junit-jupiter:${JUnitCoverage.LATEST_JUPITER_VERSION}')
+            }
+        """
+        file('src/test/java/JupiterTestClass.java') << '''
+            class JupiterTestClass {
+                @org.junit.jupiter.api.Test
+                void test() {}
+            }
+        '''
+
+        when:
+        succeeds("test")
+
+        then:
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted('JupiterTestClass')
+        result.testClass('JupiterTestClass').assertTestPassed('test')
+    }
+
+    def "uses TestNG if its jar is on the classpath"() {
+        given:
+        buildFile << """
+            dependencies {
+                testImplementation('junit:junit:${JUnitCoverage.JUNIT_4_LATEST}')
+                testImplementation('org.testng:testng:${TestNGCoverage.NEWEST}')
+            }
+        """
+        file('src/test/java/TestNGTestClass.java') << '''
+            public class TestNGTestClass {
+                @org.testng.annotations.Test
+                public void test() {}
+            }
+        '''
+
+        when:
+        succeeds("test")
+
+        then:
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted('TestNGTestClass')
+        result.testClass('TestNGTestClass').assertTestPassed('test')
+    }
+
+    def "uses JUnit 4 if neither JUnit Platform nor TestNG are on the classpath"() {
+        given:
+        buildFile << """
+            dependencies {
+                testImplementation('junit:junit:${JUnitCoverage.JUNIT_4_LATEST}')
+            }
+        """
+        file('src/test/java/JUnit4TestClass.java') << '''
+            public class JUnit4TestClass {
+                @org.junit.Test
+                public void test() {}
+            }
+        '''
+
+        when:
+        succeeds("test")
+
+        then:
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted('JUnit4TestClass')
+        result.testClass('JUnit4TestClass').assertTestPassed('test')
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -235,6 +235,24 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         succeeds("tasks")
     }
 
+    def "nags when discontinued testFramework() method is used"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            test.testFramework {}
+        """
+
+        when:
+        executer.expectDeprecationWarning()
+        succeeds("tasks")
+
+        then:
+        with(result.output) {
+            contains("The testFramework method has been deprecated")
+            contains("Please call useJUnit(), useJUnitPlatform(), or useTestNG() instead")
+        }
+    }
+
     private static String standaloneTestClass() {
         return testClass('MyTest')
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkAutoDetection.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkAutoDetection.java
@@ -16,15 +16,12 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import org.gradle.api.file.EmptyFileVisitor;
-import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework;
 import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework;
 import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.internal.MutableReference;
 
-import javax.annotation.Nonnull;
+import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,24 +41,22 @@ public class TestFrameworkAutoDetection {
     }
 
     private static Class<? extends TestFramework> detectTestFrameworkFromClasspath(Test task) {
-        final MutableReference<Class<? extends TestFramework>> testFramework = MutableReference.empty();
-        testFramework.set(JUnitTestFramework.class);
-        task.getClasspath().getAsFileTree().visit(new EmptyFileVisitor() {
-            @Override
-            public void visitFile(@Nonnull FileVisitDetails fileDetails) {
-                Matcher matcher = VERSIONED_JAR_PATTERN.matcher(fileDetails.getName());
+        Class<? extends TestFramework> testFramework = JUnitTestFramework.class;
+        for (File file : task.getClasspath().getFiles()) {
+            if (file.isFile()) {
+                Matcher matcher = VERSIONED_JAR_PATTERN.matcher(file.getName());
                 if (matcher.matches()) {
                     String artifactName = matcher.group(1);
                     if ("junit-platform-engine".equals(artifactName)) {
-                        testFramework.set(JUnitPlatformTestFramework.class);
-                        fileDetails.stopVisiting();
+                        testFramework = JUnitPlatformTestFramework.class;
+                        break;
                     } else if ("testng".equals(artifactName)) {
-                        testFramework.set(TestNGTestFramework.class);
+                        testFramework = TestNGTestFramework.class;
                     }
                 }
             }
-        });
-        return testFramework.get();
+        }
+        return testFramework;
     }
 
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkAutoDetection.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkAutoDetection.java
@@ -17,9 +17,6 @@
 package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework;
-import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework;
-import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
 import org.gradle.api.tasks.testing.Test;
 
 import java.io.File;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkAutoDetection.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkAutoDetection.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.api.file.EmptyFileVisitor;
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework;
+import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework;
+import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.MutableReference;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TestFrameworkAutoDetection {
+
+    private static final Pattern VERSIONED_JAR_PATTERN = Pattern.compile("([a-z-]+)-\\d.*\\.jar");
+
+    public static void configure(Test task) {
+        Class<? extends TestFramework> testFrameworkClass = detectTestFrameworkFromClasspath(task);
+        if (JUnitTestFramework.class.equals(testFrameworkClass)) {
+            task.useJUnit();
+        } else if (TestNGTestFramework.class.equals(testFrameworkClass)) {
+            task.useTestNG();
+        } else if (JUnitPlatformTestFramework.class.equals(testFrameworkClass)) {
+            task.useJUnitPlatform();
+        }
+    }
+
+    private static Class<? extends TestFramework> detectTestFrameworkFromClasspath(Test task) {
+        final MutableReference<Class<? extends TestFramework>> testFramework = MutableReference.empty();
+        testFramework.set(JUnitTestFramework.class);
+        task.getClasspath().getAsFileTree().visit(new EmptyFileVisitor() {
+            @Override
+            public void visitFile(@Nonnull FileVisitDetails fileDetails) {
+                Matcher matcher = VERSIONED_JAR_PATTERN.matcher(fileDetails.getName());
+                if (matcher.matches()) {
+                    String artifactName = matcher.group(1);
+                    if ("junit-platform-engine".equals(artifactName)) {
+                        testFramework.set(JUnitPlatformTestFramework.class);
+                        fileDetails.stopVisiting();
+                    } else if ("testng".equals(artifactName)) {
+                        testFramework.set(TestNGTestFramework.class);
+                    }
+                }
+            }
+        });
+        return testFramework.get();
+    }
+
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
 import org.gradle.api.internal.tasks.testing.TestFramework;
+import org.gradle.api.internal.tasks.testing.TestFrameworkAutoDetection;
 import org.gradle.api.internal.tasks.testing.detection.DefaultTestExecuter;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
 import org.gradle.api.internal.tasks.testing.junit.JUnitTestFramework;
@@ -71,6 +72,7 @@ import org.gradle.process.ProcessForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.process.internal.worker.WorkerProcessFactory;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -93,9 +95,11 @@ import static org.gradle.util.ConfigureUtil.configureUsing;
  * apply plugin: 'java' // adds 'test' task
  *
  * test {
- *   // enable TestNG support (default is JUnit)
+ *   // enable JUnit support
+ *   useJUnit()
+ *   // Alternatively, enable TestNG support
  *   useTestNG()
- *   // enable JUnit Platform (a.k.a. JUnit 5) support
+ *   // Alternatively, enable JUnit Platform (a.k.a. JUnit 5) support
  *   useJUnitPlatform()
  *
  *   // set a system property for the test JVM(s)
@@ -820,10 +824,15 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
 
     @Internal
     public TestFramework getTestFramework() {
-        return testFramework(null);
+        if (testFramework == null) {
+            TestFrameworkAutoDetection.configure(this);
+        }
+        return testFramework;
     }
 
+    @Deprecated
     public TestFramework testFramework(@Nullable Closure testFrameworkConfigure) {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("testFramework", "Please call useJUnit(), useJUnitPlatform(), or useTestNG() instead.");
         if (testFramework == null) {
             useJUnit(testFrameworkConfigure);
         }


### PR DESCRIPTION
When the TestFramework of a Test task is not configured explicitly it
used to default to `useJUnit()`. Now, the task's classpath is inspected
for a junit-platform-engine.jar or testng.jar. If one of them is found,
the task uses the JUnit Platform or TestNG to execute tests,
respectively.

Since we have internal dependencies on the JUnit Platform and TestNG,
all Test tasks in our own build are configured to `useJUnit()` and
explicitly.