### PR TITLE
Make more buckets

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -7,15 +7,11 @@ import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProjects: List<String> = listOf(), stage: Stage, buildTypeName: String = "", extraParameters: String = "") : BaseGradleBuildType(model, stage = stage, init = {
-    uuid = testCoverage.asConfigurationId(model, buildTypeName)
+class FunctionalTest(model: CIBuildModel, uuid: String, name: String, description: String, testCoverage: TestCoverage, stage: Stage, subProjects: List<String> = listOf(), extraParameters: String = "") : BaseGradleBuildType(model, stage = stage, init = {
+    this.uuid = uuid
+    this.name = name
+    this.description = description
     id = AbsoluteId(uuid)
-    name = testCoverage.asName() + " (" + (if (buildTypeName.contains("_")) buildTypeName else subProjects.joinToString(", ")) + ")"
-    description = "${testCoverage.asName()} for ${when (subProjects.size) {
-        0 -> "all projects "
-        1 -> "project ${if (buildTypeName.isEmpty()) subProjects[0] else buildTypeName}"
-        else -> "projects ${subProjects.joinToString(", ")}"
-    }}"
     val testTaskName = "${testCoverage.testType.name}Test"
     val testTasks = if (subProjects.isEmpty())
         testTaskName

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -10,7 +10,7 @@ import model.TestType
 class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProjects: List<String> = listOf(), stage: Stage, buildTypeName: String = "", extraParameters: String = "") : BaseGradleBuildType(model, stage = stage, init = {
     uuid = testCoverage.asConfigurationId(model, buildTypeName)
     id = AbsoluteId(uuid)
-    name = testCoverage.asName() + if (buildTypeName.isEmpty()) "" else " ($buildTypeName)"
+    name = testCoverage.asName() + " (" + (if (buildTypeName.contains("_")) buildTypeName else subProjects.joinToString(", ")) + ")"
     description = "${testCoverage.asName()} for ${when (subProjects.size) {
         0 -> "all projects "
         1 -> "project ${if (buildTypeName.isEmpty()) subProjects[0] else buildTypeName}"

--- a/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
@@ -8,7 +8,6 @@ import common.distributedPerformanceTestParameters
 import common.gradleWrapper
 import common.performanceTestCommandLine
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
-import jetbrains.buildServer.configs.kotlin.v2018_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildStep.ExecutionMode
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildSteps
 import model.CIBuildModel
@@ -32,7 +31,7 @@ class PerformanceTestCoordinator(model: CIBuildModel, type: PerformanceTestType,
         param("performance.baselines", type.defaultBaselines)
     }
 
-    fun BuildSteps.runner(runnerName: String, runnerTasks: String, extraParameters: String = "", runnerExecutionMode: BuildStep.ExecutionMode = ExecutionMode.DEFAULT) {
+    fun BuildSteps.runner(runnerName: String, runnerTasks: String, extraParameters: String = "", runnerExecutionMode: ExecutionMode = ExecutionMode.DEFAULT) {
         gradleWrapper {
             name = runnerName
             tasks = ""

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -200,16 +200,20 @@ data class CIBuildModel(
 
     init {
         val subprojectMap = subProjects.map { it.name to it }.toMap()
-        val buckets = listOf(
-            listOf("resources", "resourcesGcs", "resourcesHttp", "resourcesS3", "resourcesSftp"),
-            listOf("platformBase", "platformJvm", "platformNative")
+        val buckets = mapOf(
+            "resources" to listOf("resources", "resourcesGcs", "resourcesHttp", "resourcesS3", "resourcesSftp"),
+            "platformBase" to listOf("platformBase", "platformJvm", "platformNative"),
+            "bucket1" to listOf("kotlinDslProviderPlugins", "buildCachePackaging", "native", "snapshots", "internalPerformanceTesting", "internalIntegTesting", "execution", "publish", "ear", "languageJvm"),
+            "bucket2" to listOf("baseServices", "processServices", "messaging", "buildProfile", "modelGroovy"),
+            "bucket3" to listOf("javascript", "fileCollections", "buildCache", "toolingNative", "buildCacheHttp"),
+            "bucket4" to listOf("antlr", "languageGroovy", "reporting", "diagnostics", "versionControl")
         )
-        val largeSubprojects = mapOf("integTest" to 3, "core" to 3, "dependencyManagement" to 3)
+        val largeSubprojects = mapOf("integTest" to 3, "core" to 4, "dependencyManagement" to 3, "toolingApi" to 2)
 
         val nonTrivialBuckets = listOf<BuildTypeBucket>(
             SubprojectBucket(name = "AllUnitTest", subprojects = subProjects.filter { it.hasOnlyUnitTests() })
-        ) + buckets.map { projectsInBucket ->
-            SubprojectBucket(name = projectsInBucket[0], subprojects = projectsInBucket.map { subprojectMap.getValue(it) })
+        ) + buckets.map { entry ->
+            SubprojectBucket(name = entry.key, subprojects = entry.value.map { subprojectMap.getValue(it) })
         } + largeSubprojects.map { entry ->
             SubprojectSplit(subproject = subprojectMap.getValue(entry.key), number = 1, total = entry.value)
         }

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -267,8 +267,8 @@ data class SubprojectSplit(val subproject: GradleSubproject, val total: Int) : B
 data class SubprojectBucket(val name: String, val subprojects: List<GradleSubproject>) : BuildTypeBucket, Validatable {
     override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage) = listOf(
         FunctionalTest(model, testCoverage.asConfigurationId(model, name),
-            "${testCoverage.asName()} (${subprojects.map { it.name }.joinToString(", ")})",
-            "${testCoverage.asName()} for ${subprojects.map { it.name }.joinToString(", ")}",
+            "${testCoverage.asName()} (${subprojects.joinToString(", ") { it.name }})",
+            "${testCoverage.asName()} for ${subprojects.joinToString(", ") { it.name }}",
             testCoverage,
             stage,
             subprojects.map { it.name }
@@ -285,7 +285,7 @@ data class SubprojectBucket(val name: String, val subprojects: List<GradleSubpro
         if (!hasSameProperties { it.unitTests } ||
             !hasSameProperties { it.functionalTests } ||
             !hasSameProperties { it.crossVersionTests }) {
-            consumer.consumeError("All merged subprojects must have same properties: ${subprojects.map { it.name }.joinToString(" ")}")
+            consumer.consumeError("All merged subprojects must have same properties: ${subprojects.joinToString(" ") { it.name }}")
         }
 
         Os.values().forEach {
@@ -364,7 +364,7 @@ data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val t
     fun asConfigurationId(model: CIBuildModel, subproject: String = ""): String {
         val prefix = "${testCoveragePrefix}_"
         val shortenedSubprojectName = shortenSubprojectName(model.projectPrefix, prefix + subproject)
-        return model.projectPrefix + if (!subproject.isEmpty()) shortenedSubprojectName else "${prefix}0"
+        return model.projectPrefix + if (subproject.isNotEmpty()) shortenedSubprojectName else "${prefix}0"
     }
 
     private

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -47,7 +47,7 @@ class StageProject(model: CIBuildModel, stage: Stage, rootProjectUuid: String, d
 
         val (topLevelCoverage, allCoverage) = stage.functionalTests.partition { it.testType == TestType.soak }
         val topLevelFunctionalTests = topLevelCoverage
-            .map { FunctionalTest(model, it, stage = stage) }
+            .map { FunctionalTest(model, it.asConfigurationId(model), it.asName(), it.asName(), it, stage = stage) }
         topLevelFunctionalTests.forEach(this::buildType)
 
         val functionalTestProjects = allCoverage


### PR DESCRIPTION
### Context 

Since https://github.com/gradle/gradle/pull/10552, we can have buckets to avoid tiny build overhead or long-running build. This commit makes an attempt to split into more buckets based on the data: https://builds.gradle.org/repository/download/Hygiene_CiHealthDaily/26825943:id/reports/master/build-time-statistics/without-tests/index.html?redirectSupported=false

I'm not sure `bucket1` is a good name, though.