### PR TITLE
Forbid unnecessary parenthesis in IntelliJ

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -25,6 +25,11 @@
     </inspection_tool>
     <inspection_tool class="SafeVarargsDetector" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryParentheses" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="ignoreClarifyingParentheses" value="true" />
+      <option name="ignoreParenthesesOnConditionals" value="false" />
+      <option name="ignoreParenthesesOnLambdaParameter" value="false" />
+    </inspection_tool>
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="unstableApiAnnotations">
         <set>


### PR DESCRIPTION
This is an error in Checkstyle so we should call it out in IntelliJ as well.
