### PR TITLE
Deincubate the new C++ and Swift plugins

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/component/BuildableComponent.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/BuildableComponent.java
@@ -16,14 +16,11 @@
 
 package org.gradle.api.component;
 
-import org.gradle.api.Incubating;
-
 /**
  * Represents a component that can be built.
  *
  * @since 4.7
  */
-@Incubating
 public interface BuildableComponent extends SoftwareComponent {
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/PublishableComponent.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/PublishableComponent.java
@@ -16,13 +16,10 @@
 
 package org.gradle.api.component;
 
-import org.gradle.api.Incubating;
-
 /**
  * Represents a component that can be published.
  *
  * @since 4.7
  */
-@Incubating
 public interface PublishableComponent extends SoftwareComponent, ComponentWithCoordinates {
 }

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.ide.visualstudio.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
@@ -61,7 +60,6 @@ import javax.inject.Inject;
 /**
  * A plugin for creating a Visual Studio solution for a gradle project.
  */
-@Incubating
 public class VisualStudioPlugin extends IdePlugin {
     private static final String LIFECYCLE_TASK_NAME = "visualStudio";
 

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginRules.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginRules.java
@@ -16,6 +16,7 @@
 
 package org.gradle.ide.visualstudio.plugins;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
@@ -33,6 +34,7 @@ import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.NativeBinarySpec;
 import org.gradle.platform.base.BinaryContainer;
 
+@Incubating
 class VisualStudioPluginRules {
     static class VisualStudioExtensionRules extends RuleSource {
         @Model

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioExtension.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioExtension.java
@@ -16,13 +16,11 @@
 
 package org.gradle.ide.visualstudio;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectSet;
 
 /**
  * The configuration for mapping a set of native components to a Visual Studio project.
  */
-@Incubating
 public interface VisualStudioExtension {
     /**
      * The {@link VisualStudioProject}s generated.

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioProject.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioProject.java
@@ -47,23 +47,25 @@ import org.gradle.internal.HasInternalProtocol;
  *  }
  * </pre>
  */
-@Incubating
 @HasInternalProtocol
 public interface VisualStudioProject extends Named, Buildable {
     /**
      * Configuration for the generated project file.
      */
     @Internal
+    @Incubating
     XmlConfigFile getProjectFile();
 
     /**
      * Configuration for the generated filters file.
      */
     @Internal
+    @Incubating
     XmlConfigFile getFiltersFile();
 
     @Override
     @Internal
+    @Incubating
     TaskDependency getBuildDependencies();
 
     @Override

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioRootExtension.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioRootExtension.java
@@ -17,14 +17,12 @@
 package org.gradle.ide.visualstudio;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * The configuration for mapping a set of native components to a Visual Studio project and solution.
  *
  * @since 4.6
  */
-@Incubating
 public interface VisualStudioRootExtension extends VisualStudioExtension {
     /**
      * Returns the generated  {@link VisualStudioSolution} for this build.

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioSolution.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/VisualStudioSolution.java
@@ -54,6 +54,7 @@ public interface VisualStudioSolution extends Named, Buildable, IdeWorkspace {
      * Configuration for the generated solution file.
      */
     @Internal
+    @Incubating
     TextConfigFile getSolutionFile();
 
     /**
@@ -65,6 +66,7 @@ public interface VisualStudioSolution extends Named, Buildable, IdeWorkspace {
 
     @Override
     @Internal
+    @Incubating
     TaskDependency getBuildDependencies();
 
     @Override

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/package-info.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Model classes for visual studio.
  */
-@org.gradle.api.Incubating
 package org.gradle.ide.visualstudio;

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeExtension.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeExtension.java
@@ -16,14 +16,11 @@
 
 package org.gradle.ide.xcode;
 
-import org.gradle.api.Incubating;
-
 /**
  * The configuration for mapping a C++ or Swift project to an XCode project.
  *
  * @since 4.2
  */
-@Incubating
 public interface XcodeExtension {
     /**
      * Returns the generated Xcode project for this Gradle project.

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeProject.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeProject.java
@@ -16,14 +16,11 @@
 
 package org.gradle.ide.xcode;
 
-import org.gradle.api.Incubating;
-
 /**
  * A xcode project, created from C++ or Swift capable project.
  *
  * @since 4.2
  * @see <a href="https://developer.apple.com/library/content/featuredarticles/XcodeConcepts/Concept-Projects.html">XCode Project Concept</a>
  */
-@Incubating
 public interface XcodeProject {
 }

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeRootExtension.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeRootExtension.java
@@ -16,14 +16,11 @@
 
 package org.gradle.ide.xcode;
 
-import org.gradle.api.Incubating;
-
 /**
  * The configuration for mapping a C++ or Swift project to XCode project and workspace.
  *
  * @since 4.7
  */
-@Incubating
 public interface XcodeRootExtension extends XcodeExtension {
     /**
      * Returns the generated Xcode workspace for this Gradle build.

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeWorkspace.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/XcodeWorkspace.java
@@ -16,7 +16,6 @@
 
 package org.gradle.ide.xcode;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 import org.gradle.plugins.ide.IdeWorkspace;
@@ -26,7 +25,6 @@ import org.gradle.plugins.ide.IdeWorkspace;
  *
  * @since 4.7
  */
-@Incubating
 public interface XcodeWorkspace extends IdeWorkspace {
     /**
      * Returns the location of the generated workspace.

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/package-info.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 4.2
  */
-@org.gradle.api.Incubating
 package org.gradle.ide.xcode;

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/XcodePlugin.java
@@ -19,7 +19,6 @@ package org.gradle.ide.xcode.plugins;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.ArtifactView;
@@ -82,7 +81,6 @@ import java.io.File;
  *
  * @since 4.2
  */
-@Incubating
 public class XcodePlugin extends IdePlugin {
     private final GidGenerator gidGenerator;
     private final ObjectFactory objectFactory;

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/package-info.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/plugins/package-info.java
@@ -19,5 +19,4 @@
  *
  * @since 4.2
  */
-@org.gradle.api.Incubating
 package org.gradle.ide.xcode.plugins;

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryCollection.java
@@ -17,7 +17,6 @@
 package org.gradle.language;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
@@ -32,7 +31,6 @@ import java.util.Set;
  * @param <T> type of the elements in this container.
  * @since 4.5
  */
-@Incubating
 public interface BinaryCollection<T extends SoftwareComponent> {
     /**
      * Returns a {@link BinaryProvider} that contains the single binary matching the specified type and specification. The binary will be in the finalized state. The provider can be used to apply configuration to the element before it is finalized.

--- a/subprojects/language-native/src/main/java/org/gradle/language/BinaryProvider.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/BinaryProvider.java
@@ -17,7 +17,6 @@
 package org.gradle.language;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 
 /**
@@ -26,7 +25,6 @@ import org.gradle.api.provider.Provider;
  * @since 4.5
  * @param <T> The type of binary.
  */
-@Incubating
 public interface BinaryProvider<T> extends Provider<T> {
     /**
      * Registers an action to execute to configure the binary. The action is executed only when the element is required.

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentDependencies.java
@@ -17,7 +17,6 @@
 package org.gradle.language;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.artifacts.ExternalModuleDependency;
  *
  * @since 4.6
  */
-@Incubating
 public interface ComponentDependencies {
     /**
      * Adds an implementation dependency to this component. An implementation dependency is not visible to consumers that are compiled against this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithBinaries.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithBinaries.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.component.SoftwareComponent;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithBinaries extends SoftwareComponent {
     /**
      * Returns the binaries of this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithDependencies.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.component.SoftwareComponent;
  *
  * @since 4.6
  */
-@Incubating
 public interface ComponentWithDependencies extends SoftwareComponent {
     /**
      * Returns the dependencies of this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithOutputs.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithOutputs.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
 
@@ -25,7 +24,6 @@ import org.gradle.api.file.FileCollection;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithOutputs extends SoftwareComponent {
     /**
      * Returns the outputs produced for this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithTargetMachines.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithTargetMachines.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.nativeplatform.TargetMachine;
 
@@ -25,7 +24,6 @@ import org.gradle.nativeplatform.TargetMachine;
  *
  * @since 5.2
  */
-@Incubating
 public interface ComponentWithTargetMachines {
     /**
      * Specifies the target machines this component should be built for.  The "machines" extension property (see {@link org.gradle.nativeplatform.TargetMachineFactory}) can be used to construct common operating system and architecture combinations.

--- a/subprojects/language-native/src/main/java/org/gradle/language/LibraryDependencies.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/LibraryDependencies.java
@@ -17,7 +17,6 @@
 package org.gradle.language;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 
 /**
@@ -25,7 +24,6 @@ import org.gradle.api.artifacts.ExternalModuleDependency;
  *
  * @since 4.6
  */
-@Incubating
 public interface LibraryDependencies extends ComponentDependencies {
     /**
      * Adds an API dependency to this library. An API dependency is made visible to consumers that are compiled against this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/ProductionComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ProductionComponent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.provider.Provider;
 
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.5
  */
-@Incubating
 public interface ProductionComponent extends SoftwareComponent {
     /**
      * Returns the binary of the component to use as the default for development.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppApplication.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 
 /**
@@ -26,7 +25,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.2
  */
-@Incubating
 public interface CppApplication extends ProductionCppComponent {
     /**
      * {@inheritDoc}

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppBinary.java
@@ -16,11 +16,10 @@
 
 package org.gradle.language.cpp;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.component.BuildableComponent;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.component.BuildableComponent;
 import org.gradle.language.ComponentWithDependencies;
 import org.gradle.language.cpp.tasks.CppCompile;
 import org.gradle.language.nativeplatform.ComponentWithObjectFiles;
@@ -31,7 +30,6 @@ import org.gradle.nativeplatform.Linkage;
  *
  * @since 4.2
  */
-@Incubating
 public interface CppBinary extends ComponentWithObjectFiles, ComponentWithDependencies, BuildableComponent {
     /**
      * The dependency resolution attribute use to indicate whether a binary is debuggable or not.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
@@ -17,7 +17,6 @@
 package org.gradle.language.cpp;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -37,7 +36,6 @@ import org.gradle.language.ComponentWithTargetMachines;
  *
  * @since 4.2
  */
-@Incubating
 public interface CppComponent extends ComponentWithBinaries, ComponentWithDependencies, ComponentWithTargetMachines {
     /**
      * Specifies the base name for this component. This name is used to calculate various output file names. The default value is calculated from the project name.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppExecutable.java
@@ -16,11 +16,10 @@
 
 package org.gradle.language.cpp;
 
-import org.gradle.api.Incubating;
+import org.gradle.api.component.PublishableComponent;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
-import org.gradle.api.component.PublishableComponent;
 import org.gradle.language.nativeplatform.ComponentWithExecutable;
 import org.gradle.language.nativeplatform.ComponentWithInstallation;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
@@ -30,7 +29,6 @@ import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
  *
  * @since 4.2
  */
-@Incubating
 public interface CppExecutable extends CppBinary, ComponentWithExecutable, ComponentWithInstallation, ComponentWithOutputs, ComponentWithRuntimeUsage, PublishableComponent {
     /**
      * Returns the executable file to use with a debugger for this executable.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppLibrary.java
@@ -17,7 +17,6 @@
 package org.gradle.language.cpp;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -33,7 +32,6 @@ import org.gradle.nativeplatform.Linkage;
  *
  * @since 4.2
  */
-@Incubating
 public interface CppLibrary extends ProductionCppComponent {
     /**
      * Defines the public header file directories of this library.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppPlatform.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppPlatform.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp;
 
-import org.gradle.api.Incubating;
 import org.gradle.nativeplatform.TargetMachine;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.nativeplatform.TargetMachine;
  *
  * @since 4.5
  */
-@Incubating
 public interface CppPlatform {
     /**
      * Returns the target machine for this platform.

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppSharedLibrary.java
@@ -16,9 +16,8 @@
 
 package org.gradle.language.cpp;
 
-import org.gradle.api.Incubating;
-import org.gradle.language.ComponentWithOutputs;
 import org.gradle.api.component.PublishableComponent;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
@@ -28,6 +27,5 @@ import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
  *
  * @since 4.2
  */
-@Incubating
 public interface CppSharedLibrary extends CppBinary, ComponentWithSharedLibrary, ComponentWithLinkUsage, ComponentWithRuntimeUsage, ComponentWithOutputs, PublishableComponent {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppStaticLibrary.java
@@ -16,9 +16,8 @@
 
 package org.gradle.language.cpp;
 
-import org.gradle.api.Incubating;
-import org.gradle.language.ComponentWithOutputs;
 import org.gradle.api.component.PublishableComponent;
+import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
 import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
@@ -28,6 +27,5 @@ import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
  *
  * @since 4.5
  */
-@Incubating
 public interface CppStaticLibrary extends CppBinary, ComponentWithStaticLibrary, ComponentWithLinkUsage, ComponentWithRuntimeUsage, ComponentWithOutputs, PublishableComponent {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/ProductionCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/ProductionCppComponent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.ProductionComponent;
 
@@ -25,7 +24,6 @@ import org.gradle.language.ProductionComponent;
  *
  * @since 4.5
  */
-@Incubating
 public interface ProductionCppComponent extends CppComponent, ProductionComponent {
     /**
      * {@inheritDoc}

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -48,7 +47,6 @@ import static org.gradle.language.nativeplatform.internal.Dimensions.useHostAsDe
  *
  * @since 4.5
  */
-@Incubating
 public class CppApplicationPlugin implements Plugin<Project> {
     private final NativeComponentFactory componentFactory;
     private final ToolChainSelector toolChainSelector;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppBasePlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -47,7 +46,6 @@ import java.util.concurrent.Callable;
  *
  * @since 4.1
  */
-@Incubating
 @NonNullApi
 public class CppBasePlugin implements Plugin<Project> {
     private final ProjectPublicationRegistry publicationRegistry;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.cpp.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -30,9 +29,9 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppLibrary;
+import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.CppSharedLibrary;
 import org.gradle.language.cpp.CppStaticLibrary;
-import org.gradle.language.cpp.CppPlatform;
 import org.gradle.language.cpp.internal.DefaultCppLibrary;
 import org.gradle.language.cpp.internal.DefaultCppPlatform;
 import org.gradle.language.internal.NativeComponentFactory;
@@ -61,7 +60,6 @@ import static org.gradle.language.nativeplatform.internal.Dimensions.useHostAsDe
  *
  * @since 4.1
  */
-@Incubating
 public class CppLibraryPlugin implements Plugin<Project> {
     private final NativeComponentFactory componentFactory;
     private final ToolChainSelector toolChainSelector;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Plugins for building from C++ language sources.
  */
-@org.gradle.api.Incubating
 package org.gradle.language.cpp.plugins;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/tasks/CppCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/tasks/CppCompile.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.language.cpp.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.language.cpp.tasks.internal.DefaultCppCompileSpec;
 import org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask;
@@ -24,7 +23,6 @@ import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
 /**
  * Compiles C++ source files into object files.
  */
-@Incubating
 @CacheableTask
 public class CppCompile extends AbstractNativeSourceCompileTask {
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithExecutable.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
@@ -28,7 +27,6 @@ import org.gradle.nativeplatform.tasks.LinkExecutable;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithExecutable extends ComponentWithNativeRuntime {
     /**
      * Returns the link libraries to use to link the executable. Includes the link libraries of the component's dependencies.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithInstallation.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
@@ -27,7 +26,6 @@ import org.gradle.nativeplatform.tasks.InstallExecutable;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithInstallation extends ComponentWithNativeRuntime {
     /**
      * Returns the runtime libraries required for the installation. Includes the runtime libraries of the component's dependencies.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkFile.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
@@ -26,7 +25,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithLinkFile extends ComponentWithNativeRuntime {
     /**
      * Returns the task that should be run to produce the link file of this component. This isn't necessarily the link task for the component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithLinkUsage.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.Provider;
 
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithLinkUsage extends ComponentWithNativeRuntime {
     /**
      * Returns the outgoing link elements of this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithNativeRuntime.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithNativeRuntime.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.provider.Provider;
 import org.gradle.nativeplatform.TargetMachine;
@@ -27,7 +26,6 @@ import org.gradle.nativeplatform.toolchain.NativeToolChain;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithNativeRuntime extends SoftwareComponent {
     /**
      * Returns the base name of this component. This is used to calculate output file names.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithObjectFiles.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithObjectFiles.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.file.FileCollection;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithObjectFiles extends ComponentWithNativeRuntime {
     /**
      * Returns the object files created for this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeFile.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithRuntimeFile extends ComponentWithNativeRuntime {
     /**
      * Returns the runtime file of this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeUsage.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithRuntimeUsage.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.Provider;
 
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithRuntimeUsage extends ComponentWithNativeRuntime {
     /**
      * Returns the outgoing runtime elements of this component.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithSharedLibrary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
@@ -26,7 +25,6 @@ import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithSharedLibrary extends ComponentWithLinkFile, ComponentWithRuntimeFile {
     /**
      * Returns the link libraries to use to link the shared library. Includes the link libraries of the component's dependencies.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/ComponentWithStaticLibrary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
 
@@ -25,7 +24,6 @@ import org.gradle.nativeplatform.tasks.CreateStaticLibrary;
  *
  * @since 4.5
  */
-@Incubating
 public interface ComponentWithStaticLibrary extends ComponentWithLinkFile {
     /**
      * Returns the task to create the static library.

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -16,7 +16,6 @@
 package org.gradle.language.nativeplatform.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
@@ -60,7 +59,6 @@ import java.util.Map;
 /**
  * Compiles native source files into object files.
  */
-@Incubating
 public abstract class AbstractNativeCompileTask extends DefaultTask {
     private final Property<NativePlatform> targetPlatform;
     private final Property<NativeToolChain> toolChain;
@@ -116,7 +114,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     }
 
     @TaskAction
-    public void compile(InputChanges inputs) {
+    protected void compile(InputChanges inputs) {
         BuildOperationLogger operationLogger = getOperationLoggerFactory().newOperationLogger(getName(), getTemporaryDir());
         NativeCompileSpec spec = createCompileSpec();
         spec.setTargetPlatform(targetPlatform.get());

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeSourceCompileTask.java
@@ -38,7 +38,6 @@ import java.io.File;
 /**
  * Compiles native source files into object files.
  */
-@Incubating
 public abstract class AbstractNativeSourceCompileTask extends AbstractNativeCompileTask {
     private PreCompiledHeader preCompiledHeader;
 
@@ -75,10 +74,12 @@ public abstract class AbstractNativeSourceCompileTask extends AbstractNativeComp
      * Returns the pre-compiled header to be used during compilation
      */
     @Nullable @Optional @Nested
+    @Incubating
     public PreCompiledHeader getPreCompiledHeader() {
         return preCompiledHeader;
     }
 
+    @Incubating
     public void setPreCompiledHeader(@Nullable PreCompiledHeader preCompiledHeader) {
         this.preCompiledHeader = preCompiledHeader;
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/UnexportMainSymbol.java
@@ -18,7 +18,6 @@ package org.gradle.language.nativeplatform.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -46,7 +45,6 @@ import java.io.IOException;
  *
  * @since 4.4
  */
-@Incubating
 @CacheableTask
 public class UnexportMainSymbol extends DefaultTask {
     private final ConfigurableFileCollection source = getProject().files();
@@ -85,7 +83,7 @@ public class UnexportMainSymbol extends DefaultTask {
     }
 
     @TaskAction
-    public void unexport(InputChanges inputChanges) {
+    protected void unexport(InputChanges inputChanges) {
         for (FileChange change : inputChanges.getFileChanges(getObjects())) {
             if (change.getChangeType() == ChangeType.REMOVED) {
                 File relocatedFileLocation = relocatedObject(change.getFile());

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Base classes for native language compile tasks.
  */
-@org.gradle.api.Incubating
 package org.gradle.language.nativeplatform.tasks;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/ProductionSwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/ProductionSwiftComponent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.ProductionComponent;
 
@@ -25,7 +24,6 @@ import org.gradle.language.ProductionComponent;
  *
  * @since 4.5
  */
-@Incubating
 public interface ProductionSwiftComponent extends SwiftComponent, ProductionComponent {
     /**
      * {@inheritDoc}

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftApplication.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 
 /**
@@ -26,7 +25,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.2
  */
-@Incubating
 public interface SwiftApplication extends ProductionSwiftComponent {
     /**
      * {@inheritDoc}

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftBinary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
@@ -29,7 +28,6 @@ import org.gradle.language.swift.tasks.SwiftCompile;
  *
  * @since 4.2
  */
-@Incubating
 public interface SwiftBinary extends ComponentWithObjectFiles, ComponentWithDependencies {
     /**
      * Returns the name of the Swift module that this binary defines.

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
@@ -17,13 +17,12 @@
 package org.gradle.language.swift;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
-import org.gradle.language.ComponentWithBinaries;
 import org.gradle.language.BinaryCollection;
+import org.gradle.language.ComponentWithBinaries;
 import org.gradle.language.ComponentWithDependencies;
 import org.gradle.language.ComponentWithTargetMachines;
 
@@ -36,7 +35,6 @@ import org.gradle.language.ComponentWithTargetMachines;
  *
  * @since 4.2
  */
-@Incubating
 public interface SwiftComponent extends ComponentWithBinaries, ComponentWithDependencies, ComponentWithTargetMachines {
     /**
      * Defines the Swift module for this component. The default value is calculated from the project name.

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftExecutable.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.ComponentWithOutputs;
@@ -28,7 +27,6 @@ import org.gradle.language.nativeplatform.ComponentWithInstallation;
  *
  * @since 4.2
  */
-@Incubating
 public interface SwiftExecutable extends SwiftBinary, ComponentWithExecutable, ComponentWithInstallation, ComponentWithOutputs {
     /**
      * Returns the executable file to use with a debugger for this binary.

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftLibrary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.language.LibraryDependencies;
@@ -29,7 +28,6 @@ import org.gradle.nativeplatform.Linkage;
  *
  * @since 4.2
  */
-@Incubating
 public interface SwiftLibrary extends ProductionSwiftComponent {
     /**
      * Returns the dependencies of this library.

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftPlatform.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftPlatform.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.nativeplatform.TargetMachine;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.nativeplatform.TargetMachine;
  *
  * @since 5.2
  */
-@Incubating
 public interface SwiftPlatform {
     /**
      * Returns the target machine for this platform.

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftSharedLibrary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
@@ -27,6 +26,5 @@ import org.gradle.language.nativeplatform.ComponentWithSharedLibrary;
  *
  * @since 4.2
  */
-@Incubating
 public interface SwiftSharedLibrary extends SwiftBinary, ComponentWithSharedLibrary, ComponentWithRuntimeUsage, ComponentWithLinkUsage, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftStaticLibrary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
 import org.gradle.language.ComponentWithOutputs;
 import org.gradle.language.nativeplatform.ComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.ComponentWithRuntimeUsage;
@@ -27,6 +26,5 @@ import org.gradle.language.nativeplatform.ComponentWithStaticLibrary;
  *
  * @since 4.5
  */
-@Incubating
 public interface SwiftStaticLibrary extends SwiftBinary, ComponentWithStaticLibrary, ComponentWithRuntimeUsage, ComponentWithLinkUsage, ComponentWithOutputs {
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -48,7 +47,6 @@ import static org.gradle.language.nativeplatform.internal.Dimensions.tryToBuildO
  *
  * @since 4.5
  */
-@Incubating
 public class SwiftApplicationPlugin implements Plugin<Project> {
     private final NativeComponentFactory componentFactory;
     private final ToolChainSelector toolChainSelector;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftBasePlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.attributes.AttributeCompatibilityRule;
@@ -47,7 +46,6 @@ import javax.inject.Inject;
  *
  * @since 4.1
  */
-@Incubating
 public class SwiftBasePlugin implements Plugin<Project> {
     private final ProjectPublicationRegistry publicationRegistry;
     private final MacOSSdkPathLocator locator;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.swift.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -34,13 +33,13 @@ import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
 import org.gradle.language.swift.SwiftBinary;
 import org.gradle.language.swift.SwiftComponent;
 import org.gradle.language.swift.SwiftLibrary;
+import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.SwiftSharedLibrary;
 import org.gradle.language.swift.SwiftStaticLibrary;
-import org.gradle.language.swift.SwiftPlatform;
 import org.gradle.language.swift.internal.DefaultSwiftLibrary;
+import org.gradle.language.swift.internal.DefaultSwiftPlatform;
 import org.gradle.language.swift.internal.DefaultSwiftSharedLibrary;
 import org.gradle.language.swift.internal.DefaultSwiftStaticLibrary;
-import org.gradle.language.swift.internal.DefaultSwiftPlatform;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.OperatingSystemFamily;
 import org.gradle.nativeplatform.TargetMachineFactory;
@@ -67,7 +66,6 @@ import static org.gradle.language.nativeplatform.internal.Dimensions.useHostAsDe
  *
  * @since 4.2
  */
-@Incubating
 public class SwiftLibraryPlugin implements Plugin<Project> {
     private final NativeComponentFactory componentFactory;
     private final ToolChainSelector toolChainSelector;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Plugins for building from Swift language sources.
  */
-@org.gradle.api.Incubating
 package org.gradle.language.swift.plugins;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -19,7 +19,6 @@ package org.gradle.language.swift.tasks;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
@@ -74,7 +73,6 @@ import java.util.Set;
  *
  * @since 4.1
  */
-@Incubating
 @CacheableTask
 public class SwiftCompile extends DefaultTask {
     private final Property<String> moduleName;
@@ -278,7 +276,7 @@ public class SwiftCompile extends DefaultTask {
     }
 
     @TaskAction
-    void compile(InputChanges inputs) {
+    protected void compile(InputChanges inputs) {
         final List<File> removedFiles = Lists.newArrayList();
         final Set<File> changedFiles = Sets.newHashSet();
         boolean isIncremental = inputs.isIncremental();

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/package-info.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Tasks for compiling Swift sources for a native runtime.
  */
-@org.gradle.api.Incubating
 package org.gradle.language.swift.tasks;

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/Package.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/Package.java
@@ -16,7 +16,6 @@
 
 package org.gradle.swiftpm;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.util.Set;
@@ -26,7 +25,7 @@ import java.util.Set;
  *
  * @since 4.6
  */
-@HasInternalProtocol @Incubating
+@HasInternalProtocol
 public interface Package {
     /**
      * Returns the products of this package.

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/Product.java
@@ -16,7 +16,6 @@
 
 package org.gradle.swiftpm;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -25,7 +24,7 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 4.6
  */
-@HasInternalProtocol @Incubating
+@HasInternalProtocol
 public interface Product extends Named {
     /**
      * Returns the name of this product.

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.swiftpm.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -73,7 +72,6 @@ import java.util.concurrent.Callable;
  *
  * @since 4.6
  */
-@Incubating
 public class SwiftPackageManagerExportPlugin implements Plugin<Project> {
     private final VcsResolver vcsResolver;
     private final VersionSelectorScheme versionSelectorScheme;

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -18,7 +18,6 @@ package org.gradle.swiftpm.tasks;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -49,7 +48,6 @@ import java.util.TreeSet;
  *
  * @since 4.6
  */
-@Incubating
 public class GenerateSwiftPackageManagerManifest extends DefaultTask {
     private final RegularFileProperty manifestFile;
     private final Property<Package> packageProperty;

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/Platform.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/Platform.java
@@ -16,7 +16,6 @@
 
 package org.gradle.platform.base;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -26,7 +25,6 @@ import org.gradle.api.tasks.Internal;
  *
  * Examples: the JvmPlatform defines a java runtime, while the NativePlatform defines the Operating System and Architecture for a native app.
  */
-@Incubating
 public interface Platform extends Named {
     @Override
     @Input

--- a/subprojects/platform-native/src/main/java/org/gradle/language/swift/SwiftVersion.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/language/swift/SwiftVersion.java
@@ -16,14 +16,11 @@
 
 package org.gradle.language.swift;
 
-import org.gradle.api.Incubating;
-
 /**
  * Swift version.
  *
  * @since 4.6
  */
-@Incubating
 public enum SwiftVersion {
     SWIFT3(3), SWIFT4(4),
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/Linkage.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/Linkage.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.Named;
  *
  * @since 4.5
  */
-@Incubating
 public enum Linkage implements Named {
     /**
      * Statically link binaries together.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/MachineArchitecture.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/MachineArchitecture.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.tasks.Input;
@@ -26,7 +25,6 @@ import org.gradle.api.tasks.Input;
  *
  * @since 5.1
  */
-@Incubating
 public abstract class MachineArchitecture implements Named {
     public static final Attribute<MachineArchitecture> ARCHITECTURE_ATTRIBUTE = Attribute.of("org.gradle.native.architecture", MachineArchitecture.class);
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/OperatingSystemFamily.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/OperatingSystemFamily.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.tasks.Input;
@@ -27,7 +26,6 @@ import org.gradle.api.tasks.Input;
  *
  * @since 5.1
  */
-@Incubating
 public abstract class OperatingSystemFamily implements Named {
     public static final Attribute<OperatingSystemFamily> OPERATING_SYSTEM_ATTRIBUTE = Attribute.of("org.gradle.native.operatingSystem", OperatingSystemFamily.class);
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/TargetMachine.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/TargetMachine.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Nested;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.tasks.Nested;
  *
  * @since 5.1
  */
-@Incubating
 public interface TargetMachine {
     /**
      * Returns the target operating system

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/TargetMachineBuilder.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/TargetMachineBuilder.java
@@ -16,14 +16,11 @@
 
 package org.gradle.nativeplatform;
 
-import org.gradle.api.Incubating;
-
 /**
  * A builder for configuring the architecture of a {@link TargetMachine} objects.
  *
  * @since 5.2
  */
-@Incubating
 public interface TargetMachineBuilder extends TargetMachine {
     /**
      * Returns a {@link TargetMachine} for the operating system of this machine and the x86 32-bit architecture

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/TargetMachineFactory.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/TargetMachineFactory.java
@@ -16,14 +16,11 @@
 
 package org.gradle.nativeplatform;
 
-import org.gradle.api.Incubating;
-
 /**
  * A factory for creating {@link TargetMachine} objects.
  *
  * @since 5.1
  */
-@Incubating
 public interface TargetMachineFactory {
     /**
      * Returns a {@link TargetMachineBuilder} for the Windows operating system family and the architecture of the current host.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/package-info.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Classes that model aspects of native component projects.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/Architecture.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/Architecture.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.nativeplatform.platform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -57,7 +56,6 @@ import org.gradle.internal.HasInternalProtocol;
  *     </tr>
  * </table>
  */
-@Incubating
 @HasInternalProtocol
 public interface Architecture extends Named {
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/NativePlatform.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/NativePlatform.java
@@ -17,7 +17,6 @@
 package org.gradle.nativeplatform.platform;
 
 import org.gradle.api.Describable;
-import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Nested;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.platform.base.Platform;
@@ -37,7 +36,6 @@ import org.gradle.platform.base.Platform;
  *     }
  * </pre>
  */
-@Incubating
 @HasInternalProtocol
 public interface NativePlatform extends Platform, Describable {
     /**

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.nativeplatform.platform;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -46,7 +45,6 @@ import org.gradle.api.tasks.Internal;
  *     </tr>
  * </table>
  */
-@Incubating
 public interface OperatingSystem extends Named {
     @Input
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/package-info.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Classes that allow defining a native binary platform.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform.platform;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -16,7 +16,6 @@
 package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -56,7 +55,6 @@ import javax.inject.Inject;
 /**
  * Base task for linking a native binary from object files and libraries.
  */
-@Incubating
 public abstract class AbstractLinkTask extends DefaultTask implements ObjectFilesToBinary {
     private final RegularFileProperty linkedFile;
     private final DirectoryProperty destinationDirectory;
@@ -209,7 +207,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     }
 
     @Inject
-    public BuildOperationLoggerFactory getOperationLoggerFactory() {
+    protected BuildOperationLoggerFactory getOperationLoggerFactory() {
         throw new UnsupportedOperationException();
     }
 
@@ -219,7 +217,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     }
 
     @TaskAction
-    public void link() {
+    protected void link() {
         boolean cleanedOutputs = StaleOutputCleaner.cleanOutputs(
             getDeleter(),
             getOutputs().getPreviousOutputFiles(),

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -16,7 +16,6 @@
 package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
@@ -51,7 +50,6 @@ import javax.inject.Inject;
 /**
  * Assembles a static library from object files.
  */
-@Incubating
 public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBinary {
 
     private final ConfigurableFileCollection source;
@@ -95,7 +93,7 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
     // TODO: Need to track version/implementation of ar tool.
 
     @TaskAction
-    public void link() {
+    protected void link() {
 
         StaticLibraryArchiverSpec spec = new DefaultStaticLibraryArchiverSpec();
         spec.setTempDir(getTemporaryDir());

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
@@ -17,7 +17,6 @@
 package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -47,7 +46,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
  *
  * @since 4.5
  */
-@Incubating
 public class ExtractSymbols extends DefaultTask {
     private final RegularFileProperty binaryFile;
     private final RegularFileProperty symbolFile;
@@ -103,7 +101,7 @@ public class ExtractSymbols extends DefaultTask {
     // TODO: Need to track version/implementation of symbol extraction tool.
 
     @TaskAction
-    public void extractSymbols() {
+    protected void extractSymbols() {
         BuildOperationLogger operationLogger = getServices().get(BuildOperationLoggerFactory.class).newOperationLogger(getName(), getTemporaryDir());
 
         SymbolExtractorSpec spec = new DefaultSymbolExtractorSpec();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -16,7 +16,6 @@
 package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -54,7 +53,6 @@ import java.util.Collection;
 /**
  * Installs an executable with it's dependent libraries so it can be easily executed.
  */
-@Incubating
 public class InstallExecutable extends DefaultTask {
     private final Property<NativePlatform> targetPlatform;
     private final Property<NativeToolChain> toolChain;
@@ -196,7 +194,7 @@ public class InstallExecutable extends DefaultTask {
     }
 
     @TaskAction
-    public void install() {
+    protected void install() {
         NativePlatform nativePlatform = targetPlatform.get();
         File executable = getExecutableFile().get().getAsFile();
         File libDirectory = getLibDirectory().get().getAsFile();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkExecutable.java
@@ -15,14 +15,12 @@
  */
 package org.gradle.nativeplatform.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.nativeplatform.internal.DefaultLinkerSpec;
 import org.gradle.nativeplatform.internal.LinkerSpec;
 
 /**
  * Links a binary executable from object files and libraries.
  */
-@Incubating
 public class LinkExecutable extends AbstractLinkTask {
     @Override
     protected LinkerSpec createLinkerSpec() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkMachOBundle.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkMachOBundle.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.nativeplatform.internal.BundleLinkerSpec;
 import org.gradle.nativeplatform.internal.DefaultLinkerSpec;
 import org.gradle.nativeplatform.internal.LinkerSpec;
@@ -26,7 +25,6 @@ import org.gradle.nativeplatform.internal.LinkerSpec;
  *
  * @since 4.3
  */
-@Incubating
 public class LinkMachOBundle extends AbstractLinkTask {
     @Override
     protected LinkerSpec createLinkerSpec() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.nativeplatform.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
@@ -35,7 +34,6 @@ import java.util.concurrent.Callable;
 /**
  * Links a binary shared library from object files and imported libraries.
  */
-@Incubating
 public class LinkSharedLibrary extends AbstractLinkTask {
     private final Property<String> installName = getProject().getObjects().property(String.class);
     private final RegularFileProperty importLibrary = getProject().getObjects().fileProperty();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ObjectFilesToBinary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ObjectFilesToBinary.java
@@ -16,13 +16,11 @@
 
 package org.gradle.nativeplatform.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 
 /**
  * A task that combines a set of object files into a single binary.
  */
-@Incubating
 public interface ObjectFilesToBinary extends Task {
     /**
      * Adds a set of object files to be combined into the file binary.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
@@ -17,7 +17,6 @@
 package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -47,7 +46,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
  *
  * @since 4.5
  */
-@Incubating
 public class StripSymbols extends DefaultTask {
     private final RegularFileProperty binaryFile;
     private final RegularFileProperty outputFile;
@@ -104,7 +102,7 @@ public class StripSymbols extends DefaultTask {
     // TODO: Need to track version/implementation of symbol strip tool.
 
     @TaskAction
-    public void stripSymbols() {
+    protected void stripSymbols() {
         BuildOperationLogger operationLogger = getServices().get(BuildOperationLoggerFactory.class).newOperationLogger(getName(), getTemporaryDir());
 
         StripperSpec spec = new DefaultStripperSpec();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/package-info.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Tasks for building native component projects.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform.tasks;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/NativeToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/NativeToolChain.java
@@ -16,14 +16,12 @@
 
 package org.gradle.nativeplatform.toolchain;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.platform.base.ToolChain;
 
 /**
  * A set of compilers and linkers that are used together to construct a native binary.
  */
-@Incubating
 @HasInternalProtocol
 public interface NativeToolChain extends ToolChain {
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/TestComponent.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/TestComponent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.provider.Provider;
@@ -26,7 +25,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.5
  */
-@Incubating
 public interface TestComponent extends SoftwareComponent {
     /**
      * Returns the task that runs the tests for this component.

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/TestSuiteComponent.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/TestSuiteComponent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.provider.Provider;
 
@@ -25,7 +24,6 @@ import org.gradle.api.provider.Provider;
  *
  * @since 4.5
  */
-@Incubating
 public interface TestSuiteComponent extends SoftwareComponent {
     /**
      * Returns the binary to use as the default to run this test suite.

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/CppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/CppTestExecutable.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.cpp;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.nativeplatform.ComponentWithExecutable;
@@ -29,7 +28,6 @@ import org.gradle.nativeplatform.test.tasks.RunTestExecutable;
  *
  * @since 4.5
  */
-@Incubating
 public interface CppTestExecutable extends CppBinary, ComponentWithExecutable, ComponentWithInstallation, TestComponent {
     /**
      * {@inheritDoc}

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/CppTestSuite.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/CppTestSuite.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.cpp;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.nativeplatform.test.TestSuiteComponent;
@@ -26,7 +25,6 @@ import org.gradle.nativeplatform.test.TestSuiteComponent;
  *
  * @since 4.4
  */
-@Incubating
 public interface CppTestSuite extends CppComponent, TestSuiteComponent {
     /**
      * {@inheritDoc}

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/package-info.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/package-info.java
@@ -16,5 +16,4 @@
 /**
  * API classes for C++ test integration.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform.test.cpp;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.cpp.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
@@ -66,7 +65,6 @@ import static org.gradle.language.nativeplatform.internal.Dimensions.tryToBuildO
  *
  * @since 4.4
  */
-@Incubating
 public class CppUnitTestPlugin implements Plugin<Project> {
     private final NativeComponentFactory componentFactory;
     private final ToolChainSelector toolChainSelector;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/package-info.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/package-info.java
@@ -16,5 +16,4 @@
 /**
  * Plugins for C++ test integration.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform.test.cpp.plugins;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/package-info.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/package-info.java
@@ -17,5 +17,4 @@
 /**
  * API classes for testing native binaries.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform.test;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/tasks/RunTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/tasks/RunTestExecutable.java
@@ -16,7 +16,6 @@
 package org.gradle.nativeplatform.test.tasks;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.Incubating;
 import org.gradle.api.tasks.AbstractExecTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -30,7 +29,6 @@ import java.io.File;
 /**
  * Runs a compiled and installed test executable.
  */
-@Incubating
 public class RunTestExecutable extends AbstractExecTask<RunTestExecutable> implements VerificationTask {
     /**
      * The directory where the results should be generated.

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBinary.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBinary.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.xctest;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
@@ -30,7 +29,6 @@ import org.gradle.nativeplatform.test.xctest.tasks.XCTest;
  *
  * @since 4.4
  */
-@Incubating
 public interface SwiftXCTestBinary extends SwiftBinary, TestComponent {
     /**
      * Returns the executable test file for this binary.

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestBundle.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.xctest;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.nativeplatform.tasks.LinkMachOBundle;
 
@@ -25,7 +24,6 @@ import org.gradle.nativeplatform.tasks.LinkMachOBundle;
  *
  * @since 4.5
  */
-@Incubating
 public interface SwiftXCTestBundle extends SwiftXCTestBinary {
     /**
      * Returns the link task for this bundle.

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestExecutable.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.xctest;
 
-import org.gradle.api.Incubating;
 import org.gradle.language.nativeplatform.ComponentWithExecutable;
 import org.gradle.language.nativeplatform.ComponentWithInstallation;
 
@@ -25,6 +24,5 @@ import org.gradle.language.nativeplatform.ComponentWithInstallation;
  *
  * @since 4.5
  */
-@Incubating
 public interface SwiftXCTestExecutable extends SwiftXCTestBinary, ComponentWithExecutable, ComponentWithInstallation {
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestSuite.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/SwiftXCTestSuite.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.xctest;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.BinaryCollection;
 import org.gradle.language.swift.SwiftComponent;
@@ -27,7 +26,6 @@ import org.gradle.nativeplatform.test.TestSuiteComponent;
  *
  * @since 4.2
  */
-@Incubating
 public interface SwiftXCTestSuite extends SwiftComponent, TestSuiteComponent {
     /**
      * {@inheritDoc}

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.nativeplatform.test.xctest.plugins;
 
 import com.google.common.collect.Lists;
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
@@ -37,6 +36,7 @@ import org.gradle.language.internal.NativeComponentFactory;
 import org.gradle.language.nativeplatform.internal.Dimensions;
 import org.gradle.language.nativeplatform.internal.Names;
 import org.gradle.language.nativeplatform.internal.toolchains.ToolChainSelector;
+import org.gradle.language.nativeplatform.tasks.UnexportMainSymbol;
 import org.gradle.language.swift.ProductionSwiftComponent;
 import org.gradle.language.swift.SwiftApplication;
 import org.gradle.language.swift.SwiftComponent;
@@ -45,7 +45,6 @@ import org.gradle.language.swift.internal.DefaultSwiftBinary;
 import org.gradle.language.swift.internal.DefaultSwiftPlatform;
 import org.gradle.language.swift.plugins.SwiftBasePlugin;
 import org.gradle.language.swift.tasks.SwiftCompile;
-import org.gradle.language.nativeplatform.tasks.UnexportMainSymbol;
 import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.nativeplatform.TargetMachine;
 import org.gradle.nativeplatform.TargetMachineFactory;
@@ -80,7 +79,6 @@ import static org.gradle.language.nativeplatform.internal.Dimensions.useHostAsDe
  *
  * @since 4.2
  */
-@Incubating
 public class XCTestConventionPlugin implements Plugin<Project> {
     private final MacOSSdkPlatformPathLocator sdkPlatformPathLocator;
     private final ToolChainSelector toolChainSelector;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/package-info.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Plugins for XCTest testing.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform.test.xctest.plugins;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
@@ -20,7 +20,6 @@ import com.google.common.io.Files;
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
@@ -53,7 +52,6 @@ import java.util.concurrent.Callable;
  *
  * @since 4.4
  */
-@Incubating
 public class InstallXCTestBundle extends DefaultTask {
     private final DirectoryProperty installDirectory;
     private final RegularFileProperty bundleBinaryFile;
@@ -82,7 +80,7 @@ public class InstallXCTestBundle extends DefaultTask {
     }
 
     @TaskAction
-    void install() throws IOException {
+    protected void install() throws IOException {
         File bundleFile = bundleBinaryFile.get().getAsFile();
         File bundleDir = installDirectory.get().file(bundleFile.getName() + ".xctest").getAsFile();
         installToDir(bundleDir, bundleFile);

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XCTest.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XCTest.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.test.xctest.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
@@ -44,7 +43,6 @@ import java.util.List;
  *
  * @since 4.5
  */
-@Incubating
 public class XCTest extends AbstractTestTask {
     private final DirectoryProperty workingDirectory;
     private final DirectoryProperty testInstallDirectory;

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/package-info.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Tasks for XCTest execution.
  */
-@org.gradle.api.Incubating
 package org.gradle.nativeplatform.test.xctest.tasks;


### PR DESCRIPTION
# Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Deincubate C++ and Swift plugins. There have been there for a while now and true to be told we shouldn't break anything without first deprecating it now. This PR deincubate `cpp-application`, `cpp-library`, `swift-application`, `swift-library`, `cpp-unit-test`, `xctest`, `swiftpm-export`, `visual-studio` and `xcode`. Only the public types strictly related to those plugins are being deincubated. C++ precompile headers is still incubating because of the usage of internal types. Low-level modification of Visual Studio solution and project files are still incubating, please open an issue if you are using them. Task type for Visual Studio IDE and Xcode IDE are still incubating, please open an issue if you are using them.

The native software model plugins are still incubating as they will be eventually phased out.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fdeincubating)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
