### PR TITLE
Always register optional features for publishing

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishFeaturesJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishFeaturesJavaIntegTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy
+
+import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.test.fixtures.ivy.IvyFileModule
+import org.gradle.test.fixtures.ivy.IvyJavaModule
+
+abstract class AbstractIvyPublishFeaturesJavaIntegTest extends AbstractIvyPublishIntegTest {
+    IvyFileModule module = ivyRepo.module("org.gradle.test", "publishTest", "1.9")
+    IvyJavaModule javaLibrary = javaLibrary(module)
+
+    def setup() {
+        createBuildScripts("""
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                    }
+                }
+            }
+""")
+    }
+
+    def createBuildScripts(def append) {
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        buildFile << """
+            apply plugin: 'ivy-publish'
+            apply plugin: 'java-library'
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+            }
+            group = 'org.gradle.test'
+            version = '1.9'
+
+$append
+"""
+
+    }
+
+    @Override
+    protected ExecutionResult run(String... tasks) {
+        try {
+            return super.run(tasks)
+        } finally {
+            module.removeGradleMetadataRedirection()
+        }
+    }
+}

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishFeaturesJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishFeaturesJavaIntegTest.groovy
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy
+
+
+import spock.lang.Unroll
+
+class IvyPublishFeaturesJavaIntegTest extends AbstractIvyPublishFeaturesJavaIntegTest {
+
+    def "can publish java-library with a feature"() {
+        ivyRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeatureImplementation
+                optionalFeatureRuntimeElements {
+                    extendsFrom optionalFeatureImplementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME_JARS))
+                    }
+                    outgoing.capability("org:optional-feature:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+            
+            dependencies {
+                optionalFeatureImplementation 'org:optionaldep:1.0'
+            }
+            
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
+                it.mapToOptional()
+            }
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeatureRuntimeElements") {
+            dependency('org', 'optionaldep', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedIvy.dependencies.size() == 1
+        javaLibrary.parsedIvy.dependencies['org:optionaldep:1.0'].hasConf('optionalFeatureRuntimeElements->default')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+
+        resolveRuntimeArtifacts(javaLibrary) {
+            optionalFeatureCapabilities << "org:optional-feature:1.0"
+            withModuleMetadata {
+                expectFiles "publishTest-1.9.jar", "optionaldep-1.0.jar"
+            }
+            withoutModuleMetadata {
+                // documents the current behavior - ivy does not use variant matching and hence the requested capability is ignored and the default configuration is selected
+                expectFiles "publishTest-1.9.jar"
+            }
+        }
+    }
+
+    def "can group dependencies by feature"() {
+        ivyRepo.module('org', 'optionaldep-g1', '1.0').publish()
+        ivyRepo.module('org', 'optionaldep1-g2', '1.0').publish()
+        ivyRepo.module('org', 'optionaldep2-g2', '1.0').publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeature1Implementation
+                optionalFeature1RuntimeElements {
+                    extendsFrom optionalFeature1Implementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME_JARS))
+                    }
+                    outgoing.capability("org:optional-feature1:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeature1Implementation)
+                
+                optionalFeature2Implementation
+                optionalFeature2RuntimeElements {
+                    extendsFrom optionalFeature2Implementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME_JARS))
+                    }
+                    outgoing.capability("org:optional-feature2:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeature2Implementation)
+            }
+            
+            dependencies {
+                optionalFeature1Implementation 'org:optionaldep-g1:1.0'
+                optionalFeature2Implementation 'org:optionaldep1-g2:1.0'
+                optionalFeature2Implementation 'org:optionaldep2-g2:1.0'
+            }
+            
+            components.java.addVariantsFromConfiguration(configurations.optionalFeature1RuntimeElements) {
+                it.mapToOptional()
+            }
+            components.java.addVariantsFromConfiguration(configurations.optionalFeature2RuntimeElements) {
+                it.mapToOptional()
+            }
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeature1RuntimeElements") {
+            dependency('org', 'optionaldep-g1', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeature2RuntimeElements") {
+            dependency('org', 'optionaldep1-g2', '1.0')
+            dependency('org', 'optionaldep2-g2', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedIvy.dependencies.size() == 3
+        javaLibrary.parsedIvy.dependencies['org:optionaldep-g1:1.0'].hasConf('optionalFeature1RuntimeElements->default')
+        javaLibrary.parsedIvy.dependencies['org:optionaldep1-g2:1.0'].hasConf('optionalFeature2RuntimeElements->default')
+        javaLibrary.parsedIvy.dependencies['org:optionaldep2-g2:1.0'].hasConf('optionalFeature2RuntimeElements->default')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+    }
+
+    @Unroll("publish java-library with feature with additional artifact #id (#optionalFeatureFileName)")
+    def "publish java-library with feature with additional artifact"() {
+        ivyRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeatureImplementation
+                optionalFeatureRuntimeElements {
+                    extendsFrom optionalFeatureImplementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME_JARS))
+                    }
+                    outgoing.capability("org:optional-feature:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+            
+            dependencies {
+                optionalFeatureImplementation 'org:optionaldep:1.0'
+            }
+            
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
+                it.mapToOptional()
+            }
+            
+            artifacts {     
+                if ('$classifier' == 'null') {
+                    optionalFeatureRuntimeElements file:file("\$buildDir/$optionalFeatureFileName"), builtBy:'touchFile'
+                } else {
+                    optionalFeatureRuntimeElements file:file("\$buildDir/$optionalFeatureFileName"), builtBy:'touchFile', classifier: '$classifier'
+                }
+            }
+            
+            task touchFile {
+                doLast {
+                    file("\$buildDir/$optionalFeatureFileName") << "test"
+                }
+            }
+        """
+
+        when:
+        if (failureText) {
+            fails "publish"
+        } else {
+            run "publish"
+        }
+
+        then:
+        if (failureText) {
+            failure.assertHasCause(failureText)
+        } else {
+            javaLibrary.withClassifiedArtifact("optional-feature", "jar")
+            javaLibrary.parsedModuleMetadata.variant("apiElements") {
+                assert files*.name == ["publishTest-1.9.jar"]
+                noMoreDependencies()
+            }
+            javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+                assert files*.name == ["publishTest-1.9.jar"]
+                noMoreDependencies()
+            }
+            javaLibrary.parsedModuleMetadata.variant("optionalFeatureRuntimeElements") {
+                assert files*.name == ["publishTest-1.9-optional-feature.jar"]
+                dependency('org', 'optionaldep', '1.0')
+                noMoreDependencies()
+            }
+            assert javaLibrary.parsedIvy.dependencies['org:optionaldep:1.0'].hasConf('optionalFeatureRuntimeElements->default')
+            assert javaLibrary.parsedIvy.artifacts.size() == 2
+            javaLibrary.parsedIvy.artifacts[0].hasAttributes("jar", "jar", ["compile", "runtime"])
+            javaLibrary.parsedIvy.artifacts[1].hasAttributes("jar", "jar", ["optionalFeatureRuntimeElements"], "optional-feature")
+
+            resolveRuntimeArtifacts(javaLibrary) {
+                optionalFeatureCapabilities << "org:optional-feature:1.0"
+                withModuleMetadata {
+                    expectFiles "publishTest-1.9.jar", "optionaldep-1.0.jar", "publishTest-1.9-optional-feature.jar"
+                }
+                withoutModuleMetadata {
+                    // documents the current behavior - ivy does not use variant matching and hence the requested capability is ignored and the default configuration is selected
+                    expectFiles "publishTest-1.9.jar"
+                }
+            }
+        }
+
+        where:
+        id                                                   | optionalFeatureFileName                | classifier         | failureText
+        "with the same name and an implicit classifier"      | "publishTest-1.9-optional-feature.jar" | null               | null
+        "with an arbitrary name and no classifier"           | "optional-feature-1.9.jar"             | null               | "Invalid publication 'ivy': multiple artifacts with the identical name, extension, type and classifier ('publishTest', jar', 'jar', 'null'"
+        "with an arbitrary name and a classifier"            | "other-1.9.jar"                        | "optional-feature" | null
+        "with an arbitrary name with an implicit classifier" | "other-1.9-optional-feature.jar"       | null               | null
+        "with the same name and no classifier"               | "publishTest-1.9.jar"                  | null               | "Invalid publication 'ivy': multiple artifacts with the identical name, extension, type and classifier ('publishTest', jar', 'jar', 'null'"
+        "with the same name and a classifier"                | "publishTest-1.9.jar"                  | "optional-feature" | null
+
+    }
+
+    def "can publish java-library with a feature from a configuration with more than one outgoing variant"() {
+        ivyRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeatureImplementation
+                optionalFeatureRuntimeElements {
+                    extendsFrom optionalFeatureImplementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME_JARS))
+                    }
+                    outgoing.capability("org:optional-feature:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+            
+            dependencies {
+                optionalFeatureImplementation 'org:optionaldep:1.0'
+            }
+            
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
+                it.mapToOptional()
+            }
+            
+            def alt = configurations.optionalFeatureRuntimeElements.outgoing.variants.create("alternate")
+            alt.attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-runtime-alt'))
+            }
+            def altFile = file("\${buildDir}/\${name}-\${version}-alt.jar")
+            task createFile { doFirst { altFile.parentFile.mkdirs(); altFile.text = "test file" } }
+            alt.artifact(file:altFile, builtBy: 'createFile')
+            
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeatureRuntimeElements") {
+            dependency('org', 'optionaldep', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeatureRuntimeElementsAlternate") {
+            dependency('org', 'optionaldep', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedIvy.dependencies['org:optionaldep:1.0'].hasConf('optionalFeatureRuntimeElements->default')
+        javaLibrary.parsedIvy.dependencies['org:optionaldep:1.0'].hasConf('optionalFeatureRuntimeElementsAlternate->default')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+
+        resolveRuntimeArtifacts(javaLibrary) {
+            optionalFeatureCapabilities << "org:optional-feature:1.0"
+            withModuleMetadata {
+                expectFiles "publishTest-1.9.jar", "optionaldep-1.0.jar"
+            }
+            withoutModuleMetadata {
+                // documents the current behavior - ivy does not use variant matching and hence the requested capability is ignored and the default configuration is selected
+                expectFiles "publishTest-1.9.jar"
+            }
+        }
+    }
+
+    def "can publish java-library with a feature from a configuration with more than one outgoing variant and filter out variants"() {
+        ivyRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeatureImplementation
+                optionalFeatureRuntimeElements {
+                    extendsFrom optionalFeatureImplementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                    outgoing.capability("org:optional-feature:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+            
+            dependencies {
+                optionalFeatureImplementation 'org:optionaldep:1.0'
+            }
+            
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
+                if (it.configurationVariant.name != 'alternate') {
+                    it.skip()
+                } else {
+                    it.mapToOptional()
+                } 
+            }
+            
+            def alt = configurations.optionalFeatureRuntimeElements.outgoing.variants.create("alternate")
+            alt.attributes {
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-runtime'))
+            }
+            def altFile = file("\${buildDir}/\${name}-\${version}-alt.jar")
+            task createFile { doFirst { altFile.parentFile.mkdirs(); altFile.text = "test file" } }
+            alt.artifact(file:altFile, builtBy: 'createFile')
+            
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        !javaLibrary.parsedModuleMetadata.variants.name.contains('optionalFeatureRuntimeElements')
+        javaLibrary.parsedModuleMetadata.variant("optionalFeatureRuntimeElementsAlternate") {
+            dependency('org', 'optionaldep', '1.0')
+            files.name == ['publishTest-1.9-alt.jar']
+            noMoreDependencies()
+        }
+        javaLibrary.parsedIvy.dependencies['org:optionaldep:1.0'].hasConf('optionalFeatureRuntimeElementsAlternate->default')
+        !javaLibrary.parsedIvy.configurations.containsKey('optionalFeatureRuntimeElements')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+
+        resolveRuntimeArtifacts(javaLibrary) {
+            optionalFeatureCapabilities << "org:optional-feature:1.0"
+            withModuleMetadata {
+                // the first file comes from the fact the test fixture adds 2 dependencies (main component, optional feature)
+                expectFiles "publishTest-1.9.jar", "publishTest-1.9-alt.jar", "optionaldep-1.0.jar"
+            }
+            withoutModuleMetadata {
+                // documents the current behavior - ivy does not use variant matching and hence the requested capability is ignored and the default configuration is selected
+                expectFiles "publishTest-1.9.jar"
+            }
+        }
+    }
+}

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishFeaturesJavaPluginIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishFeaturesJavaPluginIntegTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.ivy
+
+import spock.lang.Unroll
+
+class IvyPublishFeaturesJavaPluginIntegTest extends AbstractIvyPublishFeaturesJavaIntegTest {
+    def "can publish java-library with feature using extension"() {
+        ivyRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            
+            java {
+                registerFeature("feature") {
+                    usingSourceSet(sourceSets.main)
+                }
+            }
+            
+            dependencies {
+                featureImplementation 'org:optionaldep:1.0'
+            }
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("featureApiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("featureRuntimeElements") {
+            assert files*.name == ['publishTest-1.9.jar']
+            dependency('org', 'optionaldep', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedIvy.dependencies.size() == 1
+        javaLibrary.parsedIvy.dependencies['org:optionaldep:1.0'].hasConf('featureRuntimeElements->default')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+
+        resolveRuntimeArtifacts(javaLibrary) {
+            optionalFeatureCapabilities << "org.gradle.test:publishTest-feature:1.0"
+            withModuleMetadata {
+                expectFiles "publishTest-1.9.jar", "optionaldep-1.0.jar"
+            }
+            withoutModuleMetadata {
+                // documents the current behavior - ivy does not use variant matching and hence the requested capability is ignored and the default configuration is selected
+                expectFiles "publishTest-1.9.jar"
+            }
+        }
+    }
+
+    @Unroll
+    def "can update #prop after feature has been registered"() {
+        ivyRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            
+            java {
+                registerFeature("feature") {
+                    usingSourceSet(sourceSets.main)
+                }
+            }
+            
+            dependencies {
+                featureImplementation 'org:optionaldep:1.0'
+            }
+            
+            $prop = "$newValue"
+        """
+
+        when:
+        def mod = ivyRepo.module(group, name, version)
+        javaLibrary = javaLibrary(mod)
+        run "publish"
+        mod.removeGradleMetadataRedirection()
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("featureApiElements") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("featureRuntimeElements") {
+            assert files*.name == ["${name}-${version}.jar"]
+            dependency('org', 'optionaldep', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedIvy.dependencies.size() == 1
+        javaLibrary.parsedIvy.dependencies['org:optionaldep:1.0'].hasConf('featureRuntimeElements->default')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "${name}-${version}.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "${name}-${version}.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "${name}-${version}.jar" }
+
+        resolveRuntimeArtifacts(javaLibrary) {
+            optionalFeatureCapabilities << "$group:${name}-feature:1.0"
+            withModuleMetadata {
+                expectFiles "${name}-${version}.jar", "optionaldep-1.0.jar"
+            }
+            withoutModuleMetadata {
+                // documents the current behavior - ivy does not use variant matching and hence the requested capability is ignored and the default configuration is selected
+                expectFiles "${name}-${version}.jar"
+            }
+        }
+
+        where:
+        prop      | group             | name          | version | newValue
+        'group'   | 'newgroup'        | 'publishTest' | '1.9'   | 'newgroup'
+        'version' | 'org.gradle.test' | 'publishTest' | '2.0'   | '2.0'
+    }
+
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -284,20 +284,25 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         if (artifactsOverridden) {
             return;
         }
-        Map<PublishArtifact, IvyArtifact> seenArtifacts = Maps.newHashMap();
+        Map<String, IvyArtifact> seenArtifacts = Maps.newHashMap();
         for (UsageContext usageContext : component.getUsages()) {
             String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
             for (PublishArtifact publishArtifact : usageContext.getArtifacts()) {
-                IvyArtifact ivyArtifact = seenArtifacts.get(publishArtifact);
+                String key = artifactKey(publishArtifact);
+                IvyArtifact ivyArtifact = seenArtifacts.get(key);
                 if (ivyArtifact == null) {
                     ivyArtifact = artifact(publishArtifact);
                     ivyArtifact.setConf(conf);
-                    seenArtifacts.put(publishArtifact, ivyArtifact);
+                    seenArtifacts.put(key, ivyArtifact);
                 } else {
                     ivyArtifact.setConf(ivyArtifact.getConf() + "," + conf);
                 }
             }
         }
+    }
+
+    private String artifactKey(PublishArtifact publishArtifact) {
+        return publishArtifact.getName() + ":" + publishArtifact.getType() + ":" + publishArtifact.getExtension() + ":" + publishArtifact.getClassifier();
     }
 
     private void populateDependencies(PublicationWarningsCollector publicationWarningsCollector) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -35,7 +35,6 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
@@ -152,16 +151,11 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
             configurationContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(impl);
         }
 
-        pluginManager.withPlugin("maven-publish", new Action<AppliedPlugin>() {
-            @Override
-            public void execute(AppliedPlugin plugin) {
-                final AdhocComponentWithVariants component = findComponent();
-                if (component != null) {
-                    component.addVariantsFromConfiguration(apiElements, new JavaConfigurationVariantMapping("compile", true));
-                    component.addVariantsFromConfiguration(runtimeElements, new JavaConfigurationVariantMapping("runtime", true));
-                }
-            }
-        });
+        final AdhocComponentWithVariants component = findComponent();
+        if (component != null) {
+            component.addVariantsFromConfiguration(apiElements, new JavaConfigurationVariantMapping("compile", true));
+            component.addVariantsFromConfiguration(runtimeElements, new JavaConfigurationVariantMapping("runtime", true));
+        }
     }
 
     private void configureTargetPlatform(Configuration configuration) {


### PR DESCRIPTION
So far this was only done when the `maven-publish` plugin was applied. With this change, optional features can also be published to ivy repositories (using GMM).

The PR adds test coverage for optional features in ivy and fixes one issue with duplicated artifacts in an Ivy publication that was discovered with the new tests.