### PR TITLE
Update AGP nightly to the latest in instant execution integ tests

### DIFF
--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -95,6 +95,7 @@ tasks {
     withType<IntegrationTest>().configureEach {
         dependsOn(santaTrackerJava)
         dependsOn(santaTrackerKotlin)
+        inputs.property("androidHomeIsSet", System.getenv("ANDROID_HOME") != null)
     }
 
     register<Delete>("cleanRemoteProjects") {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionAndroidIntegrationTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.test.fixtures.file.TestFile
 @CompileStatic
 abstract class AbstractInstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
-    static final String AGP_VERSION = "3.6.0-20190825022937+0200"
+    static final String AGP_VERSION = "3.6.0-20190901022914+0200"
 
     static final String AGP_NIGHTLY_REPOSITORY_DECLARATION = '''
         maven {


### PR DESCRIPTION
and add whether `ANDROID_HOME` is set to the inputs of instant execution integ tests