### PR TITLE
Removed out-dated advice about disabling the daemon for ephemeral CI builds.

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle_daemon.adoc
@@ -30,8 +30,6 @@ The reasoning is simple: improve build speed by reusing computations from previo
 
 The Gradle Daemon is enabled by default starting with Gradle 3.0, so you don't have to do anything to benefit from it.
 
-If you run CI builds in ephemeral environments (such as containers) that do not reuse any processes, use of the Daemon will slightly decrease performance (due to caching additional information) for no benefit, and may be disabled.
-
 [[sec:status]]
 == Running Daemon Status
 


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This advice is outdated, and, e.g., @oehme now tells people there's no reason to disable the daemon, even in this context. See Slack conversation [here](https://gradle-community.slack.com/archives/CALL1EXGT/p1568655798003700?thread_ts=1567793713.010900&cid=CALL1EXGT).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
