### PR TITLE
Migrate tests to use new transforms API

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/api/artifacts/transform/ArtifactTransformBuildScanIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/api/artifacts/transform/ArtifactTransformBuildScanIntegrationTest.groovy
@@ -49,20 +49,24 @@ class ArtifactTransformBuildScanIntegrationTest extends AbstractIntegrationSpec 
                     }
                 }
                 dependencies {
-                    registerTransform {
+                    registerTransform(FileSizer) {
                         from.attribute(artifactType, "jar")
                         to.attribute(artifactType, "size")
-                        artifactTransform(FileSizer)
                     }
                 }
             }
 
-            class FileSizer extends ArtifactTransform {
-                List<File> transform(File input) {
-                    File output = new File(outputDirectory, input.name + ".txt")
+            import org.gradle.api.artifacts.transform.TransformParameters
+
+            abstract class FileSizer implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    File output = outputs.file(input.name + ".txt")
                     output.text = String.valueOf(input.length())
-                    println "Transformed \$input.name to \$output.name into \$outputDirectory"
-                    return [output]
+                    println "Transformed \$input.name to \$output.name into \${output.parentFile}"
                 }
             }
             

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -500,11 +500,15 @@ task show {
 
         buildFile << """
 
-class VariantArtifactTransform extends ArtifactTransform {
-    List<File> transform(File input) {
-        def output = new File(outputDirectory, "transformed-" + input.name)
+import org.gradle.api.artifacts.transform.TransformParameters
+
+abstract class VariantArtifactTransform implements TransformAction<TransformParameters.None> {
+    @InputArtifact
+    abstract Provider<FileSystemLocation> getInputArtifact()
+
+    void transform(TransformOutputs outputs) {
+        def output = outputs.file("transformed-" + inputArtifact.get().asFile.name)
         output << "transformed"
-        return [output]         
     }
 }
 
@@ -518,10 +522,9 @@ dependencies {
     compile project(':a')
     compile project(':b')
     compile 'org:test:1.0'
-    registerTransform {
+    registerTransform(VariantArtifactTransform) {
         from.attribute(usage, "compile")
         to.attribute(usage, "transformed")
-        artifactTransform(VariantArtifactTransform)
     }
 }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactFilterIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactFilterIntegrationTest.groovy
@@ -225,12 +225,12 @@ class ArtifactFilterIntegrationTest extends AbstractHttpDependencyResolutionTest
         buildFile << """
             def artifactType = Attribute.of('artifactType', String)
 
-            class Jar2Class extends ArtifactTransform {
-                List<File> transform(File input) {
+            import org.gradle.api.artifacts.transform.TransformParameters
+
+            abstract class Jar2Class implements TransformAction<TransformParameters.None> {
+                void transform(TransformOutputs outputs) {
                     println "Jar2Class"
-                    def classes = new File(outputDirectory, 'classes')
-                    classes.mkdirs()
-                    return [classes]
+                    def classes = outputs.dir('classes')
                 }
             }
 
@@ -238,10 +238,9 @@ class ArtifactFilterIntegrationTest extends AbstractHttpDependencyResolutionTest
                 compile project('libInclude')
                 compile project('libExclude')
                 
-                registerTransform {
+                registerTransform(Jar2Class) {
                     from.attribute(Attribute.of('artifactType', String), "jar")
                     to.attribute(Attribute.of('artifactType', String), "class")
-                    artifactTransform(Jar2Class)
                 }
             }
             def artifactFilter = { component -> component.projectPath == ':libInclude' }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -44,7 +44,9 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
             include 'util'
             include 'app'
         """
-        buildFile << resolveTask
+        buildFile << resolveTask << """
+            import org.gradle.api.artifacts.transform.TransformParameters
+        """
     }
 
     def "transform is applied to each file once per build"() {
@@ -172,54 +174,56 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                 dependencies {
                     compile project(':lib')
                     
-                    registerTransform {
+                    registerTransform(MakeBlueToGreenThings) {
                         from.attribute(Attribute.of('color', String), "blue")
                         to.attribute(Attribute.of('color', String), "green")
-                        artifactTransform(MakeBlueToGreenThings)
                     }
-                    registerTransform {
+                    registerTransform(MakeGreenToRedThings) {
                         from.attribute(Attribute.of('color', String), "green")
                         to.attribute(Attribute.of('color', String), "red")
-                        artifactTransform(MakeGreenToRedThings)
                     }
-                    registerTransform {
+                    registerTransform(MakeGreenToYellowThings) {
                         from.attribute(Attribute.of('color', String), "green")
                         to.attribute(Attribute.of('color', String), "yellow")
-                        artifactTransform(MakeGreenToYellowThings)
                     }
                 }
             }
 
-            class MakeGreenToRedThings extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".red")
+            abstract class MakeThingsColored implements TransformAction<TransformParameters.None> {
+                private final String targetColor
+
+                MakeThingsColored(String targetColor) {
+                    this.targetColor = targetColor
+                }
+
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file(input.name + ".\${targetColor}")
+                    assert output.parentFile.directory && output.parentFile.list().length == 0
                     println "Transforming \${input.name} to \${output.name}"
                     println "Input exists: \${input.exists()}"
                     output.text = String.valueOf(input.length())
-                    return [output]
+                }
+            } 
+
+            abstract class MakeGreenToRedThings extends MakeThingsColored {
+                MakeGreenToRedThings() {
+                    super('red')
                 }
             }
 
-            class MakeGreenToYellowThings extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".yellow")
-                    println "Transforming \${input.name} to \${output.name}"
-                    println "Input exists: \${input.exists()}"
-                    output.text = String.valueOf(input.length())
-                    return [output]
+            abstract class MakeGreenToYellowThings extends MakeThingsColored {
+                MakeGreenToYellowThings() {
+                    super('yellow')
                 }
             }
 
-            class MakeBlueToGreenThings extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".green")
-                    println "Transforming \${input.name} to \${output.name}"
-                    println "Input exists: \${input.exists()}"
-                    output.text = String.valueOf(input.length())
-                    return [output]
+            abstract class MakeBlueToGreenThings extends MakeThingsColored {
+                MakeBlueToGreenThings() {
+                    super('green')
                 }
             }
         """ << withJarTasks()
@@ -308,45 +312,44 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     def "each file is transformed once per set of configuration parameters"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << withLibJarDependency("lib3.jar") << """
-            class TransformWithMultipleTargets extends ArtifactTransform {
-                private String target
-                
-                @javax.inject.Inject
-                TransformWithMultipleTargets(String target) {
-                    this.target = target
+            abstract class TransformWithMultipleTargets implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters {
+                    @Input
+                    Property<String> getTarget() 
                 }
                 
-                List<File> transform(File input) {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     assert input.exists()
+                    def output = outputs.file(input.name + ".\${parameters.target.get()}")
+                    def outputDirectory = output.parentFile
                     assert outputDirectory.directory && outputDirectory.list().length == 0
-                    if (target.equals("size")) {
-                        def outSize = new File(outputDirectory, input.name + ".size")
-                        println "Transformed \$input.name to \$outSize.name into \$outputDirectory"
-                        outSize.text = String.valueOf(input.length())
-                        return [outSize]
-                    } else if (target.equals("hash")) {
-                        def outHash = new File(outputDirectory, input.name + ".hash")
-                        println "Transformed \$input.name to \$outHash.name into \$outputDirectory"
-                        outHash.text = 'hash'
-                        return [outHash]
+                    if (parameters.target.get() == "size") {
+                        output.text = String.valueOf(input.length())
+                    } else if (parameters.target.get() == "hash") {
+                        output.text = 'hash'
                     }             
+                    println "Transformed \$input.name to \$output.name into \$outputDirectory"
                 }
             }
             
             allprojects {
                 dependencies {
-                    registerTransform {
+                    registerTransform(TransformWithMultipleTargets) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'size')
-                        artifactTransform(TransformWithMultipleTargets) {
-                            params('size')
+                        parameters {
+                            target.set('size')
                         }
                     }
-                    registerTransform {
+                    registerTransform(TransformWithMultipleTargets) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'hash')
-                        artifactTransform(TransformWithMultipleTargets) {
-                            params('hash')
+                        parameters {
+                            target.set('hash')
                         }
                     }
                 }
@@ -415,46 +418,45 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                 String value
             }
             
-            class TransformWithMultipleTargets extends ArtifactTransform {
-                private CustomType target
-                
-                @javax.inject.Inject
-                TransformWithMultipleTargets(CustomType target) {
-                    this.target = target
+            abstract class TransformWithMultipleTargets implements TransformAction<Parameters> {
+            
+                interface Parameters extends TransformParameters {
+                    @Input
+                    CustomType getTarget()
+                    void setTarget(CustomType target)
                 }
                 
-                List<File> transform(File input) {
-                    assert input.exists()
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    if (target.value == "size") {
-                        def outSize = new File(outputDirectory, input.name + ".size")
-                        println "Transformed \$input.name to \$outSize.name into \$outputDirectory"
-                        outSize.text = String.valueOf(input.length())
-                        return [outSize]
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file(input.name + ".\${parameters.target.value}")
+                    def outputDirectory = output.parentFile
+                    if (parameters.target.value == "size") {
+                        output.text = String.valueOf(input.length())
                     }
-                    if (target.value == "hash") {
-                        def outHash = new File(outputDirectory, input.name + ".hash")
-                        println "Transformed \$input.name to \$outHash.name into \$outputDirectory"
-                        outHash.text = 'hash'
-                        return [outHash]
+                    if (parameters.target.value == "hash") {
+                        output.text = 'hash'
                     }             
+                    println "Transformed \$input.name to \$output.name into \$outputDirectory"
                 }
             }
             
             allprojects {
                 dependencies {
-                    registerTransform {
+                    registerTransform(TransformWithMultipleTargets) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'size')
-                        artifactTransform(TransformWithMultipleTargets) {
-                            params(new CustomType(value: 'size'))
+                        parameters {
+                            target = new CustomType(value: 'size')
                         }
                     }
-                    registerTransform {
+                    registerTransform(TransformWithMultipleTargets) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'hash')
-                        artifactTransform(TransformWithMultipleTargets) {
-                            params(new CustomType(value: 'hash'))
+                        parameters {
+                            target = new CustomType(value: 'hash')
                         }
                     }
                 }
@@ -515,31 +517,33 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     def "can use configuration parameter of type #type"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << """
-            class TransformWithMultipleTargets extends ArtifactTransform {
-                private $type target
-                
-                @javax.inject.Inject
-                TransformWithMultipleTargets($type target) {
-                    this.target = target
+            abstract class TransformWithMultipleTargets implements TransformAction<Parameters> {
+
+                interface Parameters extends TransformParameters {
+                    @Input
+                    $type getTarget()
+                    void setTarget($type target)
                 }
                 
-                List<File> transform(File input) {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     assert input.exists()
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def outSize = new File(outputDirectory, input.name + ".value")
-                    println "Transformed \$input.name to \$outSize.name into \$outputDirectory"
-                    outSize.text = String.valueOf(input.length()) + String.valueOf(target)
-                    return [outSize]
+                    def output = outputs.file(input.name + ".value")
+                    println "Transformed \$input.name to \$output.name into \$output.parentFile"
+                    output.text = String.valueOf(input.length()) + String.valueOf(parameters.target)
                 }
             }
             
             allprojects {
                 dependencies {
-                    registerTransform {
+                    registerTransform(TransformWithMultipleTargets) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'value')
-                        artifactTransform(TransformWithMultipleTargets) {
-                            params($value)
+                        parameters {
+                            target = $value
                         }
                     }
                 }
@@ -602,50 +606,59 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     def "each file is transformed once per transform class"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << withLibJarDependency("lib3.jar") << """
-            class Sizer extends ArtifactTransform {
-                @javax.inject.Inject
-                Sizer(String target) {
-                    // ignore config
+            abstract class Sizer implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters {
+                    @Input
+                    Property<String> getTarget()
                 }
                 
-                List<File> transform(File input) {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     assert input.exists()
+                    def output = outputs.file(input.name + ".size")
+                    def outputDirectory = output.parentFile 
                     assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def outSize = new File(outputDirectory, input.name + ".size")
-                    println "Transformed \$input.name to \$outSize.name into \$outputDirectory"
-                    outSize.text = String.valueOf(input.length())
-                    return [outSize]
+                    println "Transformed \$input.name to \$output.name into \$outputDirectory"
+                    output.text = String.valueOf(input.length())
                 }
             }
-            class Hasher extends ArtifactTransform {
-                private String target
-                
-                @javax.inject.Inject
-                Hasher(String target) {
-                    // ignore config
+            abstract class Hasher implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters {
+                    @Input
+                    Property<String> getTarget()
                 }
                 
-                List<File> transform(File input) {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     assert input.exists()
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def outHash = new File(outputDirectory, input.name + ".hash")
-                    println "Transformed \$input.name to \$outHash.name into \$outputDirectory"
-                    outHash.text = 'hash'
-                    return [outHash]
+                    def output = outputs.file(input.name + ".hash")
+                    def outputDirectory = output.parentFile 
+                    println "Transformed \$input.name to \$output.name into \$outputDirectory"
+                    output.text = 'hash'
                 }
             }
             
             allprojects {
                 dependencies {
-                    registerTransform {
+                    registerTransform(Sizer) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'size')
-                        artifactTransform(Sizer) { params('size') }
+                        parameters {
+                            target.set('size')
+                        }
                     }
-                    registerTransform {
+                    registerTransform(Hasher) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'hash')
-                        artifactTransform(Hasher) { params('hash') }
+                        parameters {
+                            target.set('hash')
+                        }
                     }
                 }
                 task resolveSize(type: Resolve) {
@@ -814,15 +827,21 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
             allprojects {
                 dependencies {
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "jar")
                         to.attribute(artifactType, "green")
-                        artifactTransform(Duplicator) { params(2, false) }
+                        parameters {
+                            numberOfOutputFiles.set(2)
+                            differentOutputFileNames.set(false)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "green")
                         to.attribute(artifactType, "blue")
-                        artifactTransform(Duplicator) { params(2, false) }
+                        parameters {
+                            numberOfOutputFiles.set(2)
+                            differentOutputFileNames.set(false)
+                        }
                     }
                 }
                 task resolve(type: Resolve) {
@@ -870,25 +889,37 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
             allprojects {
                 dependencies {
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "jar")
                         to.attribute(artifactType, "green")
-                        artifactTransform(Duplicator) { params(2, true) }
+                        parameters {
+                            numberOfOutputFiles.set(2)
+                            differentOutputFileNames.set(true)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "green")
                         to.attribute(artifactType, "blue")
-                        artifactTransform(Duplicator)  { params(1, false) }
+                        parameters {
+                            numberOfOutputFiles.set(1)
+                            differentOutputFileNames.set(false)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "blue")
                         to.attribute(artifactType, "yellow")
-                        artifactTransform(Duplicator)  { params(3, false) }
+                        parameters {
+                            numberOfOutputFiles.set(3)
+                            differentOutputFileNames.set(false)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "yellow")
                         to.attribute(artifactType, "orange")
-                        artifactTransform(Duplicator)  { params(1, true) }
+                        parameters {
+                            numberOfOutputFiles.set(1)
+                            differentOutputFileNames.set(true)
+                        }
                     }
                 }
                 task resolve(type: Resolve) {
@@ -914,15 +945,10 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
             index == failingTransform ? "FailingDuplicator" : "Duplicator"
         }
         buildFile << declareAttributes() << withJarTasks() << withLibJarDependency("lib3.jar") << duplicatorTransform << """
-            class FailingDuplicator extends Duplicator {
+            abstract class FailingDuplicator extends Duplicator {
                 
-                @javax.inject.Inject
-                FailingDuplicator(int numberOfOutputFiles, boolean differentOutputFileNames) {
-                    super(numberOfOutputFiles, differentOutputFileNames) 
-                }                                                       
-
                 @Override
-                List<File> transform(File input) {
+                void transform(TransformOutputs outputs) {
                     throw new RuntimeException("broken")
                 }                
             }
@@ -935,25 +961,37 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
             allprojects {
                 dependencies {
-                    registerTransform {
+                    registerTransform(${possiblyFailingTransform(1)}) {
                         from.attribute(artifactType, "jar")
                         to.attribute(artifactType, "green")
-                        artifactTransform(${possiblyFailingTransform(1)}) { params(2, true) }
+                        parameters {
+                            numberOfOutputFiles.set(2)
+                            differentOutputFileNames.set(true)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(${possiblyFailingTransform(2)}) {
                         from.attribute(artifactType, "green")
                         to.attribute(artifactType, "blue")
-                        artifactTransform(${possiblyFailingTransform(2)})  { params(1, false) }
+                        parameters {
+                            numberOfOutputFiles.set(1)
+                            differentOutputFileNames.set(false)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(${possiblyFailingTransform(3)}) {
                         from.attribute(artifactType, "blue")
                         to.attribute(artifactType, "yellow")
-                        artifactTransform(${possiblyFailingTransform(3)})  { params(3, false) }
+                        parameters {
+                            numberOfOutputFiles.set(3)
+                            differentOutputFileNames.set(false)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(${possiblyFailingTransform(4)}) {
                         from.attribute(artifactType, "yellow")
                         to.attribute(artifactType, "orange")
-                        artifactTransform(${possiblyFailingTransform(4)})  { params(1, true) }
+                        parameters {
+                            numberOfOutputFiles.set(1)
+                            differentOutputFileNames.set(true)
+                        }
                     }
                 }
                 task resolve(type: Resolve) {
@@ -1006,20 +1044,29 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                 }
             
                 dependencies {
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "jar")
                         to.attribute(artifactType, "green")
-                        artifactTransform(Duplicator) { params(2, true) }
+                        parameters {
+                            numberOfOutputFiles.set(2)
+                            differentOutputFileNames.set(true)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "green")
                         to.attribute(artifactType, "blue")
-                        artifactTransform(Duplicator)  { params(1, false) }
+                        parameters {
+                            numberOfOutputFiles.set(1)
+                            differentOutputFileNames.set(false)
+                        }
                     }
-                    registerTransform {
+                    registerTransform(Duplicator) {
                         from.attribute(artifactType, "blue")
                         to.attribute(artifactType, "yellow")
-                        artifactTransform(Duplicator)  { params(3, false) }
+                        parameters {
+                            numberOfOutputFiles.set(3)
+                            differentOutputFileNames.set(false)
+                        }
                     }
                 }
                 task resolve(type: Resolve) {
@@ -1047,30 +1094,27 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     String duplicatorTransform = """
             import java.nio.file.Files
 
-            class Duplicator extends ArtifactTransform {
-            
-                final int numberOfOutputFiles
-                final boolean differentOutputFileNames                                            
+            abstract class Duplicator implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters {
+                    @Input
+                    Property<Integer> getNumberOfOutputFiles()
+                    @Input
+                    Property<Boolean> getDifferentOutputFileNames()
+                }            
                            
-                @javax.inject.Inject
-                Duplicator(int numberOfOutputFiles, boolean differentOutputFileNames) {
-                    this.numberOfOutputFiles = numberOfOutputFiles
-                    this.differentOutputFileNames = differentOutputFileNames                      
-                } 
-        
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
                 @Override
-                List<File> transform(File input) {
-                    def result = []
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println("Transforming \${input.name}")
-                    for (int i = 0; i < numberOfOutputFiles; i++) {
-                        def suffix = differentOutputFileNames ? i : ""
-                        def output = new File(outputDirectory, "\$i/" + input.name + suffix)
-                        output.parentFile.mkdirs()
+                    for (int i = 0; i < parameters.numberOfOutputFiles.get(); i++) {
+                        def suffix = parameters.differentOutputFileNames.get() ? i : ""
+                        def output = outputs.file("\$i/\${input.name}\$suffix")
                         Files.copy(input.toPath(), output.toPath())
-                        println "Transformed \${input.name} to \$i/\${output.name} into \$outputDirectory"
-                        result.add(output)
+                        println "Transformed \${input.name} to \$i/\${output.name} into \$output.parentFile.parentFile"
                     }
-                    return result
                 }
             }
     """
@@ -1410,22 +1454,25 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         and:
         buildFile << declareAttributes() << withLibJarDependency() << """
-            class BlockingTransform extends ArtifactTransform {
-                List<File> transform(File input) {
-                    def output = new File(outputDirectory, "\${input.name}.txt");
+            abstract class BlockingTransform implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file("\${input.name}.txt")
+                    def outputDirectory = output.parentFile
                     output.text = ""
                     println "Transformed \$input.name to \$output.name into \$outputDirectory"
                     ${blockingHttpServer.callFromBuild("transform")}
-                    return [output]
                 }
             }
             
             project(':app') {
                 dependencies {
-                    registerTransform {
+                    registerTransform(BlockingTransform) {
                         from.attribute(artifactType, "jar")
                         to.attribute(artifactType, "blocking")
-                        artifactTransform(BlockingTransform)
                     }
                     compile project(':lib')
                 }
@@ -1516,7 +1563,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     def multiProjectWithJarSizeTransform(Map options = [:]) {
         def paramValue = options.paramValue ?: "1"
         def fileValue = options.fileValue ?: "String.valueOf(input.length())"
-        def useParameterObject = options.parameterObject ?: false
+        def useParameterObject = options.parameterObject == null ? true : options.parameterObject
 
         """
             ext.paramValue = $paramValue
@@ -1657,7 +1704,7 @@ ${getFileSizerBody(fileValue, 'outputs.dir(', 'outputs.file(')}
         """
     }
 
-    def withClassesSizeTransform(boolean useParameterObject = false) {
+    def withClassesSizeTransform(boolean useParameterObject = true) {
         """
             allprojects {
                 dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -62,17 +62,27 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
     private static String getFileSizer() {
         """
-            class FileSizer extends org.gradle.api.artifacts.transform.ArtifactTransform {
+            import org.gradle.api.artifacts.transform.InputArtifact
+            import org.gradle.api.artifacts.transform.TransformAction
+            import org.gradle.api.artifacts.transform.TransformOutputs
+            import org.gradle.api.artifacts.transform.TransformParameters
+            import org.gradle.api.file.FileSystemLocation
+            import org.gradle.api.provider.Provider
+
+            abstract class FileSizer implements TransformAction<TransformParameters.None> {
                 FileSizer() {
                     println "Creating FileSizer"
                 }
                 
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".txt")
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+                
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file(input.name + ".txt")
+                    assert output.parentFile.directory && output.parentFile.list().length == 0
                     println "Transforming \${input.name} to \${output.name}"
                     output.text = String.valueOf(input.length())
-                    return [output]
                 }
             }
         """
@@ -130,10 +140,9 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 def artifactType = Attribute.of('artifactType', String)
                 dependencies {
 
-                    registerTransform {
+                    registerTransform(FileSizer) {
                         from.attribute(artifactType, 'jar')
                         to.attribute(artifactType, 'size')
-                        artifactTransform(FileSizer)
                     }
 
                     classpath 'org.apache.commons:commons-math3:3.6.1'
@@ -544,10 +553,9 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 dependencies {
                     compile project(':lib')
 
-                    registerTransform {
+                    registerTransform(MakeRedThings) {
                         from.attribute(Attribute.of('color', String), "green")
                         to.attribute(Attribute.of('color', String), "red")
-                        artifactTransform(MakeRedThings)
                     }
                 }
 
@@ -568,13 +576,16 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
             }
 
-            class MakeRedThings extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".red")
+            abstract class MakeRedThings implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file(input.name + ".red")
+                    assert output.parentFile.directory && output.parentFile.list().length == 0
                     println "Transforming \${input.name} to \${output.name}"
                     output.text = String.valueOf(input.length())
-                    return [output]
                 }
             }
         """
@@ -646,15 +657,13 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 dependencies {
                     compile project(':lib')
                     
-                    registerTransform {
+                    registerTransform(MakeBlueToRedThings) {
                         from.attribute(Attribute.of('color', String), "blue")
                         to.attribute(Attribute.of('color', String), "red")
-                        artifactTransform(MakeBlueToRedThings)
                     }
-                    registerTransform {
+                    registerTransform(MakeGreenToBlueThings) {
                         from.attribute(Attribute.of('color', String), "green")
                         to.attribute(Attribute.of('color', String), "blue")
-                        artifactTransform(MakeGreenToBlueThings)
                     }
                 }
         
@@ -677,25 +686,31 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
             }
 
-            class MakeGreenToBlueThings extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".blue")
+            abstract class MakeGreenToBlueThings implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file(input.name + ".blue")
+                    assert output.parentFile.directory && output.parentFile.list().length == 0
                     println "Transforming \${input.name} to \${output.name}"
                     println "Input exists: \${input.exists()}"
                     output.text = String.valueOf(input.length())
-                    return [output]
                 }
             }
 
-            class MakeBlueToRedThings extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".red")
+            abstract class MakeBlueToRedThings implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file(input.name + ".red")
+                    assert output.parentFile.directory && output.parentFile.list().length == 0
                     println "Transforming \${input.name} to \${output.name}"
                     println "Input exists: \${input.exists()}"
                     output.text = String.valueOf(input.length())
-                    return [output]
                 }
             }
         """
@@ -746,10 +761,9 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
             }
 
             dependencies {
-                registerTransform {
+                registerTransform(FileSizer) {
                     from.attribute(artifactType, 'jar')
                     to.attribute(artifactType, 'size')
-                    artifactTransform(FileSizer)
                 }
             }
 
@@ -854,15 +868,18 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
             ${configurationAndTransform('LineSplitter')}
 
-            class LineSplitter extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    File outputA = new File(outputDirectory, input.name + ".A.txt")
+            abstract class LineSplitter implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    File outputA = outputs.file(input.name + ".A.txt")
+                    assert outputA.parentFile.directory && outputA.parentFile.list().length == 0
                     outputA.text = "Output A"
             
-                    File outputB = new File(outputDirectory, input.name + ".B.txt")
+                    File outputB = outputs.file(input.name + ".B.txt")
                     outputB.text = "Output B"
-                    return [outputA, outputB]
                 }
             }
 """
@@ -896,11 +913,12 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
             ${configurationAndTransform('EmptyOutput')}
 
-            class EmptyOutput extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    println "Transforming \$input.name"
-                    return []
+            abstract class EmptyOutput implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    println "Transforming \${inputArtifact.get().asFile.name}"
                 }
             }
 """
@@ -945,19 +963,17 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
 
                 dependencies {
-                    registerTransform {
+                    registerTransform(BrokenTransform) {
                         from.attribute(artifactType, 'custom')
                         to.attribute(artifactType, 'transformed')
                         from.attribute(extraAttribute, 'foo')
                         to.attribute(extraAttribute, 'bar')
-                        artifactTransform(BrokenTransform)
                     }
-                    registerTransform {
+                    registerTransform(BrokenTransform) {
                         from.attribute(artifactType, 'custom')
                         to.attribute(artifactType, 'transformed')
                         from.attribute(extraAttribute, 'foo')
                         to.attribute(extraAttribute, 'baz')
-                        artifactTransform(BrokenTransform)
                     }
                 }
     
@@ -970,8 +986,8 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 }
             }
     
-            class BrokenTransform extends ArtifactTransform {
-                List<File> transform(File input) {
+            abstract class BrokenTransform implements TransformAction<TransformParameters.None> {
+                void transform(TransformOutputs outputs) {
                     throw new AssertionError("should not be used")
                 }
             }
@@ -1043,17 +1059,15 @@ Found the following transforms:
                 }
 
                 dependencies {
-                    registerTransform {
+                    registerTransform(BrokenTransform) {
                         from.attribute(artifactType, 'jar')
                         from.attribute(buildType, 'release')
                         to.attribute(artifactType, 'transformed')
-                        artifactTransform(BrokenTransform)
                     }
-                    registerTransform {
+                    registerTransform(BrokenTransform) {
                         from.attribute(artifactType, 'jar')
                         from.attribute(buildType, 'debug')
                         to.attribute(artifactType, 'transformed')
-                        artifactTransform(BrokenTransform)
                     }
                 }
     
@@ -1068,8 +1082,8 @@ Found the following transforms:
                 }
             }
 
-            class BrokenTransform extends ArtifactTransform {
-                List<File> transform(File input) {
+            abstract class BrokenTransform implements TransformAction<TransformParameters.None> {
+                void transform(TransformOutputs outputs) {
                     throw new AssertionError("should not be used")
                 }
             }
@@ -1142,10 +1156,9 @@ Found the following transforms:
                     }
                 }
                 dependencies {
-                    registerTransform {
+                    registerTransform(FileSizer) {
                         from.attribute(artifactType, "jar")
                         to.attribute(artifactType, "size")
-                        artifactTransform(FileSizer)
                     }
                 }
                 ext.checkArtifacts = { artifacts ->
@@ -1281,20 +1294,23 @@ Found the following transforms:
                 artifacts { compile jar1, jar2 }
             }
 
-            class Hasher extends ArtifactTransform {
-                int count
+            abstract class Hasher implements TransformAction<TransformParameters.None> {
+                private int count
 
                 Hasher() {
                     println "Creating Transform"
                 }
                 
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
-                    def output = new File(outputDirectory, input.name + ".txt")
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    def output = outputs.file(input.name + ".txt")
+                    assert output.parentFile.directory && output.parentFile.list().length == 0
                     count++
                     println "Transforming \${input.name} to \${output.name} with count \${count}"
                     output.text = String.valueOf(count)
-                    return [output]
                 }
             }
 
@@ -1364,13 +1380,17 @@ Found the following transforms:
                 compile files(a, b)
             }
 
-            class TransformWithIllegalArgumentException extends ArtifactTransform {
-                List<File> transform(File input) {
+            abstract class TransformWithIllegalArgumentException implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     if (input.name == 'a.jar') {
                         throw new IllegalArgumentException("broken")
                     }
                     println "Transforming " + input.name
-                    return [input]
+                    outputs.file(input)
                 }
             }
             ${configurationAndTransform('TransformWithIllegalArgumentException')}
@@ -1484,7 +1504,8 @@ Found the following transforms:
         outputContains("files: [thing1.jar.txt, thing2.jar.txt]")
     }
 
-    def "user gets a reasonable error message when a output property returns null"() {
+    @Unroll
+    def "user gets a reasonable error message when null is registered via outputs.#method"() {
         given:
         buildFile << """
             def a = file('a.jar')
@@ -1494,9 +1515,9 @@ Found the following transforms:
                 compile files(a)
             }
 
-            class ToNullTransform extends ArtifactTransform {
-                List<File> transform(File input) {
-                    return null
+            abstract class ToNullTransform implements TransformAction<TransformParameters.None> {
+                void transform(TransformOutputs outputs) {
+                    outputs.${method}(null)
                 }
             }
             ${configurationAndTransform('ToNullTransform')}
@@ -1510,7 +1531,10 @@ Found the following transforms:
         failure.assertHasCause("Could not resolve all files for configuration ':compile'.")
         failure.assertHasCause("Failed to transform a.jar to match attributes {artifactType=size}")
         failure.assertHasCause("Execution failed for ToNullTransform: ${file("a.jar").absolutePath}.")
-        failure.assertHasCause("Transform returned null result.")
+        failure.assertHasCause("path may not be null or empty string. path='null'")
+
+        where:
+        method << ['dir', 'file']
     }
 
     def "user gets a reasonable error message when transform returns a non-existing file"() {
@@ -1523,9 +1547,9 @@ Found the following transforms:
                 compile files(a)
             }
 
-            class NoExistTransform extends ArtifactTransform {
-                List<File> transform(File input) {
-                    return [new File('this_file_does_not.exist')]
+            abstract class NoExistTransform implements TransformAction<TransformParameters.None> {
+                void transform(TransformOutputs outputs) {
+                    outputs.file('this_file_does_not.exist')
                 }
             }
             ${configurationAndTransform('NoExistTransform')}
@@ -1713,11 +1737,11 @@ Found the following transforms:
 
             SomewhereElseTransform.output = file("other.jar")
 
-            class SomewhereElseTransform extends ArtifactTransform {
+            abstract class SomewhereElseTransform implements TransformAction<TransformParameters.None> {
                 static def output
-                List<File> transform(File input) {
+                void transform(TransformOutputs outputs) {
+                    outputs.file(output)
                     output.text = "123"
-                    return [output]
                 }
             }
             ${configurationAndTransform('SomewhereElseTransform')}
@@ -1783,11 +1807,11 @@ Found the following transforms:
                 compile files(a)
             }
 
-            class BrokenTransform extends ArtifactTransform {
+            abstract class BrokenTransform implements TransformAction<TransformParameters.None> {
                 BrokenTransform() {
                     throw new RuntimeException("broken")
                 }
-                List<File> transform(File input) {
+                void transform(TransformOutputs outputs) {
                     throw new IllegalArgumentException("broken")
                 }
             }
@@ -1830,14 +1854,17 @@ Found the following transforms:
                 compile 'test:c:2.0'
             }
 
-            class TransformWithIllegalArgumentException extends ArtifactTransform {
-                List<File> transform(File input) {
-                    assert outputDirectory.directory && outputDirectory.list().length == 0
+            abstract class TransformWithIllegalArgumentException implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     if (input.name.contains('broken')) {
                         throw new IllegalArgumentException("broken: " + input.name)
                     }
                     println "Transforming " + input.name
-                    return [input]
+                    outputs.file(inputArtifact)
                 }
             }
             ${configurationAndTransform('TransformWithIllegalArgumentException')}
@@ -1881,7 +1908,7 @@ Found the following transforms:
         when:
         buildFile << """
             dependencies {
-                registerTransform {
+                registerTransform(FileSizer) {
                     throw new Exception("Bad registration")
                 }
             }
@@ -2021,15 +2048,17 @@ Found the following transforms:
              * the original file name, thus losing the classifier that
              * was encoded in it.
              */ 
-            class NameManglingTransform extends ArtifactTransform {
+            abstract class NameManglingTransform implements TransformAction<TransformParameters.None> {
                 NameManglingTransform() {
                     println "Creating NameManglingTransform"
                 }
                 
-                List<File> transform(File input) {
-                    def output = new File(outputDirectory, "out.txt")
-                    output.text = input.text
-                    return [output]
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def output = outputs.file("out.txt")
+                    output.text = inputArtifact.get().asFile.text
                 }
             }
 
@@ -2227,8 +2256,8 @@ Found the following transforms:
                 ${configurationAndTransform('BrokenTransform')}
             }
 
-            class BrokenTransform extends ArtifactTransform {
-                List<File> transform(File input) {
+            abstract class BrokenTransform implements TransformAction<TransformParameters.None> {
+                void transform(TransformOutputs outputs) {
                     throw new GradleException('broken')
                 }
             }
@@ -2299,10 +2328,9 @@ Found the following transforms:
     def declareTransform(String transformImplementation) {
         """
             dependencies {
-                registerTransform {
+                registerTransform(${transformImplementation}) {
                     from.attribute(artifactType, 'jar')
                     to.attribute(artifactType, 'size')
-                    artifactTransform(${transformImplementation})
                 }
             }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -52,10 +52,9 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                         }
                     }
                     dependencies {
-                        registerTransform {
+                        registerTransform(SynchronizedTransform) {
                             from.attribute(artifactType, "jar")
                             to.attribute(artifactType, "size")
-                            artifactTransform(SynchronizedTransform)
                         }
                     }
                     configurations {
@@ -63,8 +62,14 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                     }            
                 }
     
-                class SynchronizedTransform extends ArtifactTransform {
-                    List<File> transform(File input) {
+                import org.gradle.api.artifacts.transform.TransformParameters
+
+                abstract class SynchronizedTransform implements TransformAction<TransformParameters.None> {
+                    @InputArtifact
+                    abstract Provider<FileSystemLocation> getInputArtifact()
+    
+                    void transform(TransformOutputs outputs) {
+                        def input = inputArtifact.get().asFile
                         ${server.callFromBuildUsingExpression("input.name")}
                         if (input.name.startsWith("bad")) {
                             throw new RuntimeException("Transform Failure: " + input.name)
@@ -72,10 +77,9 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
                         if (!input.exists()) {
                             throw new IllegalStateException("Input file \${input} does not exist")
                         }
-                        def output = new File(outputDirectory, input.name + ".txt")
+                        def output = outputs.file(input.name + ".txt")
                         println "Transforming \${input.name} to \${output.name}"
                         output.text = String.valueOf(input.length())
-                        return [output]
                     }
                 }
             """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ConcurrentBuildsArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ConcurrentBuildsArtifactTransformIntegrationTest.groovy
@@ -29,30 +29,38 @@ class ConcurrentBuildsArtifactTransformIntegrationTest extends AbstractDependenc
 enum Color { Red, Green, Blue }
 def type = Attribute.of("artifactType", String)
 
-class ToColor extends ArtifactTransform {
-    Color color
+abstract class ToColor implements TransformAction<Parameters> {
+    interface Parameters extends TransformParameters {
+        @Input
+        Property<Color> getColor()
+    }
 
-    @javax.inject.Inject
-    ToColor(Color color) { this.color = color }
+    @InputArtifact
+    abstract Provider<FileSystemLocation> getInputArtifact()
 
-    List<File> transform(File input) { 
+    void transform(TransformOutputs outputs) {
+        def input = inputArtifact.get().asFile
+        def color = parameters.color.get()
         println "Transforming \$input.name to \$color"
-        def out = new File(outputDirectory, color.toString())
+        def out = outputs.file(color.toString())
         out.text = input.name
-        [out]
     }
 }
 
 dependencies {
-    registerTransform {
+    registerTransform(ToColor) {
         from.attribute(type, "jar")
         to.attribute(type, "red")
-        artifactTransform(ToColor) { params(Color.Red) }
+        parameters {
+            color.set(Color.Red)
+        }
     }
-    registerTransform {
+    registerTransform(ToColor) {
         from.attribute(type, "jar")
         to.attribute(type, "blue")
-        artifactTransform(ToColor) { params(Color.Blue) }
+        parameters {
+            color.set(Color.Blue)
+        }
     }
 }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/CrashingBuildsArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/CrashingBuildsArtifactTransformIntegrationTest.groovy
@@ -26,32 +26,39 @@ class CrashingBuildsArtifactTransformIntegrationTest extends AbstractDependencyR
 enum Color { Red, Green, Blue }
 def type = Attribute.of("artifactType", String)
 
-class ToColor extends ArtifactTransform {
-    Color color
+abstract class ToColor implements TransformAction<Parameters> {
+    interface Parameters extends TransformParameters {
+        @Input
+        Property<Color> getColor()
+    }
 
-    @javax.inject.Inject
-    ToColor(Color color) { this.color = color }
+    @InputArtifact
+    abstract Provider<FileSystemLocation> getInputArtifact()
 
-    List<File> transform(File input) {
+    void transform(TransformOutputs outputs) {
+        def input = inputArtifact.get().asFile
+        def color = parameters.color.get()
+        def one = outputs.file("one")
+        def outputDirectory = one.parentFile
         assert outputDirectory.directory && outputDirectory.list().length == 0
         println "Transforming \$input.name to \$color"
-        def one = new File(outputDirectory, "one")
         one.text = "one"
         // maybe killed here
         if (System.getProperty("crash")) {
             Runtime.runtime.halt(1)
         }
-        def two = new File(outputDirectory, "two")
+        def two = outputs.file("two")
         two.text = "two"
-        [one, two]
     }
 }
 
 dependencies {
-    registerTransform {
+    registerTransform(ToColor) {
         from.attribute(type, "jar")
         to.attribute(type, "red")
-        artifactTransform(ToColor) { params(Color.Red) }
+        parameters {
+            color.set(Color.Red)
+        }
     }
 }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformOutputs.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformOutputs.java
@@ -50,7 +50,7 @@ public class DefaultTransformOutputs implements TransformOutputsInternal {
     public ImmutableList<File> getRegisteredOutputs() {
         ImmutableList<File> outputs = outputsBuilder.build();
         for (File output : outputs) {
-            TransformOutputsInternal.validateOutputExists(output);
+            TransformOutputsInternal.validateOutputExists(outputDirPrefix, output);
             if (outputFiles.contains(output) && !output.isFile()) {
                 throw new InvalidUserDataException("Transform output file " + output.getPath() + " must be a file, but is not.");
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -101,7 +101,7 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
         String inputFilePrefix = inputArtifact.getPath() + File.separator;
         String outputDirPrefix = outputDir.getPath() + File.separator;
         for (File output : outputs) {
-            TransformOutputsInternal.validateOutputExists(output);
+            TransformOutputsInternal.validateOutputExists(outputDirPrefix, output);
             TransformOutputsInternal.determineOutputLocationType(output, inputArtifact, inputFilePrefix, outputDir, outputDirPrefix);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformOutputsInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformOutputsInternal.java
@@ -40,9 +40,13 @@ public interface TransformOutputsInternal extends TransformOutputs {
         throw new InvalidUserDataException("Transform output " + output.getPath() + " must be a part of the input artifact or refer to a relative path.");
     }
 
-    static void validateOutputExists(File output) {
+    static void validateOutputExists(String outputDirPrefix, File output) {
         if (!output.exists()) {
-            throw new InvalidUserDataException("Transform output " + output.getPath() + " must exist.");
+            String outputAbsolutePath = output.getAbsolutePath();
+            String reportedPath = outputAbsolutePath.startsWith(outputDirPrefix)
+                ? outputAbsolutePath.substring(outputDirPrefix.length())
+                : outputAbsolutePath;
+            throw new InvalidUserDataException("Transform output " + reportedPath + " must exist.");
         }
     }
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
@@ -75,52 +75,47 @@ class CppCustomHeaderDependencyIntegrationTest extends AbstractInstalledToolChai
                     }
                 }
                 
-                registerTransform {
+                registerTransform(UnzipTransform) {
                     from.attribute(USAGE, CUSTOM).attribute(artifactType, 'zip')
                     to.attribute(USAGE, C_PLUS_PLUS_API).attribute(artifactType, 'directory')
-                    artifactTransform(UnzipTransform) {
-                        params(file('lib/src/main/headers'))
+                    parameters {
+                        headerDir.set(file('lib/src/main/headers'))
                     }
                 }
                 
-                registerTransform {
+                registerTransform(EmptyTransform) {
                     from.attribute(USAGE, CUSTOM).attribute(artifactType, 'zip')
                     to.attribute(USAGE, NATIVE_RUNTIME).attribute(artifactType, 'directory')
-                    artifactTransform(EmptyTransform)
                 }
                 
-                registerTransform {
+                registerTransform(EmptyTransform) {
                     from.attribute(USAGE, CUSTOM).attribute(artifactType, 'zip')
                     to.attribute(USAGE, NATIVE_LINK).attribute(artifactType, 'directory')
-                    artifactTransform(EmptyTransform)
                 }
             }
-            
+
             // Simulates unzipping headers by copying the contents of a configured directory
             // This is to avoid pulling in an external dependency to do this or investing the 
             // effort of writing our own unzip which would be pure yak-shaving for this test.
-            class UnzipTransform extends ArtifactTransform {
-                File headerDir
-                
-                @Inject
-                UnzipTransform(File headerDir) {
-                   this.headerDir = headerDir
+            import org.gradle.api.artifacts.transform.TransformParameters
+            
+            abstract class UnzipTransform implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters {
+                    @InputDirectory
+                    DirectoryProperty getHeaderDir()
                 }
                 
-                List<File> transform(File file) {
-                    def unzipped = new File(outputDirectory, "unzipped")
-                    unzipped.mkdirs()
-                    headerDir.listFiles().each { sourceFile ->
+                void transform(TransformOutputs outputs) {
+                    def unzipped = outputs.dir("unzipped")
+                    parameters.headerDir.get().asFile.listFiles().each { sourceFile ->
                         def headerFile = new File(unzipped, sourceFile.name)
                         headerFile.text = sourceFile.text
                     }
-                    return [unzipped]
                 }
             }
             
-            class EmptyTransform extends ArtifactTransform {
-                List<File> transform(File file) {
-                    return []
+            abstract class EmptyTransform implements TransformAction<TransformParameters.None> {
+                void transform(TransformOutputs outputs) {
                 }
             }
         """


### PR DESCRIPTION
Given that the old artifact transforms API is deprecated, our tests should (mostly) test the new API.