### PR TITLE
Small improvements to performance test report

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DefaultPerformanceReporter.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DefaultPerformanceReporter.groovy
@@ -71,11 +71,16 @@ class DefaultPerformanceReporter implements PerformanceReporter {
             }
         })
 
-        // SLF4J: Class path contains multiple SLF4J bindings.
-        String message = output.toString().readLines().findAll { !it.contains("WARNING: ") && !it.contains("SLF4J") }.join("\n")
+        String message = output.toString().readLines().findAll { line ->
+            ! [
+                // WARNING: All illegal access operations will be denied in a future release
+                "WARNING",
+                // SLF4J: Class path contains multiple SLF4J bindings.
+                "SLF4J"
+            ].any { line.contains(it) }
+        }.join("\n")
 
         if (result.exitValue != 0) {
-            // WARNING: All illegal access operations will be denied in a future release
             throw new GradleException("Performance test failed: " + message)
         } else {
             println(message)

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -491,7 +491,7 @@ class DistributedPerformanceTest extends PerformanceTest {
 
     @TypeChecked(TypeCheckingMode.SKIP)
     private void checkForErrors() {
-        if(isRerun()) {
+        if (isRerun()) {
             // report generation will control the coordinator failure status
             return
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioResult.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioResult.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ScenarioResult {
+
+    enum Status {
+        SUCCESS,
+        FAILURE,
+        UNKNOWN,
+        STABLE_REGRESSION,
+        SMALL_FLAKY_REGRESSION,
+        BIG_FLAKY_REGRESSION
+    }
+
+    private final Status status;
+    private final List<ScenarioBuildResultData> individualResults;
+    private final List<ScenarioBuildResultData.ExecutionData> currentBuildExecutions = new ArrayList<>();
+    private final List<ScenarioBuildResultData.ExecutionData> recentExecutions = new ArrayList<>();
+    private final boolean crossVersion;
+
+    public ScenarioResult(Status status, List<ScenarioBuildResultData> individualResults, boolean crossVersion) {
+        this.status = status;
+        this.individualResults = individualResults;
+        this.crossVersion = crossVersion;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public List<ScenarioBuildResultData> getIndividualResults() {
+        return individualResults;
+    }
+
+    public List<ScenarioBuildResultData.ExecutionData> getCurrentBuildExecutions() {
+        return currentBuildExecutions;
+    }
+
+    public List<ScenarioBuildResultData.ExecutionData> getRecentExecutions() {
+        return recentExecutions;
+    }
+
+    public boolean isCrossVersion() {
+        return crossVersion;
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceFlakinessDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceFlakinessDataProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.performance.results.report;
 
 import org.gradle.performance.results.CrossVersionResultsStore;
+import org.gradle.performance.results.ScenarioBuildResultData;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -45,7 +46,11 @@ public class DefaultPerformanceFlakinessDataProvider implements PerformanceFlaki
     }
 
     @Override
-    public ScenarioRegressionResult getScenarioRegressionResult(String scenarioName, double regressionPercentage) {
+    public ScenarioRegressionResult getScenarioRegressionResult(ScenarioBuildResultData scenario) {
+        return getScenarioRegressionResult(scenario.getScenarioName(), scenario.getDifferencePercentage());
+    }
+
+    private ScenarioRegressionResult getScenarioRegressionResult(String scenarioName, double regressionPercentage) {
         if (isStableScenario(scenarioName)) {
             return STABLE_REGRESSION;
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
@@ -54,11 +54,11 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
                     buildFailure.getAndIncrement();
                 } else if (scenario.getRawData().stream().allMatch(ScenarioBuildResultData::isRegressed)) {
                     Set<PerformanceFlakinessDataProvider.ScenarioRegressionResult> regressionResults = scenario.getRawData().stream()
-                        .map(rawScenario -> flakinessDataProvider.getScenarioRegressionResult(rawScenario.getScenarioName(), rawScenario.getDifferencePercentage()))
+                        .map(flakinessDataProvider::getScenarioRegressionResult)
                         .collect(Collectors.toSet());
                     if (regressionResults.contains(STABLE_REGRESSION)) {
                         stableScenarioRegression.getAndIncrement();
-                    } else if (regressionResults.stream().allMatch(it -> it == BIG_FLAKY_REGRESSION)) {
+                    } else if (regressionResults.stream().allMatch(BIG_FLAKY_REGRESSION::equals)) {
                         flakyScenarioBigRegression.getAndIncrement();
                     } else {
                         flakyScenarioSmallRegression.getAndIncrement();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultReportGenerator.java
@@ -60,9 +60,11 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
                     }
                 }
             });
+        String resultString = formatResultString(buildFailure.get(), stableScenarioRegression.get(), flakyScenarioBigRegression.get(), flakyScenarioSmallRegression.get());
         if (buildFailure.get() + stableScenarioRegression.get() + flakyScenarioBigRegression.get() != 0) {
-            throw new GradleException(formatErrorString(buildFailure.get(), stableScenarioRegression.get(), flakyScenarioBigRegression.get(), flakyScenarioSmallRegression.get()));
+            throw new GradleException("Performance test failed" + resultString);
         }
+        System.out.println("Performance test passed" + resultString);
 
         markBuildAsSuccessfulIfFlaky(executionDataProvider);
     }
@@ -74,8 +76,8 @@ public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsSt
         }
     }
 
-    private String formatErrorString(int buildFailure, int stableScenarioRegression, int flakyScenarioBigRegression, int flakyScenarioSmallRegression) {
-        StringBuilder sb = new StringBuilder("Performance test failed");
+    private String formatResultString(int buildFailure, int stableScenarioRegression, int flakyScenarioBigRegression, int flakyScenarioSmallRegression) {
+        StringBuilder sb = new StringBuilder();
         if (buildFailure != 0) {
             sb.append(", ").append(buildFailure).append(" scenario(s) failed");
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/IndexPageGenerator.java
@@ -20,7 +20,6 @@ import org.gradle.performance.results.ResultsStore;
 import org.gradle.performance.results.ResultsStoreHelper;
 import org.gradle.performance.results.ScenarioBuildResultData;
 
-import java.io.IOException;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.util.HashSet;
@@ -43,7 +42,7 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
     }
 
     @Override
-    public void render(final ResultsStore store, Writer writer) throws IOException {
+    public void render(final ResultsStore store, Writer writer) {
         long successCount = executionDataProvider.getScenarioExecutionData().stream().filter(ScenarioBuildResultData::isSuccessful).count();
         long failureCount = executionDataProvider.getScenarioExecutionData().size() - successCount;
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceFlakinessDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceFlakinessDataProvider.java
@@ -16,6 +16,8 @@
 
 package org.gradle.performance.results.report;
 
+import org.gradle.performance.results.ScenarioBuildResultData;
+
 import java.math.BigDecimal;
 
 public interface PerformanceFlakinessDataProvider {
@@ -56,7 +58,7 @@ public interface PerformanceFlakinessDataProvider {
      */
     BigDecimal getFailureThreshold(String scenario);
 
-    ScenarioRegressionResult getScenarioRegressionResult(String scenarioName, double regressionPercentage);
+    ScenarioRegressionResult getScenarioRegressionResult(ScenarioBuildResultData scenario);
 
     enum ScenarioRegressionResult {
         STABLE_REGRESSION(true),
@@ -88,7 +90,7 @@ public interface PerformanceFlakinessDataProvider {
         }
 
         @Override
-        public ScenarioRegressionResult getScenarioRegressionResult(String scenarioName, double regressionPercentage) {
+        public ScenarioRegressionResult getScenarioRegressionResult(ScenarioBuildResultData scenario) {
             return ScenarioRegressionResult.STABLE_REGRESSION;
         }
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceFlakinessDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/PerformanceFlakinessDataProvider.java
@@ -56,6 +56,24 @@ public interface PerformanceFlakinessDataProvider {
      */
     BigDecimal getFailureThreshold(String scenario);
 
+    ScenarioRegressionResult getScenarioRegressionResult(String scenarioName, double regressionPercentage);
+
+    enum ScenarioRegressionResult {
+        STABLE_REGRESSION(true),
+        SMALL_FLAKY_REGRESSION(false),
+        BIG_FLAKY_REGRESSION(true);
+
+        private final boolean failsBuild;
+
+        ScenarioRegressionResult(boolean failsBuild) {
+            this.failsBuild = failsBuild;
+        }
+
+        public boolean isFailsBuild() {
+            return failsBuild;
+        }
+    }
+
     enum EmptyPerformanceFlakinessDataProvider implements PerformanceFlakinessDataProvider {
         INSTANCE;
 
@@ -67,6 +85,11 @@ public interface PerformanceFlakinessDataProvider {
         @Override
         public BigDecimal getFailureThreshold(String scenario) {
             return null;
+        }
+
+        @Override
+        public ScenarioRegressionResult getScenarioRegressionResult(String scenarioName, double regressionPercentage) {
+            return ScenarioRegressionResult.STABLE_REGRESSION;
         }
     }
 }


### PR DESCRIPTION
- Always show result message
- Show small regressions in table not as failed, but as nearly failing

This can still be improved, though I think the changes are good as is already.