### PR TITLE
Make TaskInputs.getProperties() unmodifiable

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -69,7 +69,10 @@ public interface TaskInputs {
     TaskInputFilePropertyBuilder dir(Object dirPath);
 
     /**
-     * Returns the set of input properties for this task.
+     * Returns a map of input properties for this task.
+     *
+     * The returned map is unmodifiable, and does not reflect further changes to the task's properties.
+     * Trying to modify the map will result in an {@link UnsupportedOperationException} being thrown.
      *
      * @return The properties.
      */

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
@@ -153,4 +153,18 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         outputContains("files = [a, b, c]")
     }
 
+    def "cannot modify task's input properties via returned map"() {
+        given:
+        buildFile << """
+            tasks.create("thing") {
+                inputs.properties.put("Won't", "happen")
+            }
+        """
+
+        when:
+        fails("thing")
+
+        then:
+        errorOutput.contains("java.lang.UnsupportedOperationException")
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.TaskInputPropertyBuilder;
 import org.gradle.api.tasks.TaskInputs;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -155,7 +156,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
     public Map<String, Object> getProperties() {
         GetInputPropertiesVisitor visitor = new GetInputPropertiesVisitor(task.getName());
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
-        return visitor.getPropertyValuesSupplier().get();
+        return Collections.unmodifiableMap(visitor.getPropertyValuesSupplier().get());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputPropertiesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputPropertiesVisitor.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
 
 public class GetInputPropertiesVisitor extends PropertyVisitor.Adapter {
     private final String beanName;
-    private List<InputPropertySpec> inputProperties = new ArrayList<InputPropertySpec>();
+    private final List<InputPropertySpec> inputProperties = new ArrayList<>();
 
     public GetInputPropertiesVisitor(String beanName) {
         this.beanName = beanName;
@@ -40,7 +40,7 @@ public class GetInputPropertiesVisitor extends PropertyVisitor.Adapter {
 
     public Supplier<Map<String, Object>> getPropertyValuesSupplier() {
         return () -> {
-            Map<String, Object> result = new HashMap<String, Object>();
+            Map<String, Object> result = new HashMap<>();
             for (InputPropertySpec inputProperty : inputProperties) {
                 String propertyName = inputProperty.getPropertyName();
                 try {

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -218,6 +218,8 @@ The following breaking changes will appear as deprecation warnings with Gradle 5
 * The `getEffectiveAnnotationProcessorPath()` method is removed from the `JavaCompile` and `ScalaCompile` tasks.
 * Changing the value of a task property with type `Property<T>` after the task has started execution now results in an error.
 * The `isLegacyLayout()` method is removed from `SourceSetOutput`.
+* The map returned by `TaskInputs.getProperties()` is now unmodifiable.
+  Trying to modify it will result in an `UnsupportedOperationException` being thrown.
 
 [[changes_5.6]]
 == Upgrading from 5.5 and earlier


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #6821
