### PR TITLE
Improve teamcity DSL code for bucket generation

### DIFF
--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -4,6 +4,8 @@ import common.applyDefaultSettings
 import common.gradleWrapper
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2018_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2018_2.Dependencies
 import jetbrains.buildServer.configs.kotlin.v2018_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2018_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2018_2.triggers.ScheduleTrigger
@@ -12,11 +14,11 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2018_2.triggers.vcs
 import model.CIBuildModel
 import model.Stage
-import model.TestType
 import model.Trigger
 import projects.FunctionalTestProject
+import projects.StageProject
 
-class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean) : BaseGradleBuildType(model, init = {
+class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean, stageProject: StageProject) : BaseGradleBuildType(model, init = {
     uuid = stageTriggerUuid(model, stage)
     id = stageTriggerId(model, stage)
     name = stage.stageName.stageName + " (Trigger)"
@@ -98,36 +100,9 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
             }
         }
 
-        stage.specificBuilds.forEach {
-            dependency(it.create(model, stage)) {
-                snapshot {}
-            }
-        }
-
-        stage.performanceTests.forEach { performanceTest ->
-            dependency(AbsoluteId(performanceTest.asId(model))) {
-                snapshot {}
-            }
-        }
-
-        stage.functionalTests.forEach { testCoverage ->
-            val isSplitIntoBuckets = testCoverage.testType != TestType.soak
-            if (isSplitIntoBuckets) {
-                model.buildTypeBuckets.filter { bucket ->
-                    !bucket.shouldBeSkipped(testCoverage) && !bucket.shouldBeSkippedInStage(stage)
-                }.forEach { subProjectBucket ->
-                    if (subProjectBucket.hasTestsOf(testCoverage.testType)) {
-                        subProjectBucket.forTestType(testCoverage.testType).forEach {
-                            dependency(AbsoluteId(testCoverage.asConfigurationId(model, it.name))) { snapshot {} }
-                        }
-                    }
-                }
-            } else {
-                dependency(AbsoluteId(testCoverage.asConfigurationId(model))) {
-                    snapshot {}
-                }
-            }
-        }
+        snapshotDependencies(stageProject.specificBuildTypes)
+        snapshotDependencies(stageProject.performanceTests)
+        snapshotDependencies(stageProject.functionalTests)
 
         if (containsDeferredTests) {
             model.buildTypeBuckets.forEach { bucket ->
@@ -147,3 +122,11 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
 
 fun stageTriggerUuid(model: CIBuildModel, stage: Stage) = "${model.projectPrefix}Stage_${stage.stageName.uuid}_Trigger"
 fun stageTriggerId(model: CIBuildModel, stage: Stage) = AbsoluteId("${model.projectPrefix}Stage_${stage.stageName.id}_Trigger")
+
+fun Dependencies.snapshotDependencies(buildTypes: Iterable<BuildType>) {
+    buildTypes.forEach {
+        dependency(it.id!!) {
+            snapshot {}
+        }
+    }
+}

--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -15,10 +15,9 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.triggers.vcs
 import model.CIBuildModel
 import model.Stage
 import model.Trigger
-import projects.FunctionalTestProject
 import projects.StageProject
 
-class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, containsDeferredTests: Boolean, stageProject: StageProject) : BaseGradleBuildType(model, init = {
+class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stageProject: StageProject) : BaseGradleBuildType(model, init = {
     uuid = stageTriggerUuid(model, stage)
     id = stageTriggerId(model, stage)
     name = stage.stageName.stageName + " (Trigger)"
@@ -103,20 +102,6 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
         snapshotDependencies(stageProject.specificBuildTypes)
         snapshotDependencies(stageProject.performanceTests)
         snapshotDependencies(stageProject.functionalTests)
-
-        if (containsDeferredTests) {
-            model.buildTypeBuckets.forEach { bucket ->
-                if (bucket.containsSlowTests()) {
-                    FunctionalTestProject.missingTestCoverage.filter {
-                        bucket.hasTestsOf(it.testType)
-                    }.forEach { testConfig ->
-                        bucket.forTestType(testConfig.testType).forEach {
-                            dependency(AbsoluteId(testConfig.asConfigurationId(model, it.name))) { snapshot {} }
-                        }
-                    }
-                }
-            }
-        }
     }
 })
 

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -7,35 +7,27 @@ import model.CIBuildModel
 import model.Stage
 import model.TestCoverage
 
-class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage: Stage) : Project({
+class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage: Stage, deferredFunctionalTests: MutableList<FunctionalTest>) : Project({
     this.uuid = testConfig.asId(model)
     this.id = AbsoluteId(uuid)
     this.name = testConfig.asName()
-
 }) {
     val functionalTests = model.buildTypeBuckets.flatMap { bucket ->
         if (bucket.shouldBeSkipped(testConfig) || !bucket.hasTestsOf(testConfig.testType)) {
             return@flatMap emptyList<FunctionalTest>()
         }
+        val functionalTestsForCurrentBucket = bucket.forTestType(testConfig.testType).map {
+            buildTypeBucket -> FunctionalTest(model, testConfig, buildTypeBucket.getSubprojectNames(), stage, buildTypeBucket.name, buildTypeBucket.extraParameters())
+        }
         if (bucket.shouldBeSkippedInStage(stage)) {
-            addMissingTestCoverage(testConfig)
+            deferredFunctionalTests.addAll(functionalTestsForCurrentBucket)
             return@flatMap emptyList<FunctionalTest>()
         }
 
-        bucket.forTestType(testConfig.testType).map {
-            buildTypeBucket -> FunctionalTest(model, testConfig, buildTypeBucket.getSubprojectNames(), stage, buildTypeBucket.name, buildTypeBucket.extraParameters())
-        }
+        functionalTestsForCurrentBucket
     }
 
     init {
         functionalTests.forEach(this::buildType)
-    }
-
-    companion object {
-        val missingTestCoverage = mutableSetOf<TestCoverage>()
-
-        private fun addMissingTestCoverage(coverage: TestCoverage) {
-            this.missingTestCoverage.add(coverage)
-        }
     }
 }

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -3,31 +3,30 @@ package projects
 import configurations.FunctionalTest
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2018_2.Project
+import model.BuildTypeBucket
 import model.CIBuildModel
 import model.Stage
 import model.TestCoverage
 
-class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage: Stage, deferredFunctionalTests: MutableList<FunctionalTest>) : Project({
+class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage: Stage, deferredFunctionalTests: MutableList<(Stage) -> List<FunctionalTest>>) : Project({
     this.uuid = testConfig.asId(model)
     this.id = AbsoluteId(uuid)
     this.name = testConfig.asName()
 }) {
-    val functionalTests = model.buildTypeBuckets.flatMap { bucket ->
-        if (bucket.shouldBeSkipped(testConfig) || !bucket.hasTestsOf(testConfig.testType)) {
-            return@flatMap emptyList<FunctionalTest>()
-        }
-        val functionalTestsForCurrentBucket = bucket.forTestType(testConfig.testType).map {
-            buildTypeBucket -> FunctionalTest(model, testConfig, buildTypeBucket.getSubprojectNames(), stage, buildTypeBucket.name, buildTypeBucket.extraParameters())
-        }
-        if (bucket.shouldBeSkippedInStage(stage)) {
-            deferredFunctionalTests.addAll(functionalTestsForCurrentBucket)
-            return@flatMap emptyList<FunctionalTest>()
-        }
-
-        functionalTestsForCurrentBucket
-    }
+    val functionalTests: List<FunctionalTest>
 
     init {
+        fun createFunctionalTests(stage: Stage, bucket: BuildTypeBucket) = bucket.forTestType(testConfig.testType).map {
+            buildTypeBucket -> FunctionalTest(model, testConfig, buildTypeBucket.getSubprojectNames(), stage, buildTypeBucket.name, buildTypeBucket.extraParameters())
+        }
+
+        val (deferredTests, currentTests) = model.buildTypeBuckets
+            .filter { !it.shouldBeSkipped(testConfig) && it.hasTestsOf(testConfig.testType) }
+            .partition { it.shouldBeSkippedInStage(stage) }
+        functionalTests = currentTests.flatMap { createFunctionalTests(stage, it) }
+        deferredFunctionalTests.addAll(deferredTests.map { bucket ->
+            { stage: Stage -> createFunctionalTests(stage, bucket) }
+        })
         functionalTests.forEach(this::buildType)
     }
 }

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -1,5 +1,6 @@
 package projects
 
+import configurations.FunctionalTest
 import configurations.StagePasses
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2018_2.Project
@@ -27,13 +28,10 @@ class RootProject(model: CIBuildModel) : Project({
     }
 
     var prevStage: Stage? = null
-    var deferredAlreadyDeclared = false
-    FunctionalTestProject.missingTestCoverage.clear()
+    val deferredFunctionalTests = mutableListOf<FunctionalTest>()
     model.stages.forEach { stage ->
-        val containsDeferredTests = !stage.omitsSlowProjects && !deferredAlreadyDeclared
-        deferredAlreadyDeclared = deferredAlreadyDeclared || containsDeferredTests
-        val stageProject = StageProject(model, stage, containsDeferredTests, uuid)
-        val stagePasses = StagePasses(model, stage, prevStage, containsDeferredTests, stageProject)
+        val stageProject = StageProject(model, stage, uuid, deferredFunctionalTests)
+        val stagePasses = StagePasses(model, stage, prevStage, stageProject)
         buildType(stagePasses)
         subProject(stageProject)
         prevStage = stage

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -32,8 +32,10 @@ class RootProject(model: CIBuildModel) : Project({
     model.stages.forEach { stage ->
         val containsDeferredTests = !stage.omitsSlowProjects && !deferredAlreadyDeclared
         deferredAlreadyDeclared = deferredAlreadyDeclared || containsDeferredTests
-        buildType(StagePasses(model, stage, prevStage, containsDeferredTests))
-        subProject(StageProject(model, stage, containsDeferredTests, uuid))
+        val stageProject = StageProject(model, stage, containsDeferredTests, uuid)
+        val stagePasses = StagePasses(model, stage, prevStage, containsDeferredTests, stageProject)
+        buildType(stagePasses)
+        subProject(stageProject)
         prevStage = stage
     }
 

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -28,7 +28,7 @@ class RootProject(model: CIBuildModel) : Project({
     }
 
     var prevStage: Stage? = null
-    val deferredFunctionalTests = mutableListOf<FunctionalTest>()
+    val deferredFunctionalTests = mutableListOf<(Stage) -> List<FunctionalTest>>()
     model.stages.forEach { stage ->
         val stageProject = StageProject(model, stage, uuid, deferredFunctionalTests)
         val stagePasses = StagePasses(model, stage, prevStage, stageProject)

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -5,6 +5,7 @@ import configurations.PerformanceTestCoordinator
 import configurations.SanityCheck
 import configurations.buildReportTab
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2018_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2018_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2018_2.IdOwner
 import jetbrains.buildServer.configs.kotlin.v2018_2.Project
@@ -19,69 +20,84 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
     this.id = AbsoluteId("${model.projectPrefix}Stage_${stage.stageName.id}")
     this.name = stage.stageName.stageName
     this.description = stage.stageName.description
+}) {
+    val specificBuildTypes: List<BuildType>
 
-    features {
-        if (stage.specificBuilds.contains(SpecificBuild.SanityCheck)) {
-            buildReportTab("API Compatibility Report", "report-distributions-binary-compatibility-report.html")
-            buildReportTab("Incubating APIs Report", "incubation-reports/all-incubating.html")
+    val performanceTests: List<PerformanceTestCoordinator>
+
+    val functionalTests: List<FunctionalTest>
+
+    init {
+        features {
+            if (stage.specificBuilds.contains(SpecificBuild.SanityCheck)) {
+                buildReportTab("API Compatibility Report", "report-distributions-binary-compatibility-report.html")
+                buildReportTab("Incubating APIs Report", "incubation-reports/all-incubating.html")
+            }
+            if (!stage.performanceTests.isEmpty()) {
+                buildReportTab("Performance", "report-performance-performance-tests.zip!report/index.html")
+            }
         }
-        if (!stage.performanceTests.isEmpty()) {
-            buildReportTab("Performance", "report-performance-performance-tests.zip!report/index.html")
+
+        specificBuildTypes = stage.specificBuilds.map {
+            it.create(model, stage)
         }
-    }
+        specificBuildTypes.forEach { buildType(it) }
 
-    val specificBuildTypes = stage.specificBuilds.map {
-        it.create(model, stage)
-    }
-    specificBuildTypes.forEach { buildType(it) }
+        performanceTests = stage.performanceTests.map { PerformanceTestCoordinator(model, it, stage) }
+        performanceTests.forEach(this::buildType)
 
-    stage.performanceTests.forEach {
-        buildType(PerformanceTestCoordinator(model, it, stage))
-    }
+        val topLevelFunctionalTests = stage.functionalTests
+            .filter { it.testType == TestType.soak }
+            .map { FunctionalTest(model, it, stage = stage) }
+        topLevelFunctionalTests.forEach(this::buildType)
 
-    stage.functionalTests.forEach { testCoverage ->
-        val isSoakTest = testCoverage.testType == TestType.soak
-        if (isSoakTest) {
-            buildType(FunctionalTest(model, testCoverage, stage = stage))
-        } else {
-            val functionalTests = FunctionalTestProject(model, testCoverage, stage)
-            subProject(functionalTests)
-            if (stage.functionalTestsDependOnSpecificBuilds) {
-                specificBuildTypes.forEach { specificBuildType ->
-                    functionalTests.addDependencyForAllBuildTypes(specificBuildType)
+        val functionalTestProjects = stage.functionalTests
+            .filter { it.testType != TestType.soak }
+            .map { testCoverage ->
+                val functionalTestProject = FunctionalTestProject(model, testCoverage, stage)
+                if (stage.functionalTestsDependOnSpecificBuilds) {
+                    specificBuildTypes.forEach { specificBuildType ->
+                        functionalTestProject.addDependencyForAllBuildTypes(specificBuildType)
+                    }
                 }
+                if (!(stage.functionalTestsDependOnSpecificBuilds && stage.specificBuilds.contains(SpecificBuild.SanityCheck)) && stage.dependsOnSanityCheck) {
+                    functionalTestProject.addDependencyForAllBuildTypes(AbsoluteId(SanityCheck.buildTypeId(model)))
+                }
+                functionalTestProject
             }
-            if (!(stage.functionalTestsDependOnSpecificBuilds && stage.specificBuilds.contains(SpecificBuild.SanityCheck)) && stage.dependsOnSanityCheck) {
-                functionalTests.addDependencyForAllBuildTypes(AbsoluteId(SanityCheck.buildTypeId(model)))
-            }
-        }
-    }
 
-    if (containsDeferredTests) {
-        val deferredTestsProject = Project {
-            uuid = "${rootProjectUuid}_deferred_tests"
-            id = AbsoluteId(uuid)
-            name = "Test coverage deferred from Quick Feedback and Ready for Merge"
-            model.buildTypeBuckets
-                .filter(BuildTypeBucket::containsSlowTests)
-                .forEach { bucket ->
-                    FunctionalTestProject.missingTestCoverage
-                        .filter { testConfig ->
-                            bucket.hasTestsOf(testConfig.testType)
-                        }
-                        .forEach { testConfig ->
-                            bucket.forTestType(testConfig.testType).forEach {
-                                buildType(FunctionalTest(model, testConfig, it.getSubprojectNames(), stage, it.name))
+        functionalTestProjects.forEach {
+            subProject(it)
+        }
+
+        functionalTests = topLevelFunctionalTests + functionalTestProjects.flatMap(FunctionalTestProject::functionalTests)
+
+        if (containsDeferredTests) {
+            val deferredTestsProject = Project {
+                uuid = "${rootProjectUuid}_deferred_tests"
+                id = AbsoluteId(uuid)
+                name = "Test coverage deferred from Quick Feedback and Ready for Merge"
+                model.buildTypeBuckets
+                    .filter(BuildTypeBucket::containsSlowTests)
+                    .forEach { bucket ->
+                        FunctionalTestProject.missingTestCoverage
+                            .filter { testConfig ->
+                                bucket.hasTestsOf(testConfig.testType)
                             }
-                        }
-                }
+                            .forEach { testConfig ->
+                                bucket.forTestType(testConfig.testType).forEach {
+                                    buildType(FunctionalTest(model, testConfig, it.getSubprojectNames(), stage, it.name))
+                                }
+                            }
+                    }
+            }
+            subProject(deferredTestsProject)
         }
-        subProject(deferredTestsProject)
     }
-})
+}
 
-private fun Project.addDependencyForAllBuildTypes(dependency: IdOwner) {
-    buildTypes.forEach { functionalTestBuildType ->
+private fun FunctionalTestProject.addDependencyForAllBuildTypes(dependency: IdOwner) {
+    functionalTests.forEach { functionalTestBuildType ->
         functionalTestBuildType.dependencies {
             dependency(dependency) {
                 snapshot {

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -32,7 +32,7 @@ class StageProject(model: CIBuildModel, stage: Stage, rootProjectUuid: String, d
                 buildReportTab("API Compatibility Report", "report-distributions-binary-compatibility-report.html")
                 buildReportTab("Incubating APIs Report", "incubation-reports/all-incubating.html")
             }
-            if (!stage.performanceTests.isEmpty()) {
+            if (stage.performanceTests.isNotEmpty()) {
                 buildReportTab("Performance", "report-performance-performance-tests.zip!report/index.html")
             }
         }
@@ -40,7 +40,7 @@ class StageProject(model: CIBuildModel, stage: Stage, rootProjectUuid: String, d
         specificBuildTypes = stage.specificBuilds.map {
             it.create(model, stage)
         }
-        specificBuildTypes.forEach { buildType(it) }
+        specificBuildTypes.forEach(this::buildType)
 
         performanceTests = stage.performanceTests.map { PerformanceTestCoordinator(model, it, stage) }
         performanceTests.forEach(this::buildType)
@@ -65,9 +65,7 @@ class StageProject(model: CIBuildModel, stage: Stage, rootProjectUuid: String, d
                 functionalTestProject
             }
 
-        functionalTestProjects.forEach {
-            subProject(it)
-        }
+        functionalTestProjects.forEach(this::subProject)
 
         val deferredTestsForThisStage = if (stage.omitsSlowProjects) emptyList() else deferredFunctionalTests.toList()
         if (deferredTestsForThisStage.isNotEmpty()) {


### PR DESCRIPTION
After these changes, the functional tests from the buckets are only created in one place - no need to repeat the same code over and over again. The handling of the deferred test coverage has also been simplified.

This makes it possible to simplify the code even further in the future.