### PR TITLE
Upgrade ktlint-convention plugin to the latest

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,7 +22,7 @@ import java.util.Properties
 plugins {
     `java`
     `kotlin-dsl` apply false
-    id("org.gradle.kotlin-dsl.ktlint-convention") version "0.3.0" apply false
+    id("org.gradle.kotlin-dsl.ktlint-convention") version "0.4.1" apply false
 }
 
 subprojects {

--- a/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     api(kotlin("reflect"))
     api(kotlin("compiler-embeddable"))
 
-    implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.3.0")
+    implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.4.1")
     implementation("com.gradle.publish:plugin-publish-plugin:0.10.0")
 
     implementation("com.thoughtworks.qdox:qdox:2.0-M9")

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -20,7 +20,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
         withBuildScript("""
             plugins {
                 `kotlin-dsl`
-                id("org.gradle.kotlin-dsl.ktlint-convention") version "0.3.0"
+                id("org.gradle.kotlin-dsl.ktlint-convention") version "0.4.1"
             }
 
             $repositoriesBlock
@@ -41,8 +41,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
         build("generateScriptPluginAdapters")
 
-        executer.expectDeprecationWarning()
-        build("ktlintC")
+        build("ktlintCheck", "-x", "ktlintKotlinScriptCheck")
     }
 
     @Test

--- a/subprojects/kotlin-dsl-provider-plugins/kotlin-dsl-provider-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-provider-plugins/kotlin-dsl-provider-plugins.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(futureKotlin("scripting-compiler-impl-embeddable")) {
         isTransitive = false
     }
-    
+
     implementation(library("slf4j_api"))
 
     testImplementation(project(":kotlinDslTestFixtures"))

--- a/subprojects/kotlin-dsl-test-fixtures/kotlin-dsl-test-fixtures.gradle.kts
+++ b/subprojects/kotlin-dsl-test-fixtures/kotlin-dsl-test-fixtures.gradle.kts
@@ -28,7 +28,7 @@ gradlebuildJava {
 
 dependencies {
     api(project(":kotlinDsl"))
-    
+
     implementation(project(":baseServices"))
     implementation(project(":coreApi"))
     implementation(project(":core"))

--- a/subprojects/kotlin-dsl-tooling-builders/kotlin-dsl-tooling-builders.gradle.kts
+++ b/subprojects/kotlin-dsl-tooling-builders/kotlin-dsl-tooling-builders.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
     crossVersionTestImplementation(library("ant"))
     crossVersionTestRuntimeOnly(project(":pluginDevelopment"))
     crossVersionTestRuntimeOnly(project(":runtimeApiInfo"))
-
 }
 
 tasks {

--- a/subprojects/soak/soak.gradle.kts
+++ b/subprojects/soak/soak.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     integTestImplementation(project(":launcher"))
     integTestImplementation(library("slf4j_api"))
     integTestImplementation(testLibrary("jetty"))
-    
+
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }
 


### PR DESCRIPTION
bringing `ktlint-gradle` 0.8.2 that fixed Gradle deprecation warnings.