### PR TITLE
Fix enableFeaturePreview failure on template project execution

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -109,9 +109,14 @@ abstract class FileContentGenerator {
             }
 
             return includedProjects + """
-            if(org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("4.6")) {
-            ${config.featurePreviews.collect { "enableFeaturePreview(\"$it\")" }.join("\n")}
-            }
+                def enableFeaturePreviewSafe(String feature) {
+                     try {
+                        enableFeaturePreview(feature)
+                     } catch(Exception ignored) {
+                     }
+                }
+
+                ${config.featurePreviews.collect { "enableFeaturePreviewSafe(\"$it\")" }.join("\n")}
             """
         }
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -112,7 +112,9 @@ abstract class FileContentGenerator {
                 def enableFeaturePreviewSafe(String feature) {
                      try {
                         enableFeaturePreview(feature)
+                        println "Enabled feature preview " + feature
                      } catch(Exception ignored) {
+                        println "Failed to enable feature preview " + feature
                      }
                 }
 


### PR DESCRIPTION
Fix https://github.com/gradle/gradle/issues/10454

Previously, lower Gradle version might not be able to execute the template project
generated because of it doesn't have some features. This commit fixes it by catching
the exception.
