### PR TITLE
signing plugin: use SHA512 instead of SHA1 when signing artifacts

### DIFF
--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatory.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatory.java
@@ -104,7 +104,7 @@ public class PgpSignatory extends SignatorySupport {
 
     public PGPSignatureGenerator createSignatureGenerator() {
         try {
-            PGPSignatureGenerator generator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(secretKey.getPublicKey().getAlgorithm(), PGPUtil.SHA1));
+            PGPSignatureGenerator generator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(secretKey.getPublicKey().getAlgorithm(), PGPUtil.SHA512));
             generator.init(PGPSignature.BINARY_DOCUMENT, privateKey);
             return generator;
         } catch (PGPException e) {


### PR DESCRIPTION
PGP signs a digest, so MITM is still possible provided an attacker can update
the artifact in such a way that its SHA1 is intact.

### Context

Relevant article is https://medium.com/@jonathan.leitschuh/many-of-these-gpg-signatures-are-signed-with-sha-1-which-is-vulnerable-to-a-second-preimage-attack-67104d827930

As you might know, Chromium does not trust SHA-1 signed certificates: https://www.chromium.org/Home/chromium-security/education/tls/sha-1

Gradle is often used to sign artifacts, so it would be nice to keep its default security level is up to date.

I'm not sure if this change needs to be represented in the documentation / upgrade notice.
AFAIK it should be backward and forward compatible, however it might make sense to clarify that "previous PGP signatures have SHA1 level of security".

I do not add tests in a hope that the code has already been covered.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
