### PR TITLE
Revert changes to classloader caching

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -101,12 +101,16 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
                     effectiveExportClassLoader = loader(id.exportId(), parent.getExportClassLoader(), export, exportLoaders);
                     effectiveLocalClassLoader = localLoader(id.localId(), effectiveExportClassLoader, local);
                 } else if (hasLocals) {
+                    classLoaderCache.remove(id.exportId());
                     effectiveExportClassLoader = parent.getExportClassLoader();
                     effectiveLocalClassLoader = localLoader(id.localId(), effectiveExportClassLoader, local);
                 } else if (hasExports) {
+                    classLoaderCache.remove(id.localId());
                     effectiveExportClassLoader = loader(id.exportId(), parent.getExportClassLoader(), export, exportLoaders);
                     effectiveLocalClassLoader = effectiveExportClassLoader;
                 } else {
+                    classLoaderCache.remove(id.localId());
+                    classLoaderCache.remove(id.exportId());
                     effectiveLocalClassLoader = parent.getExportClassLoader();
                     effectiveExportClassLoader = parent.getExportClassLoader();
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
@@ -55,4 +55,9 @@ public interface ClassLoaderCache {
      * @return the classloader.
      */
     <T extends ClassLoader> T put(ClassLoaderId id, T classLoader);
+
+    /**
+     * Discards the given classloader.
+     */
+    void remove(ClassLoaderId id);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
@@ -17,8 +17,11 @@
 package org.gradle.api.internal.initialization.loadercache;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import org.gradle.initialization.SessionLifecycleListener;
 import org.gradle.internal.classloader.ClassLoaderUtils;
@@ -32,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.lang.ref.SoftReference;
 import java.util.Map;
 import java.util.Set;
 
@@ -40,9 +42,9 @@ public class DefaultClassLoaderCache implements ClassLoaderCache, Stoppable, Ses
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClassLoaderCache.class);
 
     private final Object lock = new Object();
-    private final Map<ClassLoaderSpec, ClassLoader> bySpec = Maps.newHashMap();
-    private final Map<ClassLoaderSpec, SoftReference<ClassLoader>> previousBySpec = Maps.newHashMap();
-    private final Set<ClassLoaderSpec> usedInThisBuild = Sets.newHashSet();
+    private final Map<ClassLoaderId, CachedClassLoader> byId = Maps.newHashMap();
+    private final Map<ClassLoaderSpec, CachedClassLoader> bySpec = Maps.newHashMap();
+    private final Set<ClassLoaderId> usedInThisBuild = Sets.newHashSet();
     private final ClasspathHasher classpathHasher;
     private final HashingClassLoaderFactory classLoaderFactory;
 
@@ -64,39 +66,64 @@ public class DefaultClassLoaderCache implements ClassLoaderCache, Stoppable, Ses
         ManagedClassLoaderSpec spec = new ManagedClassLoaderSpec(id.toString(), parent, classPath, implementationHash, filterSpec);
 
         synchronized (lock) {
-            return getAndRetainLoader(classPath, spec);
+            usedInThisBuild.add(id);
+            CachedClassLoader cachedLoader = byId.get(id);
+            if (cachedLoader == null || !cachedLoader.is(spec)) {
+                CachedClassLoader newLoader = getAndRetainLoader(classPath, spec, id);
+                byId.put(id, newLoader);
+
+                if (cachedLoader != null) {
+                    LOGGER.debug("Releasing previous classloader for {}", id);
+                    cachedLoader.release(id);
+                }
+                return newLoader.classLoader;
+            } else {
+                return cachedLoader.classLoader;
+            }
         }
     }
 
     @Override
     public <T extends ClassLoader> T put(ClassLoaderId id, T classLoader) {
         synchronized (lock) {
-            ClassLoaderSpec spec = new UnmanagedClassLoaderSpec(id);
-            bySpec.put(spec, classLoader);
-            usedInThisBuild.add(spec);
+            remove(id);
+            ClassLoaderSpec spec = new UnmanagedClassLoaderSpec(classLoader);
+            CachedClassLoader cachedClassLoader = new CachedClassLoader(classLoader, spec, null);
+            cachedClassLoader.retain(id);
+            byId.put(id, cachedClassLoader);
+            bySpec.put(spec, cachedClassLoader);
+            usedInThisBuild.add(id);
         }
         return classLoader;
     }
 
-    private ClassLoader getAndRetainLoader(ClassPath classPath, ManagedClassLoaderSpec spec) {
-        ClassLoader classLoader = bySpec.get(spec);
-        if (classLoader == null) {
-            SoftReference<ClassLoader> reference = previousBySpec.remove(spec);
-            if (reference != null) {
-                classLoader = reference.get();
+    @Override
+    public void remove(ClassLoaderId id) {
+        synchronized (lock) {
+            CachedClassLoader cachedClassLoader = byId.remove(id);
+            if (cachedClassLoader != null) {
+                cachedClassLoader.release(id);
             }
-            if (classLoader == null) {
-                if (spec.isFiltered()) {
-                    ClassLoader parentCachedLoader = getAndRetainLoader(classPath, spec.unfiltered());
-                    classLoader = classLoaderFactory.createFilteringClassLoader(parentCachedLoader, spec.filterSpec);
-                } else {
-                    classLoader = classLoaderFactory.createChildClassLoader(spec.name, spec.parent, classPath, spec.implementationHash);
-                }
-            }
-            bySpec.put(spec, classLoader);
+            usedInThisBuild.remove(id);
         }
-        usedInThisBuild.add(spec);
-        return classLoader;
+    }
+
+    private CachedClassLoader getAndRetainLoader(ClassPath classPath, ManagedClassLoaderSpec spec, ClassLoaderId id) {
+        CachedClassLoader cachedLoader = bySpec.get(spec);
+        if (cachedLoader == null) {
+            ClassLoader classLoader;
+            CachedClassLoader parentCachedLoader = null;
+            if (spec.isFiltered()) {
+                parentCachedLoader = getAndRetainLoader(classPath, spec.unfiltered(), id);
+                classLoader = classLoaderFactory.createFilteringClassLoader(parentCachedLoader.classLoader, spec.filterSpec);
+            } else {
+                classLoader = classLoaderFactory.createChildClassLoader(spec.name, spec.parent, classPath, spec.implementationHash);
+            }
+            cachedLoader = new CachedClassLoader(classLoader, spec, parentCachedLoader);
+            bySpec.put(spec, cachedLoader);
+        }
+
+        return cachedLoader.retain(id);
     }
 
     @VisibleForTesting
@@ -106,85 +133,44 @@ public class DefaultClassLoaderCache implements ClassLoaderCache, Stoppable, Ses
         }
     }
 
-    @VisibleForTesting
-    public int retained() {
-        synchronized (lock) {
-            return previousBySpec.size();
-        }
-    }
-
-    @VisibleForTesting
-    public void releaseReferences() {
-        synchronized (lock) {
-            for (SoftReference<ClassLoader> value : previousBySpec.values()) {
-                value.clear();
-            }
-        }
-    }
-
     @Override
     public void stop() {
         synchronized (lock) {
-            for (Map.Entry<ClassLoaderSpec, ClassLoader> entry : bySpec.entrySet()) {
-                discard(entry.getKey(), entry.getValue());
+            for (CachedClassLoader cachedClassLoader : byId.values()) {
+                ClassLoaderUtils.tryClose(cachedClassLoader.classLoader);
             }
+            byId.clear();
             bySpec.clear();
             usedInThisBuild.clear();
         }
     }
 
-    private void discard(ClassLoaderSpec spec, ClassLoader classLoader) {
-        ClassLoaderUtils.tryClose(classLoader);
-    }
-
     @Override
     public void afterStart() {
+
     }
 
     @Override
     public void beforeComplete() {
         synchronized (lock) {
-            Set<ClassLoaderSpec> unused = Sets.newHashSet(bySpec.keySet());
+            Set<ClassLoaderId> unused = Sets.newHashSet(byId.keySet());
             unused.removeAll(usedInThisBuild);
-            for (ClassLoaderSpec spec : unused) {
-                ClassLoader classLoader = bySpec.remove(spec);
-                previousBySpec.put(spec, new SoftReference<>(classLoader));
+            for (ClassLoaderId id : unused) {
+                remove(id);
             }
             usedInThisBuild.clear();
-            previousBySpec.values().removeIf(entry -> entry.get() == null);
         }
+        assertInternalIntegrity();
     }
 
     private static abstract class ClassLoaderSpec {
     }
 
     private static class UnmanagedClassLoaderSpec extends ClassLoaderSpec {
-        private final ClassLoaderId id;
+        private final ClassLoader loader;
 
-        public UnmanagedClassLoaderSpec(ClassLoaderId id) {
-            this.id = id;
-        }
-
-        @Override
-        public String toString() {
-            return id.toString();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (obj == null || obj.getClass() != getClass()) {
-                return false;
-            }
-            UnmanagedClassLoaderSpec other = (UnmanagedClassLoaderSpec) obj;
-            return other.id.equals(id);
-        }
-
-        @Override
-        public int hashCode() {
-            return id.hashCode();
+        public UnmanagedClassLoaderSpec(ClassLoader loader) {
+            this.loader = loader;
         }
     }
 
@@ -205,11 +191,6 @@ public class DefaultClassLoaderCache implements ClassLoaderCache, Stoppable, Ses
 
         public ManagedClassLoaderSpec unfiltered() {
             return new ManagedClassLoaderSpec(name, parent, classPath, implementationHash, null);
-        }
-
-        @Override
-        public String toString() {
-            return name + "," + System.identityHashCode(parent) + "," + (filterSpec == null ? "-" : "filtered");
         }
 
         public boolean isFiltered() {
@@ -238,6 +219,60 @@ public class DefaultClassLoaderCache implements ClassLoaderCache, Stoppable, Ses
             result = 31 * result + (filterSpec != null ? filterSpec.hashCode() : 0);
             result = 31 * result + (parent != null ? parent.hashCode() : 0);
             return result;
+        }
+    }
+
+    private class CachedClassLoader {
+        private final ClassLoader classLoader;
+        private final ClassLoaderSpec spec;
+        private final CachedClassLoader parent;
+        private final Multiset<ClassLoaderId> usedBy = HashMultiset.create();
+
+        private CachedClassLoader(ClassLoader classLoader, ClassLoaderSpec spec, @Nullable CachedClassLoader parent) {
+            this.classLoader = classLoader;
+            this.spec = spec;
+            this.parent = parent;
+        }
+
+        public boolean is(ClassLoaderSpec spec) {
+            return this.spec.equals(spec);
+        }
+
+        public CachedClassLoader retain(ClassLoaderId loaderId) {
+            usedBy.add(loaderId);
+            return this;
+        }
+
+        public void release(ClassLoaderId loaderId) {
+            if (usedBy.isEmpty()) {
+                throw new IllegalStateException("Cannot release already released classloader: " + classLoader);
+            }
+
+            if (usedBy.remove(loaderId)) {
+                if (usedBy.isEmpty()) {
+                    if (parent != null) {
+                        parent.release(loaderId);
+                    }
+                    bySpec.remove(spec);
+                }
+            } else {
+                throw new IllegalStateException("Classloader '" + this + "' not used by '" + loaderId + "'");
+            }
+        }
+    }
+
+    private void assertInternalIntegrity() {
+        synchronized (lock) {
+            Map<ClassLoaderId, CachedClassLoader> orphaned = Maps.newHashMap();
+            for (Map.Entry<ClassLoaderId, CachedClassLoader> entry : byId.entrySet()) {
+                if (!bySpec.containsKey(entry.getValue().spec)) {
+                    orphaned.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            if (!orphaned.isEmpty()) {
+                throw new IllegalStateException("The following class loaders are orphaned: " + Joiner.on(",").withKeyValueSeparator(":").join(orphaned));
+            }
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
@@ -322,13 +322,13 @@ class DefaultClassLoaderScopeTest extends Specification {
         root.createChild("d").lock().exportClassLoader
 
         then:
-        classLoaderCache.size() == 3
+        classLoaderCache.size() == 1
 
         when:
         root.createChild("c").lock().exportClassLoader
 
         then:
-        classLoaderCache.size() == 3
+        classLoaderCache.size() == 0
     }
 
     static ClassLoader isolatedLoader(File... paths) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
@@ -67,7 +67,7 @@ class DefaultClassLoaderCacheTest extends Specification {
         cache.get(id1, classPath("c1"), root, null, classpathHasher.hash(classPath("c1"))) == cache.get(id1, classPath("c1"), root, null, null)
     }
 
-    def "class loaders with different ids and same spec are reused"() {
+    def "class loaders with different ids are reused"() {
         expect:
         def root = classLoader(classPath("root"))
         cache.get(id1, classPath("c1"), root, null).is cache.get(id2, classPath("c1"), root, null)
@@ -96,7 +96,7 @@ class DefaultClassLoaderCacheTest extends Specification {
         cache.get(id1, classPath("c1"), root, f1).is(cache.get(id1, classPath("c1"), root, f1))
         cache.size() == 2
         !cache.get(id1, classPath("c1"), root, f1).is(cache.get(id1, classPath("c1"), root, f2))
-        cache.size() == 3
+        cache.size() == 2
     }
 
     def "non filtered classloaders are reused"() {
@@ -106,8 +106,7 @@ class DefaultClassLoaderCacheTest extends Specification {
         cache.get(id1, classPath("c1"), root, f1)
         cache.size() == 2
         cache.get(id1, classPath("c1"), root, null)
-        cache.get(id1, classPath("c1"), root, null).is(cache.get(id1, classPath("c1"), root, f1).parent)
-        cache.size() == 2
+        cache.size() == 1
     }
 
     def "filtered classloaders are reused if they have multiple ids"() {
@@ -121,48 +120,65 @@ class DefaultClassLoaderCacheTest extends Specification {
         cache.size() == 2
     }
 
-    def "retains soft reference to unused classloaders at the end of the build"() {
+    def "unfiltered base is released when there are no more references to it"() {
         expect:
         def root = classLoader(classPath("root"))
-        def c1 = cache.get(id1, classPath("c1"), root, null)
-        def c2 = cache.get(id2, classPath("c2"), root, null)
+        def f1 = new FilteringClassLoader.Spec(["1"], [], [], [], [], [], [])
+        def f2 = new FilteringClassLoader.Spec(["2"], [], [], [], [], [], [])
+        def cp1 = classPath("c1")
+        def cp2 = classPath("c2")
 
-        cache.beforeComplete()
+        cache.get(id1, cp1, root, f1)
+        cache.get(id2, cp1, root, f2)
+        cache.size() == 3
+        cache.get(id1, cp2, root, f1)
+        cache.size() == 4
+        cache.get(id1, cp1, root, null)
         cache.size() == 2
-        cache.retained() == 0
-
-        cache.get(id1, classPath("c1"), root, null).is(c1)
-
-        cache.beforeComplete()
+        cache.get(id1, cp2, root, null)
+        cache.get(id2, cp2, root, null)
         cache.size() == 1
-        cache.retained() == 1
-
-        cache.get(id1, classPath("c1"), root, null).is(c1)
-        // Reuse from soft reference
-        cache.get(id2, classPath("c2"), root, null).is(c2)
-
-        cache.size() == 2
-        cache.retained() == 0
     }
 
-    def "recreates unused classloaders if soft reference is cleared"() {
-        expect:
+    def "removes stale classloader"() {
         def root = classLoader(classPath("root"))
-        def c1 = cache.get(id1, classPath("c1"), root, null)
-
-        cache.beforeComplete()
+        cache.get(id1, classPath("c1"), root, null)
+        def c2 = cache.get(id1, classPath("c2"), root, null)
+        expect:
         cache.size() == 1
-        cache.retained() == 0
+        c2.is cache.get(id1, classPath("c2"), root, null)
+    }
 
-        cache.beforeComplete()
+    def "can remove loaders"() {
+        expect:
         cache.size() == 0
-        cache.retained() == 1
-        cache.releaseReferences()
 
-        !cache.get(id1, classPath("c1"), root, null).is(c1)
+        when:
+        cache.remove(id1)
 
-        cache.size() == 1
-        cache.retained() == 0
+        then:
+        noExceptionThrown()
+        cache.size() == 0
+
+        when:
+        def root = classLoader(classPath("root"))
+        cache.get(id1, classPath("c2"), root, null)
+        cache.get(id2, classPath("c2"), root, null)
+
+        then:
+        cache.size() == 1 // both are the same
+
+        when:
+        cache.remove(id1)
+
+        then:
+        cache.size() == 1 // still used by id2
+
+        when:
+        cache.remove(id2)
+
+        then:
+        cache.size() == 0
     }
 
     def "can put loaders"() {
@@ -173,6 +189,12 @@ class DefaultClassLoaderCacheTest extends Specification {
 
         then:
         cache.size() == 1
+
+        when:
+        cache.remove(id1)
+
+        then:
+        cache.size() == 0
     }
 
     def "can replace specialized loader"() {
@@ -198,12 +220,12 @@ class DefaultClassLoaderCacheTest extends Specification {
         then:
         cl != loader1
         cl != loader2
-        cache.size() == 2
+        cache.size() == 1
 
         when:
         cache.put(id1, loader1)
 
         then:
-        cache.size() == 2
+        cache.size() == 1
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
@@ -39,4 +39,8 @@ public class DummyClassLoaderCache implements ClassLoaderCache {
     public <T extends ClassLoader> T put(ClassLoaderId id, T classLoader) {
         return classLoader;
     }
+
+    @Override
+    public void remove(ClassLoaderId id) {
+    }
 }

--- a/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -27,21 +27,15 @@ import org.gradle.kotlin.dsl.caching.fixtures.cachedSettingsScript
 import org.gradle.kotlin.dsl.caching.fixtures.classLoadingCache
 import org.gradle.kotlin.dsl.caching.fixtures.compilationCache
 import org.gradle.kotlin.dsl.caching.fixtures.compilationTrace
-
 import org.gradle.kotlin.dsl.execution.Program
 import org.gradle.kotlin.dsl.execution.ProgramKind.TopLevel
 import org.gradle.kotlin.dsl.execution.ProgramParser
 import org.gradle.kotlin.dsl.execution.ProgramSource
 import org.gradle.kotlin.dsl.execution.ProgramTarget
-
 import org.gradle.kotlin.dsl.fixtures.DeepThought
-
 import org.gradle.soak.categories.SoakTest
-
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
-
 import java.util.UUID
 
 
@@ -228,7 +222,6 @@ class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
         }
     }
 
-    @Ignore("https://github.com/gradle/gradle/pull/10414#issuecomment-527292101")
     @Test
     fun `in-memory script class loading cache releases memory of unused entries`() {
 


### PR DESCRIPTION

### Context

Revert simplifications to the classloader caching, as the new behaviour can temporarily increase the total amount memory required and fixing this is not worth the simplifications (at this stage).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
