### PR TITLE
Improve performance reading from instant execution cache

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -54,6 +54,13 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
         this.secondaryInputsHash = hashSecondaryInputs(isolatableParameters, implementationClass, classLoaderHierarchyHasher);
     }
 
+    public LegacyTransformer(Class<? extends ArtifactTransform> implementationClass, Isolatable<Object[]> isolatableParameters, HashCode secondaryInputsHash, InstantiationScheme actionInstantiationScheme, ImmutableAttributes fromAttributes) {
+        super(implementationClass, fromAttributes);
+        this.instantiator = actionInstantiationScheme.instantiator();
+        this.secondaryInputsHash = secondaryInputsHash;
+        this.isolatableParameters = isolatableParameters;
+    }
+
     @Override
     public boolean requiresDependencies() {
         return false;
@@ -67,6 +74,14 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
     @Override
     public boolean isCacheable() {
         return false;
+    }
+
+    public HashCode getSecondaryInputsHash() {
+        return secondaryInputsHash;
+    }
+
+    public Isolatable<Object[]> getIsolatableParameters() {
+        return isolatableParameters;
     }
 
     @Override

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":modelCore"))
     implementation(project(":fileCollections"))
     implementation(project(":dependencyManagement"))
+    implementation(project(":persistentCache"))
     // TODO - move the isolatable serializer to model-core to live with the isolatable infrastructure
     implementation(project(":workers"))
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -23,6 +23,7 @@ import org.gradle.initialization.InstantExecution
 import org.gradle.instantexecution.serialization.DefaultReadContext
 import org.gradle.instantexecution.serialization.DefaultWriteContext
 import org.gradle.instantexecution.serialization.IsolateOwner
+import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.instantexecution.serialization.codecs.BuildOperationListenersCodec
 import org.gradle.instantexecution.serialization.codecs.Codecs
 import org.gradle.instantexecution.serialization.codecs.WorkNodeCodec
@@ -51,7 +52,8 @@ import kotlin.coroutines.startCoroutine
 
 class DefaultInstantExecution internal constructor(
     private val host: Host,
-    private val scopeRegistryListener: InstantExecutionClassLoaderScopeRegistryListener
+    private val scopeRegistryListener: InstantExecutionClassLoaderScopeRegistryListener,
+    private val beanConstructors: BeanConstructors
 ) : InstantExecution {
 
     interface Host {
@@ -203,6 +205,7 @@ class DefaultInstantExecution internal constructor(
     fun readContextFor(decoder: KryoBackedDecoder) = DefaultReadContext(
         codecs.userTypesCodec,
         decoder,
+        beanConstructors,
         logger
     )
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionServices.kt
@@ -16,11 +16,17 @@
 
 package org.gradle.instantexecution
 
+import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry
 
 
 class InstantExecutionServices : AbstractPluginServiceRegistry() {
+    override fun registerGlobalServices(registration: ServiceRegistration) {
+        registration.run {
+            add(BeanConstructors::class.java)
+        }
+    }
 
     override fun registerBuildServices(registration: ServiceRegistration) {
         registration.run {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -21,6 +21,7 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.logging.Logger
 import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.instantexecution.ClassLoaderScopeSpec
+import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.instantexecution.serialization.beans.BeanPropertyWriter
 import org.gradle.instantexecution.serialization.beans.BeanStateReader
@@ -142,6 +143,9 @@ class DefaultReadContext(
     private
     val decoder: Decoder,
 
+    private
+    val constructors: BeanConstructors,
+
     override val logger: Logger
 ) : AbstractIsolateContext<ReadIsolate>(codec), ReadContext, Decoder by decoder {
 
@@ -181,7 +185,7 @@ class DefaultReadContext(
         get() = getIsolate()
 
     override fun beanStateReaderFor(beanType: Class<*>): BeanStateReader =
-        beanStateReaders.computeIfAbsent(beanType) { type -> BeanPropertyReader(type) }
+        beanStateReaders.computeIfAbsent(beanType) { type -> BeanPropertyReader(type, constructors) }
 
     override fun readClass(): Class<*> {
         val id = readSmallInt()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanConstructors.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanConstructors.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.beans
+
+import groovy.lang.GroovyObjectSupport
+import org.gradle.cache.internal.CrossBuildInMemoryCache
+import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory
+import sun.reflect.ReflectionFactory
+import java.lang.reflect.Constructor
+
+
+/**
+ * A global service that caches the serialization constructors for bean types.
+ */
+class BeanConstructors(
+    cacheFactory: CrossBuildInMemoryCacheFactory
+) {
+    private
+    val cache: CrossBuildInMemoryCache<Class<*>, Constructor<out Any>> = cacheFactory.newClassCache()
+
+    fun constructorForSerialization(beanType: Class<*>): Constructor<out Any> {
+        return cache.get(beanType) { type -> createConstructor(type) }
+    }
+
+    private
+    fun createConstructor(beanType: Class<*>): Constructor<out Any> {
+        // Initialize the super types of the bean type, as this does not seem to happen via the generated constructors
+        maybeInit(beanType)
+        if (GroovyObjectSupport::class.java.isAssignableFrom(beanType)) {
+            // Run the `GroovyObjectSupport` constructor, to initialize the metadata field
+            return newConstructorForSerialization(beanType, GroovyObjectSupport::class.java.getConstructor())
+        } else {
+            return newConstructorForSerialization(beanType, Object::class.java.getConstructor())
+        }
+    }
+
+    private
+    fun maybeInit(beanType: Class<*>) {
+        val superclass = beanType.superclass
+        if (superclass?.classLoader != null) {
+            Class.forName(superclass.name, true, superclass.classLoader)
+            maybeInit(superclass)
+        }
+    }
+
+    // TODO: What about the runtime decorations a serialized bean might have had at configuration time?
+    private
+    fun newConstructorForSerialization(beanType: Class<*>, constructor: Constructor<*>): Constructor<out Any> =
+        ReflectionFactory.getReflectionFactory().newConstructorForSerialization(beanType, constructor)
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -36,18 +36,16 @@ class BeanPropertyWriter(
 ) : BeanStateWriter {
 
     private
-    val relevantFields = relevantStateOf(beanType).toList()
+    val relevantFields = relevantStateOf(beanType)
 
     /**
      * Serializes a bean by serializing the value of each of its fields.
      */
     override suspend fun WriteContext.writeStateOf(bean: Any) {
-        writingProperties {
-            for (field in relevantFields) {
-                val fieldName = field.name
-                val fieldValue = valueOrConvention(field.get(bean), bean, fieldName)
-                writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
-            }
+        for (field in relevantFields) {
+            val fieldName = field.name
+            val fieldValue = valueOrConvention(field.get(bean), bean, fieldName)
+            writeNextProperty(fieldName, fieldValue, PropertyKind.Field)
         }
     }
 
@@ -85,7 +83,6 @@ class BeanPropertyWriter(
  */
 suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: PropertyKind): Boolean {
     withPropertyTrace(kind, name) {
-        writeString(name)
         try {
             write(value)
         } catch (passThrough: IOException) {
@@ -107,13 +104,3 @@ suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: Prop
 
 private
 fun unpackedTypeNameOf(value: Any) = GeneratedSubclasses.unpackType(value).name
-
-
-/**
- * Ensures a sequence of [writeNextProperty] calls is properly terminated
- * by the end marker (empty String) so that it can be read by [readEachProperty].
- */
-inline fun WriteContext.writingProperties(block: () -> Unit) {
-    block()
-    writeString("")
-}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanSchema.kt
@@ -26,8 +26,9 @@ import java.lang.reflect.Modifier
 
 
 internal
-fun relevantStateOf(taskType: Class<*>): Sequence<Field> =
+fun relevantStateOf(taskType: Class<*>): List<Field> =
     relevantTypeHierarchyOf(taskType)
+        .toList()
         .flatMap(Class<*>::relevantFields)
         .onEach(Field::makeAccessible)
 
@@ -60,8 +61,8 @@ val irrelevantDeclaringClasses = setOf(
 
 
 private
-val Class<*>.relevantFields: Sequence<Field>
-    get() = declaredFields.asSequence()
+val Class<*>.relevantFields: List<Field>
+    get() = declaredFields.toList()
         .filterNot { field ->
             Modifier.isStatic(field.modifiers)
                 || Modifier.isTransient(field.modifiers)
@@ -71,6 +72,7 @@ val Class<*>.relevantFields: Sequence<Field>
         .filter { field ->
             field.declaringClass != AbstractTask::class.java || field.name == "actions"
         }
+        .sortedBy { it.name }
 
 
 internal

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValueCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValueCodec.kt
@@ -19,20 +19,40 @@ package org.gradle.instantexecution.serialization.codecs
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
-import org.gradle.internal.serialize.Message
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
 
 
 object BrokenValueCodec : Codec<BrokenValue> {
     override suspend fun WriteContext.encode(value: BrokenValue) {
-        val outstream = ByteArrayOutputStream()
-        Message.send(value.failure, outstream)
-        writeBinary(outstream.toByteArray())
+        maybeEncode(value.failure.cause)
+        writeNullableString(value.failure.message)
     }
 
-    override suspend fun ReadContext.decode(): BrokenValue? {
-        val exception = Message.receive(ByteArrayInputStream(readBinary()), classLoader) as Throwable
+    private
+    fun WriteContext.maybeEncode(failure: Throwable?) {
+        if (failure == null) {
+            writeBoolean(false)
+        } else {
+            writeBoolean(true)
+            maybeEncode(failure.cause)
+            writeNullableString(failure.message)
+        }
+    }
+
+    override suspend fun ReadContext.decode(): BrokenValue {
+        val cause = maybeDecode()
+        val message = readNullableString()
+        val exception = RuntimeException(message, cause)
         return BrokenValue(exception)
+    }
+
+    private
+    fun ReadContext.maybeDecode(): Throwable? {
+        if (readBoolean()) {
+            val cause = maybeDecode()
+            val message = readNullableString()
+            return RuntimeException(message, cause)
+        } else {
+            return null
+        }
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -198,7 +198,7 @@ class Codecs(
         bind(ResolvableArtifactCodec)
         bind(TransformationStepCodec(projectStateRegistry, fingerprinterRegistry, projectFinder))
         bind(DefaultTransformerCodec(buildOperationExecutor, classLoaderHierarchyHasher, isolatableFactory, valueSnapshotter, fileCollectionFactory, fileLookup, fileCollectionFingerprinterRegistry, isolatableSerializerRegistry, parameterScheme, actionScheme))
-        bind(LegacyTransformerCodec(classLoaderHierarchyHasher, isolatableFactory, actionScheme))
+        bind(LegacyTransformerCodec(actionScheme))
         bind(ExecutionGraphDependenciesResolverCodec)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/TaskNodeCodec.kt
@@ -24,6 +24,7 @@ import org.gradle.api.internal.TaskInputsInternal
 import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.internal.provider.Providers
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType
 import org.gradle.api.internal.tasks.properties.InputParameterUtils
 import org.gradle.api.internal.tasks.properties.OutputFilePropertyType
@@ -43,12 +44,13 @@ import org.gradle.instantexecution.serialization.PropertyTrace
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.beans.BeanPropertyWriter
-import org.gradle.instantexecution.serialization.beans.readEachProperty
+import org.gradle.instantexecution.serialization.beans.readPropertyValue
 import org.gradle.instantexecution.serialization.beans.writeNextProperty
-import org.gradle.instantexecution.serialization.beans.writingProperties
+import org.gradle.instantexecution.serialization.readCollection
 import org.gradle.instantexecution.serialization.readEnum
 import org.gradle.instantexecution.serialization.withIsolate
 import org.gradle.instantexecution.serialization.withPropertyTrace
+import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.instantexecution.serialization.writeEnum
 import org.gradle.util.DeferredUtil
 
@@ -170,9 +172,7 @@ suspend fun WriteContext.writeRegisteredPropertiesOf(
 ) = propertyWriter.run {
 
     suspend fun writeProperty(propertyName: String, propertyValue: Any?, kind: PropertyKind): Boolean {
-        if (propertyValue == null) {
-            return false
-        }
+        writeString(propertyName)
         return writeNextProperty(propertyName, propertyValue, kind)
     }
 
@@ -182,42 +182,38 @@ suspend fun WriteContext.writeRegisteredPropertiesOf(
     suspend fun writeOutputProperty(propertyName: String, propertyValue: Any?): Boolean =
         writeProperty(propertyName, propertyValue, PropertyKind.OutputProperty)
 
-    writingProperties {
-        val properties = collectRegisteredInputsOf(task)
-        properties.forEach { property ->
-            property.run {
-                when (this) {
-                    is RegisteredProperty.InputFile -> {
-                        val finalValue = DeferredUtil.unpack(propertyValue)
-                        if (writeInputProperty(propertyName, finalValue)) {
-                            writeBoolean(optional)
-                            writeBoolean(true)
-                            writeEnum(filePropertyType)
-                            writeBoolean(skipWhenEmpty)
-                            writeClass(fileNormalizer!!)
-                        }
+    val inputProperties = collectRegisteredInputsOf(task)
+    writeCollection(inputProperties) { property ->
+        property.run {
+            when (this) {
+                is RegisteredProperty.InputFile -> {
+                    val finalValue = DeferredUtil.unpack(propertyValue)
+                    if (writeInputProperty(propertyName, finalValue)) {
+                        writeBoolean(optional)
+                        writeBoolean(true)
+                        writeEnum(filePropertyType)
+                        writeBoolean(skipWhenEmpty)
+                        writeClass(fileNormalizer!!)
                     }
-                    is RegisteredProperty.Input -> {
-                        val finalValue = InputParameterUtils.prepareInputParameterValue(propertyValue)
-                        if (writeInputProperty(propertyName, finalValue)) {
-                            writeBoolean(optional)
-                            writeBoolean(false)
-                        }
+                }
+                is RegisteredProperty.Input -> {
+                    val finalValue = InputParameterUtils.prepareInputParameterValue(propertyValue)
+                    if (writeInputProperty(propertyName, finalValue)) {
+                        writeBoolean(optional)
+                        writeBoolean(false)
                     }
                 }
             }
         }
     }
 
-    writingProperties {
-        val properties = collectRegisteredOutputsOf(task)
-        properties.forEach {
-            it.run {
-                val finalValue = DeferredUtil.unpack(propertyValue)
-                if (writeOutputProperty(propertyName, finalValue)) {
-                    writeBoolean(optional)
-                    writeEnum(filePropertyType)
-                }
+    val outputProperties = collectRegisteredOutputsOf(task)
+    writeCollection(outputProperties) { property ->
+        property.run {
+            val finalValue = DeferredUtil.unpack(propertyValue)
+            if (writeOutputProperty(propertyName, finalValue)) {
+                writeBoolean(optional)
+                writeEnum(filePropertyType)
             }
         }
     }
@@ -307,53 +303,61 @@ suspend fun ReadContext.readRegisteredPropertiesOf(task: Task) {
 
 private
 suspend fun ReadContext.readInputPropertiesOf(task: Task) =
-    readEachProperty(PropertyKind.InputProperty) { propertyName, propertyValue ->
-        val optional = readBoolean()
-        val isFileInputProperty = readBoolean()
-        require(propertyValue != null)
-        when {
-            isFileInputProperty -> {
-                val filePropertyType = readEnum<InputFilePropertyType>()
-                val skipWhenEmpty = readBoolean()
-                val normalizer = readClass()
-                task.inputs.run {
-                    when (filePropertyType) {
-                        InputFilePropertyType.FILE -> file(propertyValue)
-                        InputFilePropertyType.DIRECTORY -> dir(propertyValue)
-                        InputFilePropertyType.FILES -> files(propertyValue)
+    readCollection {
+        val propertyName = readString()
+        readPropertyValue(PropertyKind.InputProperty, propertyName) { propertyValue ->
+            val optional = readBoolean()
+            val isFileInputProperty = readBoolean()
+            when {
+                isFileInputProperty -> {
+                    val filePropertyType = readEnum<InputFilePropertyType>()
+                    val skipWhenEmpty = readBoolean()
+                    val normalizer = readClass()
+                    task.inputs.run {
+                        when (filePropertyType) {
+                            InputFilePropertyType.FILE -> file(pack(propertyValue))
+                            InputFilePropertyType.DIRECTORY -> dir(pack(propertyValue))
+                            InputFilePropertyType.FILES -> files(pack(propertyValue))
+                        }
+                    }.run {
+                        withPropertyName(propertyName)
+                        optional(optional)
+                        skipWhenEmpty(skipWhenEmpty)
+                        withNormalizer(normalizer.uncheckedCast())
                     }
-                }.run {
-                    withPropertyName(propertyName)
-                    optional(optional)
-                    skipWhenEmpty(skipWhenEmpty)
-                    withNormalizer(normalizer.uncheckedCast())
                 }
-            }
-            else -> {
-                task.inputs
-                    .property(propertyName, propertyValue)
-                    .optional(optional)
+                else -> {
+                    task.inputs
+                        .property(propertyName, propertyValue)
+                        .optional(optional)
+                }
             }
         }
     }
 
 
 private
+fun pack(value: Any?) = value ?: Providers.notDefined<Any>()
+
+
+private
 suspend fun ReadContext.readOutputPropertiesOf(task: Task) =
-    readEachProperty(PropertyKind.OutputProperty) { propertyName, propertyValue ->
-        val optional = readBoolean()
-        val filePropertyType = readEnum<OutputFilePropertyType>()
-        require(propertyValue != null)
-        task.outputs.run {
-            when (filePropertyType) {
-                OutputFilePropertyType.DIRECTORY -> dir(propertyValue)
-                OutputFilePropertyType.DIRECTORIES -> dirs(propertyValue)
-                OutputFilePropertyType.FILE -> file(propertyValue)
-                OutputFilePropertyType.FILES -> files(propertyValue)
+    readCollection {
+        val propertyName = readString()
+        readPropertyValue(PropertyKind.OutputProperty, propertyName) { propertyValue ->
+            val optional = readBoolean()
+            val filePropertyType = readEnum<OutputFilePropertyType>()
+            task.outputs.run {
+                when (filePropertyType) {
+                    OutputFilePropertyType.DIRECTORY -> dir(pack(propertyValue))
+                    OutputFilePropertyType.DIRECTORIES -> dirs(pack(propertyValue))
+                    OutputFilePropertyType.FILE -> file(pack(propertyValue))
+                    OutputFilePropertyType.FILES -> files(pack(propertyValue))
+                }
+            }.run {
+                withPropertyName(propertyName)
+                optional(optional)
             }
-        }.run {
-            withPropertyName(propertyName)
-            optional(optional)
         }
     }
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -19,6 +19,7 @@ package org.gradle.instantexecution.serialization.codecs
 import com.nhaarman.mockitokotlin2.mock
 
 import org.gradle.api.Project
+import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 
 import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.instantexecution.runToCompletion
@@ -27,6 +28,7 @@ import org.gradle.instantexecution.serialization.DefaultWriteContext
 import org.gradle.instantexecution.serialization.IsolateOwner
 import org.gradle.instantexecution.serialization.MutableIsolateContext
 import org.gradle.instantexecution.serialization.PropertyProblem
+import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.instantexecution.serialization.withIsolate
 
 import org.gradle.internal.io.NullOutputStream
@@ -266,6 +268,7 @@ class UserTypesCodecTest {
         DefaultReadContext(
             codec = codecs().userTypesCodec,
             decoder = KryoBackedDecoder(inputStream),
+            constructors = BeanConstructors(TestCrossBuildInMemoryCacheFactory()),
             logger = mock()
         )
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.instantiation.generator;
 
-import org.gradle.api.Transformer;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
@@ -88,14 +87,11 @@ class DefaultInstantiationScheme implements InstantiationScheme {
         public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
             //TODO:instant-execution - use the class generator instead
             try {
-                Constructor<?> constructor = constructorCache.get(implType, new Transformer<Constructor<?>, Class<?>>() {
-                    @Override
-                    public Constructor<?> transform(Class<?> aClass) {
-                        try {
-                            return ReflectionFactory.getReflectionFactory().newConstructorForSerialization(constructorSelector.forType(implType).getGeneratedClass(), baseClass.getDeclaredConstructor());
-                        } catch (NoSuchMethodException e) {
-                            throw UncheckedException.throwAsUncheckedException(e);
-                        }
+                Constructor<?> constructor = constructorCache.get(implType, type -> {
+                    try {
+                        return ReflectionFactory.getReflectionFactory().newConstructorForSerialization(constructorSelector.forType(type).getGeneratedClass(), baseClass.getDeclaredConstructor());
+                    } catch (NoSuchMethodException e) {
+                        throw UncheckedException.throwAsUncheckedException(e);
                     }
                 });
                 return implType.cast(constructor.newInstance());

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CrossBuildInMemoryCacheFactory.java
@@ -52,7 +52,9 @@ public interface CrossBuildInMemoryCacheFactory {
 
     /**
      * Creates a new map instance whose keys are Class instances. Keys are referenced using strong or weak references, values by strong or other references depending on their usage.
-     * This allows the classes to be collected. A map differs from a cache in that entries are not discarded based on memory pressure, but are discarded only when the key is collected.
+     * This allows the classes to be collected.
+     *
+     * <p>A map differs from a cache in that entries are not discarded based on memory pressure, but are discarded only when the key is collected.
      * You should prefer using a cache instead of a map where possible, and use a map only when generating other classes based on the key.
      *
      * <p>Note: this should be used to create _only_ global scoped instances.


### PR DESCRIPTION

### Context

A number of changes to improve performance when reading from the instant execution cache

- Don't serialize the exceptions for broken `Provider` or `FileCollection` instances. Instead, serialize the messages from the cause chains.
- Add some cross build caching for bean constructors
- Don't serialize property names for beans. Instead, serialize fields in a deterministic order.
- Write the secondary inputs hash for legacy transforms to the cache instead of calculating it each time the transform is read.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
