### PR TITLE
Remove `Gradle`, `Settings` and `Project` interfaces from Kotlin DSL script type hierarchies

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -115,6 +115,23 @@
             "changes": [
                 "org.gradle.api.artifacts.repositories.UrlArtifactRepository"
             ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.InitScriptApi",
+            "member": "Class org.gradle.kotlin.dsl.InitScriptApi",
+            "acceptation": "Gradle interface removed from script type hierarchy",
+            "changes": [
+                "Abstract method has been added in implemented interface"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.KotlinInitScript",
+            "member": "Class org.gradle.kotlin.dsl.KotlinInitScript",
+            "acceptation": "Gradle interface removed from script type hierarchy",
+            "changes": [
+                "Abstract method has been added in implemented interface"
+            ]
         }
     ]
+
 }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -25,6 +25,8 @@ import org.gradle.kotlin.dsl.fixtures.DeepThought
 import org.gradle.kotlin.dsl.fixtures.LightThought
 import org.gradle.kotlin.dsl.fixtures.ZeroThought
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.kotlin.dsl.support.delegates.ProjectDelegate
+import org.gradle.kotlin.dsl.support.delegates.SettingsDelegate
 import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.LeaksFileHandles
@@ -416,11 +418,13 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
     }
 
     @Test
-    fun `script plugin can by applied to either Project or Settings`() {
+    fun `script plugin can be applied to either Project or Settings`() {
 
+        // TODO:kotlin-dsl consider introducing a common `scriptTarget` property and change test script to something like `scriptTarget is Settings`
         withFile("common.gradle.kts", """
-            println("Target is Settings? ${"$"}{Settings::class.java.isAssignableFrom(this::class.java)}")
-            println("Target is Project? ${"$"}{Project::class.java.isAssignableFrom(this::class.java)}")
+            val thisType = this::class.java
+            println("Target is Settings? ${"$"}{${SettingsDelegate::class.qualifiedName}::class.java.isAssignableFrom(thisType)}")
+            println("Target is Project? ${"$"}{${ProjectDelegate::class.qualifiedName}::class.java.isAssignableFrom(thisType)}")
         """)
 
         withSettings("""

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/KotlinScriptDependenciesResolverTest.kt
@@ -20,6 +20,7 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.kotlin.dsl.support.delegates.ProjectDelegate
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItems
@@ -74,7 +75,7 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
     fun `succeeds on init script`() {
 
         assertSucceeds(withFile("my.init.gradle.kts", """
-            require(this is Gradle)
+            require(this is InitScriptApi)
         """))
     }
 
@@ -82,13 +83,13 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
     fun `succeeds on settings script`() {
 
         assertSucceeds(withSettings("""
-            require(this is Settings)
+            require(this is SettingsScriptApi)
         """))
 
         recorder.clear()
 
         assertSucceeds(withFile("my.settings.gradle.kts", """
-            require(this is Settings)
+            require(this is SettingsScriptApi)
         """))
     }
 
@@ -96,13 +97,13 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
     fun `succeeds on project script`() {
 
         assertSucceeds(withFile("build.gradle.kts", """
-            require(this is Project)
+            require(this is ${projectScriptApi()})
         """))
 
         recorder.clear()
 
         assertSucceeds(withFile("plugin.gradle.kts", """
-            require(this is Project)
+            require(this is ${projectScriptApi()})
         """))
     }
 
@@ -112,7 +113,7 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
         withKotlinBuildSrc()
 
         assertSucceeds(withFile("buildSrc/src/main/kotlin/my-plugin.init.gradle.kts", """
-            require(this is Gradle)
+            require(this is InitScriptApi)
         """))
     }
 
@@ -126,7 +127,7 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
         """)
 
         assertSucceeds(withFile("buildSrc/src/main/kotlin/my-plugin.settings.gradle.kts", """
-            require(this is Settings)
+            require(this is SettingsScriptApi)
         """))
     }
 
@@ -142,7 +143,7 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
         """)
 
         assertSucceeds(withFile("buildSrc/src/main/kotlin/my-plugin.gradle.kts", """
-            require(this is Project)
+            require(this is ${projectScriptApi()})
         """))
     }
 
@@ -342,6 +343,9 @@ class KotlinScriptDependenciesResolverTest : AbstractKotlinIntegrationTest() {
             assertSingleFileWarningReport(EditorMessages.buildConfigurationFailed)
         }
     }
+
+    private
+    fun projectScriptApi() = ProjectDelegate::class.qualifiedName
 
     private
     val recorder = ResolverTestRecorder()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -76,8 +76,8 @@ abstract class KotlinSettingsScript(
     /**
      * The [ScriptHandler] for this script.
      */
-    override fun getBuildscript(): ScriptHandler =
-        host.scriptHandler
+    override val buildscript: ScriptHandler
+        get() = host.scriptHandler
 
     override val fileOperations
         get() = host.fileOperations

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -29,6 +29,7 @@ import org.gradle.api.initialization.IncludedBuild
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.plugins.ObjectConfigurationAction
+import org.gradle.api.plugins.PluginAware
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.plugins.PluginManager
 
@@ -45,119 +46,132 @@ import java.io.File
  * Once the required interfaces are compiled with Java 8 parameter names these classes can be removed in favor
  * of Kotlin's implementation by delegation.
  */
-abstract class GradleDelegate : Gradle {
+// TODO:kotlin-dsl merge with `InitScriptApi`
+abstract class GradleDelegate : PluginAware {
 
     internal
     abstract val delegate: Gradle
 
-    override fun getGradleVersion(): String =
-        delegate.gradleVersion
+    val gradleVersion: String
+        get() = delegate.gradleVersion
 
-    override fun getGradleUserHomeDir(): File =
-        delegate.gradleUserHomeDir
+    val gradleUserHomeDir: File
+        get() = delegate.gradleUserHomeDir
 
-    override fun getGradleHomeDir(): File? =
-        delegate.gradleHomeDir
+    val gradleHomeDir: File?
+        get() = delegate.gradleHomeDir
 
-    override fun getParent(): Gradle? =
+    // TODO:kotlin-dsl remove
+    fun getParent(): Gradle? =
         delegate.parent
 
-    override fun getRootProject(): Project =
-        delegate.rootProject
+    val rootProject: Project
+        get() = delegate.rootProject
 
-    override fun rootProject(action: Action<in Project>) =
+    fun rootProject(action: Action<in Project>) =
         delegate.rootProject(action)
 
-    override fun allprojects(action: Action<in Project>) =
+    fun allprojects(action: Action<in Project>) =
         delegate.allprojects(action)
 
-    override fun getTaskGraph(): TaskExecutionGraph =
-        delegate.taskGraph
+    val taskGraph: TaskExecutionGraph
+        get() = delegate.taskGraph
 
-    override fun getStartParameter(): StartParameter =
-        delegate.startParameter
+    val startParameter: StartParameter
+        get() = delegate.startParameter
 
-    override fun addProjectEvaluationListener(listener: ProjectEvaluationListener): ProjectEvaluationListener =
+    fun addProjectEvaluationListener(listener: ProjectEvaluationListener): ProjectEvaluationListener =
         delegate.addProjectEvaluationListener(listener)
 
-    override fun removeProjectEvaluationListener(listener: ProjectEvaluationListener) =
+    fun removeProjectEvaluationListener(listener: ProjectEvaluationListener) =
         delegate.removeProjectEvaluationListener(listener)
 
-    override fun beforeProject(closure: Closure<Any>) =
+    // TODO:kotlin-dsl remove
+    fun beforeProject(closure: Closure<Any>) =
         delegate.beforeProject(closure)
 
-    override fun beforeProject(action: Action<in Project>) =
+    fun beforeProject(action: Action<in Project>) =
         delegate.beforeProject(action)
 
-    override fun afterProject(closure: Closure<Any>) =
+    // TODO:kotlin-dsl remove
+    fun afterProject(closure: Closure<Any>) =
         delegate.afterProject(closure)
 
-    override fun afterProject(action: Action<in Project>) =
+    fun afterProject(action: Action<in Project>) =
         delegate.afterProject(action)
 
-    override fun buildStarted(closure: Closure<Any>) =
+    // TODO:kotlin-dsl remove
+    fun buildStarted(closure: Closure<Any>) =
         delegate.buildStarted(closure)
 
-    override fun buildStarted(action: Action<in Gradle>) =
+    fun buildStarted(action: Action<in Gradle>) =
         delegate.buildStarted(action)
 
-    override fun settingsEvaluated(closure: Closure<Any>) =
+    // TODO:kotlin-dsl remove
+    fun settingsEvaluated(closure: Closure<Any>) =
         delegate.settingsEvaluated(closure)
 
-    override fun settingsEvaluated(action: Action<in Settings>) =
+    fun settingsEvaluated(action: Action<in Settings>) =
         delegate.settingsEvaluated(action)
 
-    override fun projectsLoaded(closure: Closure<Any>) =
+    // TODO:kotlin-dsl remove
+    fun projectsLoaded(closure: Closure<Any>) =
         delegate.projectsLoaded(closure)
 
-    override fun projectsLoaded(action: Action<in Gradle>) =
+    fun projectsLoaded(action: Action<in Gradle>) =
         delegate.projectsLoaded(action)
 
-    override fun projectsEvaluated(closure: Closure<Any>) =
+    // TODO:kotlin-dsl remove
+    fun projectsEvaluated(closure: Closure<Any>) =
         delegate.projectsEvaluated(closure)
 
-    override fun projectsEvaluated(action: Action<in Gradle>) =
+    fun projectsEvaluated(action: Action<in Gradle>) =
         delegate.projectsEvaluated(action)
 
-    override fun buildFinished(closure: Closure<Any>) =
+    // TODO:kotlin-dsl remove
+    fun buildFinished(closure: Closure<Any>) =
         delegate.buildFinished(closure)
 
-    override fun buildFinished(action: Action<in BuildResult>) =
+    fun buildFinished(action: Action<in BuildResult>) =
         delegate.buildFinished(action)
 
-    override fun addBuildListener(buildListener: BuildListener) =
+    fun addBuildListener(buildListener: BuildListener) =
         delegate.addBuildListener(buildListener)
 
-    override fun addListener(listener: Any) =
+    fun addListener(listener: Any) =
         delegate.addListener(listener)
 
-    override fun removeListener(listener: Any) =
+    fun removeListener(listener: Any) =
         delegate.removeListener(listener)
 
-    override fun useLogger(logger: Any) =
+    fun useLogger(logger: Any) =
         delegate.useLogger(logger)
 
-    override fun getGradle(): Gradle =
-        delegate.gradle
+    val gradle: Gradle
+        get() = delegate.gradle
 
-    override fun getIncludedBuilds(): MutableCollection<IncludedBuild> =
-        delegate.includedBuilds
+    val includedBuilds: MutableCollection<IncludedBuild>
+        get() = delegate.includedBuilds
 
-    override fun includedBuild(name: String): IncludedBuild =
+    fun includedBuild(name: String): IncludedBuild =
         delegate.includedBuild(name)
 
+    // TODO:kotlin-dsl remove
     override fun getPlugins(): PluginContainer =
         delegate.plugins
 
+    // TODO:kotlin-dsl remove
     override fun apply(closure: Closure<Any>) =
         delegate.apply(closure)
 
     override fun apply(action: Action<in ObjectConfigurationAction>) =
         delegate.apply(action)
 
+    // TODO:kotlin-dsl remove
     override fun apply(options: Map<String, *>) =
         delegate.apply(options)
 
+    // TODO:kotlin-dsl remove
     override fun getPluginManager(): PluginManager =
         delegate.pluginManager
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/SettingsDelegate.kt
@@ -25,8 +25,10 @@ import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.initialization.Settings
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ObjectConfigurationAction
+import org.gradle.api.plugins.PluginAware
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.plugins.PluginManager
 import org.gradle.caching.configuration.BuildCacheConfiguration
@@ -41,92 +43,95 @@ import java.io.File
  *
  * See [GradleDelegate] for why this is currently necessary.
  */
-abstract class SettingsDelegate : Settings {
+// TODO:kotlin-dsl merge with SettingsScriptApi
+abstract class SettingsDelegate : PluginAware, ExtensionAware {
 
     internal
     abstract val delegate: Settings
 
-    override fun getSettings(): Settings =
-        delegate.settings
+    val settings: Settings
+        get() = delegate.settings
 
-    override fun getBuildscript(): ScriptHandler =
-        delegate.buildscript
+    open val buildscript: ScriptHandler
+        get() = delegate.buildscript
 
-    override fun getSettingsDir(): File =
-        delegate.settingsDir
+    val settingsDir: File
+        get() = delegate.settingsDir
 
-    override fun getRootDir(): File =
-        delegate.rootDir
+    val rootDir: File
+        get() = delegate.rootDir
 
-    override fun getRootProject(): ProjectDescriptor =
-        delegate.rootProject
+    val rootProject: ProjectDescriptor
+        get() = delegate.rootProject
 
-    override fun project(path: String): ProjectDescriptor =
+    fun project(path: String): ProjectDescriptor =
         delegate.project(path)
 
-    override fun findProject(path: String): ProjectDescriptor? =
+    fun findProject(path: String): ProjectDescriptor? =
         delegate.findProject(path)
 
-    override fun project(projectDir: File): ProjectDescriptor =
+    fun project(projectDir: File): ProjectDescriptor =
         delegate.project(projectDir)
 
-    override fun findProject(projectDir: File): ProjectDescriptor? =
+    fun findProject(projectDir: File): ProjectDescriptor? =
         delegate.findProject(projectDir)
 
-    override fun getGradle(): Gradle =
-        delegate.gradle
+    val gradle: Gradle
+        get() = delegate.gradle
 
-    override fun includeBuild(rootProject: Any) =
+    fun includeBuild(rootProject: Any) =
         delegate.includeBuild(rootProject)
 
-    override fun includeBuild(rootProject: Any, configuration: Action<ConfigurableIncludedBuild>) =
+    fun includeBuild(rootProject: Any, configuration: Action<ConfigurableIncludedBuild>) =
         delegate.includeBuild(rootProject, configuration)
 
-    override fun enableFeaturePreview(name: String) =
+    fun enableFeaturePreview(name: String) =
         delegate.enableFeaturePreview(name)
 
     override fun getExtensions(): ExtensionContainer =
         delegate.extensions
 
-    override fun getBuildCache(): BuildCacheConfiguration =
-        delegate.buildCache
+    val buildCache: BuildCacheConfiguration
+        get() = delegate.buildCache
 
-    override fun pluginManagement(pluginManagementSpec: Action<in PluginManagementSpec>) =
+    fun pluginManagement(pluginManagementSpec: Action<in PluginManagementSpec>) =
         delegate.pluginManagement(pluginManagementSpec)
 
-    override fun getPluginManagement(): PluginManagementSpec =
-        delegate.pluginManagement
+    val pluginManagement: PluginManagementSpec
+        get() = delegate.pluginManagement
 
-    override fun sourceControl(configuration: Action<in SourceControl>) =
+    fun sourceControl(configuration: Action<in SourceControl>) =
         delegate.sourceControl(configuration)
 
     override fun getPlugins(): PluginContainer =
         delegate.plugins
 
+    // TODO:kotlin-dsl remove
     override fun apply(closure: Closure<Any>) =
         delegate.apply(closure)
 
     override fun apply(action: Action<in ObjectConfigurationAction>) =
         delegate.apply(action)
 
+    // TODO:kotlin-dsl remove
     override fun apply(options: Map<String, *>) =
         delegate.apply(options)
 
     override fun getPluginManager(): PluginManager =
         delegate.pluginManager
 
-    override fun include(vararg projectPaths: String?) =
+    fun include(vararg projectPaths: String) =
         delegate.include(*projectPaths)
 
-    override fun includeFlat(vararg projectNames: String?) =
+    fun includeFlat(vararg projectNames: String) =
         delegate.includeFlat(*projectNames)
 
-    override fun getStartParameter(): StartParameter =
-        delegate.startParameter
+    val startParameter: StartParameter
+        get() = delegate.startParameter
 
-    override fun buildCache(action: Action<in BuildCacheConfiguration>) =
+    fun buildCache(action: Action<in BuildCacheConfiguration>) =
         delegate.buildCache(action)
 
-    override fun getSourceControl(): SourceControl =
-        delegate.sourceControl
+    val sourceControl: SourceControl
+        get() = delegate.sourceControl
 }


### PR DESCRIPTION
Fixes #9255 