### PR TITLE
Support adding variants to ivy modules with component metadata rules

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvyVariantComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvyVariantComponentMetadataRulesIntegrationTest.groovy
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.rules
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+@RequiredFeatures([
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy"),
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
+])
+class IvyVariantComponentMetadataRulesIntegrationTest extends AbstractModuleDependencyResolveTest implements ComponentMetadataRulesSupport {
+
+    @Override
+    boolean isAddVariantDerivationRuleForIvy() { false }
+
+    def "opt-into variant aware dependency resolution if variant rules are added to ivy configuration"() {
+        given:
+        repository {
+            'org.test:projectA:1.0' {
+                variant 'customConf', [:] // in ivy, this is only a configuration
+            }
+        }
+
+        when:
+        buildFile << """
+            dependencies {
+                conf group: 'org.test', name: 'projectA', version: '1.0'
+                components {
+                    withModule('org.test:projectA') {
+                        withVariant('compile') { }
+                    }
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:projectA:1.0' { expectResolve() }
+        }
+
+
+        then:
+        succeeds 'checkDep'
+        resolve.expectGraph {
+            root(':', ':test:') {
+                // we have a variant rule but did not change attributes, no attribute matching opt-in yet
+                module("org.test:projectA:1.0:default")
+            }
+        }
+
+        when:
+        buildFile << """
+            dependencies {
+                conf group: 'org.test', name: 'projectA', version: '1.0'
+                components {
+                    withModule('org.test:projectA') {
+                        withVariant('compile') { 
+                            // attribute rule that does not actually set attributes
+                            attributes {}
+                        }
+                    }
+                }
+            }
+        """
+        then:
+        succeeds 'checkDep'
+        resolve.expectGraph {
+            root(':', ':test:') {
+                // 'compile' is selected (it has no attributes, but is the only variant)
+                module("org.test:projectA:1.0:compile")
+            }
+        }
+
+        when:
+        buildFile << """
+            def a1 = Attribute.of('a1', String)
+            configurations.conf {
+                attributes { attribute(a1, 'select') }
+            }
+            dependencies {
+                components {
+                    withModule('org.test:projectA') {
+                        withVariant('compile') { 
+                            attributes { attribute(a1, 'select') }
+                        }
+                        withVariant('runtime') { 
+                            attributes { attribute(a1, 'no-select') }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        succeeds 'checkDep'
+        resolve.expectGraph {
+            root(':', ':test:') {
+                // 'compile' is selected by attribute matching
+                module("org.test:projectA:1.0:compile")
+            }
+        }
+
+        when:
+        buildFile << """
+            dependencies {
+                components {
+                    withModule('org.test:projectA') {
+                        withVariant('customConf') { 
+                            attributes { attribute(a1, 'select') }
+                        }
+                    }
+                }
+            }
+        """
+
+        then:
+        fails 'checkDep'
+        failure.assertHasCause """Cannot choose between the following variants of org.test:projectA:1.0:
+  - compile
+  - customConf
+All of them match the consumer attributes:
+  - Variant 'compile' capability org.test:projectA:1.0:
+      - Unmatched attribute:
+          - Found org.gradle.status 'integration' but wasn't required.
+      - Compatible attribute:
+          - Required a1 'select' and found compatible value 'select'.
+  - Variant 'customConf' capability org.test:projectA:1.0:
+      - Unmatched attribute:
+          - Found org.gradle.status 'integration' but wasn't required.
+      - Compatible attribute:
+          - Required a1 'select' and found compatible value 'select'."""
+    }
+
+    def "local explicit configuration selection wins over attribute matching"() {
+        given:
+        repository {
+            'org.test:projectA:1.0'()
+        }
+
+        when:
+        buildFile << """
+            def a1 = Attribute.of('a1', String)
+            configurations.conf {
+                attributes { attribute(a1, 'select') }
+            }
+            dependencies {
+                conf group: 'org.test', name: 'projectA', version: '1.0', configuration: 'runtime'
+                components {
+                    withModule('org.test:projectA') {
+                        withVariant('compile') { 
+                            attributes { attribute(a1, 'select') }
+                        }
+                    }
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:projectA:1.0' { expectResolve() }
+        }
+
+        then:
+        succeeds 'checkDep'
+        resolve.expectGraph {
+            root(':', ':test:') {
+                // explicit selection of 'runtime', attribute matching is not used
+                module("org.test:projectA:1.0:runtime")
+            }
+        }
+    }
+
+    def "attribute matching wins over published explicit configuration selection"() {
+        given:
+        repository {
+            'org.test:projectA:1.0' {
+                dependsOn group: 'org.test', artifact: 'projectB', version: '1.0', conf: '*->another'
+            }
+            'org.test:projectB:1.0'() {
+                variant 'another', [:]
+            }
+        }
+
+        when:
+        buildFile << """
+            def a1 = Attribute.of('a1', String)
+            configurations.conf {
+                attributes { attribute(a1, 'select') }
+            }
+            dependencies {
+                conf group: 'org.test', name: 'projectA', version: '1.0'
+                components {
+                    all {
+                        withVariant('compile') { 
+                            attributes { attribute(a1, 'select') }
+                        }
+                    }
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:projectA:1.0' { expectResolve() }
+            'org.test:projectB:1.0' { expectResolve() }
+        }
+
+        then:
+        succeeds 'checkDep'
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module("org.test:projectA:1.0") {
+                    // variant('default', ['org.gradle.status': 'integration']) <- override by variant matching
+                    variant('compile', ['org.gradle.status': 'integration', 'a1': 'select'])
+                    module("org.test:projectB:1.0") {
+                        // variant('another', ['org.gradle.status': 'integration'])  <- override by variant matching
+                        variant('compile', ['org.gradle.status': 'integration', 'a1': 'select'])
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -128,7 +127,7 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
         return metadata.getModuleVersionId().toString();
     }
 
-    private static class VariantNameSpec implements Spec<VariantResolveMetadata> {
+    private static class VariantNameSpec implements Spec<String> {
         private final String name;
 
         private VariantNameSpec(String name) {
@@ -136,8 +135,8 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
         }
 
         @Override
-        public boolean isSatisfiedBy(VariantResolveMetadata element) {
-            return name.equals(element.getName());
+        public boolean isSatisfiedBy(String element) {
+            return name.equals(element);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
@@ -27,7 +27,6 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
-import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -38,13 +37,13 @@ import org.gradle.internal.typeconversion.NotationParser;
  * is responsible for targetting variants subject to a rule.
  */
 public class VariantMetadataAdapter implements VariantMetadata {
-    private final Spec<? super VariantResolveMetadata> spec;
+    private final Spec<String> spec;
     private final MutableModuleComponentResolveMetadata metadata;
     private final Instantiator instantiator;
     private final NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser;
 
-    public VariantMetadataAdapter(Spec<? super VariantResolveMetadata> spec,
+    public VariantMetadataAdapter(Spec<String> spec,
                                   MutableModuleComponentResolveMetadata metadata, Instantiator instantiator,
                                   NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser,
                                   NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -61,6 +61,13 @@ public class VariantMetadataRules {
         this.variantDerivationStrategy = variantDerivationStrategy;
     }
 
+    public boolean willApplyVariantAttributeRules(String potentialVariantNam) {
+        if (variantAttributesRules != null) {
+            return variantAttributesRules.willExecuteFor(potentialVariantNam);
+        }
+        return false;
+    }
+
     public ImmutableAttributes applyVariantAttributeRules(VariantResolveMetadata variant, AttributeContainerInternal source) {
         if (variantAttributesRules != null) {
             return variantAttributesRules.execute(variant, source);
@@ -127,23 +134,27 @@ public class VariantMetadataRules {
      * @param <T> the type of the action subject
      */
     public static class VariantAction<T> {
-        private final Spec<? super VariantResolveMetadata> spec;
+        private final Spec<String> spec;
         private final Action<? super T> delegate;
 
-        public VariantAction(Spec<? super VariantResolveMetadata> spec, Action<? super T> delegate) {
+        public VariantAction(Spec<String> spec, Action<? super T> delegate) {
             this.spec = spec;
             this.delegate = delegate;
         }
 
         /**
          * Executes the underlying action if the supplied variant matches the predicate
-         * @param variant the variant metadata, used to check if the rule applies
+         * @param variantName the name of the variant used to check if the rule applies
          * @param subject the subject of the rule
          */
-        public void maybeExecute(VariantResolveMetadata variant, T subject) {
-            if (spec.isSatisfiedBy(variant)) {
+        public void maybeExecute(String variantName, T subject) {
+            if (spec.isSatisfiedBy(variantName)) {
                 delegate.execute(subject);
             }
+        }
+
+        public boolean willExecuteFor(String variantName) {
+            return spec.isSatisfiedBy(variantName);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/CapabilitiesRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/CapabilitiesRules.java
@@ -38,7 +38,7 @@ public class CapabilitiesRules {
 
     public CapabilitiesMetadata execute(VariantResolveMetadata variant, MutableCapabilitiesMetadata capabilities) {
         for (VariantMetadataRules.VariantAction<? super MutableCapabilitiesMetadata> action : actions) {
-            action.maybeExecute(variant, capabilities);
+            action.maybeExecute(variant.getName(), capabilities);
         }
         return capabilities.asImmutable();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -92,7 +92,7 @@ public class DependencyMetadataRules {
     private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(VariantResolveMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_FILTER));
         for (VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
-            dependenciesMetadataAction.maybeExecute(variant, instantiator.newInstance(
+            dependenciesMetadataAction.maybeExecute(variant.getName(), instantiator.newInstance(
                 DirectDependenciesMetadataAdapter.class, attributesFactory, calculatedDependencies, instantiator, dependencyNotationParser));
         }
         return calculatedDependencies;
@@ -101,7 +101,7 @@ public class DependencyMetadataRules {
     private <T extends ModuleDependencyMetadata> List<T> executeDependencyConstraintRules(VariantResolveMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<T>(CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER));
         for (VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
-            dependencyConstraintsMetadataAction.maybeExecute(variant, instantiator.newInstance(
+            dependencyConstraintsMetadataAction.maybeExecute(variant.getName(), instantiator.newInstance(
                 DependencyConstraintsMetadataAdapter.class, attributesFactory, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
         }
         return calculatedDependencies;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantAttributesRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantAttributesRules.java
@@ -50,8 +50,17 @@ public class VariantAttributesRules {
             attributes = attributesFactory.mutable(attributes);
         }
         for (VariantMetadataRules.VariantAction<? super AttributeContainer> action : actions) {
-            action.maybeExecute(variant, attributes);
+            action.maybeExecute(variant.getName(), attributes);
         }
         return attributes.asImmutable();
+    }
+
+    public boolean willExecuteFor(String variantName) {
+        for (VariantMetadataRules.VariantAction<? super AttributeContainer> action : actions) {
+            if (action.willExecuteFor(variantName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
With this change, it is possible to opt-into variant aware dependency resolution (i.e. attribute matching) for pure ivy modules without GMM by turning _ivy configurations_ into variants. This can be used to ease the migration from pure ivy to GMM.