### PR TITLE
Update performance tests template to not use deprecated configurations

### DIFF
--- a/subprojects/build-scan-performance/src/templates/project-with-source/build.gradle
+++ b/subprojects/build-scan-performance/src/templates/project-with-source/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 <% if (binding.hasVariable("projectDependencies")) { %>
     configurations {
-        compile.extendsFrom projectsConfiguration
+        implementation.extendsFrom projectsConfiguration
     }
 <% } %>
 
@@ -51,16 +51,16 @@ if(Boolean.getBoolean("slowTasks")) {
 }
 
 dependencies {
-    compile 'commons-lang:commons-lang:2.5'
-    compile "commons-httpclient:commons-httpclient:3.0"
-    compile "commons-codec:commons-codec:1.2"
-    compile "org.slf4j:jcl-over-slf4j:1.7.10"
-    compile "org.codehaus.groovy:groovy:2.4.10"
-    testCompile 'junit:junit:4.12'
-    runtime 'com.googlecode:reflectasm:1.01'
+    implementation 'commons-lang:commons-lang:2.5'
+    implementation "commons-httpclient:commons-httpclient:3.0"
+    implementation "commons-codec:commons-codec:1.2"
+    implementation "org.slf4j:jcl-over-slf4j:1.7.10"
+    implementation "org.codehaus.groovy:groovy:2.4.10"
+    testImplementation 'junit:junit:4.12'
+    runtimeOnly 'com.googlecode:reflectasm:1.01'
 
     <% if (dependencies) { dependencies.each { %>
-    compile "${it.shortNotation()}" <% } %>
+        implementation "${it.shortNotation()}" <% } %>
     <% } %>
     <% if (binding.hasVariable("projectDependencies") && subprojectNumber > 1) { (1..<subprojectNumber).each { %>
         projectsConfiguration project(":project${it}") <% } %>


### PR DESCRIPTION
### Context
After deprecating configurations we see failing performance tests as the scan plugin started capturing lots of deprecation events.

We updated the template to use only non deprecated api. 

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
