### PR TITLE
Support adding variants and files in component metadata rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 
@@ -71,6 +72,22 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      * @since 4.5
      */
     void allVariants(Action<? super VariantMetadata> action);
+
+    /**
+     * Add a rule for adding a new variant to the component. The new variant will be based on an existing variant
+     * of the component and initialized with the same attributes, capabilities and dependencies.
+     * These can the be modified in the given configuration action.
+     *
+     * Note: files (artifacts) are not initialized automatically and always need to be added through {@link VariantMetadata#withFiles(Action)}.
+     *
+     * @param name a name for the variant
+     * @param baseVariant name of the variant from which the new variant will be initialized
+     * @param action the action to populate the variant
+     *
+     * @since 6.0
+     */
+    @Incubating
+    void addVariant(String name, String baseVariant, Action<? super VariantMetadata> action);
 
     /**
      * Declares that this component belongs to a virtual platform, which should be

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -74,20 +74,39 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
     void allVariants(Action<? super VariantMetadata> action);
 
     /**
-     * Add a rule for adding a new variant to the component. The new variant will be based on an existing variant
-     * of the component and initialized with the same attributes, capabilities and dependencies.
-     * These can the be modified in the given configuration action.
-     *
-     * Note: files (artifacts) are not initialized automatically and always need to be added through {@link VariantMetadata#withFiles(Action)}.
+     * Add a rule for adding a new empty variant to the component.
      *
      * @param name a name for the variant
-     * @param baseVariant name of the variant from which the new variant will be initialized
      * @param action the action to populate the variant
      *
      * @since 6.0
      */
     @Incubating
-    void addVariant(String name, String baseVariant, Action<? super VariantMetadata> action);
+    void addVariant(String name, Action<? super VariantMetadata> action);
+
+    /**
+     * Add a rule for adding a new variant to the component. The new variant will be based on an existing variant
+     * or configurations of the component and initialized with the same attributes, capabilities and dependencies.
+     * These can the be modified in the given configuration action.
+     * Whether the 'base' is already a variant (with attributes) or a plain configuration (without attributes) depends on the
+     * metadata source:
+     *
+     * <ul>
+     *     <li>Gradle Module Metadata: all variants defined in the metadata are available as base</li>
+     *     <li>POM Metadata: the 'compile' and 'runtime' variants with the Java ecosystem attributes are available as base</li>
+     *     <li>Ivy Metadata: all configurations defined in the metadata are available as base</li>
+     * </ul>
+     *
+     * Note: files (artifacts) are not initialized automatically and always need to be added through {@link VariantMetadata#withFiles(Action)}.
+     *
+     * @param name a name for the variant
+     * @param base name of the variant (pom or Gradle module metadata) or configuration (ivy.xml metadata) from which the new variant will be initialized
+     * @param action the action to populate the variant
+     *
+     * @since 6.0
+     */
+    @Incubating
+    void addVariant(String name, String base, Action<? super VariantMetadata> action);
 
     /**
      * Declares that this component belongs to a virtual platform, which should be

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -86,8 +86,8 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
 
     /**
      * Add a rule for adding a new variant to the component. The new variant will be based on an existing variant
-     * or configurations of the component and initialized with the same attributes, capabilities and dependencies.
-     * These can the be modified in the given configuration action.
+     * or configurations of the component and initialized with the same attributes, capabilities, dependencies and artifacts.
+     * These can then be modified in the given configuration action.
      * Whether the 'base' is already a variant (with attributes) or a plain configuration (without attributes) depends on the
      * metadata source:
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVariantFilesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVariantFilesMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Mutable information about the files that belong to a variant.
+ *
+ * @since 6.0
+ */
+@Incubating
+public interface MutableVariantFilesMetadata {
+
+    /**
+     * Add a file, if the file location is the same as the file name.
+     *
+     * @param name name and path of the file.
+     */
+    void addFile(String name);
+
+    /**
+     * Add a file.
+     *
+     * @param name name of the file
+     * @param url location of the file, if not located next to the metadata in the repository
+     */
+    void addFile(String name, String url);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVariantFilesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVariantFilesMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.artifacts;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 
 /**
@@ -25,6 +26,13 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public interface MutableVariantFilesMetadata {
+
+    /**
+     * Remove all files already defined for the variant.
+     * Useful when files where initialized from a base variant or configuration using
+     * {@link ComponentMetadataDetails#addVariant(String, String, Action)} .
+     */
+    void removeAllFiles();
 
     /**
      * Add a file, if the file location is the same as the file name.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantFileMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantFileMetadata.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Part of a component variant's metadata representing a file and its location.
+ *
+ * @since 6.0
+ */
+@Incubating
+public interface VariantFileMetadata {
+
+    /**
+     * Get the name of the file.
+     *
+     * @return the name of the file
+     */
+    String getName();
+
+    /**
+     * Get the location of the file relative to the corresponding metadata file in the repository.
+     * This is the same as the file name, if the file is located next to the metadata file.
+     *
+     * @return relative location of the file
+     */
+    String getUrl();
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.capabilities.MutableCapabilitiesMetadata;
 
@@ -49,4 +50,13 @@ public interface VariantMetadata extends HasConfigurableAttributes<VariantMetada
      * @since 4.7
      */
     void withCapabilities(Action<? super MutableCapabilitiesMetadata> action);
+
+    /**
+     * Register a rule that modifies the artifacts of this variant.
+     *
+     * @param action the action that performs the files adjustment
+     * @since 6.0
+     */
+    @Incubating
+    void withFiles(Action<? super MutableVariantFilesMetadata> action);
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve.rules
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+import spock.lang.Unroll
+
+class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    private Map<String, ?> expectedJavaLibraryAttributes(boolean hasJavaLibraryVariants) {
+        if (hasJavaLibraryVariants) {
+            ['org.gradle.jvm.version': 8, 'org.gradle.status': useIvy() ? 'integration' : 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library']
+        } else {
+            // for ivy, we do not derive any variant attributes
+            ['org.gradle.jvm.version': 8, 'org.gradle.status': 'integration']
+        }
+    }
+
+    def setup() {
+        buildFile << """
+            class MissingJdk8VariantRule implements ComponentMetadataRule {
+                String base
+                @javax.inject.Inject
+                MissingJdk8VariantRule(String base) {
+                    this.base = base
+                }
+                @javax.inject.Inject
+                ObjectFactory getObjects() { }
+                void execute(ComponentMetadataContext context) {
+                    context.details.addVariant('jdk8Runtime', base) {
+                        attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8) }
+                        withFiles {
+                            addFile("\${context.details.id.name}-\${context.details.id.version}-jdk8.jar")
+                        }
+                    }
+                }
+            }
+
+            class MissingFileRule implements ComponentMetadataRule {
+                String classifier
+                String type
+                String url
+                @javax.inject.Inject
+                MissingFileRule(String classifier, String type, String url) {
+                    this.classifier = classifier
+                    this.type = type
+                    this.url = url
+                }
+                @javax.inject.Inject
+                ObjectFactory getObjects() { }
+                void execute(ComponentMetadataContext context) {
+                    context.details.withVariant('runtime') {
+                        withFiles {
+                            if (url.empty) {
+                                addFile("\${context.details.id.name}-\${context.details.id.version}\${classifier}.\${type}")
+                            } else {
+                                addFile("\${context.details.id.name}-\${context.details.id.version}\${classifier}.\${type}", url)
+                            }
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    def "missing variant can be added"() {
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                withModule { undeclaredArtifact(classifier: 'jdk8') }
+                dependsOn 'org.test:moduleB:1.0'
+            }
+            'org.test:moduleB:1.0'()
+        }
+
+        when:
+        buildFile << """
+            configurations.conf {
+                attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8) }
+            }
+            dependencies {
+                conf 'org.test:moduleA:1.0'
+                components {
+                    withModule('org.test:moduleA', MissingJdk8VariantRule) { params('runtime') } 
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectGetMetadata()
+                expectGetArtifact(classifier: 'jdk8')
+            }
+            'org.test:moduleB:1.0' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        def expectedLibraryAttributes = expectedJavaLibraryAttributes(useMaven() || gradleMetadataPublished)
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org.test:moduleA:1.0') {
+                    variant('jdk8Runtime', expectedLibraryAttributes)
+                    artifact(group: 'org.test', name: 'moduleA', version: '1.0', classifier: 'jdk8')
+                    module('org.test:moduleB:1.0')
+                }
+            }
+        }
+    }
+
+    def "missing variant can be added without base"() {
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                withModule { undeclaredArtifact(classifier: 'jdk8') }
+                dependsOn 'org.test:moduleB:1.0'
+            }
+            'org.test:moduleB:1.0'()
+        }
+
+        when:
+        buildFile << """
+            configurations.conf {
+                attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8) }
+            }
+            dependencies {
+                conf 'org.test:moduleA:1.0'
+                components {
+                    withModule('org.test:moduleA', MissingJdk8VariantRule) { params('this-does-not-exist') } 
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectGetMetadata()
+                expectGetArtifact(classifier: 'jdk8')
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        def expectedLibraryAttributes = ['org.gradle.jvm.version': 8, 'org.gradle.status': useIvy() ? 'integration' : 'release'] // the Java library attributes are not transferred
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org.test:moduleA:1.0') {
+                    variant('jdk8Runtime', expectedLibraryAttributes)
+                    artifact(group: 'org.test', name: 'moduleA', version: '1.0', classifier: 'jdk8')
+                }
+            }
+        }
+    }
+
+    def "file can be added to existing variant"() {
+        def dependencyDeclaration = (useMaven() || gradleMetadataPublished)
+            ? "'org.test:moduleA:1.0'" // variant matching
+            : "group: 'org.test', name: 'moduleA', version: '1.0', configuration: 'runtime'" // explicit configuration selection for pure ivy
+
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                withModule { undeclaredArtifact(classifier: 'extraFeature') }
+                dependsOn 'org.test:moduleB:1.0'
+            }
+            'org.test:moduleB:1.0'()
+        }
+
+        when:
+        buildFile << """
+            dependencies {
+                conf $dependencyDeclaration
+                components {
+                    withModule('org.test:moduleA', MissingFileRule) { params('-extraFeature', 'jar', '') }
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+                expectGetArtifact(classifier: 'extraFeature')
+            }
+            'org.test:moduleB:1.0' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org.test:moduleA:1.0:runtime') {
+                    artifact(group: 'org.test', name: 'moduleA', version: '1.0')
+                    artifact(group: 'org.test', name: 'moduleA', version: '1.0', classifier: 'extraFeature')
+                    module('org.test:moduleB:1.0')
+                }
+            }
+        }
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "capabilities of base are preserved"() {
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                variant('special-variant') {
+                    attribute('howspecial', 'notso')
+                    capability('special-feature')
+                    capability('crazy-feature')
+                    artifact('special-crazy')
+                }
+            }
+        }
+
+        when:
+        buildFile << """
+            class VerySpecialVariantRule implements ComponentMetadataRule {
+                void execute(ComponentMetadataContext context) {
+                    context.details.addVariant('very-special-variant', 'special-variant') {
+                        attributes { attribute(Attribute.of('howspecial', String), 'very') }
+                    }
+                }
+            }
+            configurations.conf {
+                attributes { attribute(Attribute.of('howspecial', String), 'very') }
+            }
+            dependencies {
+                conf('org.test:moduleA:1.0') {
+                    capabilities {
+                        requireCapability('org.test:special-feature')
+                        requireCapability('org.test:crazy-feature')
+                    }
+                }
+                components {
+                    withModule('org.test:moduleA', VerySpecialVariantRule)
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectGetMetadata()
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        def expectedVariantAttributes = ['howspecial': 'very', 'org.gradle.status': useIvy() ? 'integration' : 'release']
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org.test:moduleA:1.0') {
+                    variant('very-special-variant', expectedVariantAttributes)
+                    noArtifacts()
+                }
+            }
+        }
+    }
+
+    def "cannot add file with the same name multiple times"() {
+        def dependencyDeclaration = (useMaven() || gradleMetadataPublished)
+            ? "'org.test:moduleA:1.0'" // variant matching
+            : "group: 'org.test', name: 'moduleA', version: '1.0', configuration: 'runtime'" // explicit configuration selection for pure ivy
+
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                withModule { undeclaredArtifact(classifier: 'extraFeature') }
+            }
+        }
+
+        when:
+        buildFile << """
+            dependencies {
+                conf $dependencyDeclaration
+                components {
+                    withModule('org.test:moduleA', MissingFileRule) { params('-extraFeature', 'jar', '') }
+                    withModule('org.test:moduleA', MissingFileRule) { params('-extraFeature', 'jar', "../somewhere/some.jar") }
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectGetMetadata()
+            }
+        }
+
+        then:
+        fails 'checkDep'
+        failure.assertHasCause("Cannot add file moduleA-1.0-extraFeature.jar (url: ../somewhere/some.jar) because it is already defined (url: moduleA-1.0-extraFeature.jar)")
+    }
+
+    @RequiredFeatures([
+        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy"),
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
+    ])
+    @Unroll
+    def "can add variants for ivy - #usageAttribute"() {
+        // through this, we opt-into variant aware dependency management for a pure ivy module
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                dependsOn 'org.test:moduleB:1.0'
+            }
+            'org.test:moduleB:1.0'()
+        }
+
+        when:
+        buildFile << """
+            class IvyVariantDerivation implements ComponentMetadataRule {
+                @javax.inject.Inject
+                ObjectFactory getObjects() { }
+
+                void execute(ComponentMetadataContext context) {
+                    context.details.addVariant('runtime', 'default') { // the way it is published, the ivy 'default' configuration is the runtime variant
+                        attributes { 
+                            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+                            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+                        }
+                        withFiles {
+                            addFile("\${context.details.id.name}-\${context.details.id.version}.jar")
+                        }
+                    }
+                    context.details.addVariant('compile', 'compile') {
+                        attributes { 
+                            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+                            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+                            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+                        }
+                        withFiles {
+                            addFile("\${context.details.id.name}-\${context.details.id.version}.jar")
+                        }
+                    }
+                }
+            }
+            configurations.conf {
+                attributes { attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, '$usageAttribute')) }
+            }
+            dependencies {
+                conf 'org.test:moduleA:1.0'
+                components {
+                    withModule('org.test:moduleA', IvyVariantDerivation)
+                    withModule('org.test:moduleB', IvyVariantDerivation)
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectResolve()
+            }
+            'org.test:moduleB:1.0' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        def expectedVariantAttributes = expectedJavaLibraryAttributes(true) + ['org.gradle.usage': usageAttribute]
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org.test:moduleA:1.0') {
+                    variant(varianName, expectedVariantAttributes)
+                    module('org.test:moduleB:1.0') {
+                        variant(varianName, expectedVariantAttributes)
+                    }
+                }
+            }
+        }
+
+        where:
+        usageAttribute | varianName
+        'java-api'     | 'compile'
+        'java-runtime' | 'runtime'
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -376,7 +376,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                 ObjectFactory getObjects() { }
 
                 void execute(ComponentMetadataContext context) {
-                    context.details.addVariant('runtime', 'default') { // the way it is published, the ivy 'default' configuration is the runtime variant
+                    context.details.addVariant('runtimeElements', 'default') { // the way it is published, the ivy 'default' configuration is the runtime variant
                         attributes { 
                             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
                             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
@@ -384,7 +384,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                             attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
                         }
                     }
-                    context.details.addVariant('compile', 'compile') {
+                    context.details.addVariant('apiElements', 'compile') {
                         attributes { 
                             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
                             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
@@ -430,8 +430,8 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
 
         where:
         usageAttribute | varianName
-        'java-api'     | 'compile'
-        'java-runtime' | 'runtime'
+        'java-api'     | 'apiElements'
+        'java-runtime' | 'runtimeElements'
     }
 
     @RequiredFeatures([
@@ -470,7 +470,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         repositoryInteractions {
             'org.test:moduleA:1.0' {
                 expectGetMetadata()
-                if (!applyFileRule && extension != 'jar' ) {
+                if (!applyFileRule && extension != 'jar') {
                     expectHeadArtifact(type: extension) // testing for the file indicated by the packaging in the pom
                 }
                 if (applyFileRule) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -46,6 +46,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                     context.details.addVariant('jdk8Runtime', base) {
                         attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8) }
                         withFiles {
+                            removeAllFiles()
                             addFile("\${context.details.id.name}-\${context.details.id.version}-jdk8.jar")
                         }
                     }
@@ -271,7 +272,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                     attribute('howspecial', 'notso')
                     capability('special-feature')
                     capability('crazy-feature')
-                    artifact('special-crazy')
+                    artifact('special-data')
                 }
             }
         }
@@ -303,6 +304,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         repositoryInteractions {
             'org.test:moduleA:1.0' {
                 expectGetMetadata()
+                expectGetArtifact(classifier: 'special-data')
             }
         }
 
@@ -313,7 +315,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
             root(':', ':test:') {
                 module('org.test:moduleA:1.0') {
                     variant('very-special-variant', expectedVariantAttributes)
-                    noArtifacts()
+                    artifact(group: 'org.test', name: 'moduleA', version: '1.0', classifier: 'special-data')
                 }
             }
         }
@@ -381,9 +383,6 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
                             attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
                         }
-                        withFiles {
-                            addFile("\${context.details.id.name}-\${context.details.id.version}.jar")
-                        }
                     }
                     context.details.addVariant('compile', 'compile') {
                         attributes { 
@@ -391,9 +390,6 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
                             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
                             attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
-                        }
-                        withFiles {
-                            addFile("\${context.details.id.name}-\${context.details.id.version}.jar")
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -349,6 +349,11 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         }
 
         @Override
+        public void addVariant(String name, String baseVariant, Action<? super VariantMetadata> action) {
+
+        }
+
+        @Override
         public void belongsTo(Object notation) {
             belongsTo(notation, true);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -349,7 +349,12 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         }
 
         @Override
-        public void addVariant(String name, String baseVariant, Action<? super VariantMetadata> action) {
+        public void addVariant(String name, Action<? super VariantMetadata> action) {
+
+        }
+
+        @Override
+        public void addVariant(String name, String base, Action<? super VariantMetadata> action) {
 
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -187,7 +187,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
 
     private static class ClientModuleConfigurationMetadata extends DefaultConfigurationMetadata {
         ClientModuleConfigurationMetadata(ModuleComponentIdentifier componentId, String name, ModuleComponentArtifactMetadata artifact, List<ModuleDependencyMetadata> dependencies) {
-            super(componentId, name, true, true, ImmutableSet.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
+            super(componentId, name, true, true, ImmutableSet.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY, true);
             setDependencies(dependencies);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
@@ -22,6 +22,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
@@ -56,8 +57,8 @@ public class BaseModuleComponentRepositoryAccess implements ModuleComponentRepos
     }
 
     @Override
-    public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
-        delegate.resolveArtifacts(component, result);
+    public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
+        delegate.resolveArtifacts(component, variant, result);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -44,6 +44,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.ArtifactNotFoundException;
 import org.gradle.internal.resolve.ArtifactResolveException;
@@ -248,11 +249,11 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             final CachingModuleSource cachedModuleSource = (CachingModuleSource) component.getSource();
 
             // First try to determine the artifacts in-memory (e.g using the metadata): don't use the cache in this case
-            delegate.getLocalAccess().resolveArtifacts(component.withSource(cachedModuleSource.getDelegate()), result);
+            delegate.getLocalAccess().resolveArtifacts(component.withSource(cachedModuleSource.getDelegate()), variant, result);
             if (result.hasResult()) {
                 return;
             }
@@ -404,9 +405,9 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             final CachingModuleSource moduleSource = (CachingModuleSource) component.getSource();
-            delegate.getRemoteAccess().resolveArtifacts(component.withSource(moduleSource.getDelegate()), result);
+            delegate.getRemoteAccess().resolveArtifacts(component.withSource(moduleSource.getDelegate()), variant, result);
 
             if (result.getFailure() == null) {
                 FixedComponentArtifacts artifacts = (FixedComponentArtifacts) result.getResult();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -34,6 +34,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.ArtifactNotFoundException;
 import org.gradle.internal.resolve.ArtifactResolveException;
@@ -166,9 +167,9 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             performOperationWithRetries(result,
-                    () -> delegate.resolveArtifacts(component, result),
+                    () -> delegate.resolveArtifacts(component, variant, result),
                     () -> new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
                     throwable -> new ArtifactResolveException(component.getId(), throwable));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/FilteredModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/FilteredModuleComponentRepository.java
@@ -33,6 +33,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
@@ -126,8 +127,8 @@ public class FilteredModuleComponentRepository implements ModuleComponentReposit
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
-            delegate.resolveArtifacts(component, result);
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
+            delegate.resolveArtifacts(component, variant, result);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -23,6 +23,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
@@ -86,10 +87,10 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
-            delegate.getLocalAccess().resolveArtifacts(component, result);
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
+            delegate.getLocalAccess().resolveArtifacts(component, variant, result);
             if(!result.hasResult()) {
-                delegate.getRemoteAccess().resolveArtifacts(component, result);
+                delegate.getRemoteAccess().resolveArtifacts(component, variant, result);
             }
         }
 
@@ -126,7 +127,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
@@ -23,6 +23,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
@@ -52,7 +53,7 @@ public interface ModuleComponentRepositoryAccess {
     /**
      * Resolves a set of artifacts belonging to the given component. Any failures are packaged up in the result.
      */
-    void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result);
+    void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result);
 
     /**
      * Resolves a set of artifacts belonging to the given component, with the type specified. Any failures are packaged up in the result.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
@@ -79,9 +79,9 @@ class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifac
         ComponentResolveMetadata unpackedComponent = unpackSource(component);
         // First try to determine the artifacts locally before going remote
         DefaultBuildableComponentArtifactsResolveResult result = new DefaultBuildableComponentArtifactsResolveResult();
-        sourceRepository.getLocalAccess().resolveArtifacts(unpackedComponent, result);
+        sourceRepository.getLocalAccess().resolveArtifacts(unpackedComponent, configuration, result);
         if (!result.hasResult()) {
-            sourceRepository.getRemoteAccess().resolveArtifacts(unpackedComponent, result);
+            sourceRepository.getRemoteAccess().resolveArtifacts(unpackedComponent, configuration, result);
         }
         if (result.hasResult()) {
             return result.getResult().getArtifactsFor(component, configuration, this, sourceRepository.getArtifactCache(), artifactTypeRegistry, exclusions, overriddenAttributes);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -26,6 +26,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -102,7 +103,7 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             result.failed(new ArtifactResolveException(component.getId(), "No cached version available for offline mode"));
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -161,8 +161,8 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
         }
 
         @Override
-        public List<? extends DependencyMetadata> getDependencies() {
-            List<DependencyMetadata> result = null;
+        public List<? extends ModuleDependencyMetadata> getDependencies() {
+            List<ModuleDependencyMetadata> result = null;
             List<String> candidateVersions = platformState.getCandidateVersions();
             Set<ModuleResolveState> modules = platformState.getParticipatingModules();
             for (ModuleResolveState module : modules) {
@@ -193,10 +193,10 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
                     platformState.attachOrphanEdges();
                 }
             }
-            return result == null ? Collections.<DependencyMetadata>emptyList() : result;
+            return result == null ? Collections.emptyList() : result;
         }
 
-        private List<DependencyMetadata> registerPlatformEdge(List<DependencyMetadata> result, Set<ModuleResolveState> modules, ModuleComponentIdentifier leafId, ModuleComponentSelector leafSelector, ComponentIdentifier platformId, boolean force) {
+        private List<ModuleDependencyMetadata> registerPlatformEdge(List<ModuleDependencyMetadata> result, Set<ModuleResolveState> modules, ModuleComponentIdentifier leafId, ModuleComponentSelector leafSelector, ComponentIdentifier platformId, boolean force) {
             if (result == null) {
                 result = Lists.newArrayListWithExpectedSize(modules.size());
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -155,7 +155,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
         private final ComponentIdentifier platformId;
 
         public LenientPlatformConfigurationMetadata(VirtualPlatformState platform, ComponentIdentifier platformId) {
-            super(componentId, "default", true, false, ImmutableSet.of("default"), ImmutableList.<ModuleComponentArtifactMetadata>of(), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
+            super(componentId, "default", true, false, ImmutableSet.of("default"), ImmutableList.<ModuleComponentArtifactMetadata>of(), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY, false);
             this.platformState = platform;
             this.platformId = platformId;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -113,7 +113,7 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
             }
             return new RealisedConfigurationMetadata(
                 moduleComponentIdentifier, name, false, false,
-                ImmutableSet.of(name), ImmutableList.<ModuleComponentArtifactMetadata>of(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, dependencies.build()
+                ImmutableSet.of(name), ImmutableList.<ModuleComponentArtifactMetadata>of(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, false, dependencies.build(), false
             );
         }
         throw new IllegalArgumentException("Undefined configuration '" + name + "'");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -97,6 +97,12 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     }
 
     @Override
+    public void addVariant(String name, String baseVariant, Action<? super VariantMetadata> action) {
+        metadata.getVariantMetadataRules().addVariant(name, baseVariant);
+        withVariant(name, action);
+    }
+
+    @Override
     public void belongsTo(Object notation) {
         belongsTo(notation, true);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -97,8 +97,14 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     }
 
     @Override
-    public void addVariant(String name, String baseVariant, Action<? super VariantMetadata> action) {
-        metadata.getVariantMetadataRules().addVariant(name, baseVariant);
+    public void addVariant(String name, Action<? super VariantMetadata> action) {
+        metadata.getVariantMetadataRules().addVariant(name);
+        withVariant(name, action);
+    }
+
+    @Override
+    public void addVariant(String name, String base, Action<? super VariantMetadata> action) {
+        metadata.getVariantMetadataRules().addVariant(name, base);
         withVariant(name, action);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultMutableVariantFilesMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultMutableVariantFilesMetadata.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.MutableVariantFilesMetadata;
+import org.gradle.api.artifacts.VariantFileMetadata;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class DefaultMutableVariantFilesMetadata implements MutableVariantFilesMetadata {
+
+    private List<VariantFileMetadata> files = newArrayList();
+
+    @Override
+    public void addFile(String name) {
+        addFile(name, name);
+    }
+
+    @Override
+    public void addFile(String name, String url) {
+        for (VariantFileMetadata file : files) {
+            if (file.getName().equals(name)) {
+                throw new InvalidUserDataException("Cannot add file " + name + " (url: " + url + ") because it is already defined (url: " + file.getUrl() + ")");
+            }
+        }
+        files.add(new DefaultVariantFileMetadata(name, url));
+    }
+
+    public List<VariantFileMetadata> getFiles() {
+        return files;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultMutableVariantFilesMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultMutableVariantFilesMetadata.java
@@ -26,7 +26,14 @@ import static com.google.common.collect.Lists.newArrayList;
 
 public class DefaultMutableVariantFilesMetadata implements MutableVariantFilesMetadata {
 
+    private boolean clearExistingFiles = false;
     private List<VariantFileMetadata> files = newArrayList();
+
+    @Override
+    public void removeAllFiles() {
+        clearExistingFiles = true;
+        files.clear();
+    }
 
     @Override
     public void addFile(String name) {
@@ -41,6 +48,10 @@ public class DefaultMutableVariantFilesMetadata implements MutableVariantFilesMe
             }
         }
         files.add(new DefaultVariantFileMetadata(name, url));
+    }
+
+    public boolean isClearExistingFiles() {
+        return clearExistingFiles;
     }
 
     public List<VariantFileMetadata> getFiles() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultVariantFileMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultVariantFileMetadata.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.gradle.api.artifacts.VariantFileMetadata;
+
+public class DefaultVariantFileMetadata implements VariantFileMetadata {
+
+    private final String name;
+    private final String url;
+
+    public DefaultVariantFileMetadata(String name, String url) {
+        this.name = name;
+        this.url = url;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -48,6 +48,7 @@ import org.gradle.internal.component.external.model.MutableModuleComponentResolv
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultModuleDescriptorArtifactMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleDescriptorArtifactMetadata;
@@ -390,12 +391,12 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             T moduleMetaData = getSupportedMetadataType().cast(component);
-            resolveModuleArtifacts(moduleMetaData, result);
+            resolveModuleArtifacts(moduleMetaData, variant, result);
         }
 
-        protected abstract void resolveModuleArtifacts(T module, BuildableComponentArtifactsResolveResult result);
+        protected abstract void resolveModuleArtifacts(T module, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result);
 
         protected abstract void resolveMetaDataArtifacts(T module, BuildableArtifactSetResolveResult result);
 
@@ -458,8 +459,8 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         }
 
         @Override
-        public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
-            super.resolveArtifacts(component, result);
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
+            super.resolveArtifacts(component, variant, result);
             checkArtifactsResolved(component, "artifacts", result);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -124,7 +124,7 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
 
     private class IvyLocalRepositoryAccess extends LocalRepositoryAccess {
         @Override
-        protected void resolveModuleArtifacts(IvyModuleResolveMetadata module, BuildableComponentArtifactsResolveResult result) {
+        protected void resolveModuleArtifacts(IvyModuleResolveMetadata module, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             result.resolved(new MetadataSourcedComponentArtifacts());
         }
 
@@ -147,7 +147,7 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
 
     private class IvyRemoteRepositoryAccess extends RemoteRepositoryAccess {
         @Override
-        protected void resolveModuleArtifacts(IvyModuleResolveMetadata module, BuildableComponentArtifactsResolveResult result) {
+        protected void resolveModuleArtifacts(IvyModuleResolveMetadata module, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             // Configuration artifacts are determined locally
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -37,6 +37,7 @@ import org.gradle.internal.component.external.model.maven.MavenModuleResolveMeta
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
@@ -220,7 +221,7 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
 
     private class MavenLocalRepositoryAccess extends LocalRepositoryAccess {
         @Override
-        protected void resolveModuleArtifacts(MavenModuleResolveMetadata module, BuildableComponentArtifactsResolveResult result) {
+        protected void resolveModuleArtifacts(MavenModuleResolveMetadata module, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             if (!module.getVariants().isEmpty()) {
                 result.resolved(new MetadataSourcedComponentArtifacts());
             } else if (module.isKnownJarPackaging()) {
@@ -244,7 +245,7 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
 
     private class MavenRemoteRepositoryAccess extends RemoteRepositoryAccess {
         @Override
-        protected void resolveModuleArtifacts(MavenModuleResolveMetadata module, BuildableComponentArtifactsResolveResult result) {
+        protected void resolveModuleArtifacts(MavenModuleResolveMetadata module, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             if (module.isPomPackaging()) {
                 result.resolved(new FixedComponentArtifacts(findOptionalArtifacts(module, "jar", null)));
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -222,7 +222,7 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     private class MavenLocalRepositoryAccess extends LocalRepositoryAccess {
         @Override
         protected void resolveModuleArtifacts(MavenModuleResolveMetadata module, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
-            if (!module.getVariants().isEmpty()) {
+            if (!variant.requiresMavenArtifactDiscovery()) {
                 result.resolved(new MetadataSourcedComponentArtifacts());
             } else if (module.isKnownJarPackaging()) {
                 ModuleComponentArtifactMetadata artifact = module.artifact("jar", "jar", null);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VariantMetadataAdapter.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.MutableVariantFilesMetadata;
 import org.gradle.api.capabilities.MutableCapabilitiesMetadata;
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DependencyConstraintsMetadata;
@@ -68,6 +69,11 @@ public class VariantMetadataAdapter implements VariantMetadata {
     @Override
     public void withCapabilities(Action<? super MutableCapabilitiesMetadata> action) {
         metadata.getVariantMetadataRules().addCapabilitiesAction(new VariantMetadataRules.VariantAction<MutableCapabilitiesMetadata>(spec, action));
+    }
+
+    @Override
+    public void withFiles(Action<? super MutableVariantFilesMetadata> action) {
+        metadata.getVariantMetadataRules().addVariantFilesAction(new VariantMetadataRules.VariantAction<>(spec, action));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -24,16 +24,16 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
-import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.List;
 import java.util.Set;
 
-public abstract class AbstractConfigurationMetadata implements ConfigurationMetadata, VariantResolveMetadata {
+public abstract class AbstractConfigurationMetadata implements ModuleConfigurationMetadata, VariantResolveMetadata {
     private final ModuleComponentIdentifier componentId;
     private final String name;
     private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -169,6 +169,11 @@ public abstract class AbstractConfigurationMetadata implements ConfigurationMeta
         return capabilities;
     }
 
+    @Override
+    public boolean requiresMavenArtifactDiscovery() {
+        return false;
+    }
+
     ImmutableList<ModuleDependencyMetadata> getConfigDependencies() {
         if (configDependenciesFactory != null) {
             configDependencies = ImmutableList.copyOf(configDependenciesFactory.create());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -43,6 +43,7 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
     private final ImmutableList<ExcludeMetadata> excludes;
     private final ImmutableAttributes attributes;
     private final ImmutableCapabilities capabilities;
+    private boolean mavenArtifactDiscovery;
 
     // Should be final, and set in constructor
     private ImmutableList<ModuleDependencyMetadata> configDependencies;
@@ -51,7 +52,8 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
     AbstractConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
                                   ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableSet<String> hierarchy,
                                   ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes,
-                                  ImmutableList<ModuleDependencyMetadata> configDependencies, ImmutableCapabilities capabilities) {
+                                  ImmutableList<ModuleDependencyMetadata> configDependencies, ImmutableCapabilities capabilities,
+                                  boolean mavenArtifactDiscovery) {
 
         this.componentId = componentId;
         this.name = name;
@@ -63,13 +65,15 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
         this.attributes = attributes;
         this.configDependencies = configDependencies;
         this.capabilities = capabilities;
+        this.mavenArtifactDiscovery = mavenArtifactDiscovery;
     }
 
     AbstractConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
                                   ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableSet<String> hierarchy,
                                   ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes,
                                   Factory<List<ModuleDependencyMetadata>> configDependenciesFactory,
-                                  ImmutableCapabilities capabilities) {
+                                  ImmutableCapabilities capabilities,
+                                  boolean mavenArtifactDiscovery) {
 
         this.componentId = componentId;
         this.name = name;
@@ -81,6 +85,7 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
         this.attributes = attributes;
         this.configDependenciesFactory = configDependenciesFactory;
         this.capabilities = capabilities;
+        this.mavenArtifactDiscovery = mavenArtifactDiscovery;
     }
 
     @Override
@@ -171,7 +176,7 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
 
     @Override
     public boolean requiresMavenArtifactDiscovery() {
-        return false;
+        return mavenArtifactDiscovery;
     }
 
     ImmutableList<ModuleDependencyMetadata> getConfigDependencies() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -33,7 +33,7 @@ import org.gradle.internal.component.model.VariantResolveMetadata;
 import java.util.List;
 import java.util.Set;
 
-public abstract class AbstractConfigurationMetadata implements ModuleConfigurationMetadata, VariantResolveMetadata {
+public abstract class AbstractConfigurationMetadata implements ModuleConfigurationMetadata {
     private final ModuleComponentIdentifier componentId;
     private final String name;
     private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -23,14 +23,18 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Common base class for the lazy versions of {@link ModuleComponentResolveMetadata} implementations.
@@ -87,21 +91,59 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
         return configurationDefinitions;
     }
 
-    private Optional<ImmutableList<? extends ConfigurationMetadata>> buildVariantsForGraphTraversal(List<? extends ComponentVariant> variants) {
+    private Optional<ImmutableList<? extends ConfigurationMetadata>> buildVariantsForGraphTraversal() {
+        ImmutableList<? extends ComponentVariant> variants = getVariants();
         if (variants.isEmpty()) {
-            return maybeDeriveVariants();
+            return addVariantsByRule(maybeDeriveVariants());
         }
-        ImmutableList.Builder<ConfigurationMetadata> configurations = new ImmutableList.Builder<ConfigurationMetadata>();
+        ImmutableList.Builder<ConfigurationMetadata> configurations = new ImmutableList.Builder<>();
         for (ComponentVariant variant : variants) {
             configurations.add(new LazyVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory(), variantMetadataRules));
         }
-        return Optional.<ImmutableList<? extends ConfigurationMetadata>>of(configurations.build());
+        return addVariantsByRule(Optional.of(configurations.build()));
+
+    }
+
+    private Optional<ImmutableList<? extends ConfigurationMetadata>> addVariantsByRule(Optional<ImmutableList<? extends ConfigurationMetadata>> variants) {
+        if (variantMetadataRules.getAdditionalVariants().isEmpty()) {
+            return variants;
+        }
+        Map<String, ConfigurationMetadata> byName = variants.or(ImmutableList.of()).stream().collect(Collectors.toMap(ConfigurationMetadata::getName, Function.identity()));
+        ImmutableList.Builder<ConfigurationMetadata> builder = new ImmutableList.Builder<>();
+        if (variants.isPresent()) {
+            builder.addAll(variants.get());
+        }
+        for (Map.Entry<String, String> variantName : variantMetadataRules.getAdditionalVariants().entrySet()) {
+            ConfigurationMetadata base;
+            if (variants.isPresent()) {
+                base = byName.get(variantName.getValue());
+            } else {
+                base = getConfiguration(variantName.getValue());
+            }
+            ImmutableAttributes attributes;
+            ImmutableCapabilities capabilities;
+            List<? extends ModuleDependencyMetadata> dependencies;
+            if (base instanceof ModuleConfigurationMetadata) {
+                attributes = base.getAttributes();
+                capabilities = (ImmutableCapabilities) base.getCapabilities();
+                dependencies = ((ModuleConfigurationMetadata) base).getDependencies();
+            } else {
+                attributes = getAttributes();
+                capabilities = ImmutableCapabilities.EMPTY;
+                dependencies = ImmutableList.of();
+            }
+
+            ComponentVariant variant = new AbstractMutableModuleComponentResolveMetadata.ImmutableVariantImpl(getId(), variantName.getKey(), attributes, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), capabilities);
+            ConfigurationMetadata configurationMetadata = new LazyVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory(), variantMetadataRules, dependencies);
+            builder.add(configurationMetadata);
+        }
+        return Optional.of(builder.build());
     }
 
     @Override
     public synchronized Optional<ImmutableList<? extends ConfigurationMetadata>> getVariantsForGraphTraversal() {
         if (graphVariants == null) {
-            graphVariants = buildVariantsForGraphTraversal(getVariants());
+            graphVariants = buildVariantsForGraphTraversal();
         }
         return graphVariants;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -26,6 +26,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.descriptor.Configuration;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
@@ -133,18 +134,21 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
             ImmutableAttributes attributes;
             ImmutableCapabilities capabilities;
             List<? extends ModuleDependencyMetadata> dependencies;
+            ImmutableList<? extends ComponentArtifactMetadata> artifacts;
             if (base instanceof ModuleConfigurationMetadata) {
                 attributes = base.getAttributes();
                 capabilities = (ImmutableCapabilities) base.getCapabilities();
                 dependencies = ((ModuleConfigurationMetadata) base).getDependencies();
+                artifacts = base.getArtifacts();
             } else {
                 attributes = getAttributes();
                 capabilities = ImmutableCapabilities.EMPTY;
                 dependencies = ImmutableList.of();
+                artifacts = ImmutableList.of();
             }
 
             ComponentVariant variant = new AbstractMutableModuleComponentResolveMetadata.ImmutableVariantImpl(getId(), variantName.getKey(), attributes, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), capabilities);
-            ConfigurationMetadata configurationMetadata = new LazyVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory(), variantMetadataRules, dependencies);
+            ConfigurationMetadata configurationMetadata = new LazyVariantBackedConfigurationMetadata(getId(), variant, getAttributes(), getAttributesFactory(), variantMetadataRules, dependencies, artifacts);
             builder.add(configurationMetadata);
         }
         return Optional.of(builder.build());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -313,11 +313,11 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
     }
 
-    protected static class FileImpl implements ComponentVariant.File {
+    public static class FileImpl implements ComponentVariant.File {
         private final String name;
         private final String uri;
 
-        FileImpl(String name, String uri) {
+        public FileImpl(String name, String uri) {
             this.name = name;
             this.uri = uri;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -513,7 +513,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
     }
 
-    public static class ImmutableVariantImpl implements ComponentVariant, VariantResolveMetadata {
+    protected static class ImmutableVariantImpl implements ComponentVariant, VariantResolveMetadata {
         private final ModuleComponentIdentifier componentId;
         private final String name;
         private final ImmutableAttributes attributes;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -513,7 +513,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
     }
 
-    protected static class ImmutableVariantImpl implements ComponentVariant, VariantResolveMetadata {
+    public static class ImmutableVariantImpl implements ComponentVariant, VariantResolveMetadata {
         private final ModuleComponentIdentifier componentId;
         private final String name;
         private final ImmutableAttributes attributes;
@@ -568,12 +568,12 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
-        public List<? extends ComponentArtifactMetadata> getArtifacts() {
-            List<ComponentArtifactMetadata> artifacts = new ArrayList<ComponentArtifactMetadata>(files.size());
+        public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
+            ImmutableList.Builder<ComponentArtifactMetadata> artifacts = new ImmutableList.Builder<>();
             for (ComponentVariant.File file : files) {
                 artifacts.add(new UrlBackedArtifactMetadata(componentId, file.getName(), file.getUri()));
             }
-            return artifacts;
+            return artifacts.build();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -32,7 +32,6 @@ import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -125,7 +124,7 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         }
 
         @Override
-        public List<? extends ComponentArtifactMetadata> getArtifacts() {
+        public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
             throw new UnsupportedOperationException("NameOnlyVariantResolveMetadata cannot be used that way");
         }
 
@@ -199,12 +198,12 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         }
 
         @Override
-        public List<? extends ComponentArtifactMetadata> getArtifacts() {
-            List<ComponentArtifactMetadata> artifacts = new ArrayList<ComponentArtifactMetadata>(files.size());
+        public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
+            ImmutableList.Builder<ComponentArtifactMetadata> artifacts = new ImmutableList.Builder<>();
             for (ComponentVariant.File file : files) {
                 artifacts.add(new UrlBackedArtifactMetadata(componentId, file.getName(), file.getUri()));
             }
-            return artifacts;
+            return artifacts.build();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -16,8 +16,10 @@
 
 package org.gradle.internal.component.external.model;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -26,6 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
 import org.gradle.internal.component.external.descriptor.DefaultExclude;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -87,6 +90,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         for (String configurationName: transformed.getConfigurationNames()) {
             ConfigurationMetadata configuration = transformed.getConfiguration(configurationName);
             writeConfiguration(encoder, configuration);
+            writeFiles(encoder, configuration.getArtifacts());
             writeDependencies(encoder, configuration, deduplicationDependencyCache);
         }
     }
@@ -124,6 +128,25 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         return new GradleDependencyMetadata(selector, excludes, constraint, inheriting, reason, force, artifact);
     }
 
+    protected ImmutableList<? extends ModuleComponentArtifactMetadata> readFiles(Decoder decoder, ModuleComponentIdentifier componentIdentifier) throws IOException {
+        ImmutableList.Builder<ModuleComponentArtifactMetadata> artifacts = new ImmutableList.Builder<>();
+        int artifactsCount = decoder.readSmallInt();
+        for (int i = 0; i < artifactsCount; i++) {
+            String name = decoder.readString();
+            String type = decoder.readString();
+            String extension = decoder.readNullableString();
+            String classifier = decoder.readNullableString();
+            artifacts.add(new DefaultModuleComponentArtifactMetadata(componentIdentifier, new DefaultIvyArtifactName(name, type, extension, classifier)));
+        }
+        int filesCount = decoder.readSmallInt();
+        for (int i = 0; i < filesCount; i++) {
+            String fileName = decoder.readString();
+            String uri = decoder.readString();
+            artifacts.add(new UrlBackedArtifactMetadata(componentIdentifier, fileName, uri));
+        }
+        return artifacts.build();
+    }
+
     protected List<ExcludeMetadata> readMavenExcludes(Decoder decoder) throws IOException {
         int excludeCount = decoder.readSmallInt();
         List<ExcludeMetadata> excludes = Lists.newArrayListWithCapacity(excludeCount);
@@ -147,6 +170,28 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
             rawCapabilities.add(capability);
         }
         return ImmutableCapabilities.of(rawCapabilities);
+    }
+
+    protected void writeFiles(Encoder encoder, ImmutableList<? extends ComponentArtifactMetadata> artifacts) throws IOException {
+        int fileArtifactsCount = (int) artifacts.stream().filter(a -> a instanceof UrlBackedArtifactMetadata).count();
+        int ivyArtifactsCount = artifacts.size() - fileArtifactsCount;
+        encoder.writeSmallInt(ivyArtifactsCount);
+        for (ComponentArtifactMetadata artifact : artifacts) {
+            if (!(artifact instanceof UrlBackedArtifactMetadata)) {
+                IvyArtifactName artifactName = artifact.getName();
+                encoder.writeString(artifactName.getName());
+                encoder.writeString(artifactName.getType());
+                encoder.writeNullableString(artifactName.getExtension());
+                encoder.writeNullableString(artifactName.getClassifier());
+            }
+        }
+        encoder.writeSmallInt(fileArtifactsCount);
+        for (ComponentArtifactMetadata file : artifacts) {
+            if (file instanceof UrlBackedArtifactMetadata) {
+                encoder.writeString(((UrlBackedArtifactMetadata) file).getFileName());
+                encoder.writeString(((UrlBackedArtifactMetadata) file).getRelativeUrl());
+            }
+        }
     }
 
     protected abstract void writeDependencies(Encoder encoder, ConfigurationMetadata configuration, Map<ExternalDependencyDescriptor, Integer> deduplicationDependencyCache) throws IOException;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -30,6 +30,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.ArrayList;
@@ -40,10 +41,10 @@ import java.util.Set;
 /**
  * An immutable {@link ConfigurationMetadata} wrapper around a {@link ComponentVariant}.
  */
-class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadata {
+class AbstractVariantBackedConfigurationMetadata implements ModuleConfigurationMetadata {
     private final ModuleComponentIdentifier componentId;
     private final ComponentVariant variant;
-    private final ImmutableList<GradleDependencyMetadata> dependencies;
+    private final List<? extends ModuleDependencyMetadata> dependencies;
 
     AbstractVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant) {
         this.componentId = componentId;
@@ -73,7 +74,7 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
         this.dependencies = ImmutableList.copyOf(dependencies);
     }
 
-    AbstractVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableList<GradleDependencyMetadata> dependencies) {
+    AbstractVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, List<? extends ModuleDependencyMetadata> dependencies) {
         this.componentId = componentId;
         this.variant = variant;
         this.dependencies = dependencies;
@@ -155,7 +156,7 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
     }
 
     @Override
-    public List<? extends ComponentArtifactMetadata> getArtifacts() {
+    public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
         return variant.getArtifacts();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -150,6 +150,11 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
     }
 
     @Override
+    public boolean requiresMavenArtifactDiscovery() {
+        return false;
+    }
+
+    @Override
     public List<? extends ComponentArtifactMetadata> getArtifacts() {
         return variant.getArtifacts();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import jdk.internal.jline.internal.Nullable;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.DefaultVariantMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleConfigurationMetadata;
+import org.gradle.internal.component.model.VariantResolveMetadata;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A configuration representing an additional variant of a published component added by a component metadata rule.
+ * It can be backed by an existing configuration/variant (base) or can initially be empty (base = null).
+ */
+class LazyRuleAwareWithBaseConfigurationMetadata implements ModuleConfigurationMetadata {
+
+    private final String name;
+    private final ModuleConfigurationMetadata base;
+    private final ModuleComponentIdentifier componentId;
+    private final VariantMetadataRules variantMetadataRules;
+
+    private List<? extends ModuleDependencyMetadata> computedDependencies;
+    private ImmutableAttributes computedAttributes;
+    private CapabilitiesMetadata computedCapabilities;
+    private ImmutableList<? extends ComponentArtifactMetadata> computedArtifacts;
+    private ImmutableAttributes componentLevelAttributes;
+
+    LazyRuleAwareWithBaseConfigurationMetadata(String name, @Nullable ModuleConfigurationMetadata base, ModuleComponentIdentifier componentId, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules) {
+        this.name = name;
+        this.base = base;
+        this.componentId = componentId;
+        this.variantMetadataRules = variantMetadataRules;
+        this.componentLevelAttributes = componentLevelAttributes;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public List<? extends ModuleDependencyMetadata> getDependencies() {
+        if (computedDependencies == null) {
+            computedDependencies = variantMetadataRules.applyDependencyMetadataRules(this, base == null ? ImmutableList.of() : base.getDependencies());
+        }
+        return computedDependencies;
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        if (computedAttributes == null) {
+            computedAttributes = variantMetadataRules.applyVariantAttributeRules(this, base == null ? componentLevelAttributes : base.getAttributes());
+        }
+        return computedAttributes;
+    }
+
+    @Override
+    public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
+        if (computedArtifacts == null) {
+            computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRulesToArtifacts(this, base == null ? ImmutableList.of() : base.getArtifacts(), componentId);
+        }
+        return computedArtifacts;
+    }
+
+    @Override
+    public CapabilitiesMetadata getCapabilities() {
+        if (computedCapabilities == null) {
+            computedCapabilities = variantMetadataRules.applyCapabilitiesRules(this, base == null ? ImmutableCapabilities.EMPTY : base.getCapabilities());
+        }
+        return computedCapabilities;
+    }
+
+    @Override
+    public boolean requiresMavenArtifactDiscovery() {
+        return false;
+    }
+
+    @Override
+    public Set<? extends VariantResolveMetadata> getVariants() {
+        return ImmutableSet.of(new DefaultVariantMetadata(asDescribable(), getAttributes(), getArtifacts(), getCapabilities()));
+    }
+
+    @Override
+    public DisplayName asDescribable() {
+        return Describables.of(componentId, "configuration", name);
+    }
+
+    @Override
+    public ComponentArtifactMetadata artifact(IvyArtifactName artifact) {
+        return new DefaultModuleComponentArtifactMetadata(componentId, artifact);
+    }
+
+    @Override
+    public ImmutableSet<String> getHierarchy() {
+        return ImmutableSet.of(name);
+    }
+
+    @Override
+    public ImmutableList<ExcludeMetadata> getExcludes() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean isTransitive() {
+        return true;
+    }
+
+    @Override
+    public boolean isVisible() {
+        return true;
+    }
+
+    @Override
+    public boolean isCanBeConsumed() {
+        return true;
+    }
+
+    @Override
+    public boolean isCanBeResolved() {
+        return false;
+    }
+
+    @Override
+    public List<String> getConsumptionAlternatives() {
+        return ImmutableList.of();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
@@ -31,6 +33,9 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Utility class to help transform a lazy {@link ModuleComponentResolveMetadata} into a realised one.
@@ -50,15 +55,62 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         }
         List<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> realisedVariants = Lists.newArrayListWithExpectedSize(variants.size());
         for (ComponentVariant variant : variants) {
-            ImmutableAttributes attributes = variantMetadataRules.applyVariantAttributeRules(variant, variant.getAttributes());
-            CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, variant.getCapabilities());
-            boolean force = PlatformSupport.hasForcedDependencies(variant);
-            List<GradleDependencyMetadata> dependencies = variantMetadataRules.applyDependencyMetadataRules(variant, convertDependencies(variant.getDependencies(), variant.getDependencyConstraints(), force));
-            realisedVariants.add(new AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl(mutableMetadata.getId(), variant.getName(), attributes,
-                variant.getDependencies(), variant.getDependencyConstraints(), variant.getFiles(),
-                ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()), dependencies));
+            realisedVariants.add(applyRules(variant, variantMetadataRules, mutableMetadata.getId()));
         }
-        return ImmutableList.copyOf(realisedVariants);
+        return addVariantsFromRules(mutableMetadata, realisedVariants, variantMetadataRules);
+    }
+
+    private static ImmutableList<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> addVariantsFromRules(ModuleComponentResolveMetadata componentMetadata, List<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> declaredVariants, VariantMetadataRules variantMetadataRules) {
+        Map<String, String> additionalVariants = variantMetadataRules.getAdditionalVariants();
+        if (additionalVariants.isEmpty()) {
+            return ImmutableList.copyOf(declaredVariants);
+        }
+
+        ImmutableList.Builder<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> builder = new ImmutableList.Builder<>();
+        builder.addAll(declaredVariants);
+        Map<String, ComponentVariant> variantsByName = declaredVariants.stream().collect(Collectors.toMap(ComponentVariant::getName, Function.identity()));
+        for (Map.Entry<String, String> variantName : additionalVariants.entrySet()) {
+            String baseName = variantName.getValue();
+            ImmutableAttributes attributes;
+            ImmutableCapabilities capabilities;
+            ImmutableList<? extends ComponentVariant.Dependency> dependencies;
+            ImmutableList<? extends ComponentVariant.DependencyConstraint> dependencyConstraints;
+            ImmutableList<? extends ComponentVariant.File> files;
+
+            if (baseName == null) {
+                attributes = componentMetadata.getAttributes();
+                capabilities = ImmutableCapabilities.EMPTY;
+                dependencies = ImmutableList.of();
+                dependencyConstraints = ImmutableList.of();
+                files = ImmutableList.of();
+            } else {
+                ComponentVariant baseVariant = variantsByName.get(baseName);
+                if (baseVariant == null) {
+                    throw new InvalidUserDataException("Variant '" + baseName + "' not defined in module " + componentMetadata.getId().getDisplayName());
+                }
+                attributes = (ImmutableAttributes) baseVariant.getAttributes();
+                capabilities = (ImmutableCapabilities) baseVariant.getCapabilities();
+                dependencies = baseVariant.getDependencies();
+                dependencyConstraints = baseVariant.getDependencyConstraints();
+                files = baseVariant.getFiles();
+            }
+            AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl variant = applyRules(new AbstractMutableModuleComponentResolveMetadata.ImmutableVariantImpl(
+                componentMetadata.getId(), variantName.getKey(), attributes, dependencies, dependencyConstraints, files, capabilities),
+                variantMetadataRules, componentMetadata.getId());
+            builder.add(variant);
+        }
+        return builder.build();
+    }
+
+    private static AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl applyRules(ComponentVariant variant, VariantMetadataRules variantMetadataRules, ModuleComponentIdentifier id) {
+        ImmutableAttributes attributes = variantMetadataRules.applyVariantAttributeRules(variant, variant.getAttributes());
+        CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, variant.getCapabilities());
+        ImmutableList<? extends ComponentVariant.File> files = variantMetadataRules.applyVariantFilesMetadataRulesToFiles(variant, variant.getFiles(), id);
+        boolean force = PlatformSupport.hasForcedDependencies(variant);
+        List<GradleDependencyMetadata> dependencies = variantMetadataRules.applyDependencyMetadataRules(variant, convertDependencies(variant.getDependencies(), variant.getDependencyConstraints(), force));
+        return new AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl(id, variant.getName(), attributes,
+            variant.getDependencies(), variant.getDependencyConstraints(), files,
+            ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()), dependencies);
     }
 
     private static List<GradleDependencyMetadata> convertDependencies(List<? extends ComponentVariant.Dependency> dependencies, List<? extends ComponentVariant.DependencyConstraint> dependencyConstraints, boolean force) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -101,7 +101,7 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         @Override
         public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
             if (computedArtifacts == null) {
-                computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRules(delegate, delegate.getArtifacts(), componentId);
+                computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRulesToArtifacts(delegate, delegate.getArtifacts(), componentId);
             }
             return computedArtifacts;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -37,7 +37,12 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
     private List<? extends ModuleDependencyMetadata> calculatedDependencies;
 
     LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules) {
-        super(componentId, new RuleAwareVariant(variant, attributesFactory, componentLevelAttributes, variantMetadataRules));
+        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules));
+        this.variantMetadataRules = variantMetadataRules;
+    }
+
+    LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules, List<? extends ModuleDependencyMetadata> dependenciesOverride) {
+        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules), dependenciesOverride);
         this.variantMetadataRules = variantMetadataRules;
     }
 
@@ -55,6 +60,7 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
      * that the attributes are the same whenever we resolve the graph for dependencies and artifacts.
      */
     private static class RuleAwareVariant implements ComponentVariant {
+        private final ModuleComponentIdentifier componentId;
         private final ImmutableAttributesFactory attributesFactory;
         private final ComponentVariant delegate;
         private final ImmutableAttributes componentLevelAttributes;
@@ -62,8 +68,10 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
 
         private ImmutableAttributes computedAttributes;
         private CapabilitiesMetadata computedCapabilities;
+        private ImmutableList<? extends ComponentArtifactMetadata> computedArtifacts;
 
-        RuleAwareVariant(ComponentVariant delegate, ImmutableAttributesFactory attributesFactory, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules) {
+        RuleAwareVariant(ModuleComponentIdentifier componentId, ComponentVariant delegate, ImmutableAttributesFactory attributesFactory, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules) {
+            this.componentId = componentId;
             this.attributesFactory = attributesFactory;
             this.delegate = delegate;
             this.componentLevelAttributes = componentLevelAttributes;
@@ -96,8 +104,11 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         }
 
         @Override
-        public List<? extends ComponentArtifactMetadata> getArtifacts() {
-            return delegate.getArtifacts();
+        public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
+            if (computedArtifacts == null) {
+                computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRules(delegate, delegate.getArtifacts(), componentId);
+            }
+            return computedArtifacts;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -37,12 +37,12 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
     private List<? extends ModuleDependencyMetadata> calculatedDependencies;
 
     LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules) {
-        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules));
+        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules, null));
         this.variantMetadataRules = variantMetadataRules;
     }
 
-    LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules, List<? extends ModuleDependencyMetadata> dependenciesOverride) {
-        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules), dependenciesOverride);
+    LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules, List<? extends ModuleDependencyMetadata> dependenciesOverride, ImmutableList<? extends ComponentArtifactMetadata> artifactsOverride) {
+        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules, artifactsOverride), dependenciesOverride);
         this.variantMetadataRules = variantMetadataRules;
     }
 
@@ -65,17 +65,19 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         private final ComponentVariant delegate;
         private final ImmutableAttributes componentLevelAttributes;
         private final VariantMetadataRules variantMetadataRules;
+        private final ImmutableList<? extends ComponentArtifactMetadata> originalArtifacts;
 
         private ImmutableAttributes computedAttributes;
         private CapabilitiesMetadata computedCapabilities;
         private ImmutableList<? extends ComponentArtifactMetadata> computedArtifacts;
 
-        RuleAwareVariant(ModuleComponentIdentifier componentId, ComponentVariant delegate, ImmutableAttributesFactory attributesFactory, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules) {
+        RuleAwareVariant(ModuleComponentIdentifier componentId, ComponentVariant delegate, ImmutableAttributesFactory attributesFactory, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules, ImmutableList<? extends ComponentArtifactMetadata> originalArtifacts) {
             this.componentId = componentId;
             this.attributesFactory = attributesFactory;
             this.delegate = delegate;
             this.componentLevelAttributes = componentLevelAttributes;
             this.variantMetadataRules = variantMetadataRules;
+            this.originalArtifacts = originalArtifacts;
         }
 
         @Override
@@ -106,7 +108,8 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         @Override
         public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
             if (computedArtifacts == null) {
-                computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRules(delegate, delegate.getArtifacts(), componentId);
+                ImmutableList<? extends ComponentArtifactMetadata> artifacts = originalArtifacts == null ? delegate.getArtifacts() : originalArtifacts;
+                computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRules(delegate, artifacts, componentId);
             }
             return computedArtifacts;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyVariantBackedConfigurationMetadata.java
@@ -37,12 +37,7 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
     private List<? extends ModuleDependencyMetadata> calculatedDependencies;
 
     LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules) {
-        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules, null));
-        this.variantMetadataRules = variantMetadataRules;
-    }
-
-    LazyVariantBackedConfigurationMetadata(ModuleComponentIdentifier componentId, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory, VariantMetadataRules variantMetadataRules, List<? extends ModuleDependencyMetadata> dependenciesOverride, ImmutableList<? extends ComponentArtifactMetadata> artifactsOverride) {
-        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules, artifactsOverride), dependenciesOverride);
+        super(componentId, new RuleAwareVariant(componentId, variant, attributesFactory, componentLevelAttributes, variantMetadataRules));
         this.variantMetadataRules = variantMetadataRules;
     }
 
@@ -65,19 +60,17 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         private final ComponentVariant delegate;
         private final ImmutableAttributes componentLevelAttributes;
         private final VariantMetadataRules variantMetadataRules;
-        private final ImmutableList<? extends ComponentArtifactMetadata> originalArtifacts;
 
         private ImmutableAttributes computedAttributes;
         private CapabilitiesMetadata computedCapabilities;
         private ImmutableList<? extends ComponentArtifactMetadata> computedArtifacts;
 
-        RuleAwareVariant(ModuleComponentIdentifier componentId, ComponentVariant delegate, ImmutableAttributesFactory attributesFactory, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules, ImmutableList<? extends ComponentArtifactMetadata> originalArtifacts) {
+        RuleAwareVariant(ModuleComponentIdentifier componentId, ComponentVariant delegate, ImmutableAttributesFactory attributesFactory, ImmutableAttributes componentLevelAttributes, VariantMetadataRules variantMetadataRules) {
             this.componentId = componentId;
             this.attributesFactory = attributesFactory;
             this.delegate = delegate;
             this.componentLevelAttributes = componentLevelAttributes;
             this.variantMetadataRules = variantMetadataRules;
-            this.originalArtifacts = originalArtifacts;
         }
 
         @Override
@@ -108,8 +101,7 @@ class LazyVariantBackedConfigurationMetadata extends AbstractVariantBackedConfig
         @Override
         public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
             if (computedArtifacts == null) {
-                ImmutableList<? extends ComponentArtifactMetadata> artifacts = originalArtifacts == null ? delegate.getArtifacts() : originalArtifacts;
-                computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRules(delegate, artifacts, componentId);
+                computedArtifacts = variantMetadataRules.applyVariantFilesMetadataRules(delegate, delegate.getArtifacts(), componentId);
             }
             return computedArtifacts;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 
 import java.util.List;
@@ -49,7 +48,7 @@ public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata
     }
 
     @Override
-    public List<? extends DependencyMetadata> getDependencies() {
+    public List<? extends ModuleDependencyMetadata> getDependencies() {
         return getConfigDependencies();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
@@ -26,12 +26,16 @@ import java.util.List;
 
 public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata {
 
+    private final boolean addedByRule;
+
     public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
                                          ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                          ImmutableList<ExcludeMetadata> excludes,
                                          ImmutableAttributes componentLevelAttributes,
-                                         ImmutableCapabilities capabilities) {
-        this(componentId, name, transitive, visible, hierarchy, artifacts, excludes, componentLevelAttributes, capabilities, null);
+                                         ImmutableCapabilities capabilities,
+                                         boolean mavenArtifactDiscovery,
+                                         boolean addedByRule) {
+        this(componentId, name, transitive, visible, hierarchy, artifacts, excludes, componentLevelAttributes, capabilities, mavenArtifactDiscovery, null, addedByRule);
     }
 
     public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId,
@@ -43,8 +47,11 @@ public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata
                                          ImmutableList<ExcludeMetadata> excludes,
                                          ImmutableAttributes attributes,
                                          ImmutableCapabilities capabilities,
-                                         ImmutableList<ModuleDependencyMetadata> configDependencies) {
-        super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependencies, capabilities);
+                                         boolean mavenArtifactDiscovery,
+                                         ImmutableList<ModuleDependencyMetadata> configDependencies,
+                                         boolean addedByRule) {
+        super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependencies, capabilities, mavenArtifactDiscovery);
+        this.addedByRule = addedByRule;
     }
 
     @Override
@@ -63,7 +70,13 @@ public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata
             getExcludes(),
             getAttributes(),
             ImmutableCapabilities.of(getCapabilities().getCapabilities()),
-            dependencies
+            requiresMavenArtifactDiscovery(),
+            dependencies,
+            addedByRule
         );
+    }
+
+    public boolean isAddedByRule() {
+        return addedByRule;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedVariantBackedConfigurationMetadata.java
@@ -25,8 +25,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 
-import java.util.List;
-
 public class RealisedVariantBackedConfigurationMetadata extends AbstractVariantBackedConfigurationMetadata {
 
     public RealisedVariantBackedConfigurationMetadata(ModuleComponentIdentifier id, ComponentVariant variant, ImmutableAttributes componentLevelAttributes, ImmutableAttributesFactory attributesFactory) {
@@ -76,7 +74,7 @@ public class RealisedVariantBackedConfigurationMetadata extends AbstractVariantB
         }
 
         @Override
-        public List<? extends ComponentArtifactMetadata> getArtifacts() {
+        public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
             return delegate.getArtifacts();
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -31,11 +31,13 @@ import org.gradle.internal.component.model.IvyArtifactName;
  */
 public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadata {
     private final ModuleComponentIdentifier componentIdentifier;
+    private final String fileName;
     private final String relativeUrl;
     private final ModuleComponentFileArtifactIdentifier id;
 
     public UrlBackedArtifactMetadata(ModuleComponentIdentifier componentIdentifier, String fileName, String relativeUrl) {
         this.componentIdentifier = componentIdentifier;
+        this.fileName = fileName;
         this.relativeUrl = relativeUrl;
         id = new ModuleComponentFileArtifactIdentifier(componentIdentifier, fileName);
     }
@@ -48,6 +50,10 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
     @Override
     public ModuleComponentArtifactIdentifier getId() {
         return id;
+    }
+
+    public String getFileName() {
+        return fileName;
     }
 
     public String getRelativeUrl() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -98,11 +98,18 @@ public class VariantMetadataRules {
         return configDependencies;
     }
 
-    public <T extends ComponentArtifactMetadata> ImmutableList<T> applyVariantFilesMetadataRules(VariantResolveMetadata variant, ImmutableList<T> declaredArtifacts, ModuleComponentIdentifier componentIdentifier) {
+    public <T extends ComponentArtifactMetadata> ImmutableList<T> applyVariantFilesMetadataRulesToArtifacts(VariantResolveMetadata variant, ImmutableList<T> declaredArtifacts, ModuleComponentIdentifier componentIdentifier) {
         if (variantFilesRules != null) {
-            return variantFilesRules.execute(variant, declaredArtifacts, componentIdentifier);
+            return variantFilesRules.executeForArtifacts(variant, declaredArtifacts, componentIdentifier);
         }
         return declaredArtifacts;
+    }
+
+    public <T extends ComponentVariant.File> ImmutableList<T> applyVariantFilesMetadataRulesToFiles(VariantResolveMetadata variant, ImmutableList<T> declaredFiles, ModuleComponentIdentifier componentIdentifier) {
+        if (variantFilesRules != null) {
+            return variantFilesRules.executeForFiles(variant, declaredFiles, componentIdentifier);
+        }
+        return declaredFiles;
     }
 
     public void addDependencyAction(Instantiator instantiator, NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser, NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser, VariantAction<? super DirectDependenciesMetadata> action) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -15,9 +15,13 @@
  */
 package org.gradle.internal.component.external.model;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.MutableVariantFilesMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DependencyConstraintsMetadata;
@@ -30,6 +34,8 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.VariantFilesRules;
 import org.gradle.internal.component.model.CapabilitiesRules;
 import org.gradle.internal.component.model.DependencyMetadataRules;
 import org.gradle.internal.component.model.VariantAttributesRules;
@@ -39,14 +45,17 @@ import org.gradle.internal.typeconversion.NotationParser;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class VariantMetadataRules {
     private final ImmutableAttributesFactory attributesFactory;
     private DependencyMetadataRules dependencyMetadataRules;
     private VariantAttributesRules variantAttributesRules;
     private CapabilitiesRules capabilitiesRules;
+    private VariantFilesRules variantFilesRules;
     private VariantDerivationStrategy variantDerivationStrategy = new NoOpDerivationStrategy();
     private final ModuleVersionIdentifier moduleVersionId;
+    private Map<String, String> additionalVariants = Maps.newHashMap();
 
     public VariantMetadataRules(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier moduleVersionId) {
         this.attributesFactory = attributesFactory;
@@ -89,6 +98,13 @@ public class VariantMetadataRules {
         return configDependencies;
     }
 
+    public <T extends ComponentArtifactMetadata> ImmutableList<T> applyVariantFilesMetadataRules(VariantResolveMetadata variant, ImmutableList<T> declaredArtifacts, ModuleComponentIdentifier componentIdentifier) {
+        if (variantFilesRules != null) {
+            return variantFilesRules.execute(variant, declaredArtifacts, componentIdentifier);
+        }
+        return declaredArtifacts;
+    }
+
     public void addDependencyAction(Instantiator instantiator, NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser, NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintNotationParser, VariantAction<? super DirectDependenciesMetadata> action) {
         if (dependencyMetadataRules == null) {
             dependencyMetadataRules = new DependencyMetadataRules(instantiator, dependencyNotationParser, dependencyConstraintNotationParser, attributesFactory);
@@ -115,6 +131,21 @@ public class VariantMetadataRules {
             capabilitiesRules = new CapabilitiesRules();
         }
         capabilitiesRules.addCapabilitiesAction(action);
+    }
+
+    public void addVariantFilesAction(VariantAction<? super MutableVariantFilesMetadata> action) {
+        if (variantFilesRules == null) {
+            variantFilesRules = new VariantFilesRules();
+        }
+        variantFilesRules.addFilesAction(action);
+    }
+
+    public void addVariant(String name, String basedOn) {
+        additionalVariants.put(name, basedOn);
+    }
+
+    public Map<String, String> getAdditionalVariants() {
+        return additionalVariants;
     }
 
     public static VariantMetadataRules noOp() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -140,6 +140,10 @@ public class VariantMetadataRules {
         variantFilesRules.addFilesAction(action);
     }
 
+    public void addVariant(String name) {
+        additionalVariants.put(name, null);
+    }
+
     public void addVariant(String name, String basedOn) {
         additionalVariants.put(name, basedOn);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
@@ -97,7 +97,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractLazyModuleComponent
         ImmutableList<ModuleComponentArtifactMetadata> artifacts = configurationHelper.filterArtifacts(name, hierarchy);
         ImmutableList<ExcludeMetadata> excludesForConfiguration = configurationHelper.filterExcludes(hierarchy);
 
-        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, ImmutableList.copyOf(artifacts), componentMetadataRules, excludesForConfiguration, getAttributes().asImmutable());
+        DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, hierarchy, ImmutableList.copyOf(artifacts), componentMetadataRules, excludesForConfiguration, getAttributes().asImmutable(), false);
         configuration.setDependencies(configurationHelper.filterDependencies(configuration));
         return configuration;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
@@ -16,15 +16,18 @@
 
 package org.gradle.internal.component.external.model.ivy;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.Cast;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
@@ -41,6 +44,7 @@ import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 
 import javax.annotation.Nullable;
@@ -63,29 +67,74 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
 
         Map<String, ConfigurationMetadata> configurations = realiseConfigurations(metadata, variantMetadataRules);
 
+        if (variants.isEmpty()) {
+            addVariantsFromRules(metadata, configurations, variantMetadataRules);
+        }
+
         return new RealisedIvyModuleResolveMetadata(metadata, variants, configurations);
     }
 
     private static Map<String, ConfigurationMetadata> realiseConfigurations(DefaultIvyModuleResolveMetadata metadata, VariantMetadataRules variantMetadataRules) {
-        Map<Artifact, ModuleComponentArtifactMetadata> artifacts = new IdentityHashMap<Artifact, ModuleComponentArtifactMetadata>();
-        IvyConfigurationHelper configurationHelper = new IvyConfigurationHelper(metadata.getArtifactDefinitions(), artifacts, metadata.getExcludes(), metadata.getDependencies(), metadata.getId());
-
         Map<String, ConfigurationMetadata> configurations = Maps.newHashMapWithExpectedSize(metadata.getConfigurationNames().size());
-        ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
-        for (String configurationName: metadata.getConfigurationNames()) {
-            Configuration configuration = configurationDefinitions.get(configurationName);
-            ImmutableSet<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
-
-            NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
-            ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
-
-            CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, ImmutableCapabilities.EMPTY);
-
-
-            configurations.put(configurationName, createConfiguration(configurationHelper, variantMetadataRules, metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(), hierarchy,
-                configurationHelper.filterArtifacts(configurationName, hierarchy), configurationHelper.filterExcludes(hierarchy), variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities())));
+        for (String configurationName : metadata.getConfigurationNames()) {
+            configurations.put(configurationName, applyRules(metadata, variantMetadataRules, configurationName));
         }
         return configurations;
+    }
+
+    private static void addVariantsFromRules(DefaultIvyModuleResolveMetadata componentMetadata, Map<String, ConfigurationMetadata> declaredConfigurations, VariantMetadataRules variantMetadataRules) {
+        Map<String, String> additionalVariants = variantMetadataRules.getAdditionalVariants();
+        if (additionalVariants.isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<String, String> variantName : additionalVariants.entrySet()) {
+            String name = variantName.getKey();
+            String baseName = variantName.getValue();
+            ImmutableAttributes attributes;
+            ImmutableCapabilities capabilities;
+            List<ModuleDependencyMetadata> dependencies;
+            ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
+
+            if (baseName == null) {
+                attributes = componentMetadata.getAttributes();
+                capabilities = ImmutableCapabilities.EMPTY;
+                dependencies = ImmutableList.of();
+                artifacts = ImmutableList.of();
+            } else {
+                ModuleConfigurationMetadata baseConf = (ModuleConfigurationMetadata) declaredConfigurations.get(baseName);
+                if (baseConf == null) {
+                    throw new InvalidUserDataException("Configuration '" + baseName + "' not defined in module " + componentMetadata.getId().getDisplayName());
+                }
+                attributes = baseConf.getAttributes();
+                capabilities = (ImmutableCapabilities) baseConf.getCapabilities();
+                dependencies = Cast.uncheckedCast(baseConf.getDependencies());
+                artifacts = Cast.uncheckedCast(baseConf.getArtifacts());
+            }
+            declaredConfigurations.put(name, applyRules(componentMetadata.getId(), name, variantMetadataRules, attributes, capabilities, artifacts, ImmutableList.of(), true, true, ImmutableSet.of(), null, dependencies, true));
+        }
+    }
+
+    private static RealisedConfigurationMetadata applyRules(DefaultIvyModuleResolveMetadata metadata, VariantMetadataRules variantMetadataRules, String configurationName) {
+        ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
+        Configuration configuration = configurationDefinitions.get(configurationName);
+        IvyConfigurationHelper configurationHelper = new IvyConfigurationHelper(metadata.getArtifactDefinitions(), new IdentityHashMap<>(), metadata.getExcludes(), metadata.getDependencies(), metadata.getId());
+        ImmutableSet<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
+        ImmutableList<ExcludeMetadata> excludes = configurationHelper.filterExcludes(hierarchy);
+
+        ImmutableList<ModuleComponentArtifactMetadata> artifacts = configurationHelper.filterArtifacts(configurationName, hierarchy);
+
+        return applyRules(metadata.getId(), configurationName, variantMetadataRules, metadata.getAttributes(), ImmutableCapabilities.EMPTY, artifacts, excludes, configuration.isTransitive(), configuration.isVisible(), hierarchy, configurationHelper, null, false);
+    }
+
+    private static RealisedConfigurationMetadata applyRules(ModuleComponentIdentifier id, String configurationName, VariantMetadataRules variantMetadataRules, ImmutableAttributes attributes, ImmutableCapabilities capabilities, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                                            ImmutableList<ExcludeMetadata> excludes, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, IvyConfigurationHelper configurationHelper, List<ModuleDependencyMetadata> dependenciesOverride, boolean addedByRule) {
+        NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
+        ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, attributes);
+        CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, capabilities);
+        ImmutableList<? extends ModuleComponentArtifactMetadata> artifactsMetadata = variantMetadataRules.applyVariantFilesMetadataRulesToArtifacts(variant, artifacts, id);
+        return createConfiguration(id, configurationName, transitive, visible, hierarchy,
+            artifactsMetadata, excludes, variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()), variantMetadataRules, configurationHelper, dependenciesOverride, addedByRule);
     }
 
     private final ImmutableMap<String, Configuration> configurationDefinitions;
@@ -95,6 +144,8 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
     private final ImmutableMap<NamespaceId, String> extraAttributes;
     private final DefaultIvyModuleResolveMetadata metadata;
     private final String branch;
+
+    private Optional<ImmutableList<? extends ConfigurationMetadata>> derivedVariants;
 
     private RealisedIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata metadata, List<IvyDependencyDescriptor> dependencies, Map<String, ConfigurationMetadata> transformedConfigurations) {
         super(metadata, metadata.getVariants(), transformedConfigurations);
@@ -131,12 +182,41 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
         this.metadata = metadata;
     }
 
-    private static RealisedConfigurationMetadata createConfiguration(IvyConfigurationHelper configurationHelper, VariantMetadataRules variantMetadataRules, ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, ImmutableList<ModuleComponentArtifactMetadata> artifacts, ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes componentLevelAttributes, ImmutableCapabilities capabilities) {
-        RealisedConfigurationMetadata configuration = new RealisedConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, excludes, componentLevelAttributes, capabilities);
-        ImmutableList<ModuleDependencyMetadata> dependencyMetadata = configurationHelper.filterDependencies(configuration);
-        dependencyMetadata = ImmutableList.copyOf(variantMetadataRules.applyDependencyMetadataRules(new NameOnlyVariantResolveMetadata(name), dependencyMetadata));
+    private static RealisedConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy,
+                                                                     ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes componentLevelAttributes,
+                                                                     ImmutableCapabilities capabilities,
+                                                                     VariantMetadataRules variantMetadataRules, IvyConfigurationHelper configurationHelper, List<ModuleDependencyMetadata> dependenciesFromRule, boolean addedByRule) {
+        RealisedConfigurationMetadata configuration = new RealisedConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, excludes, componentLevelAttributes, capabilities, false, addedByRule);
+        List<ModuleDependencyMetadata> dependencyMetadata;
+        if (configurationHelper != null) {
+            dependencyMetadata = configurationHelper.filterDependencies(configuration);
+            dependencyMetadata = ImmutableList.copyOf(variantMetadataRules.applyDependencyMetadataRules(new NameOnlyVariantResolveMetadata(name), dependencyMetadata));
+        } else {
+            dependencyMetadata = dependenciesFromRule;
+        }
         configuration.setDependencies(dependencyMetadata);
         return configuration;
+    }
+
+    @Override
+    protected Optional<ImmutableList<? extends ConfigurationMetadata>> maybeDeriveVariants() {
+        if (derivedVariants == null && getConfigurationNames().size() != configurationDefinitions.size()) {
+            // if there are more configurations than definitions, configurations have been added by rules and thus they are variants
+            derivedVariants = Optional.of(allConfigurationsThatAreVariants());
+        } else {
+            derivedVariants = Optional.absent();
+        }
+        return derivedVariants;
+    }
+
+    private ImmutableList<? extends ConfigurationMetadata> allConfigurationsThatAreVariants() {
+        ImmutableList.Builder<ConfigurationMetadata> builder = new ImmutableList.Builder<>();
+        for (String potentialVariantName : getConfigurationNames()) {
+            if (!configurationDefinitions.containsKey(potentialVariantName)) {
+                builder.add(getConfiguration(potentialVariantName));
+            }
+        }
+        return builder.build();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -94,7 +94,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     @Override
     protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> parents, VariantMetadataRules componentMetadataRules) {
         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts = getArtifactsForConfiguration(name);
-        final DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of(), getAttributes());
+        final DefaultConfigurationMetadata configuration = new DefaultConfigurationMetadata(componentId, name, transitive, visible, parents, artifacts, componentMetadataRules, ImmutableList.<ExcludeMetadata>of(), getAttributes(), true);
         configuration.setConfigDependenciesFactory(new Factory<List<ModuleDependencyMetadata>>() {
             @Nullable
             @Override
@@ -128,7 +128,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
             // we construct should _not_ include the constraints. We keep the constraints in the descriptors
             // because if we actually use attribute matching, we can select the platform variant which
             // does use constraints.
-            return md.withoutConstraints();
+            return md.mutate().withoutConstraints().build();
         }
         return md;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -136,7 +136,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     private ImmutableList<? extends ModuleComponentArtifactMetadata> getArtifactsForConfiguration(String name) {
         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
         if (name.equals("compile") || name.equals("runtime") || name.equals("default") || name.equals("test")) {
-            artifacts = ImmutableList.of(new DefaultModuleComponentArtifactMetadata(getId(), new DefaultIvyArtifactName(getId().getModule(), "jar", "jar")));
+            String type = isKnownJarPackaging() ? "jar" : packaging;
+            artifacts = ImmutableList.of(new DefaultModuleComponentArtifactMetadata(getId(), new DefaultIvyArtifactName(getId().getModule(), type, type)));
         } else {
             artifacts = ImmutableList.of();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
@@ -39,6 +39,7 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactMetad
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.RealisedConfigurationMetadata;
+import org.gradle.internal.component.external.model.UrlBackedArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -115,6 +116,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
         encoder.writeSmallInt(derivedVariants.size());
         for (ConfigurationMetadata derivedVariant : derivedVariants) {
             writeConfiguration(encoder, derivedVariant);
+            writeFiles(encoder, derivedVariant.getArtifacts());
             writeDerivedVariantExtra(encoder, derivedVariant, deduplicationDependencyCache);
         }
     }
@@ -138,9 +140,11 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
             ImmutableSet<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
             ImmutableAttributes attributes = getAttributeContainerSerializer().read(decoder);
             ImmutableCapabilities capabilities = readCapabilities(decoder);
+            ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts = readFiles(decoder, metadata.getId());
 
             RealisedConfigurationMetadata configurationMetadata = new RealisedConfigurationMetadata(metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(),
-                hierarchy, RealisedMavenModuleResolveMetadata.getArtifactsForConfiguration(metadata.getId(), configurationName), ImmutableList.<ExcludeMetadata>of(), attributes, capabilities);
+                hierarchy, artifacts, ImmutableList.of(), attributes, capabilities,
+                artifacts.stream().noneMatch(a -> a instanceof UrlBackedArtifactMetadata), false);
             ImmutableList<ModuleDependencyMetadata> dependencies = readDependencies(decoder, metadata, configurationMetadata, deduplicationDependencyCache);
             configurationMetadata.setDependencies(dependencies);
             configurations.put(configurationName, configurationMetadata);
@@ -200,6 +204,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
         String name = decoder.readString();
         ImmutableAttributes attributes = attributeContainerSerializer.read(decoder);
         ImmutableCapabilities immutableCapabilities = readCapabilities(decoder);
+        ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts = readFiles(decoder, resolveMetadata.getId());
         boolean transitive = decoder.readBoolean();
         boolean visible = decoder.readBoolean();
         ImmutableSet<String> hierarchy = ImmutableSet.copyOf(readStringSet(decoder));
@@ -210,10 +215,12 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
             transitive,
             visible,
             hierarchy,
-            ImmutableList.<ModuleComponentArtifactMetadata>of(),
+            artifacts,
             ImmutableList.copyOf(excludeMetadata),
             attributes,
-            immutableCapabilities
+            immutableCapabilities,
+            artifacts.stream().noneMatch(a -> a instanceof UrlBackedArtifactMetadata),
+            false
         );
         ImmutableList<ModuleDependencyMetadata> dependencies = readDependencies(decoder, resolveMetadata, realized, deduplicationDependencyCache);
         realized.setDependencies(dependencies);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -50,7 +50,6 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,11 +103,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         // Variants
         for (Map.Entry<String, DefaultVariantMetadata> entry : allVariants.entries()) {
             DefaultVariantMetadata oldVariant = entry.getValue();
-            List<LocalComponentArtifactMetadata> newArtifacts = new ArrayList<LocalComponentArtifactMetadata>(oldVariant.getArtifacts().size());
+            ImmutableList.Builder<LocalComponentArtifactMetadata> newArtifacts = new ImmutableList.Builder<>();
             for (ComponentArtifactMetadata oldArtifact : oldVariant.getArtifacts()) {
                 newArtifacts.add(copyArtifact((LocalComponentArtifactMetadata) oldArtifact, artifacts, transformedArtifacts));
             }
-            copy.allVariants.put(entry.getKey(), new DefaultVariantMetadata(oldVariant.asDescribable(), oldVariant.getAttributes(), newArtifacts, oldVariant.getCapabilities()));
+            copy.allVariants.put(entry.getKey(), new DefaultVariantMetadata(oldVariant.asDescribable(), oldVariant.getAttributes(), newArtifacts.build(), oldVariant.getCapabilities()));
         }
 
         for (DefaultLocalConfigurationMetadata configuration : allConfigurations.values()) {
@@ -145,7 +144,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
 
     @Override
     public void addVariant(String configuration, OutgoingVariant variant) {
-        List<LocalComponentArtifactMetadata> artifacts;
+        ImmutableList<LocalComponentArtifactMetadata> artifacts;
         if (variant.getArtifacts().isEmpty()) {
             artifacts = ImmutableList.of();
         } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -509,6 +509,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             return capabilities;
         }
 
+        @Override
+        public boolean requiresMavenArtifactDiscovery() {
+            return false;
+        }
+
         private boolean include(DefaultLocalConfigurationMetadata configuration) {
             return hierarchy.contains(configuration.getName());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -285,7 +285,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         private ImmutableSet<LocalFileDependencyMetadata> configurationFileDependencies;
         private ImmutableList<ExcludeMetadata> configurationExcludes;
 
-        private List<LocalComponentArtifactMetadata> configurationArtifacts;
+        private ImmutableList<LocalComponentArtifactMetadata> configurationArtifacts;
 
         protected DefaultLocalConfigurationMetadata(String name,
                                                     String description,
@@ -477,7 +477,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         }
 
         @Override
-        public List<? extends LocalComponentArtifactMetadata> getArtifacts() {
+        public ImmutableList<? extends LocalComponentArtifactMetadata> getArtifacts() {
             if (configurationArtifacts == null) {
                 if (allArtifacts.isEmpty()) {
                     configurationArtifacts = ImmutableList.of();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalConfigurationMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.local.model;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
@@ -32,7 +33,7 @@ public interface LocalConfigurationMetadata extends ConfigurationMetadata {
     List<? extends LocalOriginDependencyMetadata> getDependencies();
 
     @Override
-    List<? extends LocalComponentArtifactMetadata> getArtifacts();
+    ImmutableList<? extends LocalComponentArtifactMetadata> getArtifacts();
 
     /**
      * Returns the files attached to this configuration, if any. These should be represented as dependencies, but are currently represented as files as a migration step.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -95,7 +95,7 @@ public interface ConfigurationMetadata extends HasAttributes {
 
     /**
      * Was this variant derived from pom metadata and requires the maven mechanism of discovering artifacts
-     * that are not may not be directly defined in the metadata (e.g. the default 'jar' artifact).
+     * that may not be directly defined in the metadata (e.g. the default 'jar' artifact).
      */
     boolean requiresMavenArtifactDiscovery();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -92,4 +92,10 @@ public interface ConfigurationMetadata extends HasAttributes {
     ComponentArtifactMetadata artifact(IvyArtifactName artifact);
 
     CapabilitiesMetadata getCapabilities();
+
+    /**
+     * Was this variant derived from pom metadata and requires the maven mechanism of discovering artifacts
+     * that are not may not be directly defined in the metadata (e.g. the default 'jar' artifact).
+     */
+    boolean requiresMavenArtifactDiscovery();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -58,7 +58,7 @@ public interface ConfigurationMetadata extends HasAttributes {
     /**
      * Returns the artifacts associated with this configuration, if known.
      */
-    List<? extends ComponentArtifactMetadata> getArtifacts();
+    ImmutableList<? extends ComponentArtifactMetadata> getArtifacts();
 
     /**
      * Returns the variants of this configuration. Should include at least one value. Exactly one variant must be selected and the artifacts of that variant used.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingConfigurationMetadata.java
@@ -109,6 +109,11 @@ public class DefaultSelectedByVariantMatchingConfigurationMetadata implements Se
     }
 
     @Override
+    public boolean requiresMavenArtifactDiscovery() {
+        return delegate.requiresMavenArtifactDiscovery();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingConfigurationMetadata.java
@@ -59,7 +59,7 @@ public class DefaultSelectedByVariantMatchingConfigurationMetadata implements Se
     }
 
     @Override
-    public List<? extends ComponentArtifactMetadata> getArtifacts() {
+    public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
         return delegate.getArtifacts();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingLocalConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingLocalConfigurationMetadata.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.component.model;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
@@ -51,7 +52,7 @@ public class DefaultSelectedByVariantMatchingLocalConfigurationMetadata extends 
     }
 
     @Override
-    public List<? extends LocalComponentArtifactMetadata> getArtifacts() {
+    public ImmutableList<? extends LocalComponentArtifactMetadata> getArtifacts() {
         return delegate.getArtifacts();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultVariantMetadata.java
@@ -16,19 +16,18 @@
 
 package org.gradle.internal.component.model;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.DisplayName;
 
-import java.util.List;
-
 public class DefaultVariantMetadata implements VariantResolveMetadata {
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
-    private final List<? extends ComponentArtifactMetadata> artifacts;
+    private final ImmutableList<? extends ComponentArtifactMetadata> artifacts;
     private final CapabilitiesMetadata capabilitiesMetadata;
 
-    public DefaultVariantMetadata(DisplayName displayName, AttributeContainerInternal attributes, List<? extends ComponentArtifactMetadata> artifacts, CapabilitiesMetadata capabilitiesMetadata) {
+    public DefaultVariantMetadata(DisplayName displayName, AttributeContainerInternal attributes, ImmutableList<? extends ComponentArtifactMetadata> artifacts, CapabilitiesMetadata capabilitiesMetadata) {
         this.displayName = displayName;
         this.attributes = attributes;
         this.artifacts = artifacts;
@@ -51,7 +50,7 @@ public class DefaultVariantMetadata implements VariantResolveMetadata {
     }
 
     @Override
-    public List<? extends ComponentArtifactMetadata> getArtifacts() {
+    public ImmutableList<? extends ComponentArtifactMetadata> getArtifacts() {
         return artifacts;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ModuleConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ModuleConfigurationMetadata.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model;
+
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+
+import java.util.List;
+
+public interface ModuleConfigurationMetadata extends ConfigurationMetadata {
+
+    @Override
+    List<? extends ModuleDependencyMetadata> getDependencies();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ModuleConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ModuleConfigurationMetadata.java
@@ -20,7 +20,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 
 import java.util.List;
 
-public interface ModuleConfigurationMetadata extends ConfigurationMetadata {
+public interface ModuleConfigurationMetadata extends ConfigurationMetadata, VariantResolveMetadata {
 
     @Override
     List<? extends ModuleDependencyMetadata> getDependencies();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantFilesRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantFilesRules.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.gradle.api.artifacts.MutableVariantFilesMetadata;
+import org.gradle.api.artifacts.VariantFileMetadata;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.repositories.resolver.DefaultMutableVariantFilesMetadata;
+import org.gradle.internal.Cast;
+import org.gradle.internal.component.external.model.UrlBackedArtifactMetadata;
+import org.gradle.internal.component.external.model.VariantMetadataRules;
+
+import java.util.List;
+
+public class VariantFilesRules {
+    private final List<VariantMetadataRules.VariantAction<? super MutableVariantFilesMetadata>> actions = Lists.newLinkedList();
+
+    public void addFilesAction(VariantMetadataRules.VariantAction<? super MutableVariantFilesMetadata> action) {
+        actions.add(action);
+    }
+
+    public <T extends ComponentArtifactMetadata> ImmutableList<T> execute(VariantResolveMetadata variant, ImmutableList<T> artifacts, ModuleComponentIdentifier componentIdentifier) {
+        DefaultMutableVariantFilesMetadata filesMetadata = new DefaultMutableVariantFilesMetadata();
+        for (VariantMetadataRules.VariantAction<? super MutableVariantFilesMetadata> action : actions) {
+            action.maybeExecute(variant, filesMetadata);
+        }
+        if (filesMetadata.getFiles().isEmpty()) {
+            return artifacts;
+        }
+        ImmutableList.Builder<T> builder = new ImmutableList.Builder<>();
+        builder.addAll(artifacts);
+        for (VariantFileMetadata file : filesMetadata.getFiles()) {
+            builder.add(Cast.<T>uncheckedNonnullCast(new UrlBackedArtifactMetadata(componentIdentifier, file.getName(), file.getUrl())));
+        }
+        return builder.build();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantFilesRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantFilesRules.java
@@ -44,9 +44,11 @@ public class VariantFilesRules {
             return artifacts;
         }
         ImmutableList.Builder<T> builder = new ImmutableList.Builder<>();
-        for (T existingArtifact : artifacts) {
-            if (isFilePathUnambiguous(existingArtifact)) {
-                builder.add(existingArtifact);
+        if (!filesMetadata.isClearExistingFiles()) {
+            for (T existingArtifact : artifacts) {
+                if (isFilePathUnambiguous(existingArtifact)) {
+                    builder.add(existingArtifact);
+                }
             }
         }
         for (VariantFileMetadata file : filesMetadata.getFiles()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/VariantResolveMetadata.java
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.component.model;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.DisplayName;
-
-import java.util.List;
 
 /**
  * Metadata for a basic variant of a component, that defines only artifacts and no dependencies.
@@ -32,7 +31,7 @@ public interface VariantResolveMetadata {
 
     AttributeContainerInternal getAttributes();
 
-    List<? extends ComponentArtifactMetadata> getArtifacts();
+    ImmutableList<? extends ComponentArtifactMetadata> getArtifacts();
 
     CapabilitiesMetadata getCapabilities();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.ComponentArtifacts
 import org.gradle.internal.component.model.ComponentOverrideMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
+import org.gradle.internal.component.model.ConfigurationMetadata
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactSetResolveResult
@@ -147,17 +148,18 @@ class CachingModuleComponentRepositoryTest extends Specification {
 
     def "does not use cache when component artifacts can be determined locally"() {
         def component = Mock(ComponentResolveMetadata)
+        def variant = Mock(ConfigurationMetadata)
         def source = Mock(ModuleSource)
         def cachingSource = new CachingModuleComponentRepository.CachingModuleSource(BigInteger.ONE, false, source)
         def result = new DefaultBuildableComponentArtifactsResolveResult()
 
         when:
-        repo.localAccess.resolveArtifacts(component, result)
+        repo.localAccess.resolveArtifacts(component, variant, result)
 
         then:
         1 * component.getSource() >> cachingSource
         1 * component.withSource(source) >> component
-        realLocalAccess.resolveArtifacts(component, result) >> {
+        realLocalAccess.resolveArtifacts(component, variant, result) >> {
             result.resolved(Stub(ComponentArtifacts))
         }
         0 * _

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolverTest.groovy
@@ -71,8 +71,8 @@ class RepositoryChainArtifactResolverTest extends Specification {
         1 * component.withSource(originalSource) >> component
         1 * repo2.artifactCache >> [:]
         1 * repo2.getLocalAccess() >> localAccess2
-        1 * localAccess2.resolveArtifacts(component, _) >> {
-            it[1].resolved(artifacts)
+        1 * localAccess2.resolveArtifacts(component, configuration, _) >> {
+            it[2].resolved(artifacts)
         }
         1 * artifacts.getArtifactsFor(component, configuration, resolver, [:], artifactTypeRegistry, exclusion, ImmutableAttributes.EMPTY) >> artifactSet
         0 * _._
@@ -96,10 +96,10 @@ class RepositoryChainArtifactResolverTest extends Specification {
         1 * component.withSource(originalSource) >> component
         1 * repo2.artifactCache >> [:]
         1 * repo2.getLocalAccess() >> localAccess2
-        1 * localAccess2.resolveArtifacts(component, _)
+        1 * localAccess2.resolveArtifacts(component, configuration, _)
         1 * repo2.getRemoteAccess() >> remoteAccess2
-        1 * remoteAccess2.resolveArtifacts(component, _) >> {
-            it[1].resolved(artifacts)
+        1 * remoteAccess2.resolveArtifacts(component, configuration, _) >> {
+            it[2].resolved(artifacts)
         }
         1 * artifacts.getArtifactsFor(component, configuration, resolver, [:], artifactTypeRegistry, exclusion, ImmutableAttributes.EMPTY) >> artifactSet
         0 * _._

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
@@ -28,11 +28,11 @@ import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransp
 import org.gradle.internal.action.ConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
-import org.gradle.internal.component.external.model.ComponentVariant
 import org.gradle.internal.component.external.model.FixedComponentArtifacts
 import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata
 import org.gradle.internal.component.external.model.MetadataSourcedComponentArtifacts
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
+import org.gradle.internal.component.model.ConfigurationMetadata
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult
 import org.gradle.internal.resource.local.FileResourceRepository
@@ -43,6 +43,7 @@ import spock.lang.Specification
 
 class MavenResolverTest extends Specification {
     def module = Mock(MavenModuleResolveMetadata)
+    def variant = Mock(ConfigurationMetadata)
     def result = Mock(BuildableComponentArtifactsResolveResult)
     def resolver = resolver()
 
@@ -51,12 +52,12 @@ class MavenResolverTest extends Specification {
         resolver.toString() == "Maven repository 'repo'"
     }
 
-    def "uses variant metadata when present"() {
+    def "uses artifacts from variant metadata"() {
         given:
-        module.variants >> ImmutableList.of(Stub(ComponentVariant))
+        variant.requiresMavenArtifactDiscovery() >> false
 
         when:
-        resolver.getLocalAccess().resolveModuleArtifacts(module, result)
+        resolver.getLocalAccess().resolveModuleArtifacts(module, variant, result)
 
         then:
         1 * result.resolved(_) >> { args ->
@@ -68,9 +69,10 @@ class MavenResolverTest extends Specification {
         given:
         module.variants >> ImmutableList.of()
         module.relocated >> true
+        variant.requiresMavenArtifactDiscovery() >> true
 
         when:
-        resolver.getLocalAccess().resolveModuleArtifacts(module, result)
+        resolver.getLocalAccess().resolveModuleArtifacts(module, variant, result)
 
         then:
         1 * result.resolved(_) >> { args ->
@@ -85,9 +87,10 @@ class MavenResolverTest extends Specification {
         module.knownJarPackaging >> true
         ModuleComponentArtifactMetadata artifact = Mock(ModuleComponentArtifactMetadata)
         module.artifact('jar', 'jar', null) >> artifact
+        variant.requiresMavenArtifactDiscovery() >> true
 
         when:
-        resolver.getLocalAccess().resolveModuleArtifacts(module, result)
+        resolver.getLocalAccess().resolveModuleArtifacts(module, variant, result)
 
         then:
         1 * result.resolved(_) >> { args ->

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
@@ -25,6 +25,7 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactIdent
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -69,7 +70,7 @@ public class TestResolver extends ExternalResourceResolver<ModuleComponentResolv
     public ModuleComponentRepositoryAccess getRemoteAccess() {
         return new RemoteRepositoryAccess() {
             @Override
-            protected void resolveModuleArtifacts(ModuleComponentResolveMetadata module, BuildableComponentArtifactsResolveResult result) {
+            protected void resolveModuleArtifacts(ModuleComponentResolveMetadata module, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
                 throw new UnsupportedOperationException();
             }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.type
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.CollectionCallbackActionDecorator
@@ -66,7 +67,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
         given:
         variant.attributes >> attrs
-        variant.artifacts >> []
+        variant.artifacts >> ImmutableList.of()
 
         expect:
         registry.mapAttributesFor(variant) == attrs
@@ -81,7 +82,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
         given:
         variant.attributes >> attrs
-        variant.artifacts >> [artifact]
+        variant.artifacts >> ImmutableList.of(artifact)
         artifact.name >> artifactName
         artifactName.extension >> "jar"
         artifactName.type >> "jar"
@@ -101,7 +102,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
         given:
         variant.attributes >> attrs
-        variant.artifacts >> [artifact]
+        variant.artifacts >> ImmutableList.of(artifact)
         artifact.name >> artifactName
         artifactName.extension >> "jar"
         artifactName.type >> "jar"
@@ -121,7 +122,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
         given:
         variant.attributes >> attrs
-        variant.artifacts >> [artifact]
+        variant.artifacts >> ImmutableList.of(artifact)
         artifact.name >> artifactName
         artifactName.extension >> "jar"
         artifactName.type >> "jar"
@@ -142,7 +143,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
         given:
         variant.attributes >> attrs
-        variant.artifacts >> [artifact1, artifact2]
+        variant.artifacts >> ImmutableList.of(artifact1, artifact2)
         artifact1.name >> artifactName1
         artifactName1.extension >> "jar"
         artifactName1.type >> "jar"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
@@ -48,12 +48,12 @@ import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.ConfigurationMetadata
 import org.gradle.internal.component.model.ConfigurationNotFoundException
 import org.gradle.internal.component.model.Exclude
-import org.gradle.internal.component.model.ExcludeMetadata 
+import org.gradle.internal.component.model.ExcludeMetadata
 
 class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
     final ModuleExclusions moduleExclusions = new ModuleExclusions()
     final ExcludeSpec nothing = moduleExclusions.nothing()
-    
+
     @Override
     ExternalDependencyDescriptor create(ModuleComponentSelector selector) {
         return mavenDependencyMetadata(MavenScope.Compile, selector, [])
@@ -92,7 +92,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         fromCompile.name >> "compile"
         toComponent.getConfiguration("compile") >> toCompile
         toComponent.getConfiguration("master") >> toMaster
-        toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
+        toMaster.artifacts >> ImmutableList.of(ComponentArtifactMetadata)
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
@@ -113,7 +113,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("runtime") >> toRuntime
         toComponent.getConfiguration("compile") >> toCompile
         toComponent.getConfiguration("master") >> toMaster
-        toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
+        toMaster.artifacts >> ImmutableList.of(ComponentArtifactMetadata)
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
@@ -134,7 +134,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("runtime") >> toRuntime
         toComponent.getConfiguration("master") >> toMaster
         toRuntime.hierarchy >> ImmutableSet.of("runtime", "compile")
-        toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
+        toMaster.artifacts >> ImmutableList.of(ComponentArtifactMetadata)
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
@@ -165,6 +165,8 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromRuntime = Stub(ConfigurationMetadata)
         def toRuntime = Stub(ConfigurationMetadata)
         def toMaster = Stub(ConfigurationMetadata)
+        toRuntime.artifacts >> ImmutableList.of()
+        toMaster.artifacts >> ImmutableList.of()
         fromRuntime.name >> "runtime"
         toComponent.getConfiguration("runtime") >> toRuntime
         toComponent.getConfiguration("master") >> toMaster
@@ -186,7 +188,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("compile") >> null
         toComponent.getConfiguration("default") >> toDefault
         toComponent.getConfiguration("master") >> toMaster
-        toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
+        toMaster.artifacts >> ImmutableList.of(ComponentArtifactMetadata)
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
@@ -205,7 +207,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("default") >> toDefault
         toComponent.getConfiguration("master") >> toMaster
         toDefault.hierarchy >> ImmutableSet.of("compile", "default")
-        toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
+        toMaster.artifacts >> ImmutableList.of(ComponentArtifactMetadata)
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model
+
+import com.google.common.collect.ImmutableListMultimap
+import org.gradle.api.Action
+import org.gradle.api.artifacts.MutableVariantFilesMetadata
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.component.external.descriptor.Artifact
+import org.gradle.internal.component.external.descriptor.Configuration
+import org.gradle.internal.component.external.descriptor.MavenScope
+import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyType
+import org.gradle.internal.component.model.ComponentAttributeMatcher
+import org.gradle.internal.component.model.DefaultIvyArtifactName
+import org.gradle.internal.component.model.LocalComponentDependencyMetadata
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.SnapshotTestUtil
+import org.gradle.util.TestUtil
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
+
+class VariantFilesMetadataRulesTest extends Specification {
+    @Shared versionIdentifier = new DefaultModuleVersionIdentifier("org.test", "producer", "1.0")
+    @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
+    @Shared attributes = AttributeTestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
+    @Shared schema = createSchema()
+    @Shared mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
+    @Shared ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
+    @Shared defaultVariant
+
+    private DefaultAttributesSchema createSchema() {
+        def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.valueSnapshotter())
+        JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
+        DependencyManagementTestUtil.platformSupport().configureSchema(schema)
+        schema
+    }
+
+    private ivyComponentMetadata(String[] deps) {
+        def dependencies = deps.collect { name ->
+            new IvyDependencyDescriptor(newSelector(DefaultModuleIdentifier.newId('org.test', name), '1.0'), ImmutableListMultimap.of('runtime', 'runtime'))
+        }
+        def runtimeConf = new Configuration('runtime', true, true, [])
+        def defaultConf = new Configuration('default', true, true, ['runtime'])
+        def artifact = new Artifact(new DefaultIvyArtifactName('producer', 'jar', 'jar'), ['runtime'] as Set)
+        ivyMetadataFactory.create(componentIdentifier, dependencies, [defaultConf, runtimeConf], [artifact], [])
+    }
+
+    private mavenComponentMetadata(String[] deps) {
+        def dependencies = deps.collect { name ->
+            new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.DEPENDENCY, newSelector(DefaultModuleIdentifier.newId("org.test", name), "1.0"), null, [])
+        }
+        def metadata = mavenMetadataFactory.create(componentIdentifier, dependencies)
+        metadata.getVariantMetadataRules().setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy())
+        metadata
+    }
+
+    private gradleComponentMetadata(String[] deps) {
+        def metadata = mavenMetadataFactory.create(componentIdentifier)
+        defaultVariant = metadata.addVariant("runtime", attributes)
+        deps.each { name ->
+            defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY, [], false)
+        }
+        defaultVariant.addFile("producer-1.0.jar", "producer-1.0.jar")
+        metadata
+    }
+
+    @Unroll
+    def "variant file metadata rules are evaluated once and lazily for #metadataType metadata"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        metadata.getVariantMetadataRules().addVariantFilesAction(new VariantMetadataRules.VariantAction<MutableVariantFilesMetadata>({ true }, rule))
+        def variant = selectTargetConfigurationMetadata(metadata)
+
+        then:
+        0 * rule.execute(_)
+        when:
+        variant.artifacts
+
+        then:
+        1 * rule.execute(_)
+
+        when:
+        variant.artifacts
+        variant.artifacts
+        variant.artifacts
+
+        then:
+        0 * rule.execute(_)
+
+        where:
+        metadataType | metadata
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    @Unroll
+    def "variant file metadata rules are not evaluated if their variant is not selected for #metadataType metadata"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        metadata.getVariantMetadataRules().addVariantFilesAction(new VariantMetadataRules.VariantAction<MutableVariantFilesMetadata>({ false }, rule))
+        selectTargetConfigurationMetadata(metadata).artifacts
+
+        then:
+        0 * rule.execute(_)
+
+        where:
+        metadataType | metadata
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    @Unroll
+    def "new variant can be added to #metadataType metadata"() {
+        when:
+        metadata.getVariantMetadataRules().addVariant("new-variant", "runtime")
+        def immutableMetadata = metadata.asImmutable()
+        def variants = immutableMetadata.variantsForGraphTraversal.get()
+        def baseVariant = variants.find { it.name == 'runtime' }
+        if (metadataType == "ivy") {
+            // no variants are derived for plain ivy, but we can use a ivy configuration
+            baseVariant = immutableMetadata.getConfiguration('runtime')
+        }
+
+        then:
+        variants.size() == initialVariantCount + 1
+        variants.last().name == 'new-variant'
+        variants.last().attributes == baseVariant.attributes
+        variants.last().capabilities == baseVariant.capabilities
+        variants.last().dependencies == baseVariant.dependencies
+        variants.last().artifacts.empty
+
+        where:
+        metadataType | metadata                       | initialVariantCount
+        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
+        "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
+    }
+
+    @Unroll
+    def "new variant can be added to #metadataType metadata without base"() {
+        when:
+        metadata.getVariantMetadataRules().addVariant("new-variant", "not-exist")
+        def immutableMetadata = metadata.asImmutable()
+        def variants = immutableMetadata.variantsForGraphTraversal.get()
+
+        then:
+        variants.size() == initialVariantCount + 1
+        variants.last().name == 'new-variant'
+        variants.last().attributes == immutableMetadata.attributes
+        variants.last().capabilities == ImmutableCapabilities.EMPTY
+        variants.last().dependencies == []
+        variants.last().artifacts.empty
+
+        where:
+        metadataType | metadata                       | initialVariantCount
+        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
+        "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
+    }
+
+    @Unroll
+    def "variant file metadata rules can add files to #metadataType metadata"() {
+        given:
+        def rule = { MutableVariantFilesMetadata files ->
+            files.addFile("added1.zip")
+            files.addFile("added2", "../path.jar")
+        }
+
+        when:
+        metadata.getVariantMetadataRules().addVariantFilesAction(new VariantMetadataRules.VariantAction<MutableVariantFilesMetadata>({ true }, rule))
+        def artifacts = selectTargetConfigurationMetadata(metadata).artifacts
+
+        then:
+        println(artifacts)
+        artifacts.size() == 3
+        artifacts[0].id.toString() == 'producer-1.0.jar (org.test:producer:1.0)'
+        artifacts[1].id.toString() == 'added1.zip (org.test:producer:1.0)'
+        artifacts[2].id.toString() == 'added2 (org.test:producer:1.0)'
+
+        artifacts[1].relativeUrl == 'added1.zip'
+        artifacts[2].relativeUrl == '../path.jar'
+
+        metadataType == "gradle" ? artifacts[0] instanceof UrlBackedArtifactMetadata : artifacts[0] instanceof DefaultModuleComponentArtifactMetadata
+        artifacts[1] instanceof UrlBackedArtifactMetadata
+        artifacts[2] instanceof UrlBackedArtifactMetadata
+
+        where:
+        metadataType | metadata
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
+    }
+
+    def selectTargetConfigurationMetadata(MutableModuleComponentResolveMetadata targetComponent) {
+        selectTargetConfigurationMetadata(targetComponent.asImmutable())
+    }
+
+    def selectTargetConfigurationMetadata(ModuleComponentResolveMetadata immutable) {
+        def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
+        def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
+        def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
+
+        consumer.selectConfigurations(attributes, immutable, schema, [] as Set)[0]
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -85,7 +85,7 @@ class VariantFilesMetadataRulesTest extends Specification {
         def metadata = mavenMetadataFactory.create(componentIdentifier)
         defaultVariant = metadata.addVariant("runtime", attributes)
         deps.each { name ->
-            defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY, [], false)
+            defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY, [], false, null)
         }
         defaultVariant.addFile("producer-1.0.jar", "producer-1.0.jar")
         metadata
@@ -190,6 +190,39 @@ class VariantFilesMetadataRulesTest extends Specification {
         "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
         "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
         "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
+    }
+
+    @Unroll
+    def "base variant metadata rules are not evaluated if the new variant is not selected for #metadataType metadata"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        metadata.variantMetadataRules.addVariant('new-variant', 'runtime')
+        metadata.variantMetadataRules.addVariantFilesAction(new VariantMetadataRules.VariantAction<MutableVariantFilesMetadata>({ true }, rule))
+        def newVariant =  metadata.asImmutable().variantsForGraphTraversal.get().find { it.name == 'new-variant' }
+
+        then:
+        0 * rule.execute(_)
+        when:
+        newVariant.artifacts
+
+        then:
+        2 * rule.execute(_)
+
+        when:
+        newVariant.artifacts
+        newVariant.artifacts
+        newVariant.artifacts
+
+        then:
+        0 * rule.execute(_)
+
+        where:
+        metadataType | metadata
+        "maven"      | mavenComponentMetadata()
+        "ivy"        | ivyComponentMetadata()
+        "gradle"     | gradleComponentMetadata()
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
@@ -301,12 +301,8 @@ All of them match the consumer attributes:
         def variant2 = variant("second", ImmutableAttributes.EMPTY)
 
         given:
-        variant1.getArtifacts() >> [
-                artifact('foo', null)
-        ]
-        variant2.getArtifacts() >> [
-                artifact('foo', 'classy')
-        ]
+        variant1.getArtifacts() >> ImmutableList.of(artifact('foo', null))
+        variant2.getArtifacts() >> ImmutableList.of(artifact('foo', 'classy'))
         component(variant1, variant2)
 
         and:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -369,7 +369,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     IvyFileModule publish() {
         moduleDir.createDir()
 
-        if (artifacts.empty) {
+        if (artifacts.findAll { !it.undeclared }.empty) {
             artifact([:])
         }
 
@@ -408,7 +408,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     }
 
     private void publishModuleMetadata() {
-        def defaultArtifacts = artifacts.collect { moduleArtifact(it) }.collect {
+        def defaultArtifacts = artifacts.findAll {!it.undeclared}.collect { moduleArtifact(it) }.collect {
             new FileSpec(it.file.name, it.file.name)
         }
         GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(organisation, module, revision,


### PR DESCRIPTION
This change allows to write component metadata rules for adding variants that are not (yet) published. This is, for example, useful when a consumed module is only published with `pom` metadata but actually provides additional variants through _classified jars_ (which are not mentioned in the pom metadata).
Using rules, consumers can then still use variant aware dependency management to consume those variants. For example, to select the right java target variant from all dependencies:
```
configurations {
  compileClasspath {
    // we want Java 8 compatibility
    attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
  }
}
dependencies {
  components.withModule("com.conversantmedia:disruptor") { // should match more modules that offer a '-jdk8.jar'
    withVariant("compile") {
      attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11) }
    }
    addVariant("jdk8", "compile") { // add a new variant based on 'compile' (everything except for the artifacts is copied)
      attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8) }
      withFiles { addFile("${id.name}-${id.version}-jdk8.jar") }
    }
  }
}
```

Limits/specifics of the implementation:
1. Artifacts can only be added but not inspected or removed. This is, because working with existing artifacts is not straight forward. We can have a mix of "traditional" artifacts which are defined in terms of _name_ + _classifier_ + _extension/type_ + _repository pattern_ and variant files which are defined through a _file name_ and a _relative url_. I think inspection and removing is not necessarily needed, because there are no good use cases for that. 
2. If you add an artifact to a variant that was derived from a maven pom, "maven artifact discovery" will be disabled for that variant. E.g. we won't search anymore for a "jar" artifact in addition to the packaging indicated in the pom. This is fine, because once you start defining additional artifacts directly, you can define all of them artifacts directly.
2. When a new variant is defined, a base (existing variant or _ivy_ configuration) can be chosen. Then dependencies, attributes and capabilities of that variant will be copied to the new one. This seems like a practical approach to me, because most use cases (like the one above) are about defining a variant for another artifact but with almost the same attributes and dependencies as the "main" variant.
