### PR TITLE
Use environment variable to shorten the command line path

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -21,6 +21,8 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
@@ -37,10 +39,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
+import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasCommandLineExceedMaxLength;
+import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasEnvironmentVariableExceedMaxLength;
+
 /**
  * Use {@link JavaExecHandleFactory} instead.
  */
 public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements JavaExecSpec {
+    private static final Logger LOGGER = Logging.getLogger(JavaExecHandleBuilder.class);
     private final FileCollectionFactory fileCollectionFactory;
     private String mainClass;
     private final List<Object> applicationArgs = new ArrayList<Object>();
@@ -53,6 +59,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
         this.fileCollectionFactory = fileCollectionFactory;
         this.javaOptions = javaForkOptionsFactory.newJavaForkOptions();
         executable(javaOptions.getExecutable());
+
     }
 
     @Override
@@ -296,6 +303,61 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
             Iterables.addAll(arguments, argumentProvider.asArguments());
         }
         return arguments;
+    }
+
+    @Override
+    protected ArgsEnvironment getEffectiveArgsEnvironment() {
+        List<String> arguments = getAllArguments();
+        Map<String, String> environment = getActualEnvironment();
+
+        if (hasCommandLineExceedMaxLength(getExecutable(), arguments)) {
+            if (shouldUseEnvironmentVariable(arguments, environment)) {
+                int classPathFlagIndex = arguments.indexOf("-cp");
+                environment.put("CLASSPATH", arguments.get(classPathFlagIndex + 1));
+                arguments.remove(classPathFlagIndex);
+                arguments.remove(classPathFlagIndex);
+            }
+        }
+
+        return new ArgsEnvironment(arguments, environment);
+    }
+
+    private boolean shouldUseEnvironmentVariable(List<String> arguments, Map<String, String> environment) {
+        int classPathFlagIndex = arguments.indexOf("-cp");
+        if (classPathFlagIndex == -1) {
+            // No class path flag, so we can't use CLASSPATH
+            LOGGER.info("No class path flag found in the command line, Gradle cannot shorten the command line");
+            return false;
+        }
+
+        if (hasEnvironmentVariableExceedMaxLength(arguments.get(classPathFlagIndex + 1))) {
+            // Class path is exceeding the maximum environment variable value length
+            LOGGER.info("Class path size is exceeding the maximum environment variable length, CLASSPATH variable cannot be used for shortening the command line");
+            return false;
+        }
+
+        if (System.getenv().containsKey("CLASSPATH")) {
+            if (environment.containsKey("CLASSPATH")) {
+                // Only if the CLASSPATH wasn't overwritten in the JavaExecSpec
+                if (System.getenv().get("CLASSPATH").equals(environment.get("CLASSPATH"))) {
+                    return true;
+                }
+                LOGGER.info("CLASSPATH environment variable was explicitly overwritten, Gradle cannot shorten the command line");
+                return false;
+            }
+            // The CLASSPATH was explicitly cleared
+            LOGGER.info("CLASSPATH environment variable was explicitly cleared, Gradle cannot shorten the command line");
+            return false;
+        }
+
+        if (environment.containsKey("CLASSPATH")) {
+            // The CLASSPATH was explicitly defined
+            LOGGER.info("CLASSPATH environment variable was explicitly defined, Gradle cannot shorten the command line");
+            return false;
+        }
+
+        // The CLASSPATH wasn't declared or inherited
+        return true;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class LongCommandLineDetectionUtil {
     // See http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
     public static final int ARG_MAX_WINDOWS = 32767; // in chars
+    public static final int ENVIRONMENT_VARIABLE_MAX_STRING_LENGTH = 32767; // in chars
     private static final String WINDOWS_LONG_COMMAND_EXCEPTION_MESSAGE = "The filename or extension is too long";
 
     private static int getMaxCommandLineLength() {
@@ -46,5 +47,16 @@ public class LongCommandLineDetectionUtil {
         } while ((cause = cause.getCause()) != null);
 
         return false;
+    }
+
+    private static int getMaxEnvironmentVariableLength() {
+        if (OperatingSystem.current().isWindows()) {
+            return ENVIRONMENT_VARIABLE_MAX_STRING_LENGTH;
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    public static boolean hasEnvironmentVariableExceedMaxLength(String value) {
+        return value.length() > getMaxCommandLineLength();
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -18,12 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import spock.lang.Issue
-
-import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.ARG_MAX_WINDOWS
-import static org.gradle.util.Matchers.containsText
 
 class JavaExecIntegrationTest extends AbstractIntegrationSpec {
 
@@ -234,45 +229,6 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         then:
         executedAndNotSkipped ":run"
         outputFile.text == "different"
-    }
-
-    @Requires(TestPrecondition.NOT_WINDOWS)
-    def "does not suggest long command line failures when execution fails on non-Windows system"() {
-        buildFile << """
-            run.classpath += project.files('${'a' * ARG_MAX_WINDOWS}')
-            run.executable 'some-java'
-        """
-
-        when:
-        def failure = fails("run")
-
-        then:
-        failure.assertThatCause(containsText("A problem occurred starting process"))
-    }
-
-    @Requires(TestPrecondition.WINDOWS)
-    def "can suggest long command line failures when execution fails for long command line on Windows system"() {
-        buildFile << """
-            run.classpath += project.files('${'a' * ARG_MAX_WINDOWS}')
-        """
-
-        when:
-        def failure = fails("run")
-
-        then:
-        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
-    }
-
-    def "does not suggest long command line failures when execution fails for short command line"() {
-        buildFile << """
-            run.executable 'some-java'
-        """
-
-        when:
-        def failure = fails("run")
-
-        then:
-        failure.assertThatCause(containsText("A problem occurred starting process"))
     }
 
     private void assertOutputFileIs(String text) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWIthLongCommandLineIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWIthLongCommandLineIntegrationTest.groovy
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.ARG_MAX_WINDOWS
+import static org.gradle.util.Matchers.containsText
+
+class JavaExecWIthLongCommandLineIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        file("src/main/java/Driver.java").text = """
+            package driver;
+
+            import java.io.*;
+            import java.lang.System;
+
+            public class Driver {
+                public static void main(String[] args) {
+                    try {
+                        FileWriter out = new FileWriter("out.txt");
+                        out.write(System.getenv("CLASSPATH"));
+                        out.write("\\n");
+                        out.close();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        """
+
+        buildFile.text = """
+            apply plugin: "java"
+
+            task run(type: JavaExec) {
+                classpath = project.layout.files(compileJava)
+                main "driver.Driver"
+                args "1"
+            }
+        """
+    }
+
+    @Requires(TestPrecondition.NOT_WINDOWS)
+    def "does not suggest long command line failures when execution fails on non-Windows system"() {
+        buildFile << """
+            run.classpath += project.files('${'a' * ARG_MAX_WINDOWS}')
+            run.executable 'some-java'
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("A problem occurred starting process"))
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "can suggest long command line failures when execution fails for long command line on Windows system"() {
+        buildFile << """
+            run.classpath += project.files('${'a' * ARG_MAX_WINDOWS}')
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
+    }
+
+    def "does not suggest long command line failures when execution fails for short command line"() {
+        buildFile << """
+            run.executable 'some-java'
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("A problem occurred starting process"))
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "succeeds when long classpath fit inside environment variable"() {
+        def fileName = 'a' * (ARG_MAX_WINDOWS / 2)
+        buildFile << """
+            run.classpath += project.files('${fileName}')
+            run.args '${fileName}'
+        """
+
+        when:
+        succeeds("run")
+
+        then:
+        executedAndNotSkipped(":run")
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "fails when long classpath fit inside environment variable but CLASSPATH was explicitly defined (no inheritance)"() {
+        def fileName = 'a' * (ARG_MAX_WINDOWS / 2)
+        buildFile << """
+            run.classpath += project.files('${fileName}')
+            run.args '${fileName}'
+            run.environment('CLASSPATH', 'some-classpath-from-task')
+        """
+
+        when:
+        executer.withEnvironmentVars([:]) // Currently this has no effect because the gradle[w].bat script leaks a CLASSPATH environment variable, see https://github.com/gradle/gradle/issues/10463
+        def failure = fails("run", "-i")
+
+        then:
+        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
+        failure.assertOutputContains("CLASSPATH environment variable was explicitly overwritten, Gradle cannot shorten the command line")
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "fails when long classpath fit inside environment variable but CLASSPATH was explicitly overwritten"() {
+        def fileName = 'a' * (ARG_MAX_WINDOWS / 2)
+        buildFile << """
+            run.classpath += project.files('${fileName}')
+            run.args '${fileName}'
+            run.environment('CLASSPATH', 'some-classpath-from-task')
+        """
+
+        when:
+        executer.withEnvironmentVars([CLASSPATH: 'some-classpath'])
+        def failure = fails("run", "-i")
+
+        then:
+        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
+        failure.assertOutputContains("CLASSPATH environment variable was explicitly overwritten, Gradle cannot shorten the command line")
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "fails when long classpath fit inside environment variable but CLASSPATH was explicitly cleared"() {
+        def fileName = 'a' * (ARG_MAX_WINDOWS / 2)
+        buildFile << """
+            run.classpath += project.files('${fileName}')
+            run.args '${fileName}'
+            def newEnvironment = run.environment
+            newEnvironment.remove('CLASSPATH')
+            run.environment = newEnvironment
+        """
+
+        when:
+        executer.withEnvironmentVars([CLASSPATH: 'some-classpath'])
+        def failure = fails("run", "-i")
+
+        then:
+        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
+        failure.assertOutputContains("CLASSPATH environment variable was explicitly cleared, Gradle cannot shorten the command line")
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "succeeds when long classpath fit inside environment variable and CLASSPATH was inherited"() {
+        def fileName = 'a' * (ARG_MAX_WINDOWS / 2)
+        buildFile << """
+            run.classpath += project.files('${fileName}')
+            run.args '${fileName}'
+        """
+
+        when:
+        executer.withEnvironmentVars([CLASSPATH: 'some-classpath'])
+        succeeds("run")
+
+        then:
+        executedAndNotSkipped(":run")
+        assertOutputFileIs("${file('build/classes/java/main')};${file('build/generated/sources/annotationProcessor/java/main')};${testDirectory.absolutePath}\\${fileName}\n")
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "fails when long classpath exceed environment variable value length"() {
+        buildFile << """
+            run.classpath += project.files('${'a' * ((ARG_MAX_WINDOWS / 2) * 3)}')
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
+    }
+
+    private void assertOutputFileIs(String text) {
+        assert file("out.txt").text == text
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
See https://github.com/gradle/gradle/issues/10114

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flong-command%2Fuse-environment-variable)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
