### PR TITLE
Add reified extensions for ComponentMetadataHandler

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -115,6 +115,36 @@
             "changes": [
                 "org.gradle.api.artifacts.repositories.UrlArtifactRepository"
             ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt",
+            "member": "Class org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt",
+            "acceptation": "Reified versions of methods that are already de-incubated",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt.all(org.gradle.api.artifacts.dsl.ComponentMetadataHandler)",
+            "acceptation": "Reified versions of methods that are already de-incubated",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt.all(org.gradle.api.artifacts.dsl.ComponentMetadataHandler,org.gradle.api.Action)",
+            "acceptation": "Reified versions of methods that are already de-incubated",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt.withModule(org.gradle.api.artifacts.dsl.ComponentMetadataHandler,java.lang.Object)",
+            "acceptation": "Reified versions of methods that are already de-incubated",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt.withModule(org.gradle.api.artifacts.dsl.ComponentMetadataHandler,java.lang.Object,org.gradle.api.Action)",
+            "acceptation": "Reified versions of methods that are already de-incubated",
+            "changes": []
         }
     ]
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ComponentMetadataHandlerExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ComponentMetadataHandlerExtensions.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.Action
+import org.gradle.api.ActionConfiguration
+import org.gradle.api.artifacts.ComponentMetadataRule
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
+
+
+/**
+ * Adds a class based rule that may modify the metadata of any resolved software component.
+ *
+ * @param T the rule to be added
+ * @return this
+ *
+ * @see [ComponentMetadataHandler.all]
+ */
+inline fun <reified T : ComponentMetadataRule> ComponentMetadataHandler.all(): ComponentMetadataHandler =
+    all(T::class.java)
+
+
+/**
+ * Adds a class based rule that may modify the metadata of any resolved software component.
+ * The rule itself is configured by the provided configure action.
+ *
+ * @param T the rule to be added
+ * @param configureAction the rule configuration
+ * @return this
+ *
+ * @see [ComponentMetadataHandler.all]
+ */
+inline fun <reified T : ComponentMetadataRule> ComponentMetadataHandler.all(configureAction: Action<in ActionConfiguration>): ComponentMetadataHandler =
+    all(T::class.java, configureAction)
+
+
+/**
+ * Adds a class based rule that may modify the metadata of any resolved software component belonging to the specified module.
+ *
+ * @param T the rule to be added
+ * @param id the module to apply this rule to in "group:module" format or as a [org.gradle.api.artifacts.ModuleIdentifier]
+ * @return this
+ *
+ * @see [ComponentMetadataHandler.withModule]
+ */
+inline fun <reified T : ComponentMetadataRule> ComponentMetadataHandler.withModule(id: Any): ComponentMetadataHandler =
+    withModule(id, T::class.java)
+
+
+/**
+ * Adds a class based rule that may modify the metadata of any resolved software component belonging to the specified module.
+ *
+ * @param T the rule to be added
+ * @param id the module to apply this rule to in "group:module" format or as a [org.gradle.api.artifacts.ModuleIdentifier]
+ * @return this
+ *
+ * @see [ComponentMetadataHandler.withModule]
+ */
+inline fun <reified T : ComponentMetadataRule> ComponentMetadataHandler.withModule(id: Any, configureAction: Action<in ActionConfiguration>): ComponentMetadataHandler =
+    withModule(id, T::class.java, configureAction)

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ComponentMetadataHandlerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ComponentMetadataHandlerExtensionsTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.inOrder
+import com.nhaarman.mockito_kotlin.mock
+import org.gradle.api.Action
+import org.gradle.api.ActionConfiguration
+import org.gradle.api.artifacts.ComponentMetadataContext
+import org.gradle.api.artifacts.ComponentMetadataRule
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
+
+import org.junit.Test
+
+
+class ComponentMetadataHandlerExtensionsTest {
+
+    @Test
+    fun all() {
+        val componentMetadataHandler = mock<ComponentMetadataHandler> {
+            on { all(any<Class<ComponentMetadataRule>>()) } doReturn mock<ComponentMetadataHandler>()
+        }
+        componentMetadataHandler.all<SomeRule>()
+        inOrder(componentMetadataHandler) {
+            verify(componentMetadataHandler).all(SomeRule::class.java)
+            verifyNoMoreInteractions()
+        }
+    }
+
+    @Test
+    fun allWithParams() {
+        val configAction = Config()
+        val componentMetadataHandler = mock<ComponentMetadataHandler> {
+            on { all(any<Class<ComponentMetadataRule>>(), any<Action<in ActionConfiguration>>()) } doReturn mock<ComponentMetadataHandler>()
+        }
+        componentMetadataHandler.all<SomeRule>(configAction)
+        inOrder(componentMetadataHandler) {
+            verify(componentMetadataHandler).all(SomeRule::class.java, configAction)
+            verifyNoMoreInteractions()
+        }
+    }
+
+    @Test
+    fun withModule() {
+        val componentMetadataHandler = mock<ComponentMetadataHandler> {
+            on { withModule(eq("org:foo"), any<Class<ComponentMetadataRule>>()) } doReturn mock<ComponentMetadataHandler>()
+        }
+        componentMetadataHandler.withModule<SomeRule>("org:foo")
+        inOrder(componentMetadataHandler) {
+            verify(componentMetadataHandler).withModule("org:foo", SomeRule::class.java)
+            verifyNoMoreInteractions()
+        }
+    }
+
+    @Test
+    fun withModuleWithParams() {
+        val configAction = Config()
+        val componentMetadataHandler = mock<ComponentMetadataHandler> {
+            on { withModule(eq("org:foo"), any<Class<ComponentMetadataRule>>(), any<Action<in ActionConfiguration>>()) } doReturn mock<ComponentMetadataHandler>()
+        }
+        componentMetadataHandler.withModule<SomeRule>("org:foo", configAction)
+        inOrder(componentMetadataHandler) {
+            verify(componentMetadataHandler).withModule("org:foo", SomeRule::class.java, configAction)
+            verifyNoMoreInteractions()
+        }
+    }
+}
+
+
+class SomeRule : ComponentMetadataRule {
+    override fun execute(context: ComponentMetadataContext) { }
+}
+
+
+class Config : Action<ActionConfiguration> {
+    override fun execute(config: ActionConfiguration) {
+        config.params("p1", "p2")
+    }
+}


### PR DESCRIPTION
Once we have this, the examples in #10735 will be adjusted and with that automatically add some integration test coverage.