### PR TITLE
Fix incorrect split

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -11,6 +11,7 @@ import org.gradle.gradlebuild.java.AvailableJavaInstallations
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
+import java.io.File
 
 
 enum class TestType(val prefix: String, val executers: List<String>, val libRepoRequired: Boolean) {
@@ -110,17 +111,23 @@ fun DistributionTest.configureTestSplitIfNecessary(sourceSet: SourceSet) {
         return
     }
 
-    val chunks = sourceFiles.chunked(sourceFiles.size / numberOfSplits)
+    val buckets = splitIntoBuckets(sourceFiles, numberOfSplits)
     if (currentSplit == numberOfSplits) {
-        println(chunks.subList(0, chunks.size - 1).flatten().joinToString(",") { it.nameWithoutExtension })
-        filter.excludePatterns.addAll(chunks.subList(0, chunks.size - 1).flatten().map { it.nameWithoutExtension })
+        filter.excludePatterns.addAll(buckets.subList(0, buckets.size - 1).flatten().map { it.nameWithoutExtension })
     } else {
-        println(chunks[currentSplit - 1].joinToString(",") { it.nameWithoutExtension })
-        filter.includePatterns.addAll(chunks[currentSplit - 1].map { it.nameWithoutExtension })
+        filter.includePatterns.addAll(buckets[currentSplit - 1].map { it.nameWithoutExtension })
     }
 
     inputs.property("testSplit", testSplit)
 }
+
+
+fun splitIntoBuckets(sourceFiles: List<File>, numberOfSplits: Int): List<List<File>> =
+    if (sourceFiles.size % numberOfSplits == 0) {
+        sourceFiles.chunked(sourceFiles.size / numberOfSplits)
+    } else {
+        sourceFiles.chunked(sourceFiles.size / numberOfSplits + 1)
+    }
 
 
 private

--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation("org.ow2.asm:asm:7.1")
     implementation("org.ow2.asm:asm-commons:7.1")
     implementation("com.google.code.gson:gson:2.7")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.4.2")
     testImplementation("junit:junit:4.12")
     testImplementation("io.mockk:mockk:1.8.13")
 }

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
@@ -21,10 +21,15 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.gradlebuild.test.integrationtests.splitIntoBuckets
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import java.io.File
 
 
 class BuildTypesPluginTest {
@@ -47,6 +52,26 @@ class BuildTypesPluginTest {
         every { project.name } returns "project"
         every { project.findProject(any()) } returns null
         every { taskContainer.findByPath(any()) } returns null
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = [
+        "100, 2",
+        "100, 3",
+        "100, 4",
+        "100, 5",
+        "100, 6",
+        "100, 7",
+        "100, 8",
+        "100, 9",
+        "100, 10"
+    ])
+    fun `can split files into buckets`(fileCount: Int, numberOfSplits: Int) {
+        val files = (1..fileCount).map { File("$it") }
+        val buckets = splitIntoBuckets(files, numberOfSplits)
+
+        Assertions.assertEquals(numberOfSplits, buckets.size)
+        Assertions.assertEquals(files, buckets.flatten())
     }
 
     @Test


### PR DESCRIPTION
### Context

I made a mistake when splitting the test sets: suppose we have 1000 tests and want to split into 3 buckets, the previous split is [333,333,333,1], so the test include/exclude patterns are:

- include 1..333
- include 334..666
- exclude 1..999

We're missing a large subset of tests! This fixes this issue by correctly splitting the buckets.