### PR TITLE
Improve publication warnings

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -944,7 +944,6 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputContains('Declares capability org:foo:1.0')
         javaLibrary.assertPublished()
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -960,6 +960,61 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         }
     }
 
+    def "can ignore publication warnings"() {
+        requiresExternalDependencies = true
+        given:
+        createBuildScripts("""
+
+            configurations.api.outgoing.capability 'org:foo:1.0'
+            configurations.implementation.outgoing.capability 'org:bar:1.0'
+
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        silencePublicationWarningsFor('apiElements')
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        outputContains('Declares capability org:foo:1.0')
+        outputContains("Variant runtimeElements")
+        outputDoesNotContain("Variant apiElements")
+        javaLibrary.assertPublished()
+    }
+
+    def "can ignore all publication warnings"() {
+        requiresExternalDependencies = true
+        given:
+        createBuildScripts("""
+
+            configurations.api.outgoing.capability 'org:foo:1.0'
+            configurations.implementation.outgoing.capability 'org:bar:1.0'
+
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        silenceAllPublicationWarnings()
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        outputDoesNotContain("Ivy publication 'ivy' warnings:")
+        outputDoesNotContain('Declares capability org:foo:1.0')
+        javaLibrary.assertPublished()
+    }
+
     def "can publish java-library with dependencies/constraints with attributes"() {
         requiresExternalDependencies = true
         given:

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -965,6 +965,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
     def "can ignore publication warnings"() {
         given:
+        def silenceMethod = "silenceIvyMetadataWarningsFor"
         createBuildScripts("""
 
             configurations.api.outgoing.capability 'org:foo:1.0'
@@ -974,7 +975,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 publications {
                     ivy(IvyPublication) {
                         from components.java
-                        silenceIvyMetadataWarningsFor('apiElements')
+                        $silenceMethod('apiElements')
                     }
                 }
             }
@@ -985,6 +986,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
+        outputContains("$silenceMethod(variant)")
         outputContains('Declares capability org:foo:1.0')
         outputContains("Variant runtimeElements")
         outputDoesNotContain("Variant apiElements")

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -118,7 +118,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublished()
         if (ivyConfiguration == 'compile') {
             javaLibrary.assertApiDependencies('org.gradle.test:b:1.2')
@@ -259,7 +259,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublishedAsJavaModule()
 
         def dep = javaLibrary.parsedIvy.expectDependency("org.springframework:spring-core:2.5.6")
@@ -316,7 +316,6 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
     @Issue("https://github.com/gradle/gradle/issues/4356, https://github.com/gradle/gradle/issues/5035")
     void "generated ivy descriptor includes configuration exclusions"() {
-        requiresExternalDependencies = true
         def exclusion = { name -> "$name-group:$name-module" }
         def exclusions = { conf -> javaLibrary.parsedIvy.exclusions.findAll { it.conf == conf }.collect { it.org + ":" + it.module } }
 
@@ -404,7 +403,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublishedAsJavaModule()
         javaLibrary.assertApiDependencies("org.test:default-dependency:1.1")
     }
@@ -449,7 +448,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublishedAsJavaModule()
         javaLibrary.assertApiDependencies('org.test:dep1:X', 'org.test:dep2:X')
     }
@@ -482,7 +481,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublished()
 
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -552,6 +551,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputContains('commons-logging:commons-logging:1.1 declared as a dependency constraint')
         javaLibrary.assertPublished()
@@ -632,6 +632,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         javaLibrary.removeGradleMetadataRedirection()
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputContains('commons-collections:commons-collections declared without version')
         javaLibrary.assertPublished()
@@ -701,6 +702,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         javaLibrary.removeGradleMetadataRedirection()
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputDoesNotContain('commons-collections:commons-collections declared without version')
         javaLibrary.assertPublished()
@@ -762,6 +764,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         javaLibrary.removeGradleMetadataRedirection()
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputDoesNotContain('commons-collections:commons-collections declared without version')
         javaLibrary.assertPublished()
@@ -826,8 +829,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         javaLibrary.removeGradleMetadataRedirection()
-        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
-        outputDoesNotContain('commons-collections:commons-collections declared without version')
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublished()
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
         javaLibrary.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.2@runtime")
@@ -887,6 +889,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         javaLibrary.removeGradleMetadataRedirection()
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublished()
 
@@ -924,7 +927,6 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
     }
 
     def "can publish java-library with capabilities"() {
-        requiresExternalDependencies = true
         given:
         createBuildScripts("""
 
@@ -944,6 +946,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains('Declares capability org:foo:1.0')
         javaLibrary.assertPublished()
 
@@ -961,7 +964,6 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
     }
 
     def "can ignore publication warnings"() {
-        requiresExternalDependencies = true
         given:
         createBuildScripts("""
 
@@ -982,6 +984,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains('Declares capability org:foo:1.0')
         outputContains("Variant runtimeElements")
         outputDoesNotContain("Variant apiElements")
@@ -989,7 +992,6 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
     }
 
     def "can ignore all publication warnings"() {
-        requiresExternalDependencies = true
         given:
         createBuildScripts("""
 
@@ -1010,13 +1012,13 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputDoesNotContain("Ivy publication 'ivy' warnings:")
         outputDoesNotContain('Declares capability org:foo:1.0')
         javaLibrary.assertPublished()
     }
 
     def "can publish java-library with dependencies/constraints with attributes"() {
-        requiresExternalDependencies = true
         given:
         settingsFile << "include 'utils'\n"
         file("utils/build.gradle") << '''
@@ -1071,6 +1073,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
         outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublished()
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -974,7 +974,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 publications {
                     ivy(IvyPublication) {
                         from components.java
-                        silencePublicationWarningsFor('apiElements')
+                        silenceIvyMetadataWarningsFor('apiElements')
                     }
                 }
             }
@@ -1002,7 +1002,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 publications {
                     ivy(IvyPublication) {
                         from components.java
-                        silenceAllPublicationWarnings()
+                        silenceAllIvyMetadataWarnings()
                     }
                 }
             }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -360,4 +361,25 @@ public interface IvyPublication extends Publication {
      */
     void versionMapping(Action<? super VersionMappingStrategy> configureAction);
 
+    /**
+     * Silences the compatibility warnings for the Ivy publication for the specified variant.
+     *
+     * Warnings are emitted when Gradle features are used that cannot be mapped completely to Ivy xml.
+     *
+     * @param variantName the variant to silence warning for
+     *
+     * @since 6.0
+     */
+    @Incubating
+    void silencePublicationWarningsFor(String variantName);
+
+    /**
+     * Silences all the compatibility warnings for the Ivy publication.
+     *
+     * Warnings are emitted when Gradle features are used that cannot be mapped completely to Ivy xml.
+     *
+     * @since 6.0
+     */
+    @Incubating
+    void silenceAllPublicationWarnings();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -371,7 +371,7 @@ public interface IvyPublication extends Publication {
      * @since 6.0
      */
     @Incubating
-    void silencePublicationWarningsFor(String variantName);
+    void silenceIvyMetadataWarningsFor(String variantName);
 
     /**
      * Silences all the compatibility warnings for the Ivy publication.
@@ -381,5 +381,5 @@ public interface IvyPublication extends Publication {
      * @since 6.0
      */
     @Incubating
-    void silenceAllPublicationWarnings();
+    void silenceAllIvyMetadataWarnings();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -98,6 +98,8 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
 
     @VisibleForTesting
     public static final String UNSUPPORTED_FEATURE = " contains dependencies that cannot be represented in a published ivy descriptor.";
+    @VisibleForTesting
+    public static final String PUBLICATION_WARNING_FOOTER = "These issues indicate information that it lost in the published 'ivy.xml' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Ivy.\nThe 'module' metadata file, which is used by Gradle 6+ is not affected.";
 
     private final String name;
     private final IvyModuleDescriptorSpecInternal descriptor;
@@ -236,7 +238,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         if (component == null) {
             return;
         }
-        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "");
+        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER);
 
         populateConfigurations();
         populateArtifacts();

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -99,7 +99,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     @VisibleForTesting
     public static final String UNSUPPORTED_FEATURE = " contains dependencies that cannot be represented in a published ivy descriptor.";
     @VisibleForTesting
-    public static final String PUBLICATION_WARNING_FOOTER = "These issues indicate information that it lost in the published 'ivy.xml' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Ivy.\nThe 'module' metadata file, which is used by Gradle 6+ is not affected.";
+    public static final String PUBLICATION_WARNING_FOOTER = "These issues indicate information that is lost in the published 'ivy.xml' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Ivy.\nThe 'module' metadata file, which is used by Gradle 6+ is not affected.";
 
     private final String name;
     private final IvyModuleDescriptorSpecInternal descriptor;
@@ -238,7 +238,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         if (component == null) {
             return;
         }
-        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER);
+        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER, "silenceIvyMetadataWarningsFor");
 
         populateConfigurations();
         populateArtifacts();
@@ -246,7 +246,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         populateGlobalExcludes();
 
         if (!silenceAllPublicationWarnings) {
-            publicationWarningsCollector.complete(getDisplayName(), silencedVariants);
+            publicationWarningsCollector.complete(getDisplayName() + " ivy metadata", silencedVariants);
         }
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -614,12 +614,12 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     @Override
-    public void silencePublicationWarningsFor(String variantName) {
+    public void silenceIvyMetadataWarningsFor(String variantName) {
         silencedVariants.add(variantName);
     }
 
     @Override
-    public void silenceAllPublicationWarnings() {
+    public void silenceAllIvyMetadataWarnings() {
         this.silenceAllPublicationWarnings = true;
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -82,6 +82,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -111,6 +112,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final PlatformSupport platformSupport;
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final VersionMappingStrategyInternal versionMappingStrategy;
+    private final Set<String> silencedVariants = new HashSet<>();
     private IvyArtifact ivyDescriptorArtifact;
     private TaskProvider<? extends Task> moduleDescriptorGenerator;
     private SingleOutputTaskIvyArtifact gradleModuleDescriptorArtifact;
@@ -120,6 +122,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private boolean populated;
     private boolean artifactsOverridden;
     private boolean versionMappingInUse = false;
+    private boolean silenceAllPublicationWarnings;
 
     @Inject
     public DefaultIvyPublication(
@@ -240,7 +243,9 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         populateDependencies(publicationWarningsCollector);
         populateGlobalExcludes();
 
-        publicationWarningsCollector.complete(getDisplayName());
+        if (!silenceAllPublicationWarnings) {
+            publicationWarningsCollector.complete(getDisplayName(), silencedVariants);
+        }
     }
 
     private void populateConfigurations() {
@@ -604,6 +609,16 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     public void versionMapping(Action<? super VersionMappingStrategy> configureAction) {
         this.versionMappingInUse = true;
         configureAction.execute(versionMappingStrategy);
+    }
+
+    @Override
+    public void silencePublicationWarningsFor(String variantName) {
+        silencedVariants.add(variantName);
+    }
+
+    @Override
+    public void silenceAllPublicationWarnings() {
+        this.silenceAllPublicationWarnings = true;
     }
 
     @Override

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -676,7 +676,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         run "publish"
 
         then:
-        outputContains(DefaultMavenPublication.UNSUPPORTED_FEATURE)
         outputContains('Declares capability org:foo:1.0')
         javaLibrary.assertPublished()
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -455,7 +455,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
 
     @Unroll('can publish java-library with dependencies with maven incompatible version notation: #version')
     def "can publish java-library with dependencies with maven incompatible version notation: #version"() {
-        requiresExternalDependencies = true
 
         given:
         createBuildScripts("""
@@ -503,7 +502,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     def "can publish java-library without warning when dependency with maven incompatible version and using versionMapping"() {
-        requiresExternalDependencies = true
 
         given:
         createBuildScripts("""
@@ -532,7 +530,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         run "publish"
 
         then:
-        outputDoesNotContain(DefaultMavenPublication.INCOMPATIBLE_FEATURE)
+        outputDoesNotContain(DefaultMavenPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublished()
 
         javaLibrary.parsedPom.scopes.keySet() == ["runtime"] as Set
@@ -656,7 +654,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     def "can publish java-library with capabilities"() {
-        requiresExternalDependencies = true
         given:
         createBuildScripts("""
 
@@ -693,7 +690,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     def "can ignore publication warnings"() {
-        requiresExternalDependencies = true
         given:
         createBuildScripts("""
 
@@ -714,6 +710,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultMavenPublication.PUBLICATION_WARNING_FOOTER)
         outputContains('Declares capability org:foo:1.0')
         outputContains("Variant apiElements")
         outputDoesNotContain("Variant runtimeElements")
@@ -721,7 +718,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     def "can ignore all publication warnings"() {
-        requiresExternalDependencies = true
         given:
         createBuildScripts("""
 
@@ -742,8 +738,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         run "publish"
 
         then:
-        outputDoesNotContain("Maven publication 'maven' warnings")
-        outputDoesNotContain('Declares capability org:foo:1.0')
+        outputDoesNotContain(DefaultMavenPublication.PUBLICATION_WARNING_FOOTER)
         javaLibrary.assertPublished()
     }
 
@@ -838,7 +833,6 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     def "can publish java-library with dependencies/constraints with attributes"() {
-        requiresExternalDependencies = true
         given:
         settingsFile << "include 'utils'\n"
         file("utils/build.gradle") << '''

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -691,6 +691,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
 
     def "can ignore publication warnings"() {
         given:
+        def silenceMethod = "silencePomMetadataWarningsFor"
         createBuildScripts("""
 
             configurations.api.outgoing.capability 'org:foo:1.0'
@@ -700,7 +701,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 publications {
                     maven(MavenPublication) {
                         from components.java
-                        silencePomMetadataWarningsFor('runtimeElements')
+                        $silenceMethod('runtimeElements')
                     }
                 }
             }
@@ -711,6 +712,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
 
         then:
         outputContains(DefaultMavenPublication.PUBLICATION_WARNING_FOOTER)
+        outputContains("$silenceMethod(variant)")
         outputContains('Declares capability org:foo:1.0')
         outputContains("Variant apiElements")
         outputDoesNotContain("Variant runtimeElements")

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -700,7 +700,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 publications {
                     maven(MavenPublication) {
                         from components.java
-                        silencePublicationWarningsFor('runtimeElements')
+                        silencePomMetadataWarningsFor('runtimeElements')
                     }
                 }
             }
@@ -728,7 +728,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 publications {
                     maven(MavenPublication) {
                         from components.java
-                        silenceAllPublicationWarnings()
+                        silenceAllPomMetadataWarnings()
                     }
                 }
             }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -129,7 +130,7 @@ public interface MavenPublication extends Publication {
      *
      * Currently 3 types of component are supported: 'components.java' (added by the JavaPlugin), 'components.web' (added by the WarPlugin)
      * and `components.javaPlatform` (added by the JavaPlatformPlugin).
-     * 
+     *
      * For any individual MavenPublication, only a single component can be provided in this way.
      *
      * The following example demonstrates how to publish the 'java' component to a Maven repository.
@@ -312,4 +313,27 @@ public interface MavenPublication extends Publication {
      * @since 5.2
      */
     void versionMapping(Action<? super VersionMappingStrategy> configureAction);
+
+    /**
+     * Silences the compatibility warnings for the Maven publication for the specified variant.
+     *
+     * Warnings are emitted when Gradle features are used that cannot be mapped completely to Maven POM.
+     *
+     * @param variantName the variant to silence warning for
+     *
+     * @since 6.0
+     */
+    @Incubating
+    void silencePublicationWarningsFor(String variantName);
+
+
+    /**
+     * Silences all the compatibility warnings for the Maven publication.
+     *
+     * Warnings are emitted when Gradle features are used that cannot be mapped completely to Maven POM.
+     *
+     * @since 6.0
+     */
+    @Incubating
+    void silenceAllPublicationWarnings();
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
@@ -324,7 +324,7 @@ public interface MavenPublication extends Publication {
      * @since 6.0
      */
     @Incubating
-    void silencePublicationWarningsFor(String variantName);
+    void silencePomMetadataWarningsFor(String variantName);
 
 
     /**
@@ -335,5 +335,5 @@ public interface MavenPublication extends Publication {
      * @since 6.0
      */
     @Incubating
-    void silenceAllPublicationWarnings();
+    void silenceAllPomMetadataWarnings();
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -124,7 +124,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     @VisibleForTesting
     public static final String UNSUPPORTED_FEATURE = " contains dependencies that cannot be represented in a published pom file.";
     @VisibleForTesting
-    public static final String PUBLICATION_WARNING_FOOTER = "These issues indicate information that it lost in the published 'pom' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Maven.\nThe 'module' metadata file, which is used by Gradle 6+ is not affected.";
+    public static final String PUBLICATION_WARNING_FOOTER = "These issues indicate information that is lost in the published 'pom' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Maven.\nThe 'module' metadata file, which is used by Gradle 6+ is not affected.";
 
 
     private final String name;
@@ -269,7 +269,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         if (component == null) {
             return;
         }
-        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, INCOMPATIBLE_FEATURE, PUBLICATION_WARNING_FOOTER);
+        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, INCOMPATIBLE_FEATURE, PUBLICATION_WARNING_FOOTER, "silencePomMetadataWarningsFor");
         Set<ArtifactKey> seenArtifacts = Sets.newHashSet();
         Set<PublishedDependency> seenDependencies = Sets.newHashSet();
         Set<DependencyConstraint> seenConstraints = Sets.newHashSet();
@@ -332,7 +332,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
         }
         if (!silenceAllPublicationWarnings) {
-            publicationWarningsCollector.complete(getDisplayName(), silencedVariants);
+            publicationWarningsCollector.complete(getDisplayName() + "pom metadata", silencedVariants);
         }
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -277,6 +277,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
             Set<ExcludeRule> globalExcludes = usageContext.getGlobalExcludes();
 
+            publicationWarningsCollector.newContext(usageContext.getName());
             Set<MavenDependencyInternal> dependencies = dependenciesFor(usageContext);
             for (ModuleDependency dependency : usageContext.getDependencies()) {
                 if (seenDependencies.add(PublishedDependency.of(dependency))) {
@@ -319,7 +320,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
             if (!usageContext.getCapabilities().isEmpty()) {
                 for (Capability capability : usageContext.getCapabilities()) {
-                    publicationWarningsCollector.addUnsupported(String.format("Declares capability %s:%s:%s", capability.getGroup(), capability.getName(), capability.getVersion()));
+                    publicationWarningsCollector.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Maven", capability.getGroup(), capability.getName(), capability.getVersion()));
                 }
             }
         }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -121,7 +121,11 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     };
     @VisibleForTesting
     public static final String INCOMPATIBLE_FEATURE = " contains dependencies that will produce a pom file that cannot be consumed by a Maven client.";
+    @VisibleForTesting
     public static final String UNSUPPORTED_FEATURE = " contains dependencies that cannot be represented in a published pom file.";
+    @VisibleForTesting
+    public static final String PUBLICATION_WARNING_FOOTER = "These issues indicate information that it lost in the published 'pom' metadata file, which may be an issue if the published library is consumed by an old Gradle version or Apache Maven.\nThe 'module' metadata file, which is used by Gradle 6+ is not affected.";
+
 
     private final String name;
     private final MavenPomInternal pom;
@@ -265,7 +269,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         if (component == null) {
             return;
         }
-        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, INCOMPATIBLE_FEATURE);
+        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, INCOMPATIBLE_FEATURE, PUBLICATION_WARNING_FOOTER);
         Set<ArtifactKey> seenArtifacts = Sets.newHashSet();
         Set<PublishedDependency> seenDependencies = Sets.newHashSet();
         Set<DependencyConstraint> seenConstraints = Sets.newHashSet();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -90,6 +90,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -140,6 +141,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final PlatformSupport platformSupport;
+    private final Set<String> silencedVariants = new HashSet<>();
     private MavenArtifact pomArtifact;
     private SingleOutputTaskMavenArtifact moduleMetadataArtifact;
     private TaskProvider<? extends Task> moduleDescriptorGenerator;
@@ -149,6 +151,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private boolean populated;
     private boolean artifactsOverridden;
     private boolean versionMappingInUse = false;
+    private boolean silenceAllPublicationWarnings;
 
     @Inject
     public DefaultMavenPublication(
@@ -324,7 +327,9 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                 }
             }
         }
-        publicationWarningsCollector.complete(getDisplayName());
+        if (!silenceAllPublicationWarnings) {
+            publicationWarningsCollector.complete(getDisplayName(), silencedVariants);
+        }
     }
 
     private boolean isDependencyWithDefaultArtifact(ModuleDependency dependency) {
@@ -488,6 +493,16 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     public void versionMapping(Action<? super VersionMappingStrategy> configureAction) {
         this.versionMappingInUse = true;
         configureAction.execute(versionMappingStrategy);
+    }
+
+    @Override
+    public void silencePublicationWarningsFor(String variantName) {
+        this.silencedVariants.add(variantName);
+    }
+
+    @Override
+    public void silenceAllPublicationWarnings() {
+        this.silenceAllPublicationWarnings = true;
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -500,12 +500,12 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     @Override
-    public void silencePublicationWarningsFor(String variantName) {
+    public void silencePomMetadataWarningsFor(String variantName) {
         this.silencedVariants.add(variantName);
     }
 
     @Override
-    public void silenceAllPublicationWarnings() {
+    public void silenceAllPomMetadataWarnings() {
         this.silenceAllPublicationWarnings = true;
     }
 

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/CollectedWarnings.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/CollectedWarnings.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.internal.validation;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+public class CollectedWarnings {
+    private Set<String> unsupportedUsages = null;
+    private Set<String> incompatibleUsages = null;
+    private String variantUnsupported;
+
+    public void addUnsupported(String text) {
+        if (unsupportedUsages == null) {
+            unsupportedUsages = Sets.newHashSet();
+        }
+        unsupportedUsages.add(text);
+    }
+
+    public void addIncompatible(String text) {
+        if (incompatibleUsages == null) {
+            incompatibleUsages = Sets.newHashSet();
+        }
+        incompatibleUsages.add(text);
+    }
+
+    public String getVariantUnsupported() {
+        return variantUnsupported;
+    }
+
+    public Set<String> getUnsupportedUsages() {
+        return unsupportedUsages;
+    }
+
+    public Set<String> getIncompatibleUsages() {
+        return incompatibleUsages;
+    }
+
+    public boolean isEmpty() {
+        return incompatibleUsages == null && unsupportedUsages == null && variantUnsupported == null;
+    }
+
+    public void addVariantUnsupported(String text) {
+        this.variantUnsupported = text;
+    }
+}

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.internal.validation;
 
 import org.gradle.api.logging.Logger;
-import org.gradle.internal.DisplayName;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -32,12 +31,14 @@ public class PublicationWarningsCollector {
     private final String unsupportedFeature;
     private final String incompatibleFeature;
     private final String footer;
+    private final String disableMethod;
     private final Map<String, CollectedWarnings> variantToWarnings;
     private String currentVariant;
     private CollectedWarnings currentWarnings;
 
-    public PublicationWarningsCollector(Logger logger, String unsupportedFeature, String incompatibleFeature, String footer) {
+    public PublicationWarningsCollector(Logger logger, String unsupportedFeature, String incompatibleFeature, String footer, String disableMethod) {
         this.footer = footer;
+        this.disableMethod = disableMethod;
         this.variantToWarnings = new TreeMap<>();
         this.logger = logger;
         this.unsupportedFeature = unsupportedFeature;
@@ -52,12 +53,12 @@ public class PublicationWarningsCollector {
         currentWarnings.addIncompatible(text);
     }
 
-    public void complete(DisplayName displayName, Set<String> silencedVariants) {
+    public void complete(String header, Set<String> silencedVariants) {
         saveVariantWarnings();
 
         if (!variantToWarnings.isEmpty()) {
             TreeFormatter treeFormatter = new TreeFormatter();
-            treeFormatter.node(displayName + " warnings (silence with 'silencePublicationWarningsFor(variant)')");
+            treeFormatter.node(header + " warnings (silence with '" + disableMethod + "(variant)')");
             treeFormatter.startChildren();
             variantToWarnings.entrySet().stream().filter(entry -> !silencedVariants.contains(entry.getKey())).forEach(entry -> {
                 CollectedWarnings warnings = entry.getValue();

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
@@ -31,11 +31,13 @@ public class PublicationWarningsCollector {
     private final Logger logger;
     private final String unsupportedFeature;
     private final String incompatibleFeature;
+    private final String footer;
     private final Map<String, CollectedWarnings> variantToWarnings;
-    String currentVariant;
-    CollectedWarnings currentWarnings;
+    private String currentVariant;
+    private CollectedWarnings currentWarnings;
 
-    public PublicationWarningsCollector(Logger logger, String unsupportedFeature, String incompatibleFeature) {
+    public PublicationWarningsCollector(Logger logger, String unsupportedFeature, String incompatibleFeature, String footer) {
+        this.footer = footer;
         this.variantToWarnings = new TreeMap<>();
         this.logger = logger;
         this.unsupportedFeature = unsupportedFeature;
@@ -55,7 +57,7 @@ public class PublicationWarningsCollector {
 
         if (!variantToWarnings.isEmpty()) {
             TreeFormatter treeFormatter = new TreeFormatter();
-            treeFormatter.node(displayName + " warnings: (silence with 'silencePublicationWarningsFor(variant)')");
+            treeFormatter.node(displayName + " warnings (silence with 'silencePublicationWarningsFor(variant)')");
             treeFormatter.startChildren();
             variantToWarnings.entrySet().stream().filter(entry -> !silencedVariants.contains(entry.getKey())).forEach(entry -> {
                 CollectedWarnings warnings = entry.getValue();
@@ -79,6 +81,7 @@ public class PublicationWarningsCollector {
                 treeFormatter.endChildren();
             });
             treeFormatter.endChildren();
+            treeFormatter.node(footer);
             logger.lifecycle(treeFormatter.toString());
         }
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
@@ -22,6 +22,7 @@ import org.gradle.internal.logging.text.TreeFormatter;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 @NotThreadSafe
@@ -49,15 +50,16 @@ public class PublicationWarningsCollector {
         currentWarnings.addIncompatible(text);
     }
 
-    public void complete(DisplayName displayName) {
+    public void complete(DisplayName displayName, Set<String> silencedVariants) {
         saveVariantWarnings();
 
         if (!variantToWarnings.isEmpty()) {
             TreeFormatter treeFormatter = new TreeFormatter();
-            treeFormatter.node(displayName + " warnings:");
+            treeFormatter.node(displayName + " warnings: (silence with 'silencePublicationWarningsFor(variant)')");
             treeFormatter.startChildren();
-            variantToWarnings.forEach((variant, warnings) -> {
-                treeFormatter.node("Variant " + variant + ":");
+            variantToWarnings.entrySet().stream().filter(entry -> !silencedVariants.contains(entry.getKey())).forEach(entry -> {
+                CollectedWarnings warnings = entry.getValue();
+                treeFormatter.node("Variant " + entry.getKey() + ":");
                 treeFormatter.startChildren();
                 if (warnings.getVariantUnsupported() != null) {
                     treeFormatter.node(warnings.getVariantUnsupported());


### PR DESCRIPTION
Mapping of Gradle features to POM or Ivy xml is not complete. Publication warnings were introduced.
These changes improve the formatting and clarity of the warnings.
It also adds an API to silence them, either per variant or globally.