### PR TITLE
Refine Kotlin Gradle Plugin smoke tests

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -76,8 +76,7 @@ abstract class AbstractSmokeTest extends Specification {
         // https://developer.android.com/studio/releases/build-tools
         static androidTools = "28.0.3"
         // https://developer.android.com/studio/releases/gradle-plugin
-        static androidGradle3x = "3.3.2"
-        static androidGradle = Versions.of("3.2.1", androidGradle3x, "3.4.2", "3.5.0")
+        static androidGradle = Versions.of("3.2.1", "3.3.2", "3.4.2", "3.5.0")
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
         static kotlin = Versions.of('1.3.31', '1.3.41', '1.3.50')
@@ -127,7 +126,8 @@ abstract class AbstractSmokeTest extends Specification {
 
     private static final String INIT_SCRIPT_LOCATION = "org.gradle.smoketests.init.script"
 
-    @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+    @Rule
+    final TemporaryFolder testProjectDir = new TemporaryFolder()
     File buildFile
 
     File settingsFile

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -159,7 +159,7 @@ abstract class AbstractSmokeTest extends Specification {
             .withTestKitDir(IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
             .withProjectDir(testProjectDir.root)
             .withArguments(tasks.toList() + ['-s'] + repoMirrorParameters()) as DefaultGradleRunner
-        gradleRunner.withJvmArguments("-Xmx8g", "-XX:MaxMetaspaceSize=768m", "-XX:+HeapDumpOnOutOfMemoryError")
+        gradleRunner.withJvmArguments("-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError")
     }
 
     private static List<String> repoMirrorParameters() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -79,7 +79,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of("3.2.1", "3.3.2", "3.4.2", "3.5.0")
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of('1.3.20', '1.3.21', '1.3.31', '1.3.41', '1.3.50')
+        static kotlin = Versions.of('1.3.21', '1.3.31', '1.3.41', '1.3.50')
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = "2.3.1"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -76,7 +76,7 @@ abstract class AbstractSmokeTest extends Specification {
         // https://developer.android.com/studio/releases/build-tools
         static androidTools = "28.0.3"
         // https://developer.android.com/studio/releases/gradle-plugin
-        static androidGradle = Versions.of("3.2.1", "3.3.2", "3.4.2", "3.5.0")
+        static androidGradle = Versions.of("3.2.1", "3.3.2", "3.4.2", "3.5.0", "3.6.0-alpha09")
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
         static kotlin = Versions.of('1.3.21', '1.3.31', '1.3.41', '1.3.50')

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -79,7 +79,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of("3.2.1", "3.3.2", "3.4.2", "3.5.0")
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of('1.3.31', '1.3.41', '1.3.50')
+        static kotlin = Versions.of('1.3.20', '1.3.21', '1.3.31', '1.3.41', '1.3.50')
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = "2.3.1"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -41,12 +41,12 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
-    def 'kotlin android #androidPluginVersion plugin'() {
+    def 'kotlin #kotlinPluginVersion android #androidPluginVersion plugins'() {
         given:
         AndroidHome.assertIsSet()
         useSample("android-kotlin-example")
         replaceVariablesInBuildFile(
-            kotlinVersion: TestedVersions.kotlin.latest(),
+            kotlinVersion: kotlinPluginVersion,
             androidPluginVersion: androidPluginVersion,
             androidBuildToolsVersion: TestedVersions.androidTools)
 
@@ -57,7 +57,8 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
         build.task(':testDebugUnitTestCoverage').outcome == SUCCESS
 
         where:
-        androidPluginVersion << TestedVersions.androidGradle
+        androidPluginVersion << TestedVersions.androidGradle * TestedVersions.kotlin.size()
+        kotlinPluginVersion << TestedVersions.kotlin * TestedVersions.androidGradle.size()
     }
 
     @Unroll


### PR DESCRIPTION
By restoring coverage for supported KGP 1.3.20 and testing the matrix of supported KGP and AGP versions.