### PR TITLE
Set Kotlin JVM target to `1.8` across the board

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/KotlinCompilerConfiguration.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/KotlinCompilerConfiguration.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JvmAnalysisFlags
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -39,6 +40,7 @@ fun KotlinCompile.configureKotlinCompilerForGradleBuild() {
             "-Xskip-runtime-version-check",
             "-progressive"
         )
+        jvmTarget = "1.8"
     }
 }
 
@@ -54,4 +56,5 @@ fun CompilerConfiguration.configureKotlinCompilerForGradleBuild() {
 
     put(JVMConfigurationKeys.PARAMETERS_METADATA, true)
     put(JVMConfigurationKeys.SKIP_RUNTIME_VERSION_CHECK, true)
+    put(JVMConfigurationKeys.JVM_TARGET, JvmTarget.JVM_1_8)
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -129,7 +129,6 @@ fun compileKotlinScriptModuleTo(
         withCompilationExceptionHandler(messageCollector) {
 
             val configuration = compilerConfigurationFor(messageCollector).apply {
-                put(JVM_TARGET, JVM_1_8)
                 put(RETAIN_OUTPUT_IN_MEMORY, false)
                 put(OUTPUT_DIRECTORY, outputDirectory)
                 setModuleName(moduleName)
@@ -300,6 +299,7 @@ fun compilerConfigurationFor(messageCollector: MessageCollector): CompilerConfig
     CompilerConfiguration().apply {
         put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
         put(JVMConfigurationKeys.USE_FAST_CLASS_FILES_READING, true)
+        put(JVM_TARGET, JVM_1_8)
         put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettings)
     }
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -64,7 +64,7 @@ class GradleApiExtensionsTest : TestWithClassPath() {
             ClassAndGroovyNamedArguments::class
         ) {
 
-            assertGeneratedJarHash("d0536e6bf6c8a8fd6c8363e664cd0407")
+            assertGeneratedJarHash("f327e4f70a6ee2c5171fe1b77345bc94")
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Rodrigo B. de Oliveira <rodrigo@gradle.com>