### PR TITLE
Introduce public api FileSystemOperations service

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemOperations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemOperations.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file;
+
+import org.gradle.api.Action;
+import org.gradle.api.tasks.WorkResult;
+
+
+/**
+ * Operations on the file system.
+ *
+ * @since 6.0
+ */
+public interface FileSystemOperations {
+
+    /**
+     * Copies the specified files.
+     * The given action is used to configure a {@link CopySpec}, which is then used to copy the files.
+     *
+     * @param action Action to configure the CopySpec
+     * @return {@link WorkResult} that can be used to check if the copy did any work.
+     */
+    WorkResult copy(Action<? super CopySpec> action);
+
+    /**
+     * Synchronizes the contents of a destination directory with some source directories and files.
+     * The given action is used to configure a {@link CopySpec}, which is then used to synchronize the files.
+     *
+     * @param action action Action to configure the CopySpec.
+     * @return {@link WorkResult} that can be used to check if the sync did any work.
+     */
+    WorkResult sync(Action<? super CopySpec> action);
+
+    /**
+     * Deletes the specified files.
+     * The given action is used to configure a {@link DeleteSpec}, which is then used to delete the files.
+     *
+     * @param action Action to configure the DeleteSpec
+     * @return {@link WorkResult} that can be used to check if delete did any work.
+     */
+    WorkResult delete(Action<? super DeleteSpec> action);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -22,6 +22,7 @@ import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
@@ -101,6 +102,13 @@ public interface ObjectFactory {
     ConfigurableFileCollection fileCollection();
 
     /**
+     * Creates a new {@link ConfigurableFileTree}. The tree has no base dir specified.
+     *
+     * @since 6.0
+     */
+    ConfigurableFileTree fileTree();
+
+    /**
      * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type. The specified type must have a public constructor which takes the name as a String parameter.</p>
      *
      * <p>All objects <b>MUST</b> expose their name as a bean property named "name". The name must be constant for the life of the object.</p>
@@ -116,7 +124,6 @@ public interface ObjectFactory {
      * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type. The given factory is used to create object instances.</p>
      *
      * <p>All objects <b>MUST</b> expose their name as a bean property named "name". The name must be constant for the life of the object.</p>
-     *
      *
      * @param elementType The type of objects for the container to contain.
      * @param factory The factory to use to create object instances.
@@ -182,6 +189,7 @@ public interface ObjectFactory {
      * Creates a {@link MapProperty} implementation to hold a {@link Map} of the given key type {@code K} and value type {@code V}. The property has an empty map as its initial value.
      *
      * <p>The implementation will return immutable {@link Map} values from its query methods.</p>
+     *
      * @param keyType the type of key.
      * @param valueType the type of value.
      * @param <K> the type of key.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileSystemOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileSystemOperations.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.DeleteSpec;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.tasks.WorkResult;
+
+
+public class DefaultFileSystemOperations implements FileSystemOperations {
+
+    private final FileOperations fileOperations;
+
+    public DefaultFileSystemOperations(FileOperations fileOperations) {
+        this.fileOperations = fileOperations;
+    }
+
+    @Override
+    public WorkResult copy(Action<? super CopySpec> action) {
+        return fileOperations.copy(action);
+    }
+
+    @Override
+    public WorkResult sync(Action<? super CopySpec> action) {
+        return fileOperations.sync(action);
+    }
+
+    @Override
+    public WorkResult delete(Action<? super DeleteSpec> action) {
+        return fileOperations.delete(action);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -22,6 +22,7 @@ import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
@@ -83,6 +84,11 @@ public class DefaultObjectFactory implements ObjectFactory {
     @Override
     public ConfigurableFileCollection fileCollection() {
         return fileCollectionFactory.configurableFiles();
+    }
+
+    @Override
+    public ConfigurableFileTree fileTree() {
+        return fileCollectionFactory.fileTree();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
@@ -52,6 +53,11 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
     @Override
     public ConfigurableFileCollection fileCollection() {
         throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing file collections");
+    }
+
+    @Override
+    public ConfigurableFileTree fileTree() {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing file trees");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -19,6 +19,7 @@ package org.gradle.internal.service.scopes;
 import org.gradle.api.Action;
 import org.gradle.api.AntBuilder;
 import org.gradle.api.component.SoftwareComponentContainer;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.MutationGuards;
@@ -34,11 +35,13 @@ import org.gradle.api.internal.component.DefaultSoftwareComponentContainer;
 import org.gradle.api.internal.file.DefaultFileCollectionFactory;
 import org.gradle.api.internal.file.DefaultFileOperations;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
+import org.gradle.api.internal.file.DefaultFileSystemOperations;
 import org.gradle.api.internal.file.DefaultProjectLayout;
 import org.gradle.api.internal.file.DefaultSourceDirectorySetFactory;
 import org.gradle.api.internal.file.DefaultTemporaryFileProvider;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
@@ -191,6 +194,10 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
             fileSystem,
             deleter
         );
+    }
+
+    protected FileSystemOperations createFileSystemOperations(FileOperations fileOperations) {
+        return new DefaultFileSystemOperations(fileOperations);
     }
 
     protected ExecFactory decorateExecFactory(ExecFactory execFactory, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, InstantiatorFactory instantiatorFactory, ObjectFactory objectFactory) {

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -91,6 +91,30 @@
             "member": "Constructor org.gradle.language.nativeplatform.tasks.UnexportMainSymbol()",
             "acceptation": "The class is incubating and was simply move",
             "changes": []
+        },
+        {
+            "type": "org.gradle.api.file.FileSystemOperations",
+            "member": "Class org.gradle.api.file.FileSystemOperations",
+            "acceptation": "New public API",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.file.FileSystemOperations",
+            "member": "Method org.gradle.api.file.FileSystemOperations.copy(org.gradle.api.Action)",
+            "acceptation": "New public API",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.file.FileSystemOperations",
+            "member": "Method org.gradle.api.file.FileSystemOperations.delete(org.gradle.api.Action)",
+            "acceptation": "New public API",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.file.FileSystemOperations",
+            "member": "Method org.gradle.api.file.FileSystemOperations.sync(org.gradle.api.Action)",
+            "acceptation": "New public API",
+            "changes": []
         }
     ]
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.project.DefaultProject
@@ -476,6 +477,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         ObjectFactory.name               | "objects"                                                   | "newInstance(SomeBean)"
         ToolingModelBuilderRegistry.name | "project.services.get(${ToolingModelBuilderRegistry.name})" | "toString()"
         WorkerExecutor.name              | "project.services.get(${WorkerExecutor.name})"              | "noIsolation()"
+        FileSystemOperations.name        | "project.services.get(${FileSystemOperations.name})"        | "toString()"
     }
 
     @Unroll

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -18,6 +18,7 @@ package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformActionScheme
@@ -169,6 +170,7 @@ class Codecs(
         bind(ownerService<FileResolver>())
         bind(ownerService<Instantiator>())
         bind(ownerService<FileCollectionFactory>())
+        bind(ownerService<FileSystemOperations>())
         bind(ownerService<FileOperations>())
         bind(ownerService<BuildOperationExecutor>())
         bind(ownerService<ToolingModelBuilderRegistry>())

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -22,7 +22,6 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -70,8 +69,6 @@ public class CppLibraryPlugin implements Plugin<Project> {
     private final TargetMachineFactory targetMachineFactory;
 
     /**
-     * Injects a {@link FileOperations} instance.
-     *
      * @since 4.2
      */
     @Inject

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -69,6 +69,8 @@ public class CppLibraryPlugin implements Plugin<Project> {
     private final TargetMachineFactory targetMachineFactory;
 
     /**
+     * CppLibraryPlugin.
+     *
      * @since 4.2
      */
     @Inject

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
@@ -20,7 +20,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.language.internal.NativeComponentFactory;
@@ -57,8 +56,6 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
     private final TargetMachineFactory targetMachineFactory;
 
     /**
-     * Injects a {@link FileOperations} instance.
-     *
      * @since 4.2
      */
     @Inject

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
@@ -56,6 +56,8 @@ public class SwiftApplicationPlugin implements Plugin<Project> {
     private final TargetMachineFactory targetMachineFactory;
 
     /**
+     * SwiftApplicationPlugin.
+     *
      * @since 4.2
      */
     @Inject

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -21,9 +21,9 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -191,7 +191,7 @@ public class InstallExecutable extends DefaultTask {
     }
 
     @Inject
-    protected FileOperations getFileOperations() {
+    protected FileSystemOperations getFileSystemOperations() {
         throw new UnsupportedOperationException();
     }
 
@@ -260,7 +260,7 @@ public class InstallExecutable extends DefaultTask {
     }
 
     private void installToDir(final File binaryDir, final File executableFile, final Collection<File> libs) {
-        getFileOperations().sync(copySpec -> {
+        getFileSystemOperations().sync(copySpec -> {
             copySpec.into(binaryDir);
             copySpec.from(executableFile);
             copySpec.from(libs);

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/JavaScriptMinify.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/JavaScriptMinify.java
@@ -20,13 +20,11 @@ import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.RelativeFile;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
@@ -64,7 +62,7 @@ public class JavaScriptMinify extends SourceTask {
     }
 
     @Inject
-    protected FileResolver getFileResolver() {
+    protected FileSystemOperations getFileSystemOperations() {
         throw new UnsupportedOperationException();
     }
 
@@ -167,8 +165,7 @@ public class JavaScriptMinify extends SourceTask {
             final File outputFileDir = new File(destinationDir, fileDetails.getRelativePath().getParent().getPathString());
 
             // Copy the raw form
-            FileOperations fileOperations = ((ProjectInternal) getProject()).getFileOperations();
-            fileOperations.copy(new Action<CopySpec>() {
+            getFileSystemOperations().copy(new Action<CopySpec>() {
                 @Override
                 public void execute(CopySpec copySpec) {
                     copySpec.from(fileDetails.getFile()).into(outputFileDir);

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
@@ -23,9 +23,9 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.InputFile;
@@ -77,7 +77,7 @@ public class InstallXCTestBundle extends DefaultTask {
     }
 
     @Inject
-    protected FileOperations getFileOperations() {
+    protected FileSystemOperations getFileSystemOperations() {
         throw new UnsupportedOperationException();
     }
 
@@ -100,7 +100,7 @@ public class InstallXCTestBundle extends DefaultTask {
     }
 
     private void installToDir(final File bundleDir, final File bundleFile) throws IOException {
-        getFileOperations().sync(new Action<CopySpec>() {
+        getFileSystemOperations().sync(new Action<CopySpec>() {
             @Override
             public void execute(CopySpec copySpec) {
                 copySpec.from(bundleFile, new Action<CopySpec>() {


### PR DESCRIPTION
for `copy`/`sync`/`delete` operations, usable from task actions without referencing `Project`.

Only exposed as a project scope service as a first step.
