### PR TITLE
Remove unnecessary `ExtensionAwareDependencyHandlerScope` class

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -37,12 +37,7 @@ private constructor(
 
     companion object {
         fun of(dependencies: DependencyHandler): DependencyHandlerScope =
-            ExtensionAwareDependencyHandlerScope(dependencies)
-
-        private
-        class ExtensionAwareDependencyHandlerScope(
-            dependencies: DependencyHandler
-        ) : DependencyHandlerScope(dependencies)
+            DependencyHandlerScope(dependencies)
     }
 
     override val delegate: DependencyHandler


### PR DESCRIPTION
Signed-off-by: Rodrigo B. de Oliveira <rodrigo@gradle.com>