### PR TITLE
Add build cache training promotion link to selected docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/build_cache.adoc
@@ -15,6 +15,8 @@
 [[build_cache]]
 = Build Cache
 
+TIP: Want to learn the tips and tricks top engineering teams use to keep builds fast and performant? https://gradle.com/training/build-cache-deep-dive/?bid=docs-build-cache[Register here] for our Build Cache Training.
+
 NOTE: The build cache feature described here is different from the https://developer.android.com/studio/build/build-cache.html[Android plugin build cache].
 
 [[sec:build_cache_intro]]

--- a/subprojects/docs/src/docs/userguide/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/build_environment.adoc
@@ -15,6 +15,8 @@
 [[build_environment]]
 = Build Environment
 
+TIP: Interested in configuring your Build Cache to speed up builds? https://gradle.com/training/build-cache-deep-dive/?bid=docs-build-environment[Register here] for our Build Cache training session to learn some of the tips and tricks top engineering teams are using to increase build speed.
+
 [.lead]
 Gradle provides multiple mechanisms for configuring behavior of Gradle itself and specific projects. The following is a reference for using these mechanisms.
 

--- a/subprojects/docs/src/docs/userguide/intro_multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/intro_multi_project_builds.adoc
@@ -15,6 +15,8 @@
 [[intro_multi_project_builds]]
 = Executing Multi-Project Builds
 
+TIP: The Gradle Build Cache can help reduce build time of multi project builds by up to 90%. https://gradle.com/training/build-cache-deep-dive/?bid=docs-multi-project-builds[Register here] for our live Build Cache training session to learn how.
+
 Only the smallest of projects has a single build file and source tree, unless it happens to be a massive, monolithic application. It’s often much easier to digest and understand a project that has been split into smaller, inter-dependent modules. The word “inter-dependent” is important, though, and is why you typically want to link the modules together through a single build.
 
 Gradle supports this scenario through _multi-project_ builds.

--- a/subprojects/docs/src/docs/userguide/migrating_from_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/migrating_from_maven.adoc
@@ -15,6 +15,8 @@
 [[migrating_from_maven]]
 = Migrating Builds From Apache Maven
 
+TIP: Suffering from slow Maven builds? https://gradle.com/training/build-cache-deep-dive/?bid=docs-migrating-maven[Register here] for our Build Cache training session to learn how Gradle Enterprise can speed up Maven builds by up to 90%.
+
 https://maven.apache.org[Apache Maven] is a build tool for Java and other JVM-based projects that's in widespread use, and so people that want to use Gradle often have to migrate an existing Maven build.
 This guide will help with such a migration by explaining the differences and similarities between the two tools' models and providing steps that you can follow to ease the process.
 

--- a/subprojects/docs/src/docs/userguide/userguide.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide.adoc
@@ -14,6 +14,8 @@
 
 = Gradle User Manual
 
+TIP: Want to learn the tips and tricks top engineering teams use to keep builds fast and performant? https://gradle.com/training/build-cache-deep-dive/?bid=docs-userguide[Register here] for our Build Cache Training.
+
 Gradle is an open-source build automation tool focused on flexibility and performance. Gradle build scripts are written using a link:https://groovy-lang.org/[Groovy] or link:https://kotlinlang.org/[Kotlin] DSL. Read about link:{website}/features/[Gradle features] to learn what is possible with Gradle.
 
  * **Highly customizable** — Gradle is modeled in a way that is customizable and extensible in the most fundamental ways.


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #? This adds Build Cache Training Promotion to some of the docs.

### Context
<!--- Why do you believe many users will benefit from this change? -->
Requested by marketing to increase build cache training attendance.
<!--- Link to relevant issues or forum discussions here -->
https://github.com/gradle/marketing/issues/1230

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
