### PR TITLE
Remove embedded-kotlin-repo and pin Kotlin dependencies with constraints

### DIFF
--- a/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
@@ -711,8 +711,6 @@ The plugin achieves this by doing the following:
 
  * Applies the link:https://kotlinlang.org/docs/reference/using-gradle.html#targeting-the-jvm[Kotlin Plugin], which adds support for compiling Kotlin source files.
  * Adds the `kotlin-stdlib-jdk8`, `kotlin-reflect` and `gradleKotlinDsl()` dependencies to the `compileOnly` and `testImplementation` configurations, which allows you to make use of those Kotlin libraries and the Gradle API in your Kotlin code.
-+
-All three libraries and their dependencies are bundled with Gradle, so these dependencies will not result in any downloads.
  * Configures the Kotlin compiler with the same settings that are used for Kotlin DSL scripts, ensuring consistency between your build logic and those scripts.
  * Enables support for <<kotdsl:precompiled_plugins,precompiled script plugins>>.
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -175,6 +175,20 @@ The abstract method `compile()` is no longer declared by `AbstractCompile`.
 Tasks extending `AbstractCompile` can implement their own `@TaskAction` method with the name of their choosing.
 They are also free to add a `@TaskAction` method with an `InputChanges` parameter without having to implement a parameter-less one as well.
 
+==== Using the `embedded-kotlin` plugin now requires a repository
+
+Just like when using the `kotlin-dsl` plugin, it is now required to declare a repository where Kotlin dependencies can be found if you apply the `embedded-kotlin` plugin.
+
+```kotlin
+plugins {
+    `embedded-kotlin`
+}
+
+repositories {
+    jcenter()
+}
+```
+
 ==== Kotlin DSL IDE support now requires Kotlin IntelliJ Plugin >= 1.3.50
 
 With Kotlin IntelliJ plugin versions prior to 1.3.50, Kotlin DSL scripts will be wrongly highlighted when the _Gradle JVM_ is set to a version different from the one in _Project SDK_.

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -171,7 +171,7 @@ Additionally, the following deprecated functionality now results in an error:
 
 ==== `AbstractCompile.compile()` is gone
 
-The abstrace method `compile()` is no longer declared by `AbstractCompile`.
+The abstract method `compile()` is no longer declared by `AbstractCompile`.
 Tasks extending `AbstractCompile` can implement their own `@TaskAction` method with the name of their choosing.
 They are also free to add a `@TaskAction` method with an `InputChanges` parameter without having to implement a parameter-less one as well.
 

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -191,9 +191,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
             import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
             buildscript {
-                repositories {
-                    jcenter()
-                }
+                $repositoriesBlock
                 dependencies {
                     classpath(kotlin("gradle-plugin", version = "$differentKotlinVersion"))
                 }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 import org.gradle.kotlin.dsl.fixtures.FoldersDsl
 import org.gradle.kotlin.dsl.fixtures.FoldersDslExpression
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.plugin.management.internal.autoapply.AutoAppliedBuildScanPlugin
 import org.gradle.test.fixtures.dsl.GradleDsl
 
 import org.gradle.test.fixtures.file.LeaksFileHandles
@@ -29,7 +30,6 @@ import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 
-import org.junit.Ignore
 import org.junit.Test
 
 import java.io.File
@@ -712,7 +712,6 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
     }
 
     @Test
-    @Ignore("TODO: change this test not to be dependent on an old version of the build-scan plugin")
     fun `given extension with inaccessible type, its accessor is typed Any`() {
 
         withFile("init.gradle", """
@@ -721,7 +720,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
                     gradlePluginPortal()
                 }
                 dependencies {
-                    classpath "com.gradle:build-scan-plugin:1.16"
+                    classpath "com.gradle:build-scan-plugin:${AutoAppliedBuildScanPlugin.VERSION}"
                 }
             }
             rootProject {

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "1.3.1"
+version = "1.3.2"
 
 base.archivesBaseName = "plugins"
 

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "1.2.12"
+version = "1.3.1"
 
 base.archivesBaseName = "plugins"
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -42,6 +42,8 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
                 `embedded-kotlin`
             }
 
+            $repositoriesBlock
+
         """)
 
         val result = build("assemble")
@@ -61,6 +63,8 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
             configurations {
                 create("compileOnlyClasspath") { extendsFrom(configurations["compileOnly"]) }
             }
+            
+            $repositoriesBlock
 
             tasks {
                 register("assertions") {
@@ -81,13 +85,15 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
     }
 
     @Test
-    fun `all embedded kotlin dependencies are resolvable without any added repository`() {
+    fun `all embedded kotlin dependencies are resolvable`() {
 
         withBuildScript("""
 
             plugins {
                 `embedded-kotlin`
             }
+
+            $repositoriesBlock
 
             dependencies {
                 ${dependencyDeclarationsFor(
@@ -96,21 +102,19 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
                 )}
             }
 
-            println(repositories.map { it.name })
             configurations["compileClasspath"].files.map { println(it) }
 
         """)
 
         val result = build("dependencies")
 
-        assertThat(result.output, containsString("Embedded Kotlin Repository"))
         listOf("stdlib", "reflect", "compiler-embeddable", "scripting-compiler-embeddable", "scripting-compiler-impl-embeddable").forEach {
             assertThat(result.output, containsString("kotlin-$it-$embeddedKotlinVersion.jar"))
         }
     }
 
     @Test
-    fun `sources and javadoc of all embedded kotlin dependencies are resolvable with an added repository`() {
+    fun `sources and javadoc of all embedded kotlin dependencies are resolvable`() {
 
         withBuildScript("""
 
@@ -174,6 +178,8 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
             plugins {
                 `embedded-kotlin`
             }
+
+            $repositoriesBlock
 
             val customConfiguration by configurations.creating
             customConfiguration.extendsFrom(configurations["embeddedKotlin"])

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -35,8 +35,7 @@ import javax.inject.Inject
  * The `embedded-kotlin` plugin.
  *
  * Applies the `org.jetbrains.kotlin.jvm` plugin,
- * adds compile only dependencies on `kotlin-stdlib` and `kotlin-reflect`,
- * configures an embedded repository that contains all embedded Kotlin libraries.
+ * adds compile only and test implementation dependencies on `kotlin-stdlib` and `kotlin-reflect`.
  */
 class EmbeddedKotlinPlugin @Inject internal constructor(
     private val embeddedKotlin: EmbeddedKotlinProvider
@@ -48,8 +47,6 @@ class EmbeddedKotlinPlugin @Inject internal constructor(
             plugins.apply(KotlinPluginWrapper::class.java)
 
             logger.warnOnDifferentKotlinVersion(getKotlinPluginVersion())
-
-            embeddedKotlin.addRepositoryTo(repositories)
 
             val embeddedKotlinConfiguration = configurations.create("embeddedKotlin")
             embeddedKotlin.addDependenciesTo(

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
@@ -49,6 +49,8 @@ class PrecompiledScriptPluginModelCrossVersionSpec extends AbstractKotlinScriptM
                 }
             }
 
+            $repositoriesBlock
+
             dependencies {
                 implementation(files("${implementationDependency.name}"))
             }
@@ -108,6 +110,8 @@ class PrecompiledScriptPluginModelCrossVersionSpec extends AbstractKotlinScriptM
             plugins {
                 `kotlin-dsl`
             }
+
+            $repositoriesBlock
         """)
 
         and:
@@ -134,6 +138,8 @@ class PrecompiledScriptPluginModelCrossVersionSpec extends AbstractKotlinScriptM
             plugins {
                 `kotlin-dsl`
             }
+
+            $repositoriesBlock
 
             dependencies {
                 implementation(files("${jar.name}"))

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
 
-val publishedKotlinDslPluginVersion = "1.3.0" // TODO:kotlin-dsl
+val publishedKotlinDslPluginVersion = "1.3.1" // TODO:kotlin-dsl
 
 tasks {
 

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -161,13 +161,13 @@ val writeEmbeddedKotlinDependencies by tasks.registering {
     outputs.file(outputFile)
     doLast {
 
+        val skippedModules = setOf(project.name, "distributionsDependencies", "kotlinCompilerEmbeddable")
+
         val modules = embeddedKotlinBaseDependencies.incoming.resolutionResult.allComponents
             .asSequence()
             .mapNotNull { it.moduleVersion }
-            .filter { it.name !in setOf(project.name, "distributionsDependencies", "kotlinCompilerEmbeddable") }
-            .associate {
-                "${it.group}:${it.name}" to it.version
-            }
+            .filter { it.name !in skippedModules }
+            .associate { "${it.group}:${it.name}" to it.version }
 
         ReproduciblePropertiesWriter.store(
             modules,

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -110,7 +110,7 @@ dependencies {
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
 
-val publishedKotlinDslPluginVersion = "1.2.11" // TODO:kotlin-dsl
+val publishedKotlinDslPluginVersion = "1.3.0" // TODO:kotlin-dsl
 
 tasks {
 

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -22,27 +22,11 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
-    fun `stdlib and reflect are pinned to the embedded kotlin version for requested plugins`() {
-        withBuildScript("""
-            plugins {
-                kotlin("jvm") version "1.3.31"
-            }
-        """)
+    fun `embedded kotlin dependencies are pinned to the embedded version`() {
 
-        val result = build("buildEnvironment")
-
-        listOf("stdlib", "reflect").forEach { module ->
-            assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-$module:1.3.31 -> $embeddedKotlinVersion"))
-        }
-    }
-
-    @Test
-    fun `stdlib and reflect are pinned to the embedded kotlin version for buildscript dependencies`() {
         withBuildScript("""
             buildscript {
-                repositories {
-                    gradlePluginPortal()
-                }
+                $repositoriesBlock
                 dependencies {
                     classpath("org.jetbrains.kotlin:kotlin-stdlib:1.0")
                     classpath("org.jetbrains.kotlin:kotlin-reflect:1.0")
@@ -54,6 +38,21 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
 
         listOf("stdlib", "reflect").forEach { module ->
             assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-$module:1.0 -> $embeddedKotlinVersion"))
+        }
+    }
+
+    @Test
+    fun `stdlib and reflect are pinned to the embedded kotlin version for requested plugins`() {
+        withBuildScript("""
+            plugins {
+                kotlin("jvm") version "1.3.31"
+            }
+        """)
+
+        val result = build("buildEnvironment")
+
+        listOf("stdlib", "reflect").forEach { module ->
+            assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-$module:1.3.31 -> $embeddedKotlinVersion"))
         }
     }
 

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -60,9 +60,7 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
     fun `compiler-embeddable is not pinned`() {
         withBuildScript("""
             buildscript {
-                repositories {
-                    gradlePluginPortal()
-                }
+                $repositoriesBlock
                 dependencies {
                     classpath("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.31")
                 }

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -72,4 +72,29 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
         assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.31"))
         assertThat(result.output, not(containsString("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.31 ->")))
     }
+
+    @Test
+    fun `fails with a reasonable message on conflict with embedded kotlin`() {
+        withBuildScript("""
+            buildscript {
+                $repositoriesBlock
+                dependencies {
+                    classpath("org.jetbrains.kotlin:kotlin-stdlib") {
+                        version { strictly("1.3.31") }
+                    }
+                }
+            }
+        """)
+
+        val result = buildAndFail("buildEnvironment")
+
+        assertThat(
+            result.error,
+            containsString("Cannot find a version of 'org.jetbrains.kotlin:kotlin-stdlib' that satisfies the version constraints")
+        )
+        assertThat(
+            result.error,
+            containsString("because of the following reason: Pinned to the embedded Kotlin")
+        )
+    }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgram.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgram.kt
@@ -43,7 +43,7 @@ sealed class ResidualProgram {
     sealed class Instruction {
 
         /**
-         * Causes the configuration of the embedded Kotlin repository and embedded Kotlin libraries
+         * Causes the configuration of the embedded Kotlin libraries
          * on the host's ScriptHandler.
          */
         object SetupEmbeddedKotlin : Instruction()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -53,13 +53,10 @@ import org.gradle.kotlin.dsl.execution.EvalOptions
 import org.gradle.kotlin.dsl.execution.Interpreter
 import org.gradle.kotlin.dsl.execution.ProgramId
 
-import org.gradle.kotlin.dsl.get
-
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
 import org.gradle.kotlin.dsl.support.ImplicitImports
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.ScriptCompilationException
-import org.gradle.kotlin.dsl.support.transitiveClosureOf
 
 import org.gradle.plugin.management.internal.DefaultPluginRequests
 import org.gradle.plugin.management.internal.PluginRequests
@@ -134,12 +131,11 @@ class StandardKotlinScriptEvaluator(
 
     private
     fun setupEmbeddedKotlinForBuildscript(scriptHandler: ScriptHandler) {
-        embeddedKotlinProvider.run {
-            addRepositoryTo(scriptHandler.repositories)
-            pinDependenciesOn(
-                scriptHandler.configurations["classpath"],
-                embeddedKotlinModules)
-        }
+        embeddedKotlinProvider.pinDependenciesOn(
+            scriptHandler.dependencies,
+            "classpath",
+            "stdlib-jdk8", "reflect"
+        )
     }
 
     private
@@ -282,10 +278,4 @@ class StandardKotlinScriptEvaluator(
         override val implicitImports: List<String>
             get() = this@StandardKotlinScriptEvaluator.implicitImports.list
     }
-}
-
-
-private
-val embeddedKotlinModules by lazy {
-    transitiveClosureOf("stdlib-jdk8", "reflect")
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -131,10 +131,9 @@ class StandardKotlinScriptEvaluator(
 
     private
     fun setupEmbeddedKotlinForBuildscript(scriptHandler: ScriptHandler) {
-        embeddedKotlinProvider.pinDependenciesOn(
+        embeddedKotlinProvider.pinEmbeddedKotlinDependenciesOn(
             scriptHandler.dependencies,
-            "classpath",
-            "stdlib-jdk8", "reflect"
+            "classpath"
         )
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -15,199 +15,46 @@
  */
 package org.gradle.kotlin.dsl.support
 
-import org.gradle.api.artifacts.ClientModule
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.internal.classpath.ModuleRegistry
-
-import org.gradle.cache.CacheRepository
-import org.gradle.cache.PersistentCache
 
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 
-import java.io.File
 
-import java.net.URI
-import java.util.*
-
-
-private
-const val embeddedRepositoryCacheKeyVersion = 3
-
-
-class EmbeddedKotlinProvider constructor(
-    private val cacheRepository: CacheRepository,
-    private val moduleRegistry: ModuleRegistry
-) {
-
-    fun addRepositoryTo(repositories: RepositoryHandler) {
-
-        repositories.maven { repo ->
-            repo.name = "Embedded Kotlin Repository"
-            repo.url = embeddedKotlinRepositoryURI
-            repo.metadataSources { sources ->
-                sources.artifact()
-            }
-        }
-    }
+class EmbeddedKotlinProvider {
 
     fun addDependenciesTo(
         dependencies: DependencyHandler,
         configuration: String,
         vararg kotlinModules: String
     ) {
-
-        embeddedKotlinModulesFor(kotlinModules).forEach { embeddedKotlinModule ->
-            dependencies.add(configuration, clientModuleFor(dependencies, embeddedKotlinModule))
+        kotlinModules.forEach { kotlinModule ->
+            dependencies.add(configuration, kotlinModuleVersionNotationFor(kotlinModule))
         }
     }
 
     internal
-    fun pinDependenciesOn(configuration: Configuration, pinnedDependencies: Set<EmbeddedModule>) {
-        configuration.resolutionStrategy.eachDependency { details ->
-            pinnedDependencies.findWithSameGroupAndNameAs(details.requested)?.let { pinned ->
-                details.useTarget(pinned.notation)
+    fun pinDependenciesOn(
+        dependencies: DependencyHandler,
+        configuration: String,
+        vararg kotlinModules: String
+    ) {
+        kotlinModules.forEach { kotlinModule ->
+            dependencies.constraints.add(configuration, kotlinModuleNotationFor(kotlinModule)) { constraint ->
+                constraint.version {
+                    it.strictly(embeddedKotlinVersion)
+                }
+                constraint.because("Pinned to the embedded Kotlin")
             }
         }
     }
-
-    private
-    val embeddedKotlinRepositoryURI: URI by lazy {
-        embeddedKotlinRepositoryDir().toURI()
-    }
-
-    private
-    fun embeddedKotlinRepositoryDir(): File =
-        cacheFor(repoDirCacheKey()).withInitializer { cache ->
-            copyEmbeddedKotlinModulesTo(cache)
-        }.open().use { cache ->
-            repoDirFrom(cache)
-        }
-
-    private
-    fun cacheFor(cacheKey: String) =
-        cacheRepository.cache(cacheKey)
-
-    private
-    fun copyEmbeddedKotlinModulesTo(cache: PersistentCache) {
-        embeddedModules.forEach { module ->
-            fileFor(module).copyTo(File(repoDirFrom(cache), module.jarRepoPath))
-        }
-    }
-
-    private
-    fun fileFor(module: EmbeddedModule) =
-        moduleRegistry.getExternalModule(module.distributionModuleName).classpath.asFiles.first()
-
-    private
-    fun repoDirCacheKey() =
-        "embedded-kotlin-repo-$embeddedKotlinVersion-$embeddedRepositoryCacheKeyVersion"
-
-    private
-    fun repoDirFrom(cache: PersistentCache) =
-        File(cache.baseDir, "repo")
-
-    private
-    fun clientModuleFor(dependencies: DependencyHandler, embeddedModule: EmbeddedModule): ClientModule =
-        (dependencies.module(embeddedModule.notation) as ClientModule).apply {
-            embeddedModule.dependencies.forEach { dependency ->
-                addDependency(clientModuleFor(dependencies, dependency))
-            }
-        }
-
-    private
-    fun Iterable<EmbeddedModule>.findWithSameGroupAndNameAs(requested: ModuleVersionSelector) =
-        find { it.name == requested.name && it.group == requested.group }
-}
-
-
-internal
-data class EmbeddedModule(
-    val group: String,
-    val name: String,
-    val version: String,
-    val dependencies: List<EmbeddedModule> = emptyList(),
-    val distributionModuleName: String = name
-) {
-
-    val notation = "$group:$name:$version"
-    val jarRepoPath = "${group.replace(".", "/")}/$name/$version/$name-$version.jar"
 }
 
 
 private
-val embeddedModules: List<EmbeddedModule> by lazy {
-
-    fun embeddedKotlin(name: String, dependencies: List<EmbeddedModule> = emptyList(), distributionModuleName: String? = null) =
-        "kotlin-$name".let { moduleName ->
-            EmbeddedModule(
-                "org.jetbrains.kotlin",
-                moduleName,
-                embeddedKotlinVersion,
-                dependencies,
-                distributionModuleName ?: moduleName
-            )
-        }
-
-    // TODO:pm could be generated at build time
-    val annotations = EmbeddedModule("org.jetbrains", "annotations", "13.0")
-    val trove4j = EmbeddedModule("org.jetbrains.intellij.deps", "trove4j", "1.0.20181211")
-    val stdlib = embeddedKotlin("stdlib", listOf(annotations))
-    val stdlibJdk7 = embeddedKotlin("stdlib-jdk7", listOf(stdlib))
-    val stdlibJdk8 = embeddedKotlin("stdlib-jdk8", listOf(stdlibJdk7))
-    val reflect = embeddedKotlin("reflect", listOf(stdlib))
-    val scriptRuntime = embeddedKotlin("script-runtime")
-    val compilerEmbeddable = embeddedKotlin(
-        "compiler-embeddable",
-        listOf(stdlib, reflect, scriptRuntime, trove4j),
-        "kotlin-compiler-embeddable-$embeddedKotlinVersion-patched-for-gradle"
-    )
-    val scriptingCompilerEmbeddable = embeddedKotlin("scripting-compiler-embeddable")
-    val scriptingCompilerImplEmbeddable = embeddedKotlin("scripting-compiler-impl-embeddable")
-    val samWithReceiverCompilerPlugin = embeddedKotlin("sam-with-receiver-compiler-plugin")
-    listOf(
-        annotations, trove4j,
-        stdlib, stdlibJdk7, stdlibJdk8,
-        reflect,
-        compilerEmbeddable,
-        scriptingCompilerEmbeddable,
-        scriptingCompilerImplEmbeddable,
-        scriptRuntime,
-        samWithReceiverCompilerPlugin
-    )
-}
-
-
-internal
-fun transitiveClosureOf(vararg kotlinModules: String) =
-    transitiveClosureOf(embeddedKotlinModulesFor(kotlinModules))
+fun kotlinModuleVersionNotationFor(kotlinModule: String) =
+    "${kotlinModuleNotationFor(kotlinModule)}:$embeddedKotlinVersion"
 
 
 private
-fun transitiveClosureOf(modules: Collection<EmbeddedModule>): Set<EmbeddedModule> =
-    identitySetOf<EmbeddedModule>().apply {
-        val q = ArrayDeque(modules)
-        while (q.isNotEmpty()) {
-            val module = q.removeFirst()
-            if (add(module)) {
-                q.addAll(module.dependencies)
-            }
-        }
-    }
-
-
-private
-fun embeddedKotlinModulesFor(kotlinModules: Array<out String>) =
-    kotlinModules.map { embeddedKotlinModuleFor(it) }
-
-
-private
-fun embeddedKotlinModuleFor(kotlinModule: String) =
-    embeddedModules.first { it.group == "org.jetbrains.kotlin" && it.name == "kotlin-$kotlinModule" }
-
-
-private
-fun <T> identitySetOf(): MutableSet<T> =
-    Collections.newSetFromMap(IdentityHashMap<T, Boolean>())
+fun kotlinModuleNotationFor(kotlinModule: String) =
+    "org.jetbrains.kotlin:kotlin-$kotlinModule"

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -40,11 +40,9 @@ class EmbeddedKotlinProvider {
         configuration: String
     ) {
         embeddedKotlinVersions.forEach { (module, version) ->
-            dependencies.constraints.add(configuration, module) { constraint ->
-                constraint.version {
-                    it.strictly(version)
-                }
-                constraint.because("Pinned to the embedded Kotlin")
+            dependencies.constraints.add(configuration, module).apply {
+                version { it.strictly(version) }
+                because("Pinned to the embedded Kotlin")
             }
         }
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleUserHomeServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleUserHomeServices.kt
@@ -15,14 +15,11 @@
  */
 package org.gradle.kotlin.dsl.support
 
-import org.gradle.api.internal.classpath.ModuleRegistry
-import org.gradle.cache.CacheRepository
-
 
 internal
 object GradleUserHomeServices {
 
     @Suppress("unused")
-    fun createEmbeddedKotlinRepositoryProvider(cacheRepository: CacheRepository, moduleRegistry: ModuleRegistry) =
-        EmbeddedKotlinProvider(cacheRepository, moduleRegistry)
+    fun createEmbeddedKotlinRepositoryProvider() =
+        EmbeddedKotlinProvider()
 }


### PR DESCRIPTION
The embedded repo was created without metadata, this is incorrect and may cause hard to troubleshoot issues. This PR simply removes it, meaning that builds using either the `embedded-kotlin` or the `kotlin-dsl` plugin will now have to resolve `kotlin-stdlib-jdk8`, `kotlin-reflect` and their transitive dependencies from a remote repository. That makes for ~4MB.

Removing that repo which included all the kotin dependencies from the distro was writing ~40MB on first use. This can now be skipped. The extra ~36MB, mostly the embedded kotlin compiler, allowed to avoid downloading it when the `kotlin-jvm` Gradle plugin was applied with the exact same version as embedded. But providing wrong artifact metadata. This PR makes things more correct at the expense of the extra download in some conditions. The extra download could be avoided in the future with https://github.com/gradle/gradle/issues/10744

This PR also changes the way `kotlin-stdlib-jdk8`, `kotlin-reflect` and their transitive dependencies, are pinned to the embedded kotlin version on build scripts classpath, from using a resolution rule to constraints that are more easy to reason with and can explain the reason when facing a conflict.

See https://github.com/gradle/gradle/issues/10745