### PR TITLE
Make resolving configurations from unmanaged threads an error

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -58,7 +58,7 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         outputContains("The configuration :bar:bar was resolved without accessing the project in a safe manner.")
     }
 
-    def "deprecation warning when configuration is resolved from a non-gradle thread"() {
+    def "exception when configuration is resolved from a non-gradle thread"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 
         settingsFile << """
@@ -69,11 +69,13 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         buildFile << """
             task resolve {
                 def thread = new Thread({
-                    println project(':bar').configurations.bar.files
+                    file('bar') << project(':bar').configurations.bar.files
                 })
                 doFirst {
                     thread.start()
                     thread.join()
+                    // this should fail
+                    assert file('bar').exists()
                 }
             }
            
@@ -94,11 +96,11 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
 
         when:
         executer.withArgument("--parallel")
-        executer.expectDeprecationWarning()
-        succeeds(":resolve")
+        executer.withStackTraceChecksDisabled()
+        fails(":resolve")
 
         then:
-        outputContains("The configuration :bar:bar was resolved without accessing the project in a safe manner.")
+        failure.assertHasErrorOutput("The configuration :bar:bar was resolved from a thread not managed by Gradle.")
     }
 
     def "deprecation warning when configuration is resolved while evaluating a different project"() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -16,8 +16,11 @@
 
 package org.gradle.smoketests
 
+import spock.lang.Ignore
+
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+@Ignore("Ignored until https://github.com/gretty-gradle-plugin/gretty/issues/80 is resolved.")
 class GrettySmokeTest extends AbstractSmokeTest {
 
     def 'run with jetty'() {


### PR DESCRIPTION
This makes resolving configurations from threads not managed by Gradle an error as it can cause deadlocks or cause other flaky behavior.