### PR TITLE
Simplify `DefaultClassLoaderCache`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -101,16 +101,12 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
                     effectiveExportClassLoader = loader(id.exportId(), parent.getExportClassLoader(), export, exportLoaders);
                     effectiveLocalClassLoader = localLoader(id.localId(), effectiveExportClassLoader, local);
                 } else if (hasLocals) {
-                    classLoaderCache.remove(id.exportId());
                     effectiveExportClassLoader = parent.getExportClassLoader();
                     effectiveLocalClassLoader = localLoader(id.localId(), effectiveExportClassLoader, local);
                 } else if (hasExports) {
-                    classLoaderCache.remove(id.localId());
                     effectiveExportClassLoader = loader(id.exportId(), parent.getExportClassLoader(), export, exportLoaders);
                     effectiveLocalClassLoader = effectiveExportClassLoader;
                 } else {
-                    classLoaderCache.remove(id.localId());
-                    classLoaderCache.remove(id.exportId());
                     effectiveLocalClassLoader = parent.getExportClassLoader();
                     effectiveExportClassLoader = parent.getExportClassLoader();
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
@@ -55,9 +55,4 @@ public interface ClassLoaderCache {
      * @return the classloader.
      */
     <T extends ClassLoader> T put(ClassLoaderId id, T classLoader);
-
-    /**
-     * Discards the given classloader.
-     */
-    void remove(ClassLoaderId id);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
@@ -322,13 +322,13 @@ class DefaultClassLoaderScopeTest extends Specification {
         root.createChild("d").lock().exportClassLoader
 
         then:
-        classLoaderCache.size() == 1
+        classLoaderCache.size() == 3
 
         when:
         root.createChild("c").lock().exportClassLoader
 
         then:
-        classLoaderCache.size() == 0
+        classLoaderCache.size() == 3
     }
 
     static ClassLoader isolatedLoader(File... paths) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
@@ -39,8 +39,4 @@ public class DummyClassLoaderCache implements ClassLoaderCache {
     public <T extends ClassLoader> T put(ClassLoaderId id, T classLoader) {
         return classLoader;
     }
-
-    @Override
-    public void remove(ClassLoaderId id) {
-    }
 }


### PR DESCRIPTION

### Context

Simplify `DefaultClassLoaderCache` to use the same caching strategy as other cross build caches, retaining soft or weak references to values used in earlier builds.

Remove the `ClassLoaderCache.remove()` method, as it is not necessary.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
