### PR TITLE
Fix verify error when decorating class with wide parameters.

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -533,8 +533,10 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
             // this.super(p0 .. pn)
             methodVisitor.visitVarInsn(ALOAD, 0);
-            for (int i = 0; i < constructor.getParameterTypes().length; i++) {
-                methodVisitor.visitVarInsn(Type.getType(constructor.getParameterTypes()[i]).getOpcode(ILOAD), i + 1);
+            for (int typeVar = 0, stackVar = 1; typeVar < paramTypes.size(); ++typeVar) {
+                Type argType = paramTypes.get(typeVar);
+                methodVisitor.visitVarInsn(argType.getOpcode(ILOAD), stackVar);
+                stackVar += argType.getSize();
             }
             methodVisitor.visitMethodInsn(INVOKESPECIAL, superclassType.getInternalName(), "<init>", methodDescriptor, false);
 
@@ -1459,12 +1461,15 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             // GENERATE <method>(…, ConfigureUtil.configureUsing(v));
             methodVisitor.visitVarInsn(ALOAD, 0);
 
-            for (int stackVar = 1; stackVar < numParams; ++stackVar) {
-                methodVisitor.visitVarInsn(closurisedParameterTypes[stackVar - 1].getOpcode(ILOAD), stackVar);
+            int stackVar = 1;
+            for (int typeVar = 0; typeVar < numParams - 1; ++typeVar) {
+                Type argType = closurisedParameterTypes[typeVar];
+                methodVisitor.visitVarInsn(argType.getOpcode(ILOAD), stackVar);
+                stackVar += argType.getSize();
             }
 
             // GENERATE ConfigureUtil.configureUsing(v);
-            methodVisitor.visitVarInsn(ALOAD, numParams);
+            methodVisitor.visitVarInsn(ALOAD, stackVar);
             methodDescriptor = Type.getMethodDescriptor(ACTION_TYPE, CLOSURE_TYPE);
             methodVisitor.visitMethodInsn(INVOKESTATIC, CONFIGURE_UTIL_TYPE.getInternalName(), "configureUsing", methodDescriptor, false);
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorDecoratedTest.groovy
@@ -398,6 +398,48 @@ class AsmBackedClassGeneratorDecoratedTest extends AbstractClassGeneratorSpec {
         then:
         values == ["bar"]
     }
+
+    def "action methods with wide parameters are compiles"() {
+        given:
+        def tester = create(ActionsTester)
+
+        when:
+        tester.actionWithLongParameter(1L) { assert it == "subject" }
+
+        then:
+        tester.lastMethod == "actionWithLongParameter"
+        tester.lastArgs.size() == 2
+        tester.lastArgs.first() == 1L
+        tester.lastArgs.last() instanceof Action
+
+        when:
+        tester.actionWithDoubleParameter(3.14d) { assert it == "subject" }
+
+        then:
+        tester.lastMethod == "actionWithDoubleParameter"
+        tester.lastArgs.size() == 2
+        tester.lastArgs.first() == 3.14d
+        tester.lastArgs.last() instanceof Action
+    }
+
+    def "class with wide constructor are compiles"() {
+        given:
+        def reference = new Object()
+
+        when:
+        def longTester = create(HasLongConstructor, 1L, reference)
+
+        then:
+        longTester.value == 1L
+        longTester.reference.is(reference)
+
+        when:
+        def doubleTester = create(HasDoubleConstructor, 3.14d, reference)
+
+        then:
+        doubleTester.value == 3.14d
+        doubleTester.reference.is(reference)
+    }
 }
 
 enum TestEnum {
@@ -536,6 +578,17 @@ class ActionsTester {
         [] as Object[]
     }
 
+    void actionWithLongParameter(long arg, Action action) {
+        lastMethod = "actionWithLongParameter"
+        lastArgs = [arg, action]
+        action.execute(subject)
+    }
+
+    void actionWithDoubleParameter(double arg, Action action) {
+        lastMethod = "actionWithDoubleParameter"
+        lastArgs = [arg, action]
+        action.execute(subject)
+    }
 }
 
 class ActionMethodWithSameNameAsProperty {
@@ -688,5 +741,25 @@ class HasToString {
     @Override
     String toString() {
         return "<bean>"
+    }
+}
+
+class HasLongConstructor {
+    long value
+    Object reference
+
+    HasLongConstructor(long value, Object reference) {
+        this.value = value
+        this.reference = reference
+    }
+}
+
+class HasDoubleConstructor {
+    double value
+    Object reference
+
+    HasDoubleConstructor(double value, Object reference) {
+        this.value = value
+        this.reference = reference
     }
 }


### PR DESCRIPTION
`long` and `double` takes 2 stack slots, but AsmBackedClassGenerator doesn't count it in mind and creates incorrect bytecode for methods like these:

```java
void name(long arg, Action action)
<init>(double arg, Object any)
```

(when wide parameter isn't last argument in general case).

*I'm unable to find any discussion for this bug, but encountered it when developing some plugin that require method `void name(long arg, Action action)`*