### PR TITLE
Do not change extension of published artifact based on pom packaging

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
@@ -45,9 +45,13 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
 
     @Override
     void assertPublished() {
+        assertPublished(null, "jar")
+    }
+
+    void assertPublished(String pomPackaging, String artifactFileExtension) {
         super.assertPublished()
 
-        List<String> expectedArtifacts = [artifact("module"), artifact("pom"), artifact("jar")]
+        List<String> expectedArtifacts = [artifact("module"), artifact("pom"), artifact(artifactFileExtension)]
         expectedArtifacts.addAll(additionalArtifacts)
         mavenModule.assertArtifactsPublished(expectedArtifacts)
 
@@ -56,8 +60,8 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
         def apiElements = mavenModule.parsedModuleMetadata.variant('apiElements')
         def runtimeElements = mavenModule.parsedModuleMetadata.variant('runtimeElements')
 
-        assert apiElements.files*.name == [artifact('jar')]
-        assert runtimeElements.files*.name == [artifact('jar')]
+        assert apiElements.files*.name == [artifact(artifactFileExtension)]
+        assert runtimeElements.files*.name == [artifact(artifactFileExtension)]
 
         // Verify it contains some expected attributes
         assert apiElements.attributes.containsKey(Bundling.BUNDLING_ATTRIBUTE.name)
@@ -66,7 +70,7 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
         assert runtimeElements.attributes.containsKey(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name)
 
         // Verify POM particulars
-        assert mavenModule.parsedPom.packaging == null
+        assert mavenModule.parsedPom.packaging == pomPackaging
     }
 
     void assertNoDependencies() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomPackagingIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomPackagingIntegTest.groovy
@@ -133,6 +133,25 @@ class MavenPublishPomPackagingIntegTest extends AbstractMavenPublishIntegTest {
         mavenModule.assertArtifactsPublished("publishTest-1.9.foo", "publishTest-1.9.pom")
     }
 
+    def "can specify packaging for known jar packaging without changing artifact extension"() {
+        given:
+        createBuildScripts """
+            pom.packaging "ejb"
+
+            artifact("content.txt") {
+                extension "jar"
+            }
+"""
+
+        when:
+        succeeds "publish"
+
+        then:
+        mavenModule.assertPublished()
+        mavenModule.parsedPom.packaging == 'ejb'
+        mavenModule.assertArtifactsPublished("publishTest-1.9.jar", "publishTest-1.9.pom")
+    }
+
     def "can specify packaging with multiple unclassified artifacts"() {
         given:
         createBuildScripts """

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomPackagingIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomPackagingIntegTest.groovy
@@ -129,8 +129,7 @@ class MavenPublishPomPackagingIntegTest extends AbstractMavenPublishIntegTest {
         then:
         mavenModule.assertPublished()
         mavenModule.parsedPom.packaging == 'foo'
-         // Ideally, the '.foo' artifact would be '.txt' as specified
-        mavenModule.assertArtifactsPublished("publishTest-1.9.foo", "publishTest-1.9.pom")
+        mavenModule.assertArtifactsPublished("publishTest-1.9.txt", "publishTest-1.9.pom")
     }
 
     def "can specify packaging for known jar packaging without changing artifact extension"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomPackagingJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishPomPackagingJavaIntegTest.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+
+import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+
+class MavenPublishPomPackagingJavaIntegTest extends AbstractMavenPublishIntegTest {
+    def javaLibrary = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
+
+    def "can specify packaging for unknown packaging without changing artifact extension"() {
+        given:
+        createBuildScripts "foo"
+
+        when:
+        succeeds "publish"
+
+        then:
+        javaLibrary.assertPublished('foo', 'jar')
+        javaLibrary.parsedModuleMetadata.variant("apiElements").files[0].name == "publishTest-1.9.jar"
+        javaLibrary.parsedModuleMetadata.variant("apiElements").files[0].url == "publishTest-1.9.jar"
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements").files[0].name == "publishTest-1.9.jar"
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements").files[0].url == "publishTest-1.9.jar"
+    }
+
+    def "can specify packaging for known jar packaging without changing artifact extension"() {
+        given:
+        createBuildScripts "ejb"
+
+        when:
+        succeeds "publish"
+
+        then:
+        javaLibrary.assertPublished('ejb', 'jar')
+        javaLibrary.parsedModuleMetadata.variant("apiElements").files[0].name == "publishTest-1.9.jar"
+        javaLibrary.parsedModuleMetadata.variant("apiElements").files[0].url == "publishTest-1.9.jar"
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements").files[0].name == "publishTest-1.9.jar"
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements").files[0].url == "publishTest-1.9.jar"
+    }
+
+    def "can align packaging and artifact extension by changing both the main artifact and the packaging"() {
+        given:
+        createBuildScripts "foo"
+        buildFile << """
+            configurations {
+                jar.archiveExtension.set('foo')
+            }
+        """
+
+        when:
+        succeeds "publish"
+
+        then:
+        javaLibrary.assertPublished('foo', 'foo')
+        javaLibrary.parsedModuleMetadata.variant("apiElements").files[0].name == "publishTest-1.9.foo"
+        javaLibrary.parsedModuleMetadata.variant("apiElements").files[0].url == "publishTest-1.9.foo"
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements").files[0].name == "publishTest-1.9.foo"
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements").files[0].url == "publishTest-1.9.foo"
+    }
+
+    def createBuildScripts(String packaging) {
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        buildFile << """
+            apply plugin: 'java-library'
+            apply plugin: 'maven-publish'
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                        pom.packaging '$packaging'
+                    }
+                }
+            }
+"""
+    }
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.publish.maven.internal.publisher;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
@@ -41,11 +42,13 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 import static org.apache.maven.artifact.ArtifactUtils.isSnapshot;
 
 abstract class AbstractMavenPublisher implements MavenPublisher {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenPublisher.class);
+    private static final Set<String> JAR_PACKAGINGS = ImmutableSet.of("jar", "ejb", "bundle", "maven-plugin", "eclipse-plugin");
 
     private static final String POM_FILE_ENCODING = "UTF-8";
     private final Factory<File> temporaryDirFactory;
@@ -76,7 +79,9 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
         }
 
         if (publication.getMainArtifact() != null) {
-            artifactPublisher.publish(null, publication.getPackaging(), publication.getMainArtifact().getFile());
+            String packaging = publication.getPackaging();
+            String extension = packaging == null || JAR_PACKAGINGS.contains(packaging) ? publication.getMainArtifact().getExtension() : packaging;
+            artifactPublisher.publish(null, extension, publication.getMainArtifact().getFile());
         }
         artifactPublisher.publish(null, "pom", publication.getPomArtifact().getFile());
         for (MavenArtifact artifact : publication.getAdditionalArtifacts()) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven.internal.publisher;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
@@ -42,13 +41,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
 
 import static org.apache.maven.artifact.ArtifactUtils.isSnapshot;
 
 abstract class AbstractMavenPublisher implements MavenPublisher {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenPublisher.class);
-    private static final Set<String> JAR_PACKAGINGS = ImmutableSet.of("jar", "ejb", "bundle", "maven-plugin", "eclipse-plugin");
 
     private static final String POM_FILE_ENCODING = "UTF-8";
     private final Factory<File> temporaryDirFactory;
@@ -79,9 +76,7 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
         }
 
         if (publication.getMainArtifact() != null) {
-            String packaging = publication.getPackaging();
-            String extension = packaging == null || JAR_PACKAGINGS.contains(packaging) ? publication.getMainArtifact().getExtension() : packaging;
-            artifactPublisher.publish(null, extension, publication.getMainArtifact().getFile());
+            artifactPublisher.publish(null, publication.getMainArtifact().getExtension(), publication.getMainArtifact().getFile());
         }
         artifactPublisher.publish(null, "pom", publication.getPomArtifact().getFile());
         for (MavenArtifact artifact : publication.getAdditionalArtifacts()) {


### PR DESCRIPTION
We now publish the artifacts as they were defined in the build. If the packaging and artifact extension should be aligned, this can easily be done by adjusting the artifact extension when building it (e.g. by utilizing jar.archiveExtension.set())

Before this change, Gradle Module Metadata was broken for artifacts that were changed after the metadata file has been generated (newly added `MavenPublishPomPackagingJavaIntegTest` tests failed).

This is a breaking change for the 6.0 major release that should in practice not affect many builds since usually jars with a known jar packaging are published as the main artifact to maven repositories.

(the first commit of this PR can be used to restore the behavior of 5.5 that was changed in 5.6 by #9445 for the 5.x release line)