### PR TITLE
Remove leftover reference to `getInstantiatorForNext`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
@@ -248,40 +248,24 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         outputContains("count = 12")
     }
 
-    def "can define task with abstract read-only @Nested Property property"() {
+    def "can query generated read only property in constructor"() {
         given:
         buildFile << """
-            interface Params {
-                Integer getCount()
-            }
-            class DefaultParams implements Params {
-                private final int count
-
-                DefaultParams(int count) {
-                    this.count = count
-                }
-                
-                @Override
-                Integer getCount() {
-                    return count
-                }
-            }
             abstract class MyTask extends DefaultTask {
-                @Nested
-                abstract Property<Params> getParams()
+                abstract Property<String> getParam()
                 
                 MyTask() {
-                    params.convention(new DefaultParams(10))
+                    param.convention("from convention")
                 }
                 
                 @TaskAction
                 void go() {
-                    println("count = \${params.get().count}")
+                    println("param = \${param.get()}")
                 }
             }
             
             tasks.create("thing", MyTask) {
-                params.set(new DefaultParams(12))
+                param.set("from configuration")
             }
         """
 
@@ -289,7 +273,7 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         succeeds("thing")
 
         then:
-        outputContains("count = 12")
+        outputContains("param = from configuration")
     }
 
     def "cannot modify task's input properties via returned map"() {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -1449,7 +1449,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
             Type returnType = Type.getType(method.getReturnType());
 
-            Type[] originalParameterTypes = CollectionUtils.collectArray(method.getParameterTypes(), Type.class, (Transformer<Type, Class>) clazz -> Type.getType(clazz));
+            Type[] originalParameterTypes = CollectionUtils.collectArray(method.getParameterTypes(), Type.class, (Transformer<Type, Class>) Type::getType);
             int numParams = originalParameterTypes.length;
             Type[] closurisedParameterTypes = new Type[numParams];
             System.arraycopy(originalParameterTypes, 0, closurisedParameterTypes, 0, numParams);
@@ -1522,7 +1522,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
         private void generateGetInstantiator() {
             MethodVisitor mv = visitor.visitMethod(ACC_PRIVATE | ACC_SYNTHETIC, FACTORY_METHOD, RETURN_MANAGED_OBJECT_FACTORY, null, null);
             mv.visitCode();
-            // GENERATE if (instantiator != null) { return instantiator; } else { return AsmBackedClassGenerator.getInstantiatorForNext(); }
+            // GENERATE if (instantiator != null) { return instantiator; } else { return AsmBackedClassGenerator.getFactoryForNext(); }
             mv.visitVarInsn(ALOAD, 0);
             mv.visitFieldInsn(GETFIELD, generatedType.getInternalName(), FACTORY_FIELD, MANAGED_OBJECT_FACTORY_TYPE.getDescriptor());
             mv.visitInsn(DUP);
@@ -1530,7 +1530,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             mv.visitJumpInsn(IFNULL, label);
             mv.visitInsn(ARETURN);
             mv.visitLabel(label);
-            mv.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), "getInstantiatorForNext", RETURN_MANAGED_OBJECT_FACTORY, false);
+            mv.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), "getFactoryForNext", RETURN_MANAGED_OBJECT_FACTORY, false);
             mv.visitInsn(ARETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -124,20 +124,23 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
     private final String suffix;
     private final int factoryId;
 
-    // Used by generated code
+    private static final String GET_DISPLAY_NAME_FOR_NEXT_METHOD_NAME = "getDisplayNameForNext";
+    // Used by generated code, see ^
     @SuppressWarnings("unused")
     @Nullable
     public static Describable getDisplayNameForNext() {
         return SERVICES_FOR_NEXT_OBJECT.get().displayName;
     }
 
-    // Used by generated code
+    private static final String GET_SERVICES_FOR_NEXT_METHOD_NAME = "getServicesForNext";
+    // Used by generated code, see ^
     @SuppressWarnings("unused")
     public static ServiceLookup getServicesForNext() {
         return SERVICES_FOR_NEXT_OBJECT.get().services;
     }
 
-    // Used by generated code
+    private static final String GET_FACTORY_FOR_NEXT_METHOD_NAME = "getFactoryForNext";
+    // Used by generated code, see ^
     @SuppressWarnings("unused")
     public static ManagedObjectFactory getFactoryForNext() {
         ObjectCreationDetails details = SERVICES_FOR_NEXT_OBJECT.get();
@@ -547,19 +550,19 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             if (requiresToString) {
                 // this.displayName = AsmBackedClassGenerator.getDisplayNameForNext()
                 methodVisitor.visitVarInsn(ALOAD, 0);
-                methodVisitor.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), "getDisplayNameForNext", RETURN_DESCRIBABLE, false);
+                methodVisitor.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), GET_DISPLAY_NAME_FOR_NEXT_METHOD_NAME, RETURN_DESCRIBABLE, false);
                 methodVisitor.visitFieldInsn(PUTFIELD, generatedType.getInternalName(), DISPLAY_NAME_FIELD, DESCRIBABLE_TYPE.getDescriptor());
             }
             if (requiresServicesMethod) {
                 // this.services = AsmBackedClassGenerator.getServicesForNext()
                 methodVisitor.visitVarInsn(ALOAD, 0);
-                methodVisitor.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), "getServicesForNext", RETURN_SERVICE_LOOKUP, false);
+                methodVisitor.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), GET_SERVICES_FOR_NEXT_METHOD_NAME, RETURN_SERVICE_LOOKUP, false);
                 methodVisitor.visitFieldInsn(PUTFIELD, generatedType.getInternalName(), SERVICES_FIELD, SERVICE_LOOKUP_TYPE.getDescriptor());
             }
             if (requiresFactory) {
                 // this.factory = AsmBackedClassGenerator.getFactoryForNext()
                 methodVisitor.visitVarInsn(ALOAD, 0);
-                methodVisitor.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), "getFactoryForNext", RETURN_MANAGED_OBJECT_FACTORY, false);
+                methodVisitor.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), GET_FACTORY_FOR_NEXT_METHOD_NAME, RETURN_MANAGED_OBJECT_FACTORY, false);
                 methodVisitor.visitFieldInsn(PUTFIELD, generatedType.getInternalName(), FACTORY_FIELD, MANAGED_OBJECT_FACTORY_TYPE.getDescriptor());
             }
             for (PropertyMetadata property : propertiesToAttach) {
@@ -931,7 +934,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             mv.visitJumpInsn(IFNULL, label);
             mv.visitInsn(ARETURN);
             mv.visitLabel(label);
-            mv.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), "getServicesForNext", RETURN_SERVICE_LOOKUP, false);
+            mv.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), GET_SERVICES_FOR_NEXT_METHOD_NAME, RETURN_SERVICE_LOOKUP, false);
             mv.visitInsn(ARETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
@@ -1530,7 +1533,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             mv.visitJumpInsn(IFNULL, label);
             mv.visitInsn(ARETURN);
             mv.visitLabel(label);
-            mv.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), "getFactoryForNext", RETURN_MANAGED_OBJECT_FACTORY, false);
+            mv.visitMethodInsn(INVOKESTATIC, ASM_BACKED_CLASS_GENERATOR_TYPE.getInternalName(), GET_FACTORY_FOR_NEXT_METHOD_NAME, RETURN_MANAGED_OBJECT_FACTORY, false);
             mv.visitInsn(ARETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();


### PR DESCRIPTION
Looks like the method is only referenced when the getter is called in
the constructor.