### PR TITLE
Synchronize log events from worker processes

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessFactory.java
@@ -70,12 +70,12 @@ public class DefaultWorkerProcessFactory implements WorkerProcessFactory {
 
     @Override
     public <P> SingleRequestWorkerProcessBuilder<P> singleRequestWorker(Class<P> protocolType, Class<? extends P> workerImplementation) {
-        return new DefaultSingleRequestWorkerProcessBuilder<P>(protocolType, workerImplementation, newWorkerProcessBuilder());
+        return new DefaultSingleRequestWorkerProcessBuilder<P>(protocolType, workerImplementation, newWorkerProcessBuilder(), outputEventListener);
     }
 
     @Override
     public <P, W extends P> MultiRequestWorkerProcessBuilder<W> multiRequestWorker(Class<W> workerType, Class<P> protocolType, Class<? extends P> workerImplementation) {
-        return new DefaultMultiRequestWorkerProcessBuilder<W>(workerType, workerImplementation, newWorkerProcessBuilder());
+        return new DefaultMultiRequestWorkerProcessBuilder<W>(workerType, workerImplementation, newWorkerProcessBuilder(), outputEventListener);
     }
 
     private DefaultWorkerProcessBuilder newWorkerProcessBuilder() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/Receiver.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/Receiver.java
@@ -18,20 +18,23 @@ package org.gradle.process.internal.worker.request;
 
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.dispatch.StreamCompletion;
+import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.remote.internal.hub.StreamFailureHandler;
+import org.gradle.process.internal.worker.DefaultWorkerLoggingProtocol;
 import org.gradle.process.internal.worker.WorkerProcessException;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-public class Receiver implements ResponseProtocol, StreamCompletion, StreamFailureHandler {
+public class Receiver extends DefaultWorkerLoggingProtocol implements ResponseProtocol, StreamCompletion, StreamFailureHandler {
     private static final Object NULL = new Object();
     private static final Object END = new Object();
     private final BlockingQueue<Object> received = new ArrayBlockingQueue<Object>(10);
     private final String baseName;
     private Object next;
 
-    public Receiver(String baseName) {
+    public Receiver(String baseName, OutputEventListener outputEventListener) {
+        super(outputEventListener);
         this.baseName = baseName;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/ResponseProtocol.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/ResponseProtocol.java
@@ -16,7 +16,9 @@
 
 package org.gradle.process.internal.worker.request;
 
-public interface ResponseProtocol {
+import org.gradle.process.internal.worker.child.WorkerLoggingProtocol;
+
+public interface ResponseProtocol extends WorkerLoggingProtocol {
     void completed(Object result);
 
     // Called when the method throws an exception

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -30,17 +30,20 @@ import org.gradle.internal.remote.internal.hub.StreamFailureHandler;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.process.internal.worker.WorkerProcessContext;
+import org.gradle.process.internal.worker.child.WorkerLogEventListener;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 
 public class WorkerAction implements Action<WorkerProcessContext>, Serializable, RequestProtocol, StreamFailureHandler, Stoppable, StreamCompletion {
     private final String workerImplementationName;
     private transient CountDownLatch completed;
     private transient ResponseProtocol responder;
+    private transient WorkerLogEventListener workerLogEventListener;
     private transient Throwable failure;
     private transient Class<?> workerImplementation;
     private transient Object implementation;
@@ -73,6 +76,7 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
         ObjectConnection connection = workerProcessContext.getServerConnection();
         connection.addIncoming(RequestProtocol.class, this);
         responder = connection.addOutgoing(ResponseProtocol.class);
+        workerLogEventListener = workerProcessContext.getServiceRegistry().get(WorkerLogEventListener.class);
         connection.connect();
 
         try {
@@ -115,7 +119,16 @@ public class WorkerAction implements Action<WorkerProcessContext>, Serializable,
             CurrentBuildOperationRef.instance().set(request.getBuildOperation());
             Object result;
             try {
-                result = method.invoke(implementation, request.getArgs());
+                // We want to use the responder as the logging protocol object here because log messages from the
+                // action will have the build operation associated.  By using the responder, we ensure that all
+                // messages arrive on the same incoming queue in the build process and the completed message will only
+                // arrive after all log messages have been processed.
+                result = workerLogEventListener.withWorkerLoggingProtocol(responder, new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return method.invoke(implementation, request.getArgs());
+                    }
+                });
             } catch (InvocationTargetException e) {
                 Throwable failure = e.getCause();
                 if (failure instanceof NoClassDefFoundError) {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLoggingIntegrationTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import spock.lang.Issue
+
+class WorkerDaemonLoggingIntegrationTest extends AbstractDaemonWorkerExecutorIntegrationSpec {
+    def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    @Issue("https://github.com/gradle/gradle/issues/10122")
+    def "can log many messages from action in a worker daemon"() {
+        def workActionThatProducesLotsOfOutput = fixture.getWorkActionThatCreatesFiles("LotsOfOutputWorkAction")
+        workActionThatProducesLotsOfOutput.with {
+            action += """
+                1000.times {
+                    println "foo!"
+                }
+            """
+        }
+
+        fixture.withWorkActionClassInBuildScript()
+        workActionThatProducesLotsOfOutput.writeToBuildFile()
+        buildFile << """
+            task runInWorker(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+                workActionClass = ${workActionThatProducesLotsOfOutput.name}.class
+            }
+        """
+
+        expect:
+        succeeds("runInWorker")
+
+        and:
+        def operation = buildOperations.only(ExecuteWorkItemBuildOperationType)
+        operation.displayName == "LotsOfOutputWorkAction"
+        with (operation.details) {
+            className == "LotsOfOutputWorkAction"
+            displayName == "LotsOfOutputWorkAction"
+        }
+
+        and:
+        operation.progress.size() == 1000
+    }
+}

--- a/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/WorkerLogEventListenerTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/WorkerLogEventListenerTest.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal.worker.child
+
+import org.gradle.internal.logging.events.LogEvent
+import org.gradle.internal.logging.events.StyledTextOutputEvent
+import spock.lang.Specification
+
+class WorkerLogEventListenerTest extends Specification {
+    WorkerLogEventListener listener = new WorkerLogEventListener()
+
+    def "listener forwards requests to the configured logging protocol object"() {
+        given:
+        def protocol = Mock(WorkerLoggingProtocol)
+        def logEvent = Mock(LogEvent)
+        def styledTextOutputEvent = Mock(StyledTextOutputEvent)
+        listener.setWorkerLoggingProtocol(protocol)
+
+        when:
+        listener.onOutput(logEvent)
+
+        then:
+        1 * protocol.sendOutputEvent(logEvent)
+
+        when:
+        listener.onOutput(styledTextOutputEvent)
+
+        then:
+        1 * protocol.sendOutputEvent(styledTextOutputEvent)
+    }
+
+    def "can forward events to a different logging protocol object temporarily"() {
+        given:
+        def protocol1 = Mock(WorkerLoggingProtocol)
+        def protocol2 = Mock(WorkerLoggingProtocol)
+        listener.setWorkerLoggingProtocol(protocol1)
+        def logEvent1 = Mock(LogEvent)
+        def logEvent2 = Mock(LogEvent)
+        def logEvent3 = Mock(StyledTextOutputEvent)
+        def logEvent4 = Mock(LogEvent)
+
+        when:
+        listener.onOutput(logEvent1)
+        listener.withWorkerLoggingProtocol(protocol2) {
+            listener.onOutput(logEvent2)
+            listener.onOutput(logEvent3)
+        }
+        listener.onOutput(logEvent4)
+
+        then:
+        1 * protocol1.sendOutputEvent(logEvent1)
+        1 * protocol2.sendOutputEvent(logEvent2)
+        1 * protocol2.sendOutputEvent(logEvent3)
+        1 * protocol1.sendOutputEvent(logEvent4)
+    }
+
+    def "cannot send events to listener before logging protocol is set"() {
+        given:
+        def logEvent = Mock(LogEvent)
+        def protocol = Mock(WorkerLoggingProtocol)
+
+        when:
+        listener.onOutput(logEvent)
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        listener.setWorkerLoggingProtocol(protocol)
+        listener.onOutput(logEvent)
+
+        then:
+        1 * protocol.sendOutputEvent(logEvent)
+
+        and:
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
Fixes #10122 

This addresses the problem by processing log event messages that occur inside the boundary of the request/response through the same incoming queue (`ResponseProtocol`), ensuring that all messages will arrive and be processed in the order that they are produced in the worker process.