### PR TITLE
Add detection of long command line on Windows

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal.util;
+
+import org.gradle.internal.os.OperatingSystem;
+
+import java.util.List;
+
+public class LongCommandLineDetectionUtil {
+    // See http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
+    public static final int ARG_MAX_WINDOWS = 32767; // in chars
+    private static final String WINDOWS_LONG_COMMAND_EXCEPTION_MESSAGE = "The filename or extension is too long";
+
+    private static int getMaxCommandLineLength() {
+        if (OperatingSystem.current().isWindows()) {
+            return ARG_MAX_WINDOWS;
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    public static boolean hasCommandLineExceedMaxLength(String command, List<String> arguments) {
+        int commandLineLength = command.length() + arguments.stream().map(String::length).reduce(Integer::sum).orElse(0) + arguments.size();
+        return commandLineLength > getMaxCommandLineLength();
+    }
+
+    public static boolean hasCommandLineExceedMaxLengthException(Throwable failureCause) {
+        Throwable cause = failureCause;
+        do {
+            if (cause.getMessage().contains(WINDOWS_LONG_COMMAND_EXCEPTION_MESSAGE)) {
+                return true;
+            }
+        } while ((cause = cause.getCause()) != null);
+
+        return false;
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -18,7 +18,12 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Issue
+
+import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.ARG_MAX_WINDOWS
+import static org.gradle.util.Matchers.containsText
 
 class JavaExecIntegrationTest extends AbstractIntegrationSpec {
 
@@ -229,6 +234,45 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         then:
         executedAndNotSkipped ":run"
         outputFile.text == "different"
+    }
+
+    @Requires(TestPrecondition.NOT_WINDOWS)
+    def "does not suggest long command line failures when execution fails on non-Windows system"() {
+        buildFile << """
+            run.classpath += project.files('${'a' * ARG_MAX_WINDOWS}')
+            run.executable 'some-java'
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("A problem occurred starting process"))
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "can suggest long command line failures when execution fails for long command line on Windows system"() {
+        buildFile << """
+            run.classpath += project.files('${'a' * ARG_MAX_WINDOWS}')
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
+    }
+
+    def "does not suggest long command line failures when execution fails for short command line"() {
+        buildFile << """
+            run.executable 'some-java'
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("A problem occurred starting process"))
     }
 
     private void assertOutputFileIs(String text) {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
See https://github.com/gradle/gradle/issues/10114

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Improve the error message when detecting the path may be too long.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fdetect-long-command-and-fail)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
