### PR TITLE
Clean up ivy publication and publish more information to ivy.xml metadata

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -358,7 +358,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         repository('ivy') {
             "org:ivy:1.0" {
                 withModule(IvyModule) {
-                    dependsOn([organisation: 'org', module: targetRepoName, revision: '1.0', conf: 'compile->compile'])
+                    dependsOn([organisation: 'org', module: targetRepoName, revision: '1.0', conf: 'runtime->compile'])
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Issue
 import spock.lang.Unroll
 
 
-class  ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponentSelectionRulesIntegrationTest {
+class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponentSelectionRulesIntegrationTest {
     boolean isWellBehaved(boolean mavenCompatible, boolean gradleCompatible = true) {
         (GradleMetadataResolveRunner.useIvy() || mavenCompatible) && (!GradleMetadataResolveRunner.gradleMetadataPublished || gradleCompatible)
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorDependencyExcludeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDescriptorDependencyExcludeResolveIntegrationTest.groovy
@@ -416,7 +416,9 @@ class IvyDescriptorDependencyExcludeResolveIntegrationTest extends AbstractIvyDe
         ivyRepo.module("org.gradle.test", "a", "1.0")
                 .dependsOn("org.gradle.dep", "dep_module", "1.134")
                 .withXml({
-            asNode().dependencies[0].dependency[0].appendNode("exclude", excludeAttributes)
+            asNode().dependencies[0].dependency.each { dep ->
+                dep.appendNode("exclude", excludeAttributes)
+            }
         })
                 .publish()
 
@@ -454,15 +456,18 @@ class IvyDescriptorDependencyExcludeResolveIntegrationTest extends AbstractIvyDe
         ivyRepo.module("a")
                 .dependsOn("c")
                 .withXml({
-            asNode().dependencies[0].dependency[0].appendNode("exclude", [module: "d"])
+            asNode().dependencies[0].dependency.each { dep ->
+                dep.appendNode("exclude", [module: "d"])
+            }
         })
                 .publish()
         ivyRepo.module("b")
                 .dependsOn("c")
                 .withXml({
-            def dep = asNode().dependencies[0].dependency[0]
-            dep.appendNode("exclude", [module: "d"])
-            dep.appendNode("exclude", [module: "e"])
+            asNode().dependencies[0].dependency.each { dep ->
+                dep.appendNode("exclude", [module: "d"])
+                dep.appendNode("exclude", [module: "e"])
+            }
         })
                 .publish()
 
@@ -491,9 +496,9 @@ task syncMerged(type: Sync) {
 
     private void addExcludeRuleToModuleDependency(IvyModule module, String dependencyName, Map<String, String> excludeAttributes) {
         module.withXml {
-            Node moduleDependency = asNode().dependencies[0].dependency.find { it.@name == dependencyName }
-            assert moduleDependency, "Failed to find module dependency with name '$dependencyName'"
-            moduleDependency.appendNode(EXCLUDE_ATTRIBUTE, excludeAttributes)
+            asNode().dependencies[0].dependency.findAll { it.@name == dependencyName }.each { Node moduleDependency ->
+                moduleDependency.appendNode(EXCLUDE_ATTRIBUTE, excludeAttributes)
+            }
         }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -543,10 +543,11 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         }
 
         when:
+        def transitiveSelectedVariant = !gradleMetadataPublished && useIvy()? 'default' : variantToTest
         buildFile << """
             class ModifyDepRule implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext context) {
-                    context.details.withVariant('$variantToTest') {
+                    context.details.withVariant('$transitiveSelectedVariant') {
                         with${toCamelCase(thing)} { d ->
                             add('org.test:moduleC:1.0')
                         }
@@ -626,10 +627,11 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         mavenGradleRepo.module("org.test", "moduleC").withModuleMetadata().variant("anotherVariantWithFormatCustom", [format: "custom"]).publish()
 
         when:
+        def transitiveSelectedVariant = !gradleMetadataPublished && useIvy()? 'default' : variantToTest
         buildFile << """
             class AddModuleCRule implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext context) {
-                    context.details.withVariant('$variantToTest') {
+                    context.details.withVariant('$transitiveSelectedVariant') {
                         withDependencies {
                             add('org.test:moduleC:1.0')
                         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -122,6 +122,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
     def "can override attributes"() {
         given:
         withDefaultVariantToTest()
+        def transitiveSelectedVariant = !gradleMetadataPublished && useIvy()? 'default' : variantToTest
         buildFile << """
             class AttributeRule implements ComponentMetadataRule {
                 Attribute attribute
@@ -132,7 +133,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                 }
 
                 void execute(ComponentMetadataContext context) {
-                    context.details.withVariant("$variantToTest") { 
+                    context.details.withVariant("$transitiveSelectedVariant") { 
                         attributes {
                             attribute(attribute, "custom")
                         }
@@ -195,7 +196,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                         } else {
                             if (GradleMetadataResolveRunner.useIvy()) {
                                 // Ivy doesn't derive any variant
-                                expectedTargetVariant = 'customVariant'
+                                expectedTargetVariant = 'default'
                                 expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                             } else {
                                 // for Maven, we derive variants for compile/runtime. Variants are then used during selection, and are subject

--- a/subprojects/docs/src/samples/ivy-publish/java-multi-project/output-ivy.xml
+++ b/subprojects/docs/src/samples/ivy-publish/java-multi-project/output-ivy.xml
@@ -11,12 +11,12 @@
   </info>
   <configurations>
     <conf name="compile" visibility="public"/>
-    <conf name="default" visibility="public" extends="compile,runtime"/>
+    <conf name="default" visibility="public" extends="runtime"/>
     <conf name="runtime" visibility="public"/>
   </configurations>
   <publications>
     <artifact name="project1" type="sources" ext="jar" conf="compile" m:classifier="sources"/>
-    <artifact name="project1" type="jar" ext="jar" conf="compile"/>
+    <artifact name="project1" type="jar" ext="jar" conf="compile,runtime"/>
   </publications>
   <dependencies>
     <dependency org="junit" name="junit" rev="4.12" conf="runtime-&gt;default"/>

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
@@ -76,7 +76,7 @@ class IvyDescriptor {
                     module: dep.@name,
                     revision: dep.@rev,
                     revisionConstraint: dep.@revConstraint,
-                    conf: dep.@conf,
+                    confs: [dep.@conf],
                     transitive: dep.@transitive
             )
 
@@ -85,7 +85,11 @@ class IvyDescriptor {
             }
 
             def key = "${ivyDependency.org}:${ivyDependency.module}:${ivyDependency.revision}"
-            dependencies[key] = ivyDependency
+            if (dependencies[key]) {
+                dependencies[key].confs += ivyDependency.confs
+            } else {
+                dependencies[key] = ivyDependency
+            }
         }
 
         ivy.dependencies.exclude.each { exclude ->
@@ -123,7 +127,7 @@ class IvyDescriptor {
     }
 
     def assertConfigurationDependsOn(String configuration, String[] expected) {
-        def actualDependencies = dependencies.values().findAll { it.conf.contains(configuration) }
+        def actualDependencies = dependencies.values().findAll { it.confs.any { it.contains(configuration) }}
         assert actualDependencies.size() == expected.length
         expected.each {
             String conf = "$configuration->default"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
@@ -21,12 +21,12 @@ class IvyDescriptorDependency {
     String module
     String revision
     String revisionConstraint
-    String conf
+    Set<String> confs
     String transitive
     Collection<IvyDescriptorDependencyExclusion> exclusions = []
 
     boolean hasConf(String conf) {
-        this.conf == conf
+        this.confs.contains(conf)
     }
 
     boolean transitiveEnabled() {
@@ -43,6 +43,6 @@ class IvyDescriptorDependency {
 
     @Override
     String toString() {
-        "$org:$module:$revision $conf ${transitive?'(transitive)':''}"
+        "$org:$module:$revision $confs ${transitive?'(transitive)':''}"
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -477,7 +477,18 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         builder.publications {
             artifacts.each { art ->
                 if (!art.undeclared) {
-                    def attrs = [name: art.name, type: art.type, ext: art.ext, conf: art.conf]
+                    Set<String> confs = []
+                    if (art.conf) {
+                        confs = [art.conf]
+                    } else {
+                        variants.each {
+                            confs += it.name == 'api' ? 'compile' : it.name
+                        }
+                        configurations.keySet().each {
+                            confs += it
+                        }
+                    }
+                    def attrs = [name: art.name, type: art.type, ext: art.ext, conf: confs.join(',')]
                     if (art.classifier) {
                         attrs["m:classifier"] = art.classifier
                     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
@@ -68,7 +68,6 @@ class IvyJavaModule extends DelegatingIvyModule<IvyFileModule> implements Publis
             assert parsedIvy.dependencies.findAll { it.value.conf == 'compile' }.isEmpty()
         } else {
             assert parsedModuleMetadata.variant('apiElements').dependencies*.coords as Set == expected as Set
-            assert parsedModuleMetadata.variant('runtimeElements').dependencies*.coords.containsAll(expected)
             parsedIvy.assertConfigurationDependsOn('compile', expected)
         }
     }
@@ -79,7 +78,7 @@ class IvyJavaModule extends DelegatingIvyModule<IvyFileModule> implements Publis
             assert parsedModuleMetadata.variant('runtimeElements').dependencies.empty
             assert parsedIvy.dependencies.findAll { it.value.conf == 'runtime' }.isEmpty()
         } else {
-            assert parsedModuleMetadata.variant('runtimeElements').dependencies*.coords.containsAll(expected)
+            assert parsedModuleMetadata.variant('runtimeElements').dependencies*.coords as Set == expected as Set
             parsedIvy.assertConfigurationDependsOn('runtime', expected)
         }
 

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependencyTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependencyTest.groovy
@@ -20,9 +20,9 @@ import spock.lang.Specification
 
 class IvyDescriptorDependencyTest extends Specification {
 
-    def "can check if given conf attribute is set"() {
+    def "can check if given confs attribute is set"() {
         given:
-        IvyDescriptorDependency ivyDescriptorDependency = new IvyDescriptorDependency(conf: givenConf)
+        IvyDescriptorDependency ivyDescriptorDependency = new IvyDescriptorDependency(confs: [givenConf])
 
         when:
         boolean matchingConf = ivyDescriptorDependency.hasConf(expectedConf)

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
@@ -98,12 +98,13 @@ class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest {
                         revision "2"
                         configurations {
                             compile {}
+                            runtime {}
                             "default" {
                                 extend "compile"
                             }
                         }
                         artifact(apiJar) {
-                            conf "compile"
+                            conf "compile,runtime"
                         }
                     }
                 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishDescriptorCustomizationIntegTest.groovy
@@ -131,7 +131,7 @@ class IvyPublishDescriptorCustomizationIntegTest extends AbstractIvyPublishInteg
         then:
         file('generated-ivy.xml').assertIsFile()
         IvyDescriptor ivy = new IvyDescriptor(file('generated-ivy.xml'))
-        ivy.expectArtifact(moduleName).hasAttributes("jar", "jar", ["compile"])
+        ivy.expectArtifact(moduleName).hasAttributes("jar", "jar", ["compile", "runtime"])
         module.ivyFile.assertDoesNotExist()
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -1137,6 +1137,36 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         optional << [true, false]
     }
 
+    def "an optional feature variant can repeat a dependency from a main variant"() {
+        given:
+        createBuildScripts("""
+            ${optionalFeatureSetup()}
+            dependencies {
+                implementation 'org:foo:1.0'
+                optionalFeatureImplementation 'org:foo:1.0'
+            }
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
+                it.mapToOptional()
+            }
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                    }
+                }
+            }
+""")
+
+        when:
+        succeeds "publish"
+
+        then:
+        with(javaLibrary.parsedIvy) {
+            assertConfigurationDependsOn("optionalFeatureRuntimeElements", "org:foo:1.0")
+            assertConfigurationDependsOn('runtime', "org:foo:1.0")
+        }
+    }
+
     private void createBuildScripts(def append) {
         settingsFile << "rootProject.name = 'publishTest' "
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -58,13 +58,13 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         with(javaLibrary.parsedIvy) {
             configurations.keySet() == ["default", "compile", "runtime"] as Set
-            configurations["default"].extend == ["runtime", "compile"] as Set
+            configurations["default"].extend == ["runtime"] as Set
             configurations["runtime"].extend == null
 
-            expectArtifact("publishTest").hasAttributes("jar", "jar", ["compile"])
+            expectArtifact("publishTest").hasAttributes("jar", "jar", ["compile", "runtime"])
         }
         javaLibrary.assertApiDependencies('commons-collections:commons-collections:3.2.2')
-        javaLibrary.assertRuntimeDependencies('commons-io:commons-io:1.4')
+        javaLibrary.assertRuntimeDependencies('commons-collections:commons-collections:3.2.2', 'commons-io:commons-io:1.4')
 
         and:
         resolveArtifacts(javaLibrary) {
@@ -122,9 +122,8 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         javaLibrary.assertPublished()
         if (ivyConfiguration == 'compile') {
             javaLibrary.assertApiDependencies('org.gradle.test:b:1.2')
-        } else {
-            javaLibrary.assertRuntimeDependencies('org.gradle.test:b:1.2')
         }
+        javaLibrary.assertRuntimeDependencies('org.gradle.test:b:1.2')
 
         where:
         plugin         | gradleConfiguration | ivyConfiguration | deprecatedConfiguration
@@ -1155,14 +1154,14 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         with(javaLibrary.parsedIvy) {
             configurations.keySet() == ["default", "compile", "runtime", "optionalFeatureRuntimeElements"] as Set
             if (optional) {
-                configurations["default"].extend == ["runtime", "compile"] as Set
+                configurations["default"].extend == ["runtime"] as Set
             } else {
-                configurations["default"].extend == ["runtime", "compile", "optionalFeatureRuntimeElements"] as Set
+                configurations["default"].extend == ["runtime", "optionalFeatureRuntimeElements"] as Set
             }
             configurations["runtime"].extend == null
             configurations["optionalFeatureRuntimeElements"].extend == null
 
-            expectArtifact("publishTest", "jar").hasConf(["compile"])
+            expectArtifact("publishTest", "jar").hasConf(["compile", "runtime"])
             expectArtifact("publishTest", "jar", "optional-feature").hasConf(["optionalFeatureRuntimeElements"])
             assertConfigurationDependsOn("optionalFeatureRuntimeElements", "org.slf4j:slf4j-api:1.7.26")
         }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -236,8 +236,8 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
         }
 
         and:
-        javaLibrary.parsedIvy.assertConfigurationDependsOn('compile', "org.test:foo:1.0")
-        javaLibrary.parsedIvy.assertConfigurationDependsOn('runtime', 'org.test:bar:1.1')
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('compile', 'org.test:foo:1.0')
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('runtime', 'org.test:foo:1.0', 'org.test:bar:1.1')
 
         and:
         resolveArtifacts(javaLibrary) {
@@ -323,13 +323,13 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
             assert it.org == 'org.test'
             assert it.module == 'foo'
             assert it.revision == '1.0'
-            assert it.conf == 'compile->default'
+            assert it.confs == ['compile->default', 'runtime->default'] as Set
         }
         dependencies.get("org.test:bar:1.1").with {
             assert it.org == 'org.test'
             assert it.module == 'bar'
             assert it.revision == '1.1'
-            assert it.conf == 'runtime->default'
+            assert it.confs == ['runtime->default'] as Set
         }
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
             constraint("org.test:bar:1.1") {


### PR DESCRIPTION
This cleans up the implementation of `DefaultIvyPublication.populateFromComponent()` and introduces the following changes that publish information which was lossy before:

- Artifacts are now added to all configurations they belong to and not just the first found
- Dependencies are now added for all configurations they belong to, with the corresponding mapping and version, and not just for the first found
- For a Java library, this means the 'runtime' now represents the full runtime variant of the library (before, only 'default' represented that)

This changes the "internals" of how an ivy file published for a java library looks. But when resolving it with the "default" configuration, we get the same result. It is only a "breaking change" if you resolve "compile" or "runtime" directly, but these were arguably wrong before. This also does not happen between multiple modules published with Gradle, as they always select "default" in the target module. So this change is ok with a major release.

## Example

**Build Script**

```
dependencies {
    implementation("org:mylib:2.0")
    api("org:otherlib:1.0")
}
```

**Before**
```
<ivy-module version="2.0">
  <info organisation="org" module="test" revision="1.0" status="integration"/>
  <configurations>
    <conf name="compile" visibility="public"/>
    <conf name="default" visibility="public" extends="compile,runtime"/>
    <conf name="runtime" visibility="public"/>
  </configurations>
  <publications>
    <artifact name="test" type="jar" ext="jar" conf="compile"/>
  </publications>
  <dependencies>
    <dependency org="org" name="otherlib" rev="1.0" conf="compile->default"/>
    <dependency org="org" name="mylib" rev="2.0" conf="runtime->default"/>
  </dependencies>
</ivy-module>

```

**After**
```
<ivy-module version="2.0">
  <info organisation="org" module="test" revision="1.0" status="integration"/>
  <configurations>
    <conf name="compile" visibility="public"/>
    <conf name="default" visibility="public" extends="runtime"/>
    <conf name="runtime" visibility="public"/>
  </configurations>
  <publications>
    <artifact name="test" type="jar" ext="jar" conf="compile,runtime"/>
  </publications>
  <dependencies>
    <dependency org="org" name="otherlib" rev="1.0" conf="compile->default"/>
    <dependency org="org" name="mylib" rev="2.0" conf="runtime->default"/>
    <dependency org="org" name="otherlib" rev="1.0" conf="runtime->default"/>
  </dependencies>
</ivy-module>
```
Part of this PR is also an adjustment to the resolving test fixture so that they represent what we would publish (they were also not 100% correct before).

