### PR TITLE
Allow shortening the command line using a pathing JAR

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executor;
 
 public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOptions implements BaseExecSpec {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
@@ -58,8 +58,8 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
 
     public abstract List<String> getAllArguments();
 
-    protected ArgsEnvironment getEffectiveArgsEnvironment() {
-        return new ArgsEnvironment(getAllArguments(), getActualEnvironment());
+    protected List<String> getEffectiveArguments() {
+        return getAllArguments();
     }
 
     @Override
@@ -146,8 +146,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
         }
 
         StreamsHandler effectiveOutputHandler = getEffectiveStreamsHandler();
-        ArgsEnvironment effectiveArgsEnvironment = getEffectiveArgsEnvironment();
-        return new DefaultExecHandle(getDisplayName(), getWorkingDir(), executable, effectiveArgsEnvironment.getArguments(), effectiveArgsEnvironment.getEnvironment(),
+        return new DefaultExecHandle(getDisplayName(), getWorkingDir(), executable, getEffectiveArguments(), getActualEnvironment(),
                 effectiveOutputHandler, inputHandler, listeners, redirectErrorStream, timeoutMillis, daemon, executor, buildCancellationToken);
     }
 
@@ -178,23 +177,5 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
     public AbstractExecHandleBuilder setTimeout(int timeoutMillis) {
         this.timeoutMillis = timeoutMillis;
         return this;
-    }
-
-    protected static class ArgsEnvironment {
-        private final List<String> arguments;
-        private final Map<String, String> environment;
-
-        public ArgsEnvironment(List<String> arguments, Map<String, String> environment) {
-            this.arguments = arguments;
-            this.environment = environment;
-        }
-
-        public List<String> getArguments() {
-            return arguments;
-        }
-
-        public Map<String, String> getEnvironment() {
-            return environment;
-        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -33,11 +33,19 @@ import org.gradle.util.GUtil;
 
 import javax.annotation.Nonnull;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
 
 import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasCommandLineExceedMaxLength;
 import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasEnvironmentVariableExceedMaxLength;
@@ -311,18 +319,32 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
         Map<String, String> environment = getActualEnvironment();
 
         if (hasCommandLineExceedMaxLength(getExecutable(), arguments)) {
-            if (shouldUseEnvironmentVariable(arguments, environment)) {
-                int classPathFlagIndex = arguments.indexOf("-cp");
-                environment.put("CLASSPATH", arguments.get(classPathFlagIndex + 1));
-                arguments.remove(classPathFlagIndex);
-                arguments.remove(classPathFlagIndex);
+            int classPathFlagIndex = arguments.indexOf("-cp");
+            if (shouldTryShorteningCommandLine(arguments)) {
+                if (shouldUseEnvironmentVariable(arguments, environment)) {
+                    environment.put("CLASSPATH", arguments.get(classPathFlagIndex + 1));
+                    arguments.remove(classPathFlagIndex);
+                    arguments.remove(classPathFlagIndex);
+                    LOGGER.info("Gradle is shortening the command line by moving the classpath to the CLASSPATH environment variable.");
+                } else {
+                    try {
+                        File pathingJarFile = File.createTempFile("gradle-javaexec-classpath", ".jar");
+                        List<String> jvmArgs = writePathingJarFile(classpath, pathingJarFile);
+                        arguments.remove(classPathFlagIndex);
+                        arguments.remove(classPathFlagIndex);
+                        arguments.addAll(classPathFlagIndex, jvmArgs);
+                        LOGGER.info("Gradle is shortening the command line by moving the classpath to a pathing JAR.");
+                    } catch (IOException e) {
+                        LOGGER.info("Pathing JAR could not be created, Gradle cannot shorten the command line.");
+                    }
+                }
             }
         }
 
         return new ArgsEnvironment(arguments, environment);
     }
 
-    private boolean shouldUseEnvironmentVariable(List<String> arguments, Map<String, String> environment) {
+    private boolean shouldTryShorteningCommandLine(List<String> arguments) {
         int classPathFlagIndex = arguments.indexOf("-cp");
         if (classPathFlagIndex == -1) {
             // No class path flag, so we can't use CLASSPATH
@@ -330,9 +352,14 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
             return false;
         }
 
+        return true;
+    }
+
+    private boolean shouldUseEnvironmentVariable(List<String> arguments, Map<String, String> environment) {
+        int classPathFlagIndex = arguments.indexOf("-cp");
         if (hasEnvironmentVariableExceedMaxLength(arguments.get(classPathFlagIndex + 1))) {
             // Class path is exceeding the maximum environment variable value length
-            LOGGER.info("Class path size is exceeding the maximum environment variable length, CLASSPATH variable cannot be used for shortening the command line");
+            LOGGER.info("Classpath size is exceeding the maximum environment variable length, Gradle cannot shorten the command line using the environment variable.");
             return false;
         }
 
@@ -342,22 +369,37 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
                 if (System.getenv().get("CLASSPATH").equals(environment.get("CLASSPATH"))) {
                     return true;
                 }
-                LOGGER.info("CLASSPATH environment variable was explicitly overwritten, Gradle cannot shorten the command line");
+                LOGGER.info("CLASSPATH environment variable was explicitly overwritten, Gradle cannot shorten the command line using the environment variable.");
                 return false;
             }
             // The CLASSPATH was explicitly cleared
-            LOGGER.info("CLASSPATH environment variable was explicitly cleared, Gradle cannot shorten the command line");
+            LOGGER.info("CLASSPATH environment variable was explicitly cleared, Gradle cannot shorten the command line using the environment variable.");
             return false;
         }
 
         if (environment.containsKey("CLASSPATH")) {
             // The CLASSPATH was explicitly defined
-            LOGGER.info("CLASSPATH environment variable was explicitly defined, Gradle cannot shorten the command line");
+            LOGGER.info("CLASSPATH environment variable was explicitly defined, Gradle cannot shorten the command line using the environment variable.");
             return false;
         }
 
         // The CLASSPATH wasn't declared or inherited
         return true;
+    }
+
+    private List<String> writePathingJarFile(FileCollection classPath, File pathingJarFile) throws IOException {
+        try (JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(pathingJarFile), toManifest(classPath))) {
+            jarOutputStream.putNextEntry(new ZipEntry("META-INF/"));
+        }
+        return Arrays.asList("-cp", pathingJarFile.getAbsolutePath());
+    }
+
+    private static Manifest toManifest(FileCollection classPath) {
+        Manifest manifest = new Manifest();
+        Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue("Class-Path", classPath.getFiles().stream().map(File::toURI).map(URI::toString).collect(Collectors.joining(" ")));
+        return manifest;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 
 import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasCommandLineExceedMaxLength;
-import static org.gradle.process.internal.util.LongCommandLineDetectionUtil.hasEnvironmentVariableExceedMaxLength;
 
 /**
  * Use {@link JavaExecHandleFactory} instead.

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -326,7 +326,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
                     arguments.remove(classPathFlagIndex);
                     arguments.remove(classPathFlagIndex);
                     arguments.addAll(classPathFlagIndex, jvmArgs);
-                    LOGGER.info("Gradle is shortening the command line by moving the classpath to a pathing JAR.");
+                    LOGGER.info("Shortening Java classpath {} with {}", this.classpath, pathingJarFile);
                 } catch (IOException e) {
                     LOGGER.info("Pathing JAR could not be created, Gradle cannot shorten the command line.");
                 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -328,7 +328,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
                     arguments.addAll(classPathFlagIndex, jvmArgs);
                     LOGGER.info("Shortening Java classpath {} with {}", this.classpath, pathingJarFile);
                 } catch (IOException e) {
-                    LOGGER.info("Pathing JAR could not be created, Gradle cannot shorten the command line.");
+                    LOGGER.info("Pathing JAR could not be created, Gradle cannot shorten the command line.", e);
                 }
             }
         }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWIthLongCommandLineIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWIthLongCommandLineIntegrationTest.groovy
@@ -131,7 +131,7 @@ class JavaExecWIthLongCommandLineIntegrationTest extends AbstractIntegrationSpec
         assert output =~ /^Shortening Java classpath ${classpath(fileName)} with .+\\/gradle-javaexec-classpath.+\.jar$/
     }
 
-    private static String classpath(String fileName) {
+    private String classpath(String fileName) {
         return "${file('build/classes/java/main')};${file('build/generated/sources/annotationProcessor/java/main')};${testDirectory.absolutePath}\\${fileName}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWIthLongCommandLineIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWIthLongCommandLineIntegrationTest.groovy
@@ -58,6 +58,19 @@ class JavaExecWIthLongCommandLineIntegrationTest extends AbstractIntegrationSpec
         failure.assertThatCause(containsText("A problem occurred starting process"))
     }
 
+    @Requires(TestPrecondition.WINDOWS)
+    def "can suggest long command line failures when execution fails for long command line on Windows system"() {
+        buildFile << """
+            run.classpath += project.files('${'a' * ARG_MAX_WINDOWS}')
+        """
+
+        when:
+        def failure = fails("run")
+
+        then:
+        failure.assertThatCause(containsText("could not be started because the command line exceed operating system limits."))
+    }
+
     @Requires(TestPrecondition.NOT_WINDOWS)
     def "does not suggest long command line failures when execution fails on non-Windows system"() {
         buildFile << """


### PR DESCRIPTION
<!--- The issue this PR addresses -->
See #10114 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flong-command%2Fuse-pathing-jar)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
