### PR TITLE
Disallow changes to the value of a task `Property` after task execution has started

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -487,7 +487,7 @@ The following types/formats are supported:
 
         then:
         failure.assertHasDescription("Could not determine the dependencies of task ':a'.")
-        failure.assertHasCause("No value has been specified for this provider.")
+        failure.assertHasCause("No value has been specified for this property.")
     }
 
     def "input file collection containing task provider implies dependency on all outputs of the task"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -39,7 +39,7 @@ class DefaultObjectFactoryTest extends Specification {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'No value has been specified for this provider.'
+        e.message == 'No value has been specified for this property.'
     }
 
     def "cannot create property for null value"() {

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -208,6 +208,7 @@ Miscellaneous::
 * Declaring an <<custom_tasks.adoc#incremental_tasks,incremental task>> without declaring outputs is now an error.
   Declare file outputs or use link:{javadocPath}/org/gradle/api/tasks/TaskOutputs.html#upToDateWhen-groovy.lang.Closure-[TaskOutputs.upToDateWhen()] instead.
 * The `getEffectiveAnnotationProcessorPath()` method is removed from the `JavaCompile` and `ScalaCompile` tasks.
+* Changing the value of a task property with type `Property<T>` after the task has started execution now results in an error.
 
 [[changes_5.6]]
 == Upgrading from 5.5 and earlier

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionPropertyIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionPropertyIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
 
-class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
+class FileCollectionPropertyIntegrationTest extends AbstractIntegrationSpec {
     @Unroll
     def "task #annotation file property is implicitly finalized when task starts execution"() {
         buildFile << """

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.gradle.api.file
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
-class FilePropertiesIntegrationTest extends AbstractIntegrationSpec {
+class FilePropertyIntegrationTest extends AbstractIntegrationSpec {
     def "can attach a calculated directory to task property"() {
         buildFile << """
             class SomeTask extends DefaultTask {

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
@@ -207,35 +207,35 @@ task useFileProviderApi {
 
         then:
         failure.assertHasDescription("Execution failed for task ':useIntTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.Directory using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.Directory using an instance of type java.lang.Integer.")
 
         when:
         fails("useIntTypeApi")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useIntTypeApi'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.Directory using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.Directory using an instance of type java.lang.Integer.")
 
         when:
         fails("useFileTypeDsl")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useFileTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.Directory using an instance of type org.gradle.api.internal.file.DefaultFilePropertyFactory\$FixedFile.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.Directory using an instance of type org.gradle.api.internal.file.DefaultFilePropertyFactory\$FixedFile.")
 
         when:
         fails("useFileProviderDsl")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useFileProviderDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.Directory using a provider of type org.gradle.api.file.RegularFile.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.Directory using a provider of type org.gradle.api.file.RegularFile.")
 
         when:
         fails("useFileProviderApi")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useFileProviderApi'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.Directory using a provider of type org.gradle.api.file.RegularFile.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.Directory using a provider of type org.gradle.api.file.RegularFile.")
     }
 
     def "reports failure to set regular file property value using incompatible type"() {
@@ -288,35 +288,35 @@ task useDirProviderApi {
 
         then:
         failure.assertHasDescription("Execution failed for task ':useIntTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.RegularFile using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.RegularFile using an instance of type java.lang.Integer.")
 
         when:
         fails("useIntTypeApi")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useIntTypeApi'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.RegularFile using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.RegularFile using an instance of type java.lang.Integer.")
 
         when:
         fails("useDirTypeDsl")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useDirTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.RegularFile using an instance of type org.gradle.api.internal.file.DefaultFilePropertyFactory\$FixedDirectory.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.RegularFile using an instance of type org.gradle.api.internal.file.DefaultFilePropertyFactory\$FixedDirectory.")
 
         when:
         fails("useDirProviderDsl")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useDirProviderDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.RegularFile using a provider of type org.gradle.api.file.Directory.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.RegularFile using a provider of type org.gradle.api.file.Directory.")
 
         when:
         fails("useDirProviderApi")
 
         then:
         failure.assertHasDescription("Execution failed for task ':useDirProviderApi'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.RegularFile using a provider of type org.gradle.api.file.Directory.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type org.gradle.api.file.RegularFile using a provider of type org.gradle.api.file.Directory.")
     }
 
     def "can wire the output file of a task as input to another task using property"() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
@@ -173,35 +173,35 @@ class DefaultFilePropertyFactoryTest extends Specification {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'No value has been specified for this provider.'
+        e.message == 'No value has been specified for this property.'
 
         when:
         fileProvider.get()
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'No value has been specified for this provider.'
+        e2.message == 'No value has been specified for this property.'
 
         when:
         dir.get()
 
         then:
         def e3 = thrown(IllegalStateException)
-        e3.message == 'No value has been specified for this provider.'
+        e3.message == 'No value has been specified for this property.'
 
         when:
         file.get()
 
         then:
         def e4 = thrown(IllegalStateException)
-        e4.message == 'No value has been specified for this provider.'
+        e4.message == 'No value has been specified for this property.'
 
         when:
         tree.files
 
         then:
         def e5 = thrown(IllegalStateException)
-        e5.message == 'No value has been specified for this provider.'
+        e5.message == 'No value has been specified for this property.'
     }
 
     @SuppressWarnings("GroovyAssignabilityCheck")

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
@@ -261,7 +261,7 @@ class CppLibraryPluginTest extends Specification {
         then:
         def e = thrown(ProjectConfigurationException)
         e.cause instanceof IllegalStateException
-        e.cause.message == 'The value for this property is final and cannot be changed any further.'
+        e.cause.message == "The value for C++ library 'main' property 'linkage' is final and cannot be changed any further."
     }
 
     def "output locations are calculated using base name defined on extension"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
@@ -266,7 +266,7 @@ class SwiftLibraryPluginTest extends Specification {
         then:
         def e = thrown(ProjectConfigurationException)
         e.cause instanceof IllegalStateException
-        e.cause.message == 'The value for this property is final and cannot be changed any further.'
+        e.cause.message == "The value for Swift library 'main' property 'linkage' is final and cannot be changed any further."
     }
 
     def "output file names are calculated from module name defined on extension"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -151,7 +151,7 @@ class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause('The value for this property cannot be changed any further.')
     }
 
-    def "task @Input property is implicitly finalized and changes ignored when task starts execution"() {
+    def "task @Input property is implicitly finalized when task starts execution"() {
         given:
         buildFile << '''
             class SomeTask extends DefaultTask {
@@ -163,10 +163,6 @@ class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
                 
                 @TaskAction
                 void go() {
-                    prop.set(['ignoredKey': 'ignoredValue'])
-                    prop.put('ignoredKey', 'ignoredValue')
-                    prop.putAll(['ignoredKey': 'ignoredValue'])
-                    prop.empty()
                     outputFile.get().asFile.text = prop.get()
                 }
             }
@@ -174,7 +170,7 @@ class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
             task thing(type: SomeTask) {
                 prop = ['key1': 'value1']
                 outputFile = layout.buildDirectory.file('out.txt')
-                doLast {
+                doFirst {
                     prop.set(['ignoredKey': 'ignoredValue'])
                 }
             }
@@ -189,22 +185,14 @@ class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
             thing.dependsOn before
-            
-            task after {
-                dependsOn thing
-                doLast {
-                    thing.prop = ['ignoredKey': 'ignoredValue']
-                    assert thing.prop.get() == ['finalKey': 'finalValue']
-                }
-            }
             '''.stripIndent()
 
         when:
-        executer.expectDeprecationWarning()
-        run('after')
+        fails('thing')
 
         then:
-        file('build/out.txt').text == '[finalKey:finalValue]'
+        failure.assertHasDescription("Execution failed for task ':thing'.")
+        failure.assertHasCause("The value for task ':thing' property 'prop' is final and cannot be changed any further.")
     }
 
     def "task ad hoc input property is implicitly finalized and changes ignored when task starts execution"() {
@@ -223,11 +211,11 @@ class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
             '''.stripIndent()
 
         when:
-        executer.expectDeprecationWarning()
-        run('thing')
+        fails('thing')
 
         then:
-        output.contains('prop = [key1:value1]')
+        failure.assertHasDescription("Execution failed for task ':thing'.")
+        failure.assertHasCause("The value for this property is final and cannot be changed any further.")
     }
 
     def "can use property with no value as optional ad hoc task input property"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -393,7 +393,7 @@ assert tasks.t.prop.get() == "changed"
         succeeds()
     }
 
-    def "can set String property value from DSL using a GString"() {
+    def "can set String property value using a GString"() {
         given:
         buildFile << """
 class SomeExtension {
@@ -406,14 +406,18 @@ class SomeExtension {
 }
 
 extensions.create('custom', SomeExtension)
-custom.prop = "\${'some value'.substring(5)}"
-assert custom.prop.get() == "value"
+custom.prop = "\${'some value 1'.substring(5)}"
+assert custom.prop.get() == "value 1"
 
-custom.prop = providers.provider { "\${'some new value'.substring(5)}" }
-assert custom.prop.get() == "new value"
+custom.prop = providers.provider { "\${'some value 2'.substring(5)}" }
+assert custom.prop.get() == "value 2"
 
-custom.prop.set("\${'some other value'.substring(5)}")
-assert custom.prop.get() == "other value"
+custom.prop = null
+custom.prop.convention("\${'some value 3'.substring(5)}")
+assert custom.prop.get() == "value 3"
+
+custom.prop.convention(providers.provider { "\${'some value 4'.substring(5)}" })
+assert custom.prop.get() == "value 4"
 """
 
         expect:
@@ -464,6 +468,25 @@ task wrongRuntimeType {
         custom.prop.get()
     }
 }
+
+task wrongConventionValueType {
+    doLast {
+        custom.prop.convention(123)
+    }
+}
+
+task wrongConventionPropertyType {
+    doLast {
+        custom.prop.convention(objects.property(Integer))
+    }
+}
+
+task wrongConventionRuntimeValueType {
+    doLast {
+        custom.prop.convention(providers.provider { 123 })
+        custom.prop.get()
+    }
+}
 """
 
         when:
@@ -471,35 +494,56 @@ task wrongRuntimeType {
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongValueTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type java.lang.String using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.lang.Integer.")
 
         when:
         fails("wrongValueTypeApi")
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongValueTypeApi'.")
-        failure.assertHasCause("Cannot set the value of a property of type java.lang.String using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.lang.Integer.")
 
         when:
         fails("wrongPropertyTypeDsl")
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongPropertyTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type java.lang.String using a provider of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using a provider of type java.lang.Integer.")
 
         when:
         fails("wrongPropertyTypeApi")
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongPropertyTypeApi'.")
-        failure.assertHasCause("Cannot set the value of a property of type java.lang.String using a provider of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using a provider of type java.lang.Integer.")
 
         when:
         fails("wrongRuntimeType")
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongRuntimeType'.")
-        failure.assertHasCause("Cannot get the value of a property of type java.lang.String as the provider associated with this property returned a value of type java.lang.Integer.")
+        failure.assertHasCause("Cannot get the value of extension 'custom' property 'prop' of type java.lang.String as the provider associated with this property returned a value of type java.lang.Integer.")
+
+        when:
+        fails("wrongConventionValueType")
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':wrongConventionValueType'.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.lang.Integer.")
+
+        when:
+        fails("wrongConventionPropertyType")
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':wrongConventionPropertyType'.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using a provider of type java.lang.Integer.")
+
+        when:
+        fails("wrongConventionRuntimeValueType")
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':wrongConventionRuntimeValueType'.")
+        failure.assertHasCause("Cannot get the value of extension 'custom' property 'prop' of type java.lang.String as the provider associated with this property returned a value of type java.lang.Integer.")
     }
 
     def "fails when specialized factory method is not used"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -183,7 +183,7 @@ property.set(12)
         failure.assertHasCause("The value for this property cannot be changed any further.")
     }
 
-    def "task @Input property is implicitly finalized and changes ignored when task starts execution"() {
+    def "task @Input property is implicitly finalized when task starts execution"() {
         given:
         buildFile << """
 class SomeTask extends DefaultTask {
@@ -195,7 +195,6 @@ class SomeTask extends DefaultTask {
     
     @TaskAction
     void go() {
-        prop.set("ignored")
         outputFile.get().asFile.text = prop.get()
     }
 }
@@ -203,8 +202,8 @@ class SomeTask extends DefaultTask {
 task thing(type: SomeTask) {
     prop = "value 1"
     outputFile = layout.buildDirectory.file("out.txt")
-    doLast {
-        prop.set("ignored")
+    doFirst {
+        prop.set("broken")
     }
 }
 
@@ -214,29 +213,22 @@ afterEvaluate {
 
 task before {
     doLast {
-        thing.prop = providers.provider { "final value" }
+        thing.prop = providers.provider { "value 3" }
     }
 }
 thing.dependsOn before
 
-task after {
-    dependsOn thing
-    doLast {
-        thing.prop = "ignore"
-        assert thing.prop.get() == "final value"
-    }
-}
 """
 
         when:
-        executer.expectDeprecationWarning()
-        run("after")
+        fails("thing")
 
         then:
-        file("build/out.txt").text == "final value"
+        failure.assertHasDescription("Execution failed for task ':thing'.")
+        failure.assertHasCause("The value for task ':thing' property 'prop' is final and cannot be changed any further.")
     }
 
-    def "task ad hoc input property is implicitly finalized and changes ignored when task starts execution"() {
+    def "task ad hoc input property is implicitly finalized when task starts execution"() {
         given:
         buildFile << """
 
@@ -245,19 +237,19 @@ def prop = project.objects.property(String)
 task thing {
     inputs.property("prop", prop)
     prop.set("value 1")
-    doLast {
-        prop.set("ignored")
+    doFirst {
+        prop.set("broken")
         println "prop = " + prop.get()
     }
 }
 """
 
         when:
-        executer.expectDeprecationWarning()
-        run("thing")
+        fails("thing")
 
         then:
-        output.contains("prop = value 1")
+        failure.assertHasDescription("Execution failed for task ':thing'.")
+        failure.assertHasCause("The value for this property is final and cannot be changed any further.")
     }
 
     def "can use property with no value as optional ad hoc task input property"() {
@@ -510,7 +502,7 @@ task wrongRuntimeType {
         failure.assertHasCause("Cannot get the value of a property of type java.lang.String as the provider associated with this property returned a value of type java.lang.Integer.")
     }
 
-    def "emits deprecation warning when specialized factory method is not used"() {
+    def "fails when specialized factory method is not used"() {
         buildFile << """
 class SomeExtension {
     final Property<List<String>> prop1

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.base.Preconditions;
-import org.gradle.api.Describable;
 import org.gradle.api.internal.provider.Collectors.ElementFromProvider;
 import org.gradle.api.internal.provider.Collectors.ElementsFromArray;
 import org.gradle.api.internal.provider.Collectors.ElementsFromCollection;
@@ -28,6 +27,7 @@ import org.gradle.api.internal.provider.Collectors.SingleElement;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -301,7 +301,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<T> collector, Collection<T> dest) {
+        public void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> dest) {
             left.collectInto(owner, collector, dest);
             right.collectInto(owner, collector, dest);
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -16,10 +16,10 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Describable;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.state.Managed;
 import org.gradle.util.GUtil;
 
@@ -45,7 +45,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     }
 
     @Override
-    public T get(@Nullable Describable owner) throws IllegalStateException {
+    public T get(DisplayName owner) throws IllegalStateException {
         return get();
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -25,13 +25,15 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     private enum State {
         ImplicitValue, ExplicitValue, Final
     }
+
     private static final DisplayName DEFAULT_DISPLAY_NAME = Describables.of("this property");
+    private static final DisplayName DEFAULT_VALIDATION_DISPLAY_NAME = Describables.of("a property");
 
     private State state = State.ImplicitValue;
     private boolean finalizeOnNextGet;
     private boolean disallowChanges;
     private Task producer;
-    private DisplayName displayName = DEFAULT_DISPLAY_NAME;
+    private DisplayName displayName;
 
     @Override
     public void attachDisplayName(DisplayName displayName) {
@@ -39,13 +41,23 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     }
 
     protected DisplayName getDisplayName() {
+        if (displayName == null) {
+            return DEFAULT_DISPLAY_NAME;
+        }
+        return displayName;
+    }
+
+    protected DisplayName getValidationDisplayName() {
+        if (displayName == null) {
+            return DEFAULT_VALIDATION_DISPLAY_NAME;
+        }
         return displayName;
     }
 
     @Override
     public void attachProducer(Task task) {
         if (this.producer != null && this.producer != task) {
-            throw new IllegalStateException(String.format("%s already has a producer task associated with it.", displayName.getCapitalizedDisplayName()));
+            throw new IllegalStateException(String.format("%s already has a producer task associated with it.", getDisplayName().getCapitalizedDisplayName()));
         }
         this.producer = task;
     }
@@ -60,7 +72,7 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     // Final - implement describeContents() instead
     @Override
     public final String toString() {
-        if (displayName != DEFAULT_DISPLAY_NAME) {
+        if (displayName != null) {
             return displayName.toString();
         } else {
             return describeContents();
@@ -160,9 +172,9 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
 
     private boolean canMutate() {
         if (state == State.Final && disallowChanges) {
-            throw new IllegalStateException(String.format("The value for %s is final and cannot be changed any further.", displayName.getDisplayName()));
+            throw new IllegalStateException(String.format("The value for %s is final and cannot be changed any further.", getDisplayName().getDisplayName()));
         } else if (disallowChanges) {
-            throw new IllegalStateException(String.format("The value for %s cannot be changed any further.", displayName.getDisplayName()));
+            throw new IllegalStateException(String.format("The value for %s cannot be changed any further.", getDisplayName().getDisplayName()));
         }
         return true;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -16,9 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Describable;
+import org.gradle.internal.DisplayName;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -28,7 +27,7 @@ import java.util.List;
 public interface Collector<T> extends ValueSupplier {
     boolean present();
 
-    void collectInto(@Nullable Describable owner,  ValueCollector<T> collector, Collection<T> dest);
+    void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> dest);
 
     boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> dest);
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -19,9 +19,9 @@ package org.gradle.api.internal.provider;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.gradle.api.Describable;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -44,7 +44,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<Object> collector, Collection<Object> dest) {
+        public void collectInto(DisplayName owner, ValueCollector<Object> collector, Collection<Object> dest) {
         }
 
         @Override
@@ -85,7 +85,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<T> collector, Collection<T> collection) {
+        public void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> collection) {
             collector.add(element, collection);
         }
 
@@ -151,7 +151,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<T> collector, Collection<T> collection) {
+        public void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> collection) {
             T value = providerOfElement.get();
             collector.add(value, collection);
         }
@@ -227,7 +227,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<T> collector, Collection<T> collection) {
+        public void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> collection) {
             collector.addAll(value, collection);
         }
 
@@ -293,7 +293,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<T> collector, Collection<T> collection) {
+        public void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> collection) {
             Iterable<? extends T> value = provider.get();
             collector.addAll(value, collection);
         }
@@ -367,7 +367,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<Object> collector, Collection<Object> dest) {
+        public void collectInto(DisplayName owner, ValueCollector<Object> collector, Collection<Object> dest) {
             throw Providers.nullValue(owner);
         }
 
@@ -414,7 +414,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<T> collector, Collection<T> dest) {
+        public void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> dest) {
             for (T t : value) {
                 collector.add(t, dest);
             }
@@ -478,7 +478,7 @@ public class Collectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, ValueCollector<T> collector, Collection<T> dest) {
+        public void collectInto(DisplayName owner, ValueCollector<T> collector, Collection<T> dest) {
             delegate.collectInto(owner, collector, dest);
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollector.java
@@ -16,9 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Describable;
+import org.gradle.internal.DisplayName;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,7 @@ public interface MapCollector<K, V> extends ValueSupplier {
 
     boolean present();
 
-    void collectInto(@Nullable Describable owner, MapEntryCollector<K, V> collector, Map<K, V> dest);
+    void collectInto(DisplayName owner, MapEntryCollector<K, V> collector, Map<K, V> dest);
 
     boolean maybeCollectInto(MapEntryCollector<K, V> collector, Map<K, V> dest);
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -18,10 +18,9 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
-import org.gradle.api.Describable;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.internal.DisplayName;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +35,7 @@ public class MapCollectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, MapEntryCollector<Object, Object> collector, Map<Object, Object> dest) {
+        public void collectInto(DisplayName owner, MapEntryCollector<Object, Object> collector, Map<Object, Object> dest) {
         }
 
         @Override
@@ -89,13 +88,13 @@ public class MapCollectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            collector.add(key, value, dest);
+        public void collectInto(DisplayName owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+            maybeCollectInto(collector, dest);
         }
 
         @Override
         public boolean maybeCollectInto(MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            collectInto(null, collector, dest);
+            collector.add(key, value, dest);
             return true;
         }
 
@@ -164,7 +163,7 @@ public class MapCollectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public void collectInto(DisplayName owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
             collector.add(key, providerOfValue.get(), dest);
         }
 
@@ -233,13 +232,13 @@ public class MapCollectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            collector.addAll(entries.entrySet(), dest);
+        public void collectInto(DisplayName owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+            maybeCollectInto(collector, dest);
         }
 
         @Override
         public boolean maybeCollectInto(MapEntryCollector<K, V> collector, Map<K, V> dest) {
-            collectInto(null, collector, dest);
+            collector.addAll(entries.entrySet(), dest);
             return true;
         }
 
@@ -289,7 +288,7 @@ public class MapCollectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
+        public void collectInto(DisplayName owner, MapEntryCollector<K, V> collector, Map<K, V> dest) {
             collector.addAll(providerOfEntries.get().entrySet(), dest);
         }
 
@@ -349,7 +348,7 @@ public class MapCollectors {
         }
 
         @Override
-        public void collectInto(@Nullable Describable owner, MapEntryCollector<Object, Object> collector, Map<Object, Object> dest) {
+        public void collectInto(DisplayName owner, MapEntryCollector<Object, Object> collector, Map<Object, Object> dest) {
             throw Providers.nullValue(owner);
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OwnerAware.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OwnerAware.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Describable;
+import org.gradle.internal.DisplayName;
 
 public interface OwnerAware {
-    void attachDisplayName(Describable displayName);
+    void attachDisplayName(DisplayName displayName);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -20,6 +20,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
+import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
 
@@ -58,5 +59,5 @@ public interface ProviderInternal<T> extends Provider<T>, TaskDependencyContaine
     /**
      * Returns a view of this provider that can be used to supply a value to a {@link org.gradle.api.provider.Property} instance.
      */
-    ScalarSupplier<T> asSupplier();
+    ScalarSupplier<T> asSupplier(DisplayName owner, Class<? super T> targetType, ValueSanitizer<? super T> sanitizer);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
@@ -20,6 +20,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
+import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
 
@@ -91,7 +92,7 @@ public class Providers {
         }
 
         @Override
-        public T get(@Nullable Describable owner) throws IllegalStateException {
+        public T get(DisplayName owner) throws IllegalStateException {
             return value;
         }
 
@@ -183,7 +184,7 @@ public class Providers {
         }
 
         @Override
-        public Object get(@Nullable Describable owner) throws IllegalStateException {
+        public Object get(DisplayName owner) throws IllegalStateException {
             throw nullValue(owner);
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Providers.java
@@ -41,11 +41,19 @@ public class Providers {
         return new FixedValueProvider<T>(value);
     }
 
+    public static <T> ScalarSupplier<T> fixedValue(DisplayName owner, T value, Class<T> targetType, ValueSanitizer<T> sanitizer) {
+        value = sanitizer.sanitize(value);
+        if (!targetType.isInstance(value)) {
+            throw new IllegalArgumentException(String.format("Cannot set the value of %s of type %s using an instance of type %s.", owner.getDisplayName(), targetType.getName(), value.getClass().getName()));
+        }
+        return new FixedValueProvider<T>(value);
+    }
+
     public static <T> ScalarSupplier<T> nullableValue(@Nullable T value) {
         if (value == null) {
             return noValue();
         } else {
-        return fixedValue(value);
+            return fixedValue(value);
         }
     }
 
@@ -69,8 +77,8 @@ public class Providers {
         }
     }
 
-    public static IllegalStateException nullValue(@Nullable Describable owner) {
-        return new IllegalStateException(owner != null ? String.format("No value has been specified for %s.", owner.getDisplayName()) : NULL_VALUE);
+    public static IllegalStateException nullValue(Describable owner) {
+        return new IllegalStateException(String.format("No value has been specified for %s.", owner.getDisplayName()));
     }
 
     public static class FixedValueProvider<T> extends AbstractProviderWithValue<T> implements ScalarSupplier<T> {
@@ -217,6 +225,11 @@ public class Providers {
         @Override
         public boolean isPresent() {
             return false;
+        }
+
+        @Override
+        public ScalarSupplier<Object> asSupplier(DisplayName owner, Class<? super Object> targetType, ValueSanitizer<? super Object> sanitizer) {
+            return this;
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ScalarSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ScalarSupplier.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Describable;
+import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
 
@@ -31,7 +31,7 @@ public interface ScalarSupplier<T> extends ValueSupplier {
      *
      * @param owner A display name that can be used in error messages.
      */
-    T get(@Nullable Describable owner) throws IllegalStateException;
+    T get(DisplayName owner) throws IllegalStateException;
 
     @Nullable
     T getOrNull();

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -405,7 +405,7 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == Providers.NULL_VALUE
+        e.message == "No value has been specified for this property."
     }
 
     def "property has no value when set to provider with no value and other values appended"() {
@@ -589,18 +589,19 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
         e.message == 'The value for this property is final and cannot be changed any further.'
     }
 
-    def "ignores set to empty list after value finalized leniently"() {
+    def "cannot set to empty list after value finalized implicitly"() {
         given:
         def property = property()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.empty()
 
+
         then:
-        property.get() == toImmutable(someValue())
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
     }
 
     def "cannot set to empty list after changes disallowed"() {
@@ -638,19 +639,25 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
         e2.message == 'The value for this property is final and cannot be changed any further.'
     }
 
-    def "ignores add element after value finalized leniently"() {
+    def "cannot add element after value finalized implicitly"() {
         given:
         def property = property()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.add("123")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
         property.add(Stub(PropertyInternal))
 
         then:
-        property.get() == toImmutable(someValue())
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for this property cannot be changed any further.'
     }
 
     def "cannot add element after changes disallowed"() {
@@ -702,20 +709,32 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
         e3.message == 'The value for this property is final and cannot be changed any further.'
     }
 
-    def "ignores add elements after value finalized leniently"() {
+    def "cannot add elements after value finalized implicitly"() {
         given:
         def property = property()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.addAll("123", "456")
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
         property.addAll(["123", "456"])
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for this property cannot be changed any further.'
+
+        when:
         property.addAll(Stub(ProviderInternal))
 
         then:
-        property.get() == toImmutable(someValue())
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for this property cannot be changed any further.'
     }
 
     def "cannot add elements after changes disallowed"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -73,7 +73,7 @@ class DefaultPropertyTest extends PropertySpec<String> {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'No value has been specified for this provider.'
+        e.message == "No value has been specified for ${displayName}."
     }
 
     def "toString() does not realize value"() {
@@ -99,17 +99,6 @@ class DefaultPropertyTest extends PropertySpec<String> {
         property.getOrNull() == null
         property.getOrElse(someValue()) == someValue()
         property.getOrElse(null) == null
-    }
-
-    def "fails when get method is called when the property has no initial value"() {
-        def property = new DefaultProperty<String>(String)
-
-        when:
-        property.get()
-
-        then:
-        def t = thrown(IllegalStateException)
-        t.message == "No value has been specified for this provider."
     }
 
     def "fails when value is set using incompatible type"() {
@@ -214,7 +203,6 @@ class DefaultPropertyTest extends PropertySpec<String> {
 
     def "mapped provider is live"() {
         def transformer = Mock(Transformer)
-        def supplier = Mock(ScalarSupplier)
         def provider = provider("abc")
 
         def property = new DefaultProperty<String>(String)

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -130,34 +130,12 @@ class DefaultPropertyTest extends PropertySpec<String> {
         !property.present
     }
 
-    def "can set value to a provider whose type is not known"() {
-        def supplier = Mock(ScalarSupplier)
-        def provider = Mock(ProviderInternal)
-
-        given:
-        provider.type >> null
-        1 * provider.map(_) >> provider
-        provider.asSupplier() >> supplier
-        supplier.get(_) >>> ["a", "b", "c"]
-
-        def property = new DefaultProperty<String>(String)
-
-        when:
-        property.set(provider)
-
-        then:
-        property.get() == "a"
-        property.get() == "b"
-        property.get() == "c"
-    }
-
     def "can set value to a provider whose type is compatible"() {
         def supplier = Mock(ScalarSupplier)
         def provider = Mock(ProviderInternal)
 
         given:
-        provider.getType() >> Integer
-        provider.asSupplier() >> supplier
+        provider.asSupplier(_, _, _) >> supplier
         supplier.get(_) >>> [1, 2, 3]
 
         def property = new DefaultProperty<Number>(Number)
@@ -172,17 +150,9 @@ class DefaultPropertyTest extends PropertySpec<String> {
     }
 
     def "fails when provider produces an incompatible value"() {
-        def supplier = Mock(ScalarSupplier)
-        def provider = Mock(ProviderInternal)
-        def transform = null
+        def provider = new DefaultProvider({ 12 })
 
         given:
-        provider.type >> null
-        1 * provider.map(_) >> { transform = it[0]; provider }
-        provider.asSupplier() >> supplier
-        supplier.get(_) >> { transform.transform(12) }
-        supplier.getOrNull() >> { transform.transform(12) }
-
         def property = new DefaultProperty<Boolean>(Boolean)
         property.set(provider)
 
@@ -199,6 +169,50 @@ class DefaultPropertyTest extends PropertySpec<String> {
         then:
         def e2 = thrown(IllegalArgumentException)
         e2.message == 'Cannot get the value of a property of type java.lang.Boolean as the provider associated with this property returned a value of type java.lang.Integer.'
+    }
+
+    def "fails when convention is set using incompatible value"() {
+        def property = new DefaultProperty<Boolean>(Boolean)
+
+        when:
+        property.convention(12)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message == "Cannot set the value of a property of type java.lang.Boolean using an instance of type java.lang.Integer."
+
+        and:
+        !property.present
+    }
+
+    def "fails when convention is set using provider whose value is known to be incompatible"() {
+        def property = new DefaultProperty<Boolean>(Boolean)
+        def other = new DefaultProperty<Number>(Number)
+
+        when:
+        property.convention(other)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message == "Cannot set the value of a property of type java.lang.Boolean using a provider of type java.lang.Number."
+
+        and:
+        !property.present
+    }
+
+    def "fails when convention is set using provider that returns incompatible value"() {
+        def provider = new DefaultProvider({ 12 })
+
+        given:
+        def property = new DefaultProperty<Boolean>(Boolean)
+        property.convention(provider)
+
+        when:
+        property.get()
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Cannot get the value of a property of type java.lang.Boolean as the provider associated with this property returned a value of type java.lang.Integer.'
     }
 
     def "mapped provider is live"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -79,6 +79,7 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "can change value to empty map"() {
         when:
+        property.set([a: 'b'])
         property.empty()
         then:
         assertValueIs([:])
@@ -454,24 +455,27 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         given:
         property.set(someValue())
         property.finalizeValue()
+
         when:
         property.empty()
+
         then:
         def e = thrown IllegalStateException
         e.message == 'The value for this property is final and cannot be changed any further.'
     }
 
-    def "ignores set to empty map after value finalized leniently"() {
+    def "cannot set to empty map after value finalized implicitly"() {
         given:
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.empty()
 
+
         then:
-        assertValueIs someValue()
+        def e = thrown IllegalStateException
+        e.message == 'The value for this property cannot be changed any further.'
     }
 
     def "cannot set to empty map after changes disallowed"() {
@@ -505,18 +509,24 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         e2.message == 'The value for this property is final and cannot be changed any further.'
     }
 
-    def "ignores add entry after value finalized leniently"() {
+    def "cannot add entry after value finalized implicitly"() {
         given:
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.put('k1', 'v1')
+
+        then:
+        def e = thrown IllegalStateException
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
         property.put('k2', Stub(ProviderInternal))
 
         then:
-        assertValueIs someValue()
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for this property cannot be changed any further.'
     }
 
     def "cannot add entry after changes disallowed"() {
@@ -546,29 +556,37 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
         when:
         property.putAll(['k3': 'v3', 'k4': 'v4'])
+
         then:
         def e = thrown IllegalStateException
         e.message == 'The value for this property is final and cannot be changed any further.'
 
         when:
         property.putAll Stub(ProviderInternal)
+
         then:
         def e2 = thrown IllegalStateException
         e2.message == 'The value for this property is final and cannot be changed any further.'
     }
 
-    def "ignores add entries after value finalized leniently"() {
+    def "ignores add entries after value finalized implicitly"() {
         given:
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.putAll(['k3': 'v3'])
-        property.putAll(Stub(ProviderInternal))
 
         then:
-        assertValueIs someValue()
+        def e = thrown IllegalStateException
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.putAll Stub(ProviderInternal)
+
+        then:
+        def e2 = thrown IllegalStateException
+        e2.message == 'The value for this property cannot be changed any further.'
     }
 
     def "cannot add entries after changes disallowed"() {
@@ -740,8 +758,8 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         def provider = Mock(ProviderInternal)
 
         given:
-        property.implicitFinalizeValue()
         property.put('k1', provider)
+        property.implicitFinalizeValue()
 
         when:
         def p = property.getting('k1')

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -1369,7 +1369,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         return new AbstractReadOnlyProvider<T>() {
             @Override
             Class<T> getType() {
-                return type()
+                return PropertySpec.this.type()
             }
 
             @Override

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.provider.Provider
 import org.gradle.internal.Describables
 import org.gradle.internal.state.Managed
-import spock.lang.Specification
 
 import java.util.concurrent.Callable
 
@@ -51,6 +50,11 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     abstract Class<T> type()
 
+    @Override
+    String getDisplayName() {
+        return "this property"
+    }
+
     protected void setToNull(def property) {
         property.set(null)
     }
@@ -64,7 +68,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
         then:
         def t = thrown(IllegalStateException)
-        t.message == "No value has been specified for this provider."
+        t.message == "No value has been specified for ${displayName}."
 
         when:
         property.attachDisplayName(Describables.of("<display-name>"))
@@ -328,7 +332,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         def provider = property.map(transformer)
 
         then:
-        0 * Specification._
+        0 * _
 
         when:
         property.set(someValue())
@@ -337,7 +341,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         r1 == someOtherValue()
         1 * transformer.transform(someValue()) >> someOtherValue()
-        0 * Specification._
+        0 * _
 
         when:
         def r2 = provider.get()
@@ -345,7 +349,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         r2 == someValue()
         1 * transformer.transform(someValue()) >> someValue()
-        0 * Specification._
+        0 * _
     }
 
     def "transformation is provided with the current value of the property each time the value is queried"() {
@@ -356,7 +360,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         def provider = property.map(transformer)
 
         then:
-        0 * Specification._
+        0 * _
 
         when:
         property.set(someValue())
@@ -365,7 +369,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         r1 == 123
         1 * transformer.transform(someValue()) >> 123
-        0 * Specification._
+        0 * _
 
         when:
         property.set(someOtherValue())
@@ -374,7 +378,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         r2 == 456
         1 * transformer.transform(someOtherValue()) >> 456
-        0 * Specification._
+        0 * _
     }
 
     def "can map value to some other type"() {
@@ -385,7 +389,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         def provider = property.map(transformer)
 
         then:
-        0 * Specification._
+        0 * _
 
         when:
         property.set(someValue())
@@ -394,7 +398,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         r1 == 12
         1 * transformer.transform(someValue()) >> 12
-        0 * Specification._
+        0 * _
 
         when:
         def r2 = provider.get()
@@ -402,7 +406,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         r2 == 10
         1 * transformer.transform(someValue()) >> 10
-        0 * Specification._
+        0 * _
     }
 
     def "mapped provider has no value and transformer is not invoked when property has no value"() {
@@ -416,14 +420,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         !provider.present
         provider.getOrNull() == null
         provider.getOrElse(someOtherValue()) == someOtherValue()
-        0 * Specification._
+        0 * _
 
         when:
         provider.get()
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'No value has been specified for this provider.'
+        e.message == "No value has been specified for ${displayName}."
     }
 
     def "can finalize value when no value defined"() {
@@ -590,14 +594,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
         then:
         1 * function.call() >> someValue()
-        0 * Specification._
+        0 * _
 
         when:
         def present = property.present
         def result = property.getOrNull()
 
         then:
-        0 * Specification._
+        0 * _
 
         and:
         present
@@ -617,7 +621,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
         then:
         1 * function.call() >> null
-        0 * Specification._
+        0 * _
 
         when:
         def present = property.present
@@ -626,7 +630,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         !present
         result == null
-        0 * Specification._
+        0 * _
     }
 
     def "replaces provider with no value with fixed missing value when value finalized on next read"() {
@@ -641,7 +645,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.implicitFinalizeValue()
 
         then:
-        0 * Specification._
+        0 * _
 
         when:
         def present = property.present
@@ -649,7 +653,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
         then:
         1 * function.call() >> null
-        0 * Specification._
+        0 * _
 
         and:
         !present
@@ -667,7 +671,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
         then:
         1 * function.call() >> someValue()
-        0 * Specification._
+        0 * _
 
         when:
         property.finalizeValue()
@@ -676,7 +680,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.disallowChanges()
 
         then:
-        0 * Specification._
+        0 * _
     }
 
     def "can finalize after changes disallowed"() {
@@ -689,14 +693,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.disallowChanges()
 
         then:
-        0 * Specification._
+        0 * _
 
         when:
         property.finalizeValue()
 
         then:
         1 * function.call() >> someValue()
-        0 * Specification._
+        0 * _
     }
 
     def "uses value from provider after changes disallowed"() {
@@ -719,7 +723,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         result == someValue()
         1 * function.call() >> someValue()
-        0 * Specification._
+        0 * _
     }
 
     def "cannot set value after value finalized"() {
@@ -748,9 +752,53 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e3 = thrown(IllegalStateException)
         e3.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(someValue())
+
+        then:
+        def e4 = thrown(IllegalStateException)
+        e4.message == 'The value for <display-name> is final and cannot be changed any further.'
     }
 
-    def "ignores set value after value finalized leniently"() {
+    def "cannot set value after value finalized implicitly and before queried"() {
+        given:
+        def property = propertyWithNoValue()
+        property.set(someValue())
+        property.implicitFinalizeValue()
+
+        when:
+        property.set(someValue())
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        setToNull(property)
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.value(someValue())
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(someValue())
+
+        then:
+        def e4 = thrown(IllegalStateException)
+        e4.message == 'The value for <display-name> cannot be changed any further.'
+    }
+
+    def "cannot set value after value finalized implicitly"() {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
@@ -758,24 +806,40 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.get()
 
         when:
-        property.set(someOtherValue())
+        property.set(someValue())
 
         then:
-        property.get() == someValue()
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property is final and cannot be changed any further.'
 
         when:
         setToNull(property)
 
         then:
-        property.get() == someValue()
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.value(someValue())
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(someValue())
+
+        then:
+        def e4 = thrown(IllegalStateException)
+        e4.message == 'The value for <display-name> is final and cannot be changed any further.'
     }
 
-    def "cannot set value after value finalized after value finalized leniently"() {
+    def "cannot set value after value finalized after value finalized implicitly"() {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.set(someOtherValue())
         property.finalizeValue()
 
         when:
@@ -798,6 +862,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e3 = thrown(IllegalStateException)
         e3.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(someValue())
+
+        then:
+        def e4 = thrown(IllegalStateException)
+        e4.message == 'The value for <display-name> is final and cannot be changed any further.'
     }
 
     def "cannot set value after changes disallowed"() {
@@ -826,6 +898,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e3 = thrown(IllegalStateException)
         e3.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(someValue())
+
+        then:
+        def e4 = thrown(IllegalStateException)
+        e4.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set value after changes disallowed and implicitly finalized"() {
@@ -877,20 +957,43 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e2 = thrown(IllegalStateException)
         e2.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(Mock(ProviderInternal))
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display-name> is final and cannot be changed any further.'
     }
 
-    def "ignores set value using provider after value finalized leniently"() {
+    def "cannot set value using provider after value finalized implicitly"() {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.set(Mock(ProviderInternal))
 
         then:
-        property.get() == someValue()
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.value(Mock(ProviderInternal))
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(Mock(ProviderInternal))
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set value using provider after changes disallowed"() {
@@ -912,6 +1015,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e2 = thrown(IllegalStateException)
         e2.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.set(Mock(ProviderInternal))
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set value using any type after value finalized"() {
@@ -933,26 +1044,43 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e2 = thrown(IllegalStateException)
         e2.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.setFromAnyValue(someValue())
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display-name> is final and cannot be changed any further.'
     }
 
-    def "ignores set value using any type after value finalized leniently"() {
+    def "cannot set value using any type after value finalized implicitly"() {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.setFromAnyValue(someOtherValue())
 
         then:
-        property.get() == someValue()
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
 
         when:
         property.setFromAnyValue(Stub(ProviderInternal))
 
         then:
-        property.get() == someValue()
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.setFromAnyValue(someValue())
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set value using any type after changes disallowed"() {
@@ -974,6 +1102,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e2 = thrown(IllegalStateException)
         e2.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.setFromAnyValue(someValue())
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set convention value after value finalized"() {
@@ -987,20 +1123,36 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e = thrown(IllegalStateException)
         e.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.convention(someValue())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display-name> is final and cannot be changed any further.'
     }
 
-    def "ignores set convention value after value finalized leniently"() {
+    def "cannot set convention value after value finalized implicitly"() {
         given:
         def property = propertyWithDefaultValue()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
-        property.convention(someOtherValue())
+        property.convention(someValue())
 
         then:
-        property.get() == someValue()
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.convention(someValue())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set convention value after changes disallowed"() {
@@ -1014,6 +1166,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e = thrown(IllegalStateException)
         e.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.convention(someValue())
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set convention value using provider after value finalized"() {
@@ -1028,20 +1188,36 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e = thrown(IllegalStateException)
         e.message == 'The value for this property is final and cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.convention(Mock(ProviderInternal))
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display-name> is final and cannot be changed any further.'
     }
 
-    def "ignores set convention value using provider after value finalized leniently"() {
+    def "cannot set convention value using provider after value finalized implicitly"() {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
         property.implicitFinalizeValue()
-        property.get()
 
         when:
         property.convention(Mock(ProviderInternal))
 
         then:
-        property.get() == someValue()
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.convention(Mock(ProviderInternal))
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "cannot set convention value using provider after changes disallowed"() {
@@ -1056,6 +1232,14 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         then:
         def e = thrown(IllegalStateException)
         e.message == 'The value for this property cannot be changed any further.'
+
+        when:
+        property.attachDisplayName(Describables.of("<display-name>"))
+        property.convention(Mock(ProviderInternal))
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display-name> cannot be changed any further.'
     }
 
     def "producer task for a property is not known by default"() {

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -37,6 +37,10 @@ abstract class ProviderSpec<T> extends Specification {
         return false
     }
 
+    String getDisplayName() {
+        return "this provider"
+    }
+
     def "can query value when it has as value"() {
         given:
         def provider = providerWithValue(someValue())
@@ -169,7 +173,7 @@ abstract class ProviderSpec<T> extends Specification {
 
         then:
         def t = thrown(IllegalStateException)
-        t.message == "No value has been specified for this provider."
+        t.message == "No value has been specified for ${displayName}."
     }
 
     def "mapped provider with no value does not use transformer"() {
@@ -189,7 +193,7 @@ abstract class ProviderSpec<T> extends Specification {
 
         then:
         def t = thrown(IllegalStateException)
-        t.message == "No value has been specified for this provider."
+        t.message == "No value has been specified for ${displayName}."
     }
 
     def "flat mapped provider with no value does not use transformer"() {
@@ -209,7 +213,7 @@ abstract class ProviderSpec<T> extends Specification {
 
         then:
         def t = thrown(IllegalStateException)
-        t.message == "No value has been specified for this provider."
+        t.message == "No value has been specified for ${displayName}."
     }
 
     def "can map to provider that uses value if present or a default value"() {


### PR DESCRIPTION
### Context

This was a deprecated behaviour and is now an error.

This PR includes some improvements for `Property` implementations: 
- Include the display name of the property (introduced in https://github.com/gradle/gradle/pull/10371) in more validation error messages.
- Validate and sanitize the values passed to `Property.convention()`, for example convert GString instances to String.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
