### PR TITLE
Add missing dependency to embedded kotlin

### DIFF
--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -74,4 +74,26 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
 
         assertThat(result.error, containsString("Could not find org.jetbrains.kotlin:kotlin-compiler-embeddable:1.0"))
     }
+
+    @Test
+    fun `embedded kotlin is compatible with locking because it properly reflects the dependency tree`() {
+        withBuildScript("""
+            ${scriptWithKotlinDslPlugin()}
+
+            dependencyLocking {
+                lockAllConfigurations()
+            }
+        """)
+
+        withFile("src/main/kotlin/test/Test.kt", """
+
+            package test
+
+            val test = true
+
+        """)
+        build("dependencies", "--configuration", "compileClasspath", "--write-locks")
+
+        build("compileKotlin")
+    }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -154,7 +154,8 @@ val embeddedModules: List<EmbeddedModule> by lazy {
     // TODO:pm could be generated at build time
     val annotations = EmbeddedModule("org.jetbrains", "annotations", "13.0")
     val trove4j = EmbeddedModule("org.jetbrains.intellij.deps", "trove4j", "1.0.20181211")
-    val stdlib = embeddedKotlin("stdlib", listOf(annotations))
+    val stdlibCommon = embeddedKotlin("stdlib-common")
+    val stdlib = embeddedKotlin("stdlib", listOf(stdlibCommon, annotations))
     val stdlibJdk7 = embeddedKotlin("stdlib-jdk7", listOf(stdlib))
     val stdlibJdk8 = embeddedKotlin("stdlib-jdk8", listOf(stdlibJdk7))
     val reflect = embeddedKotlin("reflect", listOf(stdlib))
@@ -169,7 +170,7 @@ val embeddedModules: List<EmbeddedModule> by lazy {
     val samWithReceiverCompilerPlugin = embeddedKotlin("sam-with-receiver-compiler-plugin")
     listOf(
         annotations, trove4j,
-        stdlib, stdlibJdk7, stdlibJdk8,
+        stdlibCommon, stdlib, stdlibJdk7, stdlibJdk8,
         reflect,
         compilerEmbeddable,
         scriptingCompilerEmbeddable,


### PR DESCRIPTION
* kotlin-stdlib now depends on kotlin-stdlib-common, this was not
reflected in the setup of the embedded kotlin repo.
* A way to experience this issue was with locking on a kotlin-dsl
project.