### PR TITLE
Workaround "peer not authenticated" problem on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 jdk: openjdk11
+env:		
+    global:		
+        - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2
 install: ./gradlew --version
 script: ./gradlew --continue --init-script gradle/init-scripts/public-build-scan.init.gradle.kts sanityCheck
 if: pull_request AND head_repo != gradle/gradle


### PR DESCRIPTION
### Context

- Travis builds for PRs have been failing with error message "peer not
authenticated"
- example build failure:
   - https://travis-ci.org/gradle/gradle/builds/577338997
   - https://ge-unstable.grdev.net/s/w66wvl42h457g
- source of workaround:
    https://github.com/bsideup/liiklus/blob/22efb7049ebcdd0dcf6f7f5735cdb5af1ae014de/.travis.yml#L9-L11
    mentioned in https://github.com/jitpack/jitpack.io/issues/3581

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
