### PR TITLE
Hide task shared resources from the public api for now

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -750,32 +750,4 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     @Optional
     @Incubating
     Property<Duration> getTimeout();
-
-    /**
-     * <p>Adds the given shared resource as a requirement of this task.</p>
-     *
-     * <p>Requests a single lease for the given shared resource. If the given resource has already been added as a requirement to this task calling this method has no effect.</p>
-     *
-     * @param name The name of the shared resource.
-     * @see org.gradle.api.execution.SharedResource
-     *
-     * @since 6.0
-     */
-    @Incubating
-    void requiresResource(String name);
-
-    /**
-     * <p>Adds the given shared resource as a requirement of this task.</p>
-     *
-     * <p>Requests the given number of leases for the shared resource. If the given resource has already been added as a requirement, calling this method will override the requested
-     * number of leases.</p>
-     *
-     * @param name The name of the shared resource.
-     * @param leases The number of required leases.
-     * @see org.gradle.api.execution.SharedResource
-     *
-     * @since 6.0
-     */
-    @Incubating
-    void requiresResource(String name, int leases);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/SharedResource.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/SharedResource.java
@@ -29,7 +29,6 @@ import org.gradle.api.Task;
  * exclusive resource, effectively limiting concurrency of any tasks that use that resource such that only a single one can be
  * executed at any given time.
  *
- * @see Task#requiresResource(String)
  * @since 6.0
  */
 @Incubating

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -24,7 +24,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.UnknownDomainObjectException;
-import org.gradle.api.execution.SharedResourceContainer;
 import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.initialization.Settings;
@@ -378,30 +377,4 @@ public interface Gradle extends PluginAware {
      * @since 3.1
      */
     IncludedBuild includedBuild(String name) throws UnknownDomainObjectException;
-
-    /**
-     * Returns the shared resources registered to this build.
-     *
-     * @return the collection of shared resources.
-     * @since 6.0
-     */
-    @Incubating
-    SharedResourceContainer getSharedResources();
-
-    /**
-     * Configures the shared resources for this build.
-     *
-     * An example of registering a shared resource.
-     * <pre class='autoTested'>
-     * gradle.sharedResources {
-     *     testCluster {
-     *         leases = 4
-     *     }
-     * }
-     * </pre>
-     * @param action The action to execute.
-     * @since 6.0
-     */
-    @Incubating
-    void sharedResources(Action<? super SharedResourceContainer> action);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -942,7 +942,6 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         return timeout;
     }
 
-    @Override
     public void requiresResource(String name) {
         taskMutator.mutate("Task.requiresResource(String)", new Runnable() {
             @Override
@@ -952,7 +951,6 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         });
     }
 
-    @Override
     public void requiresResource(String name, int leases) {
         taskMutator.mutate("Task.requiresResource(String, int)", new Runnable() {
             @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -45,6 +45,7 @@ import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.ResourceLockState;
 import org.gradle.internal.resources.SharedResourceLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseRegistry;
+import org.gradle.invocation.DefaultGradle;
 import org.gradle.util.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,7 +102,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         this.taskNodeFactory = taskNodeFactory;
         this.dependencyResolver = dependencyResolver;
         this.sharedResourceLeaseRegistry = sharedResourceLeaseRegistry;
-        this.sharedResourceContainer = gradle.getSharedResources();
+        this.sharedResourceContainer = ((DefaultGradle)gradle).getSharedResources();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -546,12 +546,10 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
         this.buildType = buildType;
     }
 
-    @Override
     public SharedResourceContainer getSharedResources() {
         return sharedResourceContainer;
     }
 
-    @Override
     public void sharedResources(Action<? super SharedResourceContainer> action) {
         action.execute(sharedResourceContainer);
     }


### PR DESCRIPTION
Hide task shared resources for now until we can make further improvements to the API.