### PR TITLE
Ensure plugin collection mutation results in an error

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginCollection.java
@@ -25,6 +25,8 @@ import org.gradle.api.plugins.PluginCollection;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 
+import java.util.Collection;
+
 class DefaultPluginCollection<T extends Plugin> extends DefaultDomainObjectSet<T> implements PluginCollection<T> {
     DefaultPluginCollection(Class<T> type, CollectionCallbackActionDecorator decorator) {
         super(type, decorator);
@@ -37,6 +39,26 @@ class DefaultPluginCollection<T extends Plugin> extends DefaultDomainObjectSet<T
     @Override
     protected <S extends T> DefaultPluginCollection<S> filtered(CollectionFilter<S> filter) {
         return new DefaultPluginCollection<S>(this, filter);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
@@ -26,8 +26,6 @@ import org.gradle.api.plugins.UnknownPluginException;
 import org.gradle.api.specs.Spec;
 import org.gradle.plugin.use.internal.DefaultPluginId;
 
-import java.util.Collection;
-
 /**
  * This plugin collection is optimized based on the knowledge we have about how plugins
  * are applied. The plugin manager already keeps track of all plugins and ensures they
@@ -52,26 +50,6 @@ public class DefaultPluginContainer extends DefaultPluginCollection<Plugin> impl
 
     @Override
     public boolean add(Plugin toAdd) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean addAll(Collection<? extends Plugin> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean remove(Object o) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean removeAll(Collection<?> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clear() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -275,6 +275,74 @@ class DefaultPluginContainerTest extends Specification {
         e.message == "'$TestRuleSource.name' does not implement the Plugin interface."
     }
 
+    def "cannot add plugins directly to container"() {
+        def plugin = Mock(Plugin)
+
+        when:
+        container.add(plugin)
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.withType(plugin.class).add(plugin)
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.addAll([plugin])
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.withType(plugin.class).addAll([plugin])
+
+        then:
+        thrown UnsupportedOperationException
+    }
+
+    def "cannot remove plugins from container"() {
+        def plugin = Mock(Plugin)
+
+        when:
+        container.remove(plugin)
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.withType(plugin.class).remove(plugin)
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.removeAll([plugin])
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.withType(plugin.class).removeAll([plugin])
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.clear()
+
+        then:
+        thrown UnsupportedOperationException
+
+        when:
+        container.withType(plugin.class).clear()
+
+        then:
+        thrown UnsupportedOperationException
+    }
+
     def scope(ClassLoader classLoader) {
         return Stub(ClassLoaderScope) {
             getLocalClassLoader() >> classLoader


### PR DESCRIPTION
These methods can't be removed since they are inherited from `Collection` but I've pulled them up to the `PluginCollection` interface so that they will fail even on filtered collections and added some test coverage to ensure that they fail.