### PR TITLE
No `@Optional` on method parameters

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Optional.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Optional.java
@@ -15,7 +15,11 @@
  */
 package org.gradle.api.tasks;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Marks a task property as optional. This means that a value does not have to be specified for the property, but any
@@ -38,6 +42,6 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.METHOD, ElementType.FIELD})
 public @interface Optional {
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ExcludeRuleNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ExcludeRuleNotationConverter.java
@@ -18,12 +18,13 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ExcludeRule;
-import org.gradle.api.tasks.Optional;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
+
+import javax.annotation.Nullable;
 
 public class ExcludeRuleNotationConverter extends MapNotationConverter<ExcludeRule> {
 
@@ -39,8 +40,10 @@ public class ExcludeRuleNotationConverter extends MapNotationConverter<ExcludeRu
         visitor.candidate("Maps with 'group' and/or 'module'").example("[group: 'com.google.collections', module: 'google-collections']");
     }
 
-    protected ExcludeRule parseMap(@MapKey(ExcludeRule.GROUP_KEY) @Optional String group,
-                         @MapKey(ExcludeRule.MODULE_KEY) @Optional String module) {
+    protected ExcludeRule parseMap(
+        @MapKey(ExcludeRule.GROUP_KEY) @Nullable String group,
+        @MapKey(ExcludeRule.MODULE_KEY) @Nullable String module
+    ) {
         if (group == null && module == null) {
             throw new InvalidUserDataException("Dependency exclude rule requires 'group' and/or 'module' specified. For example: [group: 'com.google.collections']");
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/typeconversion/MapNotationConverter.java
@@ -17,12 +17,14 @@ package org.gradle.internal.typeconversion;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.tasks.Optional;
+import org.gradle.internal.Cast;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.reflect.CachedInvokable;
 import org.gradle.internal.reflect.ReflectionCache;
 import org.gradle.util.ConfigureUtil;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -48,7 +50,7 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
 
     @Override
     public T parseType(Map values) throws UnsupportedNotationException {
-        Map<String, Object> mutableValues = new HashMap<String, Object>(values);
+        Map<String, Object> mutableValues = new HashMap<>(Cast.uncheckedNonnullCast(values));
         Set<String> missing = null;
         ConvertMethod convertMethod = null;
         Method method = null;
@@ -74,7 +76,7 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
             }
             if (!optional && value == null) {
                 if (missing == null) {
-                    missing = new TreeSet<String>();
+                    missing = new TreeSet<>();
                 }
                 missing.add(keyName);
             }
@@ -89,7 +91,7 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
 
         T result;
         try {
-            result = (T) method.invoke(this, params);
+            result = Cast.uncheckedNonnullCast(method.invoke(this, params));
         } catch (IllegalAccessException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         } catch (InvocationTargetException e) {
@@ -100,6 +102,7 @@ public abstract class MapNotationConverter<T> extends TypedNotationConverter<Map
         return result;
     }
 
+    @Nullable
     protected String get(Map<String, Object> args, String key) {
         Object value = args.get(key);
         String str = value != null ? value.toString() : null;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultExcludeRuleContainerTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/DefaultExcludeRuleContainerTest.java
@@ -20,9 +20,16 @@ import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.util.WrapUtil;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
 public class DefaultExcludeRuleContainerTest {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/MapNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/MapNotationConverterTest.groovy
@@ -16,12 +16,13 @@
 package org.gradle.internal.typeconversion
 
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.tasks.Optional
 import spock.lang.Specification
+
+import javax.annotation.Nullable
 
 class MapNotationConverterTest extends Specification {
     final NotationParser parser = NotationParserBuilder.toType(TargetObject).converter(new DummyConverter()).toComposite()
-    
+
     def "parses map with required keys"() {
         expect:
         def object = parser.parseNotation([name: 'name', version: 'version'])
@@ -50,10 +51,10 @@ class MapNotationConverterTest extends Specification {
     def "does not mutate original map"() {
         def source = [name: 'name', version: 'version', prop1: 'prop1', optional: '1.2']
         def copy = new HashMap<String, Object>(source)
-        
+
         when:
         parser.parseNotation(source)
-        
+
         then:
         source == copy
     }
@@ -93,11 +94,11 @@ class MapNotationConverterTest extends Specification {
         then:
         thrown(UnsupportedNotationException)
     }
-    
+
     static class DummyConverter extends MapNotationConverter<TargetObject> {
         protected TargetObject parseMap(@MapKey('name') String name,
                                         @MapKey('version') String version,
-                                        @Optional @MapKey('optional') optional) {
+                                        @MapKey('optional') @Nullable optional) {
             return new TargetObject(key1:  name, key2:  version, optional:  optional)
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.dsl;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.tasks.Optional;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
@@ -108,7 +107,7 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
 
         protected Capability parseMap(@MapKey("group") String group,
                                       @MapKey("name") String name,
-                                      @MapKey("version") @Optional String version) {
+                                      @MapKey("version") @Nullable String version) {
             return new ImmutableCapability(group, name, version);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyMapNotationConverter.java
@@ -17,11 +17,12 @@ package org.gradle.api.internal.notations;
 
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ModuleFactoryHelper;
-import org.gradle.api.tasks.Optional;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
+
+import javax.annotation.Nullable;
 
 public class DependencyMapNotationConverter<T> extends MapNotationConverter<T> {
 
@@ -38,12 +39,12 @@ public class DependencyMapNotationConverter<T> extends MapNotationConverter<T> {
         visitor.candidate("Maps").example("[group: 'org.gradle', name: 'gradle-core', version: '1.0']");
     }
 
-    protected T parseMap(@MapKey("group") @Optional String group,
-                         @MapKey("name") @Optional String name,
-                         @MapKey("version") @Optional String version,
-                         @MapKey("configuration") @Optional String configuration,
-                         @MapKey("ext") @Optional String ext,
-                         @MapKey("classifier") @Optional String classifier) {
+    protected T parseMap(@MapKey("group") @Nullable String group,
+                         @MapKey("name") @Nullable String name,
+                         @MapKey("version") @Nullable String version,
+                         @MapKey("configuration") @Nullable String configuration,
+                         @MapKey("ext") @Nullable String ext,
+                         @MapKey("classifier") @Nullable String classifier) {
         T dependency;
         if (configuration == null) {
             dependency = instantiator.newInstance(resultingType, group, name, version);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/ProjectDependencyFactory.java
@@ -18,12 +18,12 @@ package org.gradle.api.internal.notations;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
-import org.gradle.api.tasks.Optional;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 public class ProjectDependencyFactory {
@@ -48,7 +48,10 @@ public class ProjectDependencyFactory {
             this.factory = factory;
         }
 
-        protected ProjectDependency parseMap(@MapKey("path") String path, @Optional @MapKey("configuration") String configuration) {
+        protected ProjectDependency parseMap(
+            @MapKey("path") String path,
+            @MapKey("configuration") @Nullable String configuration
+        ) {
             return factory.create(projectFinder.getProject(path), configuration);
         }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/NativeDependencyNotationParser.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/NativeDependencyNotationParser.java
@@ -16,12 +16,17 @@
 
 package org.gradle.nativeplatform.internal.resolve;
 
-import org.gradle.api.tasks.Optional;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
-import org.gradle.internal.typeconversion.*;
+import org.gradle.internal.typeconversion.MapKey;
+import org.gradle.internal.typeconversion.MapNotationConverter;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.typeconversion.NotationParserBuilder;
+import org.gradle.internal.typeconversion.TypedNotationConverter;
 import org.gradle.nativeplatform.NativeLibraryRequirement;
 import org.gradle.nativeplatform.NativeLibrarySpec;
 import org.gradle.nativeplatform.internal.ProjectNativeLibraryRequirement;
+
+import javax.annotation.Nullable;
 
 class NativeDependencyNotationParser {
     public static NotationParser<Object, NativeLibraryRequirement> parser() {
@@ -51,7 +56,11 @@ class NativeDependencyNotationParser {
         }
 
         @SuppressWarnings("unused")
-        protected NativeLibraryRequirement parseMap(@MapKey("library") String libraryName, @Optional @MapKey("project") String projectPath, @Optional @MapKey("linkage") String linkage) {
+        protected NativeLibraryRequirement parseMap(
+            @MapKey("library") String libraryName,
+            @MapKey("project") @Nullable String projectPath,
+            @MapKey("linkage") @Nullable String linkage
+        ) {
             return new ProjectNativeLibraryRequirement(projectPath, libraryName, linkage);
         }
     }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/PlayPlatformNotationParser.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/PlayPlatformNotationParser.java
@@ -16,7 +16,6 @@
 
 package org.gradle.play.internal;
 
-import org.gradle.api.tasks.Optional;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.MapKey;
 import org.gradle.internal.typeconversion.MapNotationConverter;
@@ -27,6 +26,8 @@ import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.TypeConversionException;
 import org.gradle.platform.base.internal.DefaultPlatformRequirement;
 import org.gradle.platform.base.internal.PlatformRequirement;
+
+import javax.annotation.Nullable;
 
 public class PlayPlatformNotationParser {
 
@@ -51,8 +52,8 @@ public class PlayPlatformNotationParser {
         }
 
         protected PlatformRequirement parseMap(@MapKey("play") String playVersion,
-                                               @MapKey("scala") @Optional String scalaVersion,
-                                               @MapKey("java") @Optional String javaVersion) {
+                                               @MapKey("scala") @Nullable String scalaVersion,
+                                               @MapKey("java") @Nullable String javaVersion) {
             return new PlayPlatformRequirement(playVersion, scalaVersion, javaVersion);
         }
     }


### PR DESCRIPTION
Fixes #10324

We are now using `@Nullable` in `MapNotationConverter` to denote map parameters that can be `null` instead of `@Optional`.