### PR TITLE
Improve incremental compilation for Java

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -131,7 +131,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         run "compileJava"
 
         then:
-        outputs.recompiledFiles("A", "ServiceRegistry", "ServiceRegistryResource.txt", "Dependent")
+        outputs.recompiledFiles("A", "ServiceRegistry", "ServiceRegistryResource.txt")
     }
 
     def "classes files of generated sources are deleted when annotated file is deleted"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -93,7 +93,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         run "compileJava"
 
         then:
-        outputs.recompiledFiles("A", "AHelper", "Dependent", "AHelperResource.txt")
+        outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
     }
 
     def "source file is recompiled when dependency of generated file changes"() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisSerializer.java
@@ -42,16 +42,18 @@ public class ClassAnalysisSerializer extends AbstractSerializer<ClassAnalysis> {
     public ClassAnalysis read(Decoder decoder) throws Exception {
         String className = interner.intern(decoder.readString());
         boolean relatedToAll = decoder.readBoolean();
-        Set<String> classes = stringSetSerializer.read(decoder);
+        Set<String> privateClasses = stringSetSerializer.read(decoder);
+        Set<String> accessibleClasses = stringSetSerializer.read(decoder);
         IntSet constants = IntSetSerializer.INSTANCE.read(decoder);
-        return new ClassAnalysis(className, classes, relatedToAll, constants);
+        return new ClassAnalysis(className, privateClasses, accessibleClasses, relatedToAll, constants);
     }
 
     @Override
     public void write(Encoder encoder, ClassAnalysis value) throws Exception {
         encoder.writeString(value.getClassName());
         encoder.writeBoolean(value.isDependencyToAll());
-        stringSetSerializer.write(encoder, value.getClassDependencies());
+        stringSetSerializer.write(encoder, value.getPrivateClassDependencies());
+        stringSetSerializer.write(encoder, value.getAccessibleClassDependencies());
         IntSetSerializer.INSTANCE.write(encoder, value.getConstants());
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshot.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshot.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysis;
 import org.gradle.api.internal.tasks.compile.incremental.deps.DependentsSet;
 import org.gradle.internal.hash.HashCode;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -48,12 +49,15 @@ public class ClasspathEntrySnapshot {
             }
             result.add(className);
         }
-        return DependentsSet.dependentClasses(result);
+        return DependentsSet.dependentClasses(Collections.emptySet(), result);
     }
 
     public IntSet getAllConstants(DependentsSet dependents) {
         IntSet result = new IntOpenHashSet();
-        for (String cn : dependents.getDependentClasses()) {
+        for (String cn : dependents.getAccessibleDependentClasses()) {
+            result.addAll(data.getClassAnalysis().getConstants(cn));
+        }
+        for (String cn : dependents.getPrivateDependentClasses()) {
             result.addAll(data.getClassAnalysis().getConstants(cn));
         }
         return result;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassAnalysis.java
@@ -27,13 +27,15 @@ import java.util.Set;
  */
 public class ClassAnalysis {
     private final String className;
-    private final Set<String> classDependencies;
+    private final Set<String> privateClassDependencies;
+    private final Set<String> accessibleClassDependencies;
     private final boolean dependencyToAll;
     private final IntSet constants;
 
-    public ClassAnalysis(String className, Set<String> classDependencies, boolean dependencyToAll, IntSet constants) {
+    public ClassAnalysis(String className, Set<String> privateClassDependencies, Set<String> accessibleClassDependencies, boolean dependencyToAll, IntSet constants) {
         this.className = className;
-        this.classDependencies = ImmutableSet.copyOf(classDependencies);
+        this.privateClassDependencies = ImmutableSet.copyOf(privateClassDependencies);
+        this.accessibleClassDependencies = ImmutableSet.copyOf(accessibleClassDependencies);
         this.dependencyToAll = dependencyToAll;
         this.constants = constants.isEmpty() ? IntSets.EMPTY_SET : constants;
     }
@@ -42,8 +44,12 @@ public class ClassAnalysis {
         return className;
     }
 
-    public Set<String> getClassDependencies() {
-        return classDependencies;
+    public Set<String> getPrivateClassDependencies() {
+        return privateClassDependencies;
+    }
+
+    public Set<String> getAccessibleClassDependencies() {
+        return accessibleClassDependencies;
     }
 
     public IntSet getConstants() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
@@ -31,16 +31,17 @@ import java.util.Set;
 public class ClassDependentsAccumulator {
 
     private final Set<String> dependenciesToAll = Sets.newHashSet();
-    private final Map<String, Set<String>> dependents = new HashMap<String, Set<String>>();
+    private final Map<String, Set<String>> privateDependents = new HashMap<String, Set<String>>();
+    private final Map<String, Set<String>> accessibleDependents = new HashMap<String, Set<String>>();
     private final ImmutableMap.Builder<String, IntSet> classesToConstants = ImmutableMap.builder();
     private final Set<String> seenClasses = Sets.newHashSet();
     private String fullRebuildCause;
 
     public void addClass(ClassAnalysis classAnalysis) {
-        addClass(classAnalysis.getClassName(), classAnalysis.isDependencyToAll(), classAnalysis.getClassDependencies(), classAnalysis.getConstants());
+        addClass(classAnalysis.getClassName(), classAnalysis.isDependencyToAll(), classAnalysis.getPrivateClassDependencies(), classAnalysis.getAccessibleClassDependencies(), classAnalysis.getConstants());
     }
 
-    public void addClass(String className, boolean dependencyToAll, Iterable<String> classDependencies, IntSet constants) {
+    public void addClass(String className, boolean dependencyToAll, Iterable<String> privateClassDependencies, Iterable<String> accessibleClassDependencies, IntSet constants) {
         if (seenClasses.contains(className)) {
             // same classes may be found in different classpath trees/jars
             // and we keep only the first one
@@ -52,16 +53,23 @@ public class ClassDependentsAccumulator {
         }
         if (dependencyToAll) {
             dependenciesToAll.add(className);
-            dependents.remove(className);
+            privateDependents.remove(className);
+            accessibleDependents.remove(className);
         }
-        for (String dependency : classDependencies) {
+        for (String dependency : privateClassDependencies) {
             if (!dependency.equals(className) && !dependenciesToAll.contains(dependency)) {
-                addDependency(dependency, className);
+                addDependency(false, dependency, className);
+            }
+        }
+        for (String dependency : accessibleClassDependencies) {
+            if (!dependency.equals(className) && !dependenciesToAll.contains(dependency)) {
+                addDependency(true, dependency, className);
             }
         }
     }
 
-    private Set<String> rememberClass(String className) {
+    private Set<String> rememberClass(boolean accessible, String className) {
+        Map<String, Set<String>> dependents = accessible ? accessibleDependents : privateDependents;
         Set<String> d = dependents.get(className);
         if (d == null) {
             d = Sets.newHashSet();
@@ -72,15 +80,23 @@ public class ClassDependentsAccumulator {
 
     @VisibleForTesting
     Map<String, DependentsSet> getDependentsMap() {
-        if (dependenciesToAll.isEmpty() && dependents.isEmpty()) {
+        if (dependenciesToAll.isEmpty() && privateDependents.isEmpty() && accessibleDependents.isEmpty()) {
             return Collections.emptyMap();
         }
         ImmutableMap.Builder<String, DependentsSet> builder = ImmutableMap.builder();
         for (String s : dependenciesToAll) {
             builder.put(s, DependentsSet.dependencyToAll());
         }
-        for (Map.Entry<String, Set<String>> entry : dependents.entrySet()) {
-            builder.put(entry.getKey(), DependentsSet.dependentClasses(entry.getValue()));
+        Set<String> collected = Sets.newHashSet();
+        for (Map.Entry<String, Set<String>> entry : accessibleDependents.entrySet()) {
+            if (collected.add(entry.getKey())) {
+                builder.put(entry.getKey(), DependentsSet.dependentClasses(privateDependents.getOrDefault(entry.getKey(), Collections.emptySet()), entry.getValue()));
+            }
+        }
+        for (Map.Entry<String, Set<String>> entry : privateDependents.entrySet()) {
+            if (collected.add(entry.getKey())) {
+                builder.put(entry.getKey(), DependentsSet.dependentClasses(entry.getValue(), accessibleDependents.getOrDefault(entry.getKey(), Collections.emptySet())));
+            }
         }
         return builder.build();
     }
@@ -90,8 +106,8 @@ public class ClassDependentsAccumulator {
         return classesToConstants.build();
     }
 
-    private void addDependency(String dependency, String dependent) {
-        Set<String> dependents = rememberClass(dependency);
+    private void addDependency(boolean accessible, String dependency, String dependent) {
+        Set<String> dependents = rememberClass(accessible, dependency);
         dependents.add(dependent);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/DependentsSet.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/DependentsSet.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.compile.incremental.deps;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.gradle.api.internal.tasks.compile.incremental.processing.GeneratedResource;
 
 import javax.annotation.Nullable;
@@ -25,23 +26,15 @@ import java.util.Set;
 
 public abstract class DependentsSet {
 
-    public static DependentsSet dependentClasses(String... dependentClasses) {
-        if (dependentClasses.length == 0) {
-            return empty();
-        } else {
-            return new DefaultDependentsSet(ImmutableSet.copyOf(dependentClasses), Collections.<GeneratedResource>emptySet());
-        }
+    public static DependentsSet dependentClasses(Set<String> privateDependentClasses, Set<String> accessibleDependentClasses) {
+        return dependents(privateDependentClasses, accessibleDependentClasses, Collections.<GeneratedResource>emptySet());
     }
 
-    public static DependentsSet dependentClasses(Set<String> dependentClasses) {
-        return dependents(dependentClasses, Collections.<GeneratedResource>emptySet());
-    }
-
-    public static DependentsSet dependents(Set<String> dependentClasses, Set<GeneratedResource> dependentResources) {
-        if (dependentClasses.isEmpty() && dependentResources.isEmpty()) {
+    public static DependentsSet dependents(Set<String> privateDependentClasses, Set<String> accessibleDependentClasses, Set<GeneratedResource> dependentResources) {
+        if (privateDependentClasses.isEmpty() && accessibleDependentClasses.isEmpty() && dependentResources.isEmpty()) {
             return empty();
         } else {
-            return new DefaultDependentsSet(ImmutableSet.copyOf(dependentClasses), ImmutableSet.copyOf(dependentResources));
+            return new DefaultDependentsSet(ImmutableSet.copyOf(privateDependentClasses), ImmutableSet.copyOf(accessibleDependentClasses), ImmutableSet.copyOf(dependentResources));
         }
     }
 
@@ -57,7 +50,13 @@ public abstract class DependentsSet {
         return EmptyDependentsSet.INSTANCE;
     }
 
-    public abstract Set<String> getDependentClasses();
+    public abstract boolean isEmpty();
+
+    public abstract boolean hasDependentClasses();
+
+    public abstract Set<String> getPrivateDependentClasses();
+
+    public abstract Set<String> getAccessibleDependentClasses();
 
     public abstract Set<GeneratedResource> getDependentResources();
 
@@ -68,11 +67,33 @@ public abstract class DependentsSet {
     private DependentsSet() {
     }
 
+    public abstract Set<String> joinDependentClasses();
+
     private static class EmptyDependentsSet extends DependentsSet {
         private static final EmptyDependentsSet INSTANCE = new EmptyDependentsSet();
 
         @Override
-        public Set<String> getDependentClasses() {
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public boolean hasDependentClasses() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getPrivateDependentClasses() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getAccessibleDependentClasses() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> joinDependentClasses() {
             return Collections.emptySet();
         }
 
@@ -95,17 +116,47 @@ public abstract class DependentsSet {
 
     private static class DefaultDependentsSet extends DependentsSet {
 
-        private final Set<String> dependentClasses;
+        private final Set<String> privateDependentClasses;
+        private final Set<String> accessibleDependentClasses;
         private final Set<GeneratedResource> dependentResources;
 
-        private DefaultDependentsSet(Set<String> dependentClasses, Set<GeneratedResource> dependentResources) {
-            this.dependentClasses = dependentClasses;
+        private DefaultDependentsSet(Set<String> privateDependentClasses, Set<String> accessibleDependentClasses, Set<GeneratedResource> dependentResources) {
+            this.privateDependentClasses = privateDependentClasses;
+            this.accessibleDependentClasses = accessibleDependentClasses;
             this.dependentResources = dependentResources;
         }
 
         @Override
-        public Set<String> getDependentClasses() {
-            return dependentClasses;
+        public boolean isEmpty() {
+            return !hasDependentClasses() && dependentResources.isEmpty();
+        }
+
+        @Override
+        public boolean hasDependentClasses() {
+            return !privateDependentClasses.isEmpty() || !accessibleDependentClasses.isEmpty();
+        }
+
+        @Override
+        public Set<String> getPrivateDependentClasses() {
+            return privateDependentClasses;
+        }
+
+        @Override
+        public Set<String> getAccessibleDependentClasses() {
+            return accessibleDependentClasses;
+        }
+
+        @Override
+        public Set<String> joinDependentClasses() {
+            if (privateDependentClasses.isEmpty()) {
+                return accessibleDependentClasses;
+            }
+            if (accessibleDependentClasses.isEmpty()) {
+                return privateDependentClasses;
+            }
+            Set<String> r = Sets.newHashSet(accessibleDependentClasses);
+            r.addAll(privateDependentClasses);
+            return r;
         }
 
         @Override
@@ -138,7 +189,27 @@ public abstract class DependentsSet {
         }
 
         @Override
-        public Set<String> getDependentClasses() {
+        public boolean isEmpty() {
+            throw new UnsupportedOperationException("This instance of dependents set does not have dependent classes information.");
+        }
+
+        @Override
+        public boolean hasDependentClasses() {
+            throw new UnsupportedOperationException("This instance of dependents set does not have dependent classes information.");
+        }
+
+        @Override
+        public Set<String> getPrivateDependentClasses() {
+            throw new UnsupportedOperationException("This instance of dependents set does not have dependent classes information.");
+        }
+
+        @Override
+        public Set<String> getAccessibleDependentClasses() {
+            throw new UnsupportedOperationException("This instance of dependents set does not have dependent classes information.");
+        }
+
+        @Override
+        public Set<String> joinDependentClasses() {
             throw new UnsupportedOperationException("This instance of dependents set does not have dependent classes information.");
         }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathChangeDependentsFinder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathChangeDependentsFinder.java
@@ -70,11 +70,11 @@ public class ClasspathChangeDependentsFinder {
         if (allClasses.isDependencyToAll()) {
             return allClasses;
         }
-        DependentsSet affectedOnClasspath = collectDependentsFromClasspath(allClasses.getDependentClasses());
+        DependentsSet affectedOnClasspath = collectDependentsFromClasspath(allClasses.joinDependentClasses());
         if (affectedOnClasspath.isDependencyToAll()) {
             return affectedOnClasspath;
         } else {
-            return previousCompilation.getDependents(affectedOnClasspath.getDependentClasses(), previous.getAllConstants(affectedOnClasspath));
+            return previousCompilation.getDependents(affectedOnClasspath.joinDependentClasses(), previous.getAllConstants(affectedOnClasspath));
         }
     }
 
@@ -90,13 +90,16 @@ public class ClasspathChangeDependentsFinder {
         if (affectedOnClasspath.isDependencyToAll()) {
             return affectedOnClasspath;
         } else {
-            return previousCompilation.getDependents(affectedOnClasspath.getDependentClasses(), currentSnapshot.getRelevantConstants(previous, affectedOnClasspath.getDependentClasses()));
+            Set<String> joined = affectedOnClasspath.joinDependentClasses();
+            return previousCompilation.getDependents(joined, currentSnapshot.getRelevantConstants(previous, joined));
         }
     }
 
     private DependentsSet collectDependentsFromClasspath(Set<String> modified) {
-        final Set<String> dependentClasses = Sets.newHashSet(modified);
-        final Deque<String> queue = Lists.newLinkedList(dependentClasses);
+        final Set<String> privateDependentClasses = Sets.newHashSet(modified);
+        final Set<String> accessibleDependentClasses = Sets.newHashSet(modified);
+        final Deque<String> queue = Lists.newLinkedList(accessibleDependentClasses);
+        queue.addAll(privateDependentClasses);
         while (!queue.isEmpty()) {
             final String dependentClass = queue.poll();
             for (File entry : classpathSnapshot.getEntries()) {
@@ -104,15 +107,20 @@ public class ClasspathChangeDependentsFinder {
                 if (dependents.isDependencyToAll()) {
                     return dependents;
                 } else {
-                    for (String intermediate : dependents.getDependentClasses()) {
-                        if (dependentClasses.add(intermediate)) {
+                    for (String intermediate : dependents.getPrivateDependentClasses()) {
+                        if (privateDependentClasses.add(intermediate)) {
+                            queue.add(intermediate);
+                        }
+                    }
+                    for (String intermediate : dependents.getAccessibleDependentClasses()) {
+                        if (accessibleDependentClasses.add(intermediate)) {
                             queue.add(intermediate);
                         }
                     }
                 }
             }
         }
-        return DependentsSet.dependentClasses(dependentClasses);
+        return DependentsSet.dependentClasses(privateDependentClasses, accessibleDependentClasses);
     }
 
     private DependentsSet collectDependentsFromClasspathEntry(String dependentClass, File entry) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathEntryChangeProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathEntryChangeProcessor.java
@@ -33,7 +33,8 @@ public class ClasspathEntryChangeProcessor {
             spec.setFullRebuildCause(actualDependents.getDescription(), input.getFile());
             return;
         }
-        spec.getClassesToCompile().addAll(actualDependents.getDependentClasses());
+        spec.getClassesToCompile().addAll(actualDependents.getPrivateDependentClasses());
+        spec.getClassesToCompile().addAll(actualDependents.getAccessibleDependentClasses());
         spec.getResourcesToGenerate().addAll(actualDependents.getDependentResources());
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/SourceFileChangeProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/SourceFileChangeProcessor.java
@@ -38,7 +38,8 @@ class SourceFileChangeProcessor {
                 spec.setFullRebuildCause(actualDependents.getDescription(), inputFile);
                 return;
             }
-            spec.getClassesToCompile().addAll(actualDependents.getDependentClasses());
+            spec.getClassesToCompile().addAll(actualDependents.getPrivateDependentClasses());
+            spec.getClassesToCompile().addAll(actualDependents.getAccessibleDependentClasses());
             spec.getResourcesToGenerate().addAll(actualDependents.getDependentResources());
         }
     }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
@@ -31,9 +31,9 @@ class ClassDependentsAccumulatorTest extends Specification {
 
     def "remembers if class is dependency to all"() {
         // a -> b -> c
-        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET)
-        accumulator.addClass("b", true,  ["c"], IntSets.EMPTY_SET)
-        accumulator.addClass("c", false, ["a"] as Set, IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, [], ["b"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  [], ["c"], IntSets.EMPTY_SET)
+        accumulator.addClass("c", false, [], ["a"] as Set, IntSets.EMPTY_SET)
 
         expect:
         !accumulator.dependentsMap.a.dependencyToAll
@@ -43,9 +43,9 @@ class ClassDependentsAccumulatorTest extends Specification {
 
     def "remembers if class declares non-private constants"() {
         // a -> b -> c
-        accumulator.addClass("a", false, ["b"], new IntOpenHashSet(1, 2, 3, 5, 8))
-        accumulator.addClass("b", false,  ["c"], new IntOpenHashSet([0, 8]))
-        accumulator.addClass("c", false, [], new IntOpenHashSet([3, 4]))
+        accumulator.addClass("a", false, [], ["b"], new IntOpenHashSet(1, 2, 3, 5, 8))
+        accumulator.addClass("b", false, [], ["c"], new IntOpenHashSet([0, 8]))
+        accumulator.addClass("c", false, [], [], new IntOpenHashSet([3, 4]))
 
         expect:
         accumulator.classesToConstants.get('a') == [1, 2, 3, 5, 8] as Set
@@ -53,51 +53,73 @@ class ClassDependentsAccumulatorTest extends Specification {
         accumulator.classesToConstants.get('c') == [3, 4] as Set
     }
 
-    def "accumulates dependents"() {
-        accumulator.addClass("d", true, ['x'], IntSets.EMPTY_SET)
-        accumulator.addClass("a", false, ["b", "c"], IntSets.EMPTY_SET)
-        accumulator.addClass("b", true,  ["c", "a"], IntSets.EMPTY_SET)
-        accumulator.addClass("c", false, [] as Set, IntSets.EMPTY_SET)
+    def "accumulates accessible and private dependents"() {
+        accumulator.addClass("d", true,  [], ['x'], IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, ["b"], ["c"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", false, ["c"], ["a"], IntSets.EMPTY_SET)
+        accumulator.addClass("c", false, [], [] as Set, IntSets.EMPTY_SET)
 
         expect:
-        accumulator.dependentsMap.a.dependentClasses == ['b'] as Set
-        accumulator.dependentsMap.b.dependencyToAll
-        accumulator.dependentsMap.c.dependentClasses == ['b', 'a'] as Set
+        accumulator.dependentsMap.a.privateDependentClasses == [] as Set
+        accumulator.dependentsMap.a.accessibleDependentClasses == ['b'] as Set
+        accumulator.dependentsMap.b.privateDependentClasses == ['a'] as Set
+        accumulator.dependentsMap.b.accessibleDependentClasses == [] as Set
+        accumulator.dependentsMap.c.privateDependentClasses == ['b'] as Set
+        accumulator.dependentsMap.c.accessibleDependentClasses == ['a'] as Set
         accumulator.dependentsMap.d.dependencyToAll
-        accumulator.dependentsMap.x.dependentClasses == ['d'] as Set
+        accumulator.dependentsMap.x.privateDependentClasses == [] as Set
+        accumulator.dependentsMap.x.accessibleDependentClasses == ['d'] as Set
+    }
+
+    def "accumulates dependents"() {
+        accumulator.addClass("d", true,  [], ['x'], IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, [], ["b", "c"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  [], ["c", "a"], IntSets.EMPTY_SET)
+        accumulator.addClass("c", false, [], [] as Set, IntSets.EMPTY_SET)
+
+        expect:
+        accumulator.dependentsMap.a.privateDependentClasses == [] as Set
+        accumulator.dependentsMap.a.accessibleDependentClasses == ['b'] as Set
+        accumulator.dependentsMap.b.dependencyToAll
+        accumulator.dependentsMap.c.privateDependentClasses == [] as Set
+        accumulator.dependentsMap.c.accessibleDependentClasses == ['b', 'a'] as Set
+        accumulator.dependentsMap.d.dependencyToAll
+        accumulator.dependentsMap.x.privateDependentClasses == [] as Set
+        accumulator.dependentsMap.x.accessibleDependentClasses == ['d'] as Set
     }
 
     def "creates keys for all encountered classes which are dependency to another"() {
-        accumulator.addClass("a", false, ["x"], IntSets.EMPTY_SET)
-        accumulator.addClass("b", true,  ["a", "b"], IntSets.EMPTY_SET)
-        accumulator.addClass("c", true,  [] as Set, IntSets.EMPTY_SET)
-        accumulator.addClass("e", false,  [] as Set, IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, [], ["x"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  [], ["a", "b"], IntSets.EMPTY_SET)
+        accumulator.addClass("c", true,  [], [] as Set, IntSets.EMPTY_SET)
+        accumulator.addClass("e", false, [], [] as Set, IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap.keySet() == ["a", "b", "c", "x"] as Set
     }
 
     def "knows when class is dependent to all if that class is added first"() {
-        accumulator.addClass("b", true,  [] as Set, IntSets.EMPTY_SET)
-        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  [], [] as Set, IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, [], ["b"], IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap.b.dependencyToAll
     }
 
     def "knows when class is dependent to all even if that class is added last"() {
-        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET)
-        accumulator.addClass("b", true,  [] as Set, IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, [], ["b"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  [], [] as Set, IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap.b.dependencyToAll
     }
 
     def "filters out self dependencies"() {
-        accumulator.addClass("a", false, ["a", "b"], IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, [], ["a", "b"], IntSets.EMPTY_SET)
 
         expect:
-        accumulator.dependentsMap["b"].dependentClasses == ["a"] as Set
+        accumulator.dependentsMap["b"].privateDependentClasses == [] as Set
+        accumulator.dependentsMap["b"].accessibleDependentClasses == ["a"] as Set
         accumulator.dependentsMap["a"] == null
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
@@ -34,7 +34,7 @@ class ClassSetAnalysisDataSerializerTest extends Specification {
 
     def "serializes"() {
         def data = new ClassSetAnalysisData(["A", "B", "C", "D"] as Set,
-            ["A": dependentClasses("B", "C"), "B": dependentClasses("C"), "C": dependentClasses(), "D": dependencyToAll(),],
+            ["A": dependentClasses(["B", "C"] as Set, [] as Set), "B": dependentClasses(["C"] as Set, [] as Set), "C": dependentClasses([] as Set, [] as Set), "D": dependencyToAll(),],
             [C: new IntOpenHashSet([1, 2]) as IntSet, D: IntSets.EMPTY_SET]
             ,"Because"
         )
@@ -49,7 +49,8 @@ class ClassSetAnalysisDataSerializerTest extends Specification {
         read.dependents.keySet() == data.dependents.keySet()
 
         ["A", "B", "C"].each {
-            assert read.dependents[it].dependentClasses == data.dependents[it].dependentClasses
+            assert read.dependents[it].privateDependentClasses == data.dependents[it].privateDependentClasses
+            assert read.dependents[it].accessibleDependentClasses == data.dependents[it].accessibleDependentClasses
             assert read.dependents[it].dependencyToAll == data.dependents[it].dependencyToAll
         }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
@@ -30,153 +30,209 @@ class ClassSetAnalysisTest extends Specification {
                               DependentsSet aggregatedTypes = empty(), DependentsSet dependentsOnAll = empty(), String fullRebuildCause = null) {
         new ClassSetAnalysis(
             new ClassSetAnalysisData(dependents.keySet(), dependents, classToConstants, fullRebuildCause),
-            new AnnotationProcessingData([:], aggregatedTypes.dependentClasses, dependentsOnAll.dependentClasses, [:], dependentsOnAll.dependentResources, null)
+            new AnnotationProcessingData([:], aggregatedTypes.joinDependentClasses(), dependentsOnAll.joinDependentClasses(), [:], dependentsOnAll.dependentResources, null)
         )
     }
 
     def "returns empty analysis"() {
         def a = analysis([:])
-        expect: a.getRelevantDependents("Foo", IntSets.EMPTY_SET).dependentClasses.isEmpty()
+        expect: a.getRelevantDependents("Foo", IntSets.EMPTY_SET).joinDependentClasses().isEmpty()
+    }
+
+    def "does not recurse private dependencies"() {
+        def a = analysis([
+            "a": dependentSet(false, ["b"], []),
+            "b": dependentSet(false, ["c"], ["d"]),
+            "c": dependentSet(false, [], []),
+            "d": dependentSet(false, ["e"], []),
+            "e": dependentSet(false, [], [])
+        ])
+        /*
+        Class a {
+            private b _b;
+        }
+        Class b {
+            private c _c;
+            public d _d;
+        }
+        Class c {
+        }
+        Class d {
+            private e _e;
+        }
+        Class e {
+        }
+         */
+
+        when:
+        def deps = a.getRelevantDependents("a", IntSets.EMPTY_SET)
+        then:
+        deps.accessibleDependentClasses == [] as Set
+        deps.privateDependentClasses == ['b'] as Set
+
+        when:
+        deps = a.getRelevantDependents("b", IntSets.EMPTY_SET)
+        then:
+        deps.accessibleDependentClasses == ['d'] as Set
+        deps.privateDependentClasses == ['c'] as Set
+
+        when:
+        deps = a.getRelevantDependents("c", IntSets.EMPTY_SET)
+        then:
+        deps.accessibleDependentClasses == [] as Set
+        deps.privateDependentClasses == [] as Set
+
+        when:
+        deps = a.getRelevantDependents("d", IntSets.EMPTY_SET)
+        then:
+        deps.accessibleDependentClasses == [] as Set
+        deps.privateDependentClasses == ['e'] as Set
+
+        when:
+        deps = a.getRelevantDependents("e", IntSets.EMPTY_SET)
+        then:
+        deps.accessibleDependentClasses == [] as Set
+        deps.privateDependentClasses == [] as Set
     }
 
     def "does not recurse if root class is a dependency to all"() {
-        def a = analysis(["Foo": dependentSet(true, ["Bar"])])
+        def a = analysis(["Foo": dependentSet(true, [], ["Bar"])])
         def deps = a.getRelevantDependents("Foo", IntSets.EMPTY_SET)
 
         expect:
         deps.dependencyToAll
 
-        when: deps.getDependentClasses()
+        when: deps.joinDependentClasses()
         then: thrown(UnsupportedOperationException)
     }
 
     def "marks as dependency to all only if root class is a dependency to all"() {
         def a = analysis([
-            "a": dependentSet(false, ['b']),
-            'b': dependentSet(true, []),
-            "c": dependentSet(true, [])
+            "a": dependentSet(false, [], ['b']),
+            'b': dependentSet(true, [], []),
+            "c": dependentSet(true, [], [])
         ])
         def deps = a.getRelevantDependents("a", IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ['b'] as Set
+        deps.joinDependentClasses() == ['b'] as Set
         !deps.dependencyToAll
     }
 
     def "recurses nested dependencies"() {
         def a = analysis([
-            "Foo": dependentClasses("Bar"),
-            "Bar": dependentClasses("Baz"),
-            "Baz": dependentClasses(),
+            "Foo": dependentClasses([] as Set, ["Bar"] as Set),
+            "Bar": dependentClasses([] as Set, ["Baz"] as Set),
+            "Baz": dependentClasses([] as Set, [] as Set),
         ])
         def deps = a.getRelevantDependents("Foo", IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["Bar", "Baz"] as Set
-        a.getRelevantDependents("Bar", IntSets.EMPTY_SET).dependentClasses == ["Baz"] as Set
-        a.getRelevantDependents("Baz", IntSets.EMPTY_SET).dependentClasses == [] as Set
+        deps.joinDependentClasses() == ["Bar", "Baz"] as Set
+        a.getRelevantDependents("Bar", IntSets.EMPTY_SET).joinDependentClasses() == ["Baz"] as Set
+        a.getRelevantDependents("Baz", IntSets.EMPTY_SET).joinDependentClasses() == [] as Set
     }
 
     def "recurses multiple dependencies"() {
         def a = analysis([
-            "a": dependentClasses("b", "c"),
-            "b": dependentClasses("d"),
-            "c": dependentClasses("e"),
-            "d": dependentClasses(),
-            "e": dependentClasses()
+            "a": dependentClasses([] as Set, ["b", "c"] as Set),
+            "b": dependentClasses([] as Set, ["d"] as Set),
+            "c": dependentClasses([] as Set, ["e"] as Set),
+            "d": dependentClasses([] as Set, [] as Set),
+            "e": dependentClasses([] as Set, [] as Set)
         ])
         def deps = a.getRelevantDependents("a", IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["b", "c", "d", "e"] as Set
+        deps.joinDependentClasses() == ["b", "c", "d", "e"] as Set
     }
 
     def "removes self from dependents"() {
         def a = analysis([
-            "Foo": dependentClasses("Foo")
+            "Foo": dependentClasses([] as Set, ["Foo"] as Set)
         ])
         def deps = a.getRelevantDependents("Foo", IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == [] as Set
+        deps.joinDependentClasses() == [] as Set
     }
 
     def "handles dependency cycles"() {
         def a = analysis([
-            "Foo": dependentClasses("Bar"),
-            "Bar": dependentClasses("Baz"),
-            "Baz": dependentClasses("Foo"),
+            "Foo": dependentClasses([] as Set, ["Bar"] as Set),
+            "Bar": dependentClasses([] as Set, ["Baz"] as Set),
+            "Baz": dependentClasses([] as Set, ["Foo"] as Set),
         ])
         def deps = a.getRelevantDependents("Foo", IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["Bar", "Baz"] as Set
+        deps.joinDependentClasses() == ["Bar", "Baz"] as Set
     }
 
     def "recurses but filters out inner classes"() {
         def a = analysis([
-            "a": dependentClasses('a$b', 'c'),
-            'a$b': dependentClasses('d'),
-            "c": dependentClasses(),
-            "d": dependentClasses(),
+            "a": dependentClasses([] as Set, ['a$b', 'c'] as Set),
+            'a$b': dependentClasses([] as Set, ['d'] as Set),
+            "c": dependentClasses([] as Set, [] as Set),
+            "d": dependentClasses([] as Set, [] as Set),
         ])
         def deps = a.getRelevantDependents("a", IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["c", "d"] as Set
+        deps.joinDependentClasses() == ["c", "d", 'a$b'] as Set
     }
 
     def "handles cycles with inner classes"() {
         def a = analysis([
-            "a": dependentClasses('a$b'),
-            'a$b': dependentClasses('a$b', 'c'),
-            "c": dependentClasses()
+            "a": dependentClasses([] as Set, ['a$b'] as Set),
+            'a$b': dependentClasses([] as Set, ['a$b', 'c'] as Set),
+            "c": dependentClasses([] as Set, [] as Set)
         ])
         def deps = a.getRelevantDependents("a", IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["c"] as Set
+        deps.joinDependentClasses() == ["c", 'a$b'] as Set
     }
 
     def "provides dependents of all input classes"() {
         def a = analysis([
-            "A": dependentClasses("B"), "B": dependentClasses(),
-            "C": dependentClasses("D"), "D": dependentClasses(),
-            "E": dependentClasses("D"), "F": dependentClasses(),
+            "A": dependentClasses([] as Set, ["B"] as Set), "B": dependentClasses([] as Set, [] as Set),
+            "C": dependentClasses([] as Set, ["D"] as Set), "D": dependentClasses([] as Set, [] as Set),
+            "E": dependentClasses([] as Set, ["D"] as Set), "F": dependentClasses([] as Set, [] as Set),
         ])
         def deps = a.getRelevantDependents(["A", "E"], IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["D", "B"] as Set
+        deps.joinDependentClasses() == ["D", "B"] as Set
     }
 
     def "provides recursive dependents of all input classes"() {
         def a = analysis([
-            "A": dependentClasses("B"), "B": dependentClasses("C"), "C": dependentClasses(),
-            "D": dependentClasses("E"), "E": dependentClasses(),
-            "F": dependentClasses("G"), "G": dependentClasses(),
+            "A": dependentClasses([] as Set, ["B"] as Set), "B": dependentClasses([] as Set, ["C"] as Set), "C": dependentClasses([] as Set, [] as Set),
+            "D": dependentClasses([] as Set, ["E"] as Set), "E": dependentClasses([] as Set, [] as Set),
+            "F": dependentClasses([] as Set, ["G"] as Set), "G": dependentClasses([] as Set, [] as Set),
         ])
         def deps = a.getRelevantDependents(["A", "D"], IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["E", "B", "C"] as Set
+        deps.joinDependentClasses() == ["E", "B", "C"] as Set
     }
 
     def "some classes may depend on any change"() {
         def a = analysis([
-            "A": dependentClasses("B"), "B": empty(), "DependsOnAny" : dependentClasses("C")
-        ], [:], empty(), dependentClasses("DependsOnAny") )
+            "A": dependentClasses([] as Set, ["B"] as Set), "B": empty(), "DependsOnAny" : dependentClasses([] as Set, ["C"] as Set)
+        ], [:], empty(), dependentClasses([] as Set, ["DependsOnAny"] as Set) )
         def deps = a.getRelevantDependents(["A"], IntSets.EMPTY_SET)
 
         expect:
-        deps.dependentClasses == ["DependsOnAny", "B", "C"] as Set
+        deps.joinDependentClasses() == ["DependsOnAny", "B", "C"] as Set
     }
 
     def "knows when any of the input classes is a dependency to all"() {
         def a = analysis([
-            "A": dependentClasses("B"), "B": dependentClasses(),
-            "C": dependentSet(true, []),
-            "D": dependentClasses("E"), "E": dependentClasses(),
+            "A": dependentClasses([] as Set, ["B"] as Set), "B": dependentClasses([] as Set, [] as Set),
+            "C": dependentSet(true, [], []),
+            "D": dependentClasses([] as Set, ["E"] as Set), "E": dependentClasses([] as Set, [] as Set),
         ])
         def deps = a.getRelevantDependents(["A", "C", "will not be reached"], IntSets.EMPTY_SET)
 
@@ -186,8 +242,8 @@ class ClassSetAnalysisTest extends Specification {
 
     def "knows when input class is a dependency to all"() {
         def a = analysis([
-            "A": dependentClasses("B"), "B": dependentClasses(),
-            "C": dependentSet(true, []),
+            "A": dependentClasses([] as Set, ["B"] as Set), "B": dependentClasses([] as Set, [] as Set),
+            "C": dependentSet(true, [], []),
         ])
         expect:
         !a.isDependencyToAll("A")
@@ -204,7 +260,7 @@ class ClassSetAnalysisTest extends Specification {
         a.isDependencyToAll("DoesNotMatter")
     }
 
-    private static DependentsSet dependentSet(boolean dependencyToAll, Collection<String> classes) {
-        dependencyToAll ? DependentsSet.dependencyToAll() : dependentClasses(classes as Set)
+    private static DependentsSet dependentSet(boolean dependencyToAll, Collection<String> privateClasses, Collection<String> accessibleClasses) {
+        dependencyToAll ? DependentsSet.dependencyToAll() : dependentClasses(privateClasses as Set, accessibleClasses as Set)
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPackagePrivateField.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPackagePrivateField.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.test;
+
+public class AccessedFromPackagePrivateField {
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateClassPublicField.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateClassPublicField.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.test;
+
+public class AccessedFromPrivateClassPublicField {
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateField.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateField.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.test;
+
+public class AccessedFromPrivateField {
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateMethod.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateMethod.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.test;
+
+public class AccessedFromPrivateMethod {
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateMethodBody.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/AccessedFromPrivateMethodBody.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.incremental.test;
+
+public class AccessedFromPrivateMethodBody {
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/SomeClass.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/test/SomeClass.java
@@ -22,12 +22,27 @@ public class SomeClass {
 
     List<Integer> field = new LinkedList<Integer>();
 
+    private AccessedFromPrivateField accessedFromPrivateField;
+
+    AccessedFromPackagePrivateField someField;
+
+    private AccessedFromPrivateMethod accessedFromPrivateMethod() {
+        return null;
+    }
+
+    public String accessedFromPrivateMethodBody() {
+        return new AccessedFromPrivateMethodBody().toString();
+    }
+
     private Set<String> stuff(HashMap<String, String> map) {
         System.out.println(new Foo());
         return new HashSet<String>();
     }
 
     private class Foo {
+        // Hint: this field won't appear in the ClassAnalysis for SomeClass
+        public AccessedFromPrivateClassPublicField anotherField;
+
         public String toString() {
             return "" + new AccessedFromPrivateClass();
         }


### PR DESCRIPTION
This patch splits the collected dependencies found in a .class file into "accessible" and "private" dependencies.
* "Accessbile" dependencies are classes that belong to non-private fields, non-private method signatures, class signature ("extends", "implements") etc
* "Private" dependencies are classes that belong to private fields, private methods and classes used in method bodies (i.e. just in "the code")

The TL;DR of the approach is to change the algorithm in `ClassSetAnalysis.getRelevantDependents` to only recurse for "accessible" dependencies.

Goal by example:
Consider classes like
```
class A {
  private B b
}
class B {
  private C c
}
class C {
}
```

The previous algorithm in `ClassSetAnalysis.getRelevantDependents` would recompile all classes, if `C` was changed. The new algorithm recompiles
just `B` and `C`, because `C` has been changed and `B` uses `C`. But it doesn't recompile `A`, because `A` is not affected by the change. The same
is true, if `C` would have been only used in a method body of `B` or in the signature of a `private` function in `B`.

The algorithm properly handles changes to classes used in the following example:
```
public class SomeClass {
    List<Integer> field = new LinkedList<Integer>();
    private AccessedFromPrivateField accessedFromPrivateField;
    AccessedFromPackagePrivateField someField;
    private AccessedFromPrivateMethod accessedFromPrivateMethod() {
        return null;
    }
    public String accessedFromPrivateMethodBody() {
        return new AccessedFromPrivateMethodBody().toString();
    }
    private Set<String> stuff(HashMap<String, String> map) {
        System.out.println(new Foo());
        return new HashSet<String>();
    }
    private class Foo {
        // Hint: this field won't appear in the ClassAnalysis for SomeClass
        public AccessedFromPrivateClassPublicField anotherField;

        public String toString() {
            return "" + new AccessedFromPrivateClass();
        }
    }
}
```

Changes the serialization format of `ClassAnalysis` + `DependentsSet`

Signed-off-by: Robert Stupp <snazy@snazy.de>

<!--- The issue this PR addresses -->
Fixes #10420

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
