### PR TITLE
Simplify `EnumCodec.decode` and `readEnum`

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
@@ -341,4 +341,4 @@ fun <E : Enum<E>> WriteContext.writeEnum(value: E) {
 
 
 inline fun <reified E : Enum<E>> ReadContext.readEnum(): E =
-    readSmallInt().let { ordinal -> enumValues<E>().first { it.ordinal == ordinal } }
+    readSmallInt().let { ordinal -> enumValues<E>()[ordinal] }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/EnumCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/EnumCodec.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
-import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
 
@@ -29,9 +28,7 @@ object EnumCodec : EncodingProducer, Decoding {
     override suspend fun ReadContext.decode(): Any? {
         val enumClass = readClass()
         val enumOrdinal = readSmallInt()
-        return enumClass.enumConstants.uncheckedCast<Array<Enum<*>>>().first {
-            it.ordinal == enumOrdinal
-        }
+        return enumClass.enumConstants[enumOrdinal]
     }
 }
 


### PR DESCRIPTION
Taking advantage of the fact that `ordinal` represents the position of the enum constant in `enumConstants`.