### PR TITLE
Properties are rehydrated with the proper provided type

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -21,6 +21,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.internal.Cast;
 import org.gradle.internal.state.ManagedFactory;
 
 import javax.annotation.Nullable;
@@ -58,7 +59,15 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new DefaultProperty<>(Object.class).value(state));
+            if (state == null) {
+                return type.cast(new DefaultProperty<>(Object.class));
+            } else {
+                return type.cast(propertyOf(state.getClass(), Cast.uncheckedCast(state)));
+            }
+        }
+
+        static <V> Property<V> propertyOf(Class<V> type, V value) {
+            return new DefaultProperty<V>(type).value(value);
         }
 
         @Override

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 @IntegrationTestTimeout(120)
 class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     def nestingParameterType = fixture.workParameterClass("NestingParameter", "org.gradle.test").withFields([
-        "greeting": "String",
+        "greeting": "Property<String>",
         "childSubmissions": "int"
     ])
 
@@ -205,7 +205,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
             def theGreeting = parameters.greeting
             parameters.childSubmissions.times {
                 executor."\${getWorkerMethod($nestedIsolationMode)}"().submit(SecondLevelExecution) {
-                    greeting = theGreeting
+                    greeting.set(theGreeting)
                 }
             }
         """
@@ -215,7 +215,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
     WorkerExecutorFixture.WorkActionClass getSecondLevelExecution() {
         def workerClass = fixture.workActionClass("SecondLevelExecution", "org.gradle.test", nestingParameterType)
         workerClass.action = """
-            System.out.println(parameters.greeting)
+            System.out.println(parameters.greeting.get())
         """
         return workerClass
     }

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -380,8 +380,12 @@ class WorkerExecutorFixture {
             fields.each { name, type ->
                 fieldDeclarations += """
                     ${type} get${name.capitalize()}();
-                    void set${name.capitalize()}(${type} ${name.uncapitalize()});
                 """
+                if (!type.startsWith("Property<")) {
+                    fieldDeclarations += """
+                        void set${name.capitalize()}(${type} ${name.uncapitalize()});
+                    """
+                }
             }
             return fieldDeclarations
         }


### PR DESCRIPTION
This ensures that the property objects that are created when properties are isolated have a proper type associated.

Fixes #10391 

