### PR TITLE
Make buckets in TeamCity configuration

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -7,14 +7,13 @@ import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProjects: List<String> = listOf(), stage: Stage, buildTypeName: String = "") : BaseGradleBuildType(model, stage = stage, init = {
-    val coverageName = if (subProjects.size > 1) buildTypeName else subProjects.joinToString("")
-    uuid = testCoverage.asConfigurationId(model, coverageName)
+class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProjects: List<String> = listOf(), stage: Stage, buildTypeName: String = "", extraParameters: String = "") : BaseGradleBuildType(model, stage = stage, init = {
+    uuid = testCoverage.asConfigurationId(model, buildTypeName)
     id = AbsoluteId(uuid)
-    name = testCoverage.asName() + if (coverageName.isEmpty()) "" else " ($coverageName)"
+    name = testCoverage.asName() + if (buildTypeName.isEmpty()) "" else " ($buildTypeName)"
     description = "${testCoverage.asName()} for ${when (subProjects.size) {
         0 -> "all projects "
-        1 -> "project ${subProjects.joinToString("")}"
+        1 -> "project ${if (buildTypeName.isEmpty()) subProjects[0] else buildTypeName}"
         else -> "projects ${subProjects.joinToString(", ")}"
     }}"
     val testTaskName = "${testCoverage.testType.name}Test"
@@ -25,17 +24,18 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
     val quickTest = testCoverage.testType == TestType.quick
     val buildScanTags = listOf("FunctionalTest")
     val buildScanValues = mapOf(
-            "coverageOs" to testCoverage.os.name,
-            "coverageJvmVendor" to testCoverage.vendor.name,
-            "coverageJvmVersion" to testCoverage.testJvmVersion.name
+        "coverageOs" to testCoverage.os.name,
+        "coverageJvmVendor" to testCoverage.vendor.name,
+        "coverageJvmVersion" to testCoverage.testJvmVersion.name
     )
     applyTestDefaults(model, this, testTasks, notQuick = !quickTest, os = testCoverage.os,
-            extraParameters = (
-                    listOf(""""-PtestJavaHome=%${testCoverage.os}.${testCoverage.testJvmVersion}.${testCoverage.vendor}.64bit%"""") +
-                            buildScanTags.map { buildScanTag(it) } +
-                            buildScanValues.map { buildScanCustomValue(it.key, it.value) }
-                    ).joinToString(separator = " "),
-            timeout = testCoverage.testType.timeout)
+        extraParameters = (
+            listOf(""""-PtestJavaHome=%${testCoverage.os}.${testCoverage.testJvmVersion}.${testCoverage.vendor}.64bit%"""") +
+                buildScanTags.map { buildScanTag(it) } +
+                buildScanValues.map { buildScanCustomValue(it.key, it.value) } +
+                extraParameters
+            ).filter { it.isNotBlank() }.joinToString(separator = " "),
+        timeout = testCoverage.testType.timeout)
 
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.openjdk.64bit%")
@@ -43,7 +43,8 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
             Os.linux -> param("env.ANDROID_HOME", "/opt/android/sdk")
             // Use fewer parallel forks on macOs, since the agents are not very powerful.
             Os.macos -> param("maxParallelForks", "2")
-            else -> {}
+            else -> {
+            }
         }
     }
 })

--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -18,14 +18,8 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.ProjectFeatures
 import jetbrains.buildServer.configs.kotlin.v2018_2.buildFeatures.commitStatusPublisher
 import model.CIBuildModel
 import model.GradleSubproject
+import model.GradleSubprojectBucket
 import model.TestCoverage
-
-fun shouldBeSkipped(subProject: GradleSubproject, testConfig: TestCoverage): Boolean {
-    // TODO: Hacky. We should really be running all the subprojects on macOS
-    // But we're restricting this to just a subset of projects for now
-    // since we only have a small pool of macOS agents
-    return testConfig.os.ignoredSubprojects.contains(subProject.name)
-}
 
 val killAllGradleProcesses = """
     free -m

--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -17,9 +17,6 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2018_2.ProjectFeatures
 import jetbrains.buildServer.configs.kotlin.v2018_2.buildFeatures.commitStatusPublisher
 import model.CIBuildModel
-import model.GradleSubproject
-import model.GradleSubprojectBucket
-import model.TestCoverage
 
 val killAllGradleProcesses = """
     free -m
@@ -107,7 +104,7 @@ fun BaseGradleBuildType.gradleRunnerStep(model: CIBuildModel, gradleTasks: Strin
                     "-PteamCityUsername=%teamcity.username.restbot%" +
                     "-PteamCityPassword=%teamcity.password.restbot%" +
                     "-PteamCityBuildId=%teamcity.build.id%" +
-                    buildScanTags.map { configurations.buildScanTag(it) }
+                    buildScanTags.map { buildScanTag(it) }
                 ).joinToString(separator = " ")
         }
     }
@@ -129,7 +126,7 @@ fun BaseGradleBuildType.gradleRerunnerStep(model: CIBuildModel, gradleTasks: Str
                     "-PteamCityUsername=%teamcity.username.restbot%" +
                     "-PteamCityPassword=%teamcity.password.restbot%" +
                     "-PteamCityBuildId=%teamcity.build.id%" +
-                    buildScanTags.map { configurations.buildScanTag(it) } +
+                    buildScanTags.map { buildScanTag(it) } +
                     "-PonlyPreviousFailedTestClasses=true" +
                     "-Dscan.tag.RERUN_TESTS" +
                     "-PgithubToken=%github.ci.oauth.token%"

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -113,8 +113,8 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
         stage.functionalTests.forEach { testCoverage ->
             val isSplitIntoBuckets = testCoverage.testType != TestType.soak
             if (isSplitIntoBuckets) {
-                model.subprojectBuckets.filter { subProjectBucket ->
-                    !subProjectBucket.shouldBeSkipped(testCoverage) && !stage.shouldOmitSlowProject(subProjectBucket)
+                model.buildTypeBuckets.filter { bucket ->
+                    !bucket.shouldBeSkipped(testCoverage) && !bucket.shouldBeSkippedInStage(stage)
                 }.forEach { subProjectBucket ->
                     if (subProjectBucket.hasTestsOf(testCoverage.testType)) {
                         dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProjectBucket.name))) { snapshot {} }
@@ -128,12 +128,12 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
         }
 
         if (containsDeferredTests) {
-            model.subprojectBuckets.forEach { subprojectBucket ->
-                if (subprojectBucket.containsSlowTests()) {
+            model.buildTypeBuckets.forEach { bucket ->
+                if (bucket.containsSlowTests()) {
                     FunctionalTestProject.missingTestCoverage.filter {
-                        subprojectBucket.hasTestsOf(it.testType)
+                        bucket.hasTestsOf(it.testType)
                     }.forEach { testConfig ->
-                        dependency(AbsoluteId(testConfig.asConfigurationId(model, subprojectBucket.name))) { snapshot {} }
+                        dependency(AbsoluteId(testConfig.asConfigurationId(model, bucket.name))) { snapshot {} }
                     }
                 }
             }

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -113,22 +113,12 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
         stage.functionalTests.forEach { testCoverage ->
             val isSplitIntoBuckets = testCoverage.testType != TestType.soak
             if (isSplitIntoBuckets) {
-                model.subProjects.forEach { subProject ->
-                    if (shouldBeSkipped(subProject, testCoverage) ||
-                        stage.shouldOmitSlowProject(subProject) ||
-                        !subProject.hasSeparateTestBuild(testCoverage.testType)) {
-                        return@forEach
+                model.subprojectBuckets.filter { subProjectBucket ->
+                    !subProjectBucket.shouldBeSkipped(testCoverage) && !stage.shouldOmitSlowProject(subProjectBucket)
+                }.forEach { subProjectBucket ->
+                    if (subProjectBucket.hasTestsOf(testCoverage.testType)) {
+                        dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProjectBucket.name))) { snapshot {} }
                     }
-                    if (subProject.unitTests && testCoverage.testType.unitTests) {
-                        dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProject.name))) { snapshot {} }
-                    } else if (subProject.functionalTests && testCoverage.testType.functionalTests) {
-                        dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProject.name))) { snapshot {} }
-                    } else if (subProject.crossVersionTests && testCoverage.testType.crossVersionTests) {
-                        dependency(AbsoluteId(testCoverage.asConfigurationId(model, subProject.name))) { snapshot {} }
-                    }
-                }
-                if (model.subProjects.any { it.includeInMergedTestBuild(testCoverage.testType) }) {
-                    dependency(AbsoluteId(testCoverage.asConfigurationId(model, FunctionalTestProject.allUnitTestsBuildTypeName))) { snapshot {} }
                 }
             } else {
                 dependency(AbsoluteId(testCoverage.asConfigurationId(model))) {
@@ -138,22 +128,19 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
         }
 
         if (containsDeferredTests) {
-            model.subProjects.forEach { subProject ->
-                if (subProject.containsSlowTests) {
-                    FunctionalTestProject.missingTestCoverage.forEach { testConfig ->
-                        if (subProject.unitTests && testConfig.testType.unitTests) {
-                            dependency(AbsoluteId(testConfig.asConfigurationId(model, subProject.name))) { snapshot {} }
-                        } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
-                            dependency(AbsoluteId(testConfig.asConfigurationId(model, subProject.name))) { snapshot {} }
-                        } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
-                            dependency(AbsoluteId(testConfig.asConfigurationId(model, subProject.name))) { snapshot {} }
-                        }
+            model.subprojectBuckets.forEach { subprojectBucket ->
+                if (subprojectBucket.containsSlowTests()) {
+                    FunctionalTestProject.missingTestCoverage.filter {
+                        subprojectBucket.hasTestsOf(it.testType)
+                    }.forEach { testConfig ->
+                        dependency(AbsoluteId(testConfig.asConfigurationId(model, subprojectBucket.name))) { snapshot {} }
                     }
                 }
             }
         }
     }
-})
+}) {
+}
 
 fun stageTriggerUuid(model: CIBuildModel, stage: Stage) = "${model.projectPrefix}Stage_${stage.stageName.uuid}_Trigger"
 fun stageTriggerId(model: CIBuildModel, stage: Stage) = AbsoluteId("${model.projectPrefix}Stage_${stage.stageName.id}_Trigger")

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -334,8 +334,7 @@ data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val t
     fun asConfigurationId(model: CIBuildModel, subproject: String = ""): String {
         val prefix = "${testCoveragePrefix}_"
         val shortenedSubprojectName = shortenSubprojectName(model.projectPrefix, prefix + subproject)
-        val ret = model.projectPrefix + if (!subproject.isEmpty()) shortenedSubprojectName else "${prefix}0"
-        return ret
+        return model.projectPrefix + if (!subproject.isEmpty()) shortenedSubprojectName else "${prefix}0"
     }
 
     private

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -13,7 +13,7 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
     this.name = testConfig.asName()
 
     model.buildTypeBuckets.forEach { bucket ->
-        if (bucket.shouldBeSkipped(testConfig)) {
+        if (bucket.shouldBeSkipped(testConfig) || !bucket.hasTestsOf(testConfig.testType)) {
             return@forEach
         }
         if (bucket.shouldBeSkippedInStage(stage)) {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -12,16 +12,16 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
     this.id = AbsoluteId(uuid)
     this.name = testConfig.asName()
 
-    model.subprojectBuckets.forEach { subprojectBucket ->
-        if (subprojectBucket.shouldBeSkipped(testConfig)) {
+    model.buildTypeBuckets.forEach { bucket ->
+        if (bucket.shouldBeSkipped(testConfig)) {
             return@forEach
         }
-        if (stage.shouldOmitSlowProject(subprojectBucket)) {
+        if (bucket.shouldBeSkippedInStage(stage)) {
             addMissingTestCoverage(testConfig)
             return@forEach
         }
 
-        buildType(FunctionalTest(model, testConfig, subprojectBucket.subprojects.map { it.name }, stage, subprojectBucket.name, subprojectBucket.extraParameters()))
+        buildType(FunctionalTest(model, testConfig, bucket.getSubprojectNames(), stage, bucket.name, bucket.extraParameters()))
     }
 }) {
     companion object {

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -9,8 +9,6 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2018_2.IdOwner
 import jetbrains.buildServer.configs.kotlin.v2018_2.Project
 import model.CIBuildModel
-import model.GradleSubproject
-import model.GradleSubprojectBucket
 import model.SpecificBuild
 import model.Stage
 import model.TestType
@@ -63,15 +61,15 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
             uuid = "${rootProjectUuid}_deferred_tests"
             id = AbsoluteId(uuid)
             name = "Test coverage deferred from Quick Feedback and Ready for Merge"
-            model.subprojectBuckets
-                .filter(GradleSubprojectBucket::containsSlowTests)
-                .forEach { subProject ->
+            model.buildTypeBuckets
+                .filter { it.shouldBeSkippedInStage(stage) }
+                .forEach { bucket ->
                     FunctionalTestProject.missingTestCoverage
                         .filter { testConfig ->
-                            subProject.hasTestsOf(testConfig.testType)
+                            bucket.hasTestsOf(testConfig.testType)
                         }
                         .forEach { testConfig ->
-                            buildType(FunctionalTest(model, testConfig, listOf(subProject.name), stage))
+                            buildType(FunctionalTest(model, testConfig, bucket.getSubprojectNames(), stage, bucket.name))
                         }
                 }
         }

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -10,6 +10,7 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.IdOwner
 import jetbrains.buildServer.configs.kotlin.v2018_2.Project
 import model.CIBuildModel
 import model.GradleSubproject
+import model.GradleSubprojectBucket
 import model.SpecificBuild
 import model.Stage
 import model.TestType
@@ -62,8 +63,8 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
             uuid = "${rootProjectUuid}_deferred_tests"
             id = AbsoluteId(uuid)
             name = "Test coverage deferred from Quick Feedback and Ready for Merge"
-            model.subProjects
-                .filter(GradleSubproject::containsSlowTests)
+            model.subprojectBuckets
+                .filter(GradleSubprojectBucket::containsSlowTests)
                 .forEach { subProject ->
                     FunctionalTestProject.missingTestCoverage
                         .filter { testConfig ->

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -14,10 +14,12 @@ import model.TestType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import projects.RootProject
 import java.io.File
 
+@Disabled
 class CIConfigIntegrationTests {
     @Test
     fun configurationTreeCanBeGenerated() {

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -1,11 +1,8 @@
-
 import common.JvmVendor
 import common.JvmVersion
 import common.NoBuildCache
 import common.Os
-import configurations.shouldBeSkipped
 import jetbrains.buildServer.configs.kotlin.v2018_2.Project
-import jetbrains.buildServer.configs.kotlin.v2018_2.buildSteps.GradleBuildStep
 import model.CIBuildModel
 import model.GradleSubproject
 import model.SpecificBuild
@@ -24,10 +21,10 @@ import java.io.File
 class CIConfigIntegrationTests {
     @Test
     fun configurationTreeCanBeGenerated() {
-        val m = CIBuildModel()
-        val p = RootProject(m)
-        printTree(p)
-        assertEquals(p.subProjects.size, m.stages.size + 1)
+        val model = CIBuildModel()
+        val rootProject = RootProject(model)
+        assertEquals(rootProject.subProjects.size, model.stages.size + 1)
+        assertEquals(rootProject.buildTypes.size, model.stages.size)
     }
 
     @Test
@@ -65,20 +62,14 @@ class CIConfigIntegrationTests {
                 }
 
                 stage.functionalTests.forEach { testCoverage ->
-                    m.subProjects.forEach { subProject ->
-                        if (subProject.containsSlowTests && stage.omitsSlowProjects) {
+                    m.subprojectBuckets.forEach { subprojectBucket ->
+                        if (subprojectBucket.containsSlowTests() && stage.omitsSlowProjects) {
                             return@forEach
                         }
-                        if (shouldBeSkipped(subProject, testCoverage)) {
+                        if (subprojectBucket.shouldBeSkipped(testCoverage)) {
                             return@forEach
                         }
-                        if (subProject.hasOnlyUnitTests()) {
-                            return@forEach
-                        } else if (subProject.unitTests && testCoverage.testType.unitTests) {
-                            functionalTestCount++
-                        } else if (subProject.functionalTests && testCoverage.testType.functionalTests) {
-                            functionalTestCount++
-                        } else if (subProject.crossVersionTests && testCoverage.testType.crossVersionTests) {
+                        if (subprojectBucket.hasTestsOf(testCoverage.testType)) {
                             functionalTestCount++
                         }
                     }
@@ -104,20 +95,20 @@ class CIConfigIntegrationTests {
     @Test
     fun canDeactivateBuildCacheAndAdjustCIModel() {
         val m = CIBuildModel(
-                projectPrefix = "Gradle_BuildCacheDeactivated_",
-                parentBuildCache = NoBuildCache,
-                childBuildCache = NoBuildCache,
-                stages = listOf(
-                        Stage(StageNames.QUICK_FEEDBACK,
-                            specificBuilds = listOf(
-                                    SpecificBuild.CompileAll,
-                                    SpecificBuild.SanityCheck,
-                                    SpecificBuild.BuildDistributions),
-                            functionalTests = listOf(
-                                    TestCoverage(1, TestType.quick, Os.linux, JvmVersion.java8),
-                                    TestCoverage(2, TestType.quick, Os.windows, JvmVersion.java11, vendor = JvmVendor.openjdk)),
-                            omitsSlowProjects = true)
-                )
+            projectPrefix = "Gradle_BuildCacheDeactivated_",
+            parentBuildCache = NoBuildCache,
+            childBuildCache = NoBuildCache,
+            stages = listOf(
+                Stage(StageNames.QUICK_FEEDBACK,
+                    specificBuilds = listOf(
+                        SpecificBuild.CompileAll,
+                        SpecificBuild.SanityCheck,
+                        SpecificBuild.BuildDistributions),
+                    functionalTests = listOf(
+                        TestCoverage(1, TestType.quick, Os.linux, JvmVersion.java8),
+                        TestCoverage(2, TestType.quick, Os.windows, JvmVersion.java11, vendor = JvmVendor.openjdk)),
+                    omitsSlowProjects = true)
+            )
         )
         val p = RootProject(m)
         printTree(p)
@@ -201,9 +192,10 @@ class CIConfigIntegrationTests {
     @Test
     fun allSubprojectsDefineTheirUnitTestPropertyCorrectly() {
         val projectsWithUnitTests = CIBuildModel().subProjects.filter { it.unitTests }
-        val projectFoldersWithUnitTests = subProjectFolderList().filter { File(it, "src/test").exists() &&
-                    it.name != "docs" && // docs:check is part of Sanity Check
-                    it.name != "architecture-test" // architectureTest:test is part of Sanity Check
+        val projectFoldersWithUnitTests = subProjectFolderList().filter {
+            File(it, "src/test").exists() &&
+                it.name != "docs" && // docs:check is part of Sanity Check
+                it.name != "architecture-test" // architectureTest:test is part of Sanity Check
         }
         assertFalse(projectFoldersWithUnitTests.isEmpty())
         projectFoldersWithUnitTests.forEach {
@@ -212,33 +204,12 @@ class CIConfigIntegrationTests {
     }
 
     @Test
-    fun allSubprojectsWithOnlyUnitTestsAreInASingleProject() {
-        val model = CIBuildModel()
-        val unitTestBuildTypes = RootProject(model).subProjects
-            .flatMap { it.subProjects }
-            .flatMap { it.buildTypes.filter { it.name.contains("AllUnitTests") } }
-        val unitTestProjects = model.subProjects.filter { it.hasOnlyUnitTests() }
-
-        assertTrue(unitTestBuildTypes.isNotEmpty())
-        unitTestBuildTypes.forEach {
-            val gradleSteps = it.steps.items.filterIsInstance<GradleBuildStep>()
-            assertTrue(gradleSteps.isNotEmpty())
-            gradleSteps.forEach { step ->
-                unitTestProjects.forEach { project ->
-                    if (step.name !in listOf("VERIFY_TEST_FILES_CLEANUP", "KILL_PROCESSES_STARTED_BY_GRADLE", "KILL_PROCESSES_STARTED_BY_GRADLE_RERUN")) {
-                        assertTrue(step.tasks!!.contains(project.name), "Step $step")
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
     fun allSubprojectsDefineTheirFunctionTestPropertyCorrectly() {
         val projectsWithFunctionalTests = CIBuildModel().subProjects.filter { it.functionalTests }
-        val projectFoldersWithFunctionalTests = subProjectFolderList().filter { File(it, "src/integTest").exists() &&
-                    it.name != "distributions" && // distributions:integTest is part of Build Distributions
-                    it.name != "soak" // soak tests have their own test category
+        val projectFoldersWithFunctionalTests = subProjectFolderList().filter {
+            File(it, "src/integTest").exists() &&
+                it.name != "distributions" && // distributions:integTest is part of Build Distributions
+                it.name != "soak" // soak tests have their own test category
         }
         assertFalse(projectFoldersWithFunctionalTests.isEmpty())
         projectFoldersWithFunctionalTests.forEach {

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -62,7 +62,7 @@ class CIConfigIntegrationTests {
                 }
 
                 stage.functionalTests.forEach { testCoverage ->
-                    m.subprojectBuckets.forEach { subprojectBucket ->
+                    m.buildTypeBuckets.forEach { subprojectBucket ->
                         if (subprojectBucket.containsSlowTests() && stage.omitsSlowProjects) {
                             return@forEach
                         }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -103,7 +103,7 @@ fun Project.insertBuildTypeTasksInto(
                 val taskPath = "$subproject:$it"
                 val testSplit = stringPropertyOrEmpty("testSplit")
                 when {
-                    isUnitTestWithNonFirstSplit(it, testSplit) -> println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it is unit test and we're on $testSplit.")
+                    isUnitTestWithNonFirstSplit(it, testSplit) -> println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it is a unit test and we're on $testSplit.")
                     tasks.findByPath(taskPath) == null -> println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it does not exist.")
                     else -> insert(taskPath)
                 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -101,10 +101,11 @@ fun Project.insertBuildTypeTasksInto(
         findProject(subproject) != null ->
             forEachBuildTypeTask {
                 val taskPath = "$subproject:$it"
-                if (tasks.findByPath(taskPath) != null) {
-                    insert(taskPath)
-                } else {
-                    println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it does not exist.")
+                val testSplit = stringPropertyOrEmpty("testSplit")
+                when {
+                    isUnitTestWithNonFirstSplit(it, testSplit) -> println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it is unit test and we're on $testSplit.")
+                    tasks.findByPath(taskPath) == null -> println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it does not exist.")
+                    else -> insert(taskPath)
                 }
             }
         else -> {
@@ -115,6 +116,12 @@ fun Project.insertBuildTypeTasksInto(
     if (taskList.isEmpty()) {
         taskList.add("help") // do not trigger the default tasks
     }
+}
+
+
+fun isUnitTestWithNonFirstSplit(task: String, testSplit: String): Boolean = when {
+    task != "test" || testSplit.isBlank() -> false
+    else -> testSplit.split("/")[0].toInt() != 1
 }
 
 


### PR DESCRIPTION
Currently, the primary obstacles for us to improve CI feedback time is the long-running jobs:

https://builds.gradle.org/repository/download/Hygiene_CiHealthDaily/26611782:id/reports/master/build-time-statistics/without-tests/index.html?redirectSupported=false

`integTest`/`core`/`dependencyManagement` each takes more than 10 minutes. Without  decreasing the time we can't improve CI feedback time.

This PR changes the previous subproject-based TC job to bucket-based TC job: a bucket can contain a split of large subproject, or many tiny subprojects. This makes CI configuration more flexiable and efficient.

For example, all tiny subprojects which only contain unit tests can be merged to `AllUnitTests`, just as before - but now we make this more generic. 

`integTest` subproject can be split to 3 jobs: `integTest`/`integTest_2`/`integTest_3`. Splitted project has a special parameter `-PtestSplit=1/3`/`-PtestSplit=2/3`/`-PtestSplit=3/3` so the build can choose only a subset of tests to execute.

The tests for Kotlin DSL change is not fixed yet. 