### PR TITLE
Remove duplicate vendor from javaVmVersion String

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
@@ -32,7 +32,7 @@ public class RegistryAwareClassLoaderHierarchyHasher extends ConfigurableClassLo
     private static Map<ClassLoader, String> collectKnownClassLoaders(ClassLoaderRegistry registry) {
         Map<ClassLoader, String> knownClassLoaders = Maps.newHashMap();
 
-        String javaVmVersion = String.format("%s|%s|%s", System.getProperty("java.vm.name"), System.getProperty("java.vm.vendor"), System.getProperty("java.vm.vendor"));
+        String javaVmVersion = String.format("%s|%s", System.getProperty("java.vm.name"), System.getProperty("java.vm.vendor"));
         ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
         if (systemClassLoader != null) {
             addClassLoader(knownClassLoaders, systemClassLoader, "system-app" + javaVmVersion);


### PR DESCRIPTION
We only remove the duplicate (and superfluous) vendor from the Java version string.

Adresses enough of #9301 for 6.0.
