### PR TITLE
Add validation at publication time

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -36,7 +36,7 @@ class TestUsage implements org.gradle.api.internal.component.UsageContext {
     Set artifacts = []
     Set capabilities = []
     Set globalExcludes = []
-    AttributeContainer attributes
+    AttributeContainer attributes = org.gradle.api.internal.attributes.ImmutableAttributes.EMPTY
 }
 
 class TestVariant implements org.gradle.api.internal.component.SoftwareComponentInternal {
@@ -53,10 +53,14 @@ class TestCapability implements Capability {
     allprojects {
         configurations { implementation }
     }
+    
+    def testAttributes = project.services.get(org.gradle.api.internal.attributes.ImmutableAttributesFactory)
+         .mutable()
+         .attribute(Attribute.of('foo', String), 'value')
 """
     }
 
-    def "generates metadata for component with no variants"() {
+    def "fails to generate metadata for component with no variants"() {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
@@ -80,14 +84,202 @@ class TestCapability implements Capability {
         """
 
         when:
+        fails 'publish'
+
+        then:
+        failure.assertHasCause """Invalid publication 'ivy':
+  - This publication must publish at least one variant"""
+    }
+
+    def "fails to generate Gradle metadata if 2 variants have the same attributes"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = 'root'
+        """
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
+
+            comp.usages.add(new TestUsage(
+                    name: 'impl',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+            
+        """
+
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        when:
+        fails 'publish'
+
+        then:
+        failure.assertHasCause """Invalid publication 'ivy':
+  - Variants 'api' and 'impl' have the same attributes and capabilities. Please make sure either attributes or capabilities are different."""
+    }
+
+    def "generates Gradle metadata if 2 variants have the same attributes but different capabilities"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = 'root'
+        """
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
+
+            comp.usages.add(new TestUsage(
+                    name: 'impl',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes,
+                    capabilities: [new TestCapability(group:'org.test', name: 'test', version: '1')]))
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+            
+        """
+
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        when:
         succeeds 'publish'
 
         then:
-        def module = ivyRepo.module('group', 'root', '1.0')
+        succeeds 'publish'
+
+        then:
+        def module = ivyRepo.module('group', 'publishTest', '1.0')
         module.assertPublished()
-        module.parsedModuleMetadata.variants.empty
-        module.parsedModuleMetadata.attributes.size() == 1
-        module.parsedModuleMetadata.attributes['org.gradle.status'] == 'integration'
+        module.parsedModuleMetadata.variants.size() == 2
+    }
+
+    def "fails to generate Gradle metadata if 2 variants have the same name"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = 'root'
+        """
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
+
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'impl'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+            
+        """
+
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        when:
+        fails 'publish'
+
+        then:
+        failure.assertHasCause """Invalid publication 'ivy':
+  - It is invalid to have multiple variants with the same name ('api')"""
+    }
+
+    def "fails to generate Gradle metadata if a variant doesn't have attributes"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = 'root'
+        """
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    dependencies: configurations.implementation.allDependencies))
+
+            comp.usages.add(new TestUsage(
+                    name: 'impl',
+                    usage: objects.named(Usage, 'impl'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+            
+        """
+
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        when:
+        fails 'publish'
+
+        then:
+        failure.assertHasCause """Invalid publication 'ivy':
+  - Variant 'api' must declare at least one attribute."""
     }
 
     def "publishes ivy status"() {
@@ -100,6 +292,11 @@ class TestCapability implements Capability {
             version = '1.0'
 
             def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
 
             publishing {
                 repositories {
@@ -122,7 +319,7 @@ class TestCapability implements Capability {
         then:
         def module = ivyRepo.module('group', 'root', '1.0')
         module.assertPublished()
-        module.parsedModuleMetadata.variants.empty
+        module.parsedModuleMetadata.variants.size() == 1
         module.parsedModuleMetadata.attributes.size() == 1
         module.parsedModuleMetadata.attributes['org.gradle.status'] == 'milestone'
     }
@@ -151,7 +348,7 @@ class TestCapability implements Capability {
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies, 
-                    attributes: configurations.implementation.attributes))
+                    attributes: testAttributes))
 
             dependencies {
                 implementation project(':a')
@@ -215,7 +412,7 @@ class TestCapability implements Capability {
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies, 
-                    attributes: configurations.implementation.attributes))
+                    attributes: testAttributes))
 
             dependencies {
                 implementation("org:foo") {
@@ -289,7 +486,7 @@ class TestCapability implements Capability {
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
-                    attributes: configurations.implementation.attributes))
+                    attributes: testAttributes))
 
             dependencies {
                 constraints {
@@ -339,7 +536,7 @@ class TestCapability implements Capability {
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies, 
-                    attributes: configurations.implementation.attributes))
+                    attributes: testAttributes))
 
             dependencies {
                 implementation("org:foo") {
@@ -399,7 +596,7 @@ class TestCapability implements Capability {
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
-                    attributes: configurations.implementation.attributes))
+                    attributes: testAttributes))
 
             dependencies {
                 implementation("org:foo:1.0") {
@@ -453,7 +650,7 @@ class TestCapability implements Capability {
             comp.usages.add(new TestUsage(
                     name: 'api',
                     usage: objects.named(Usage, 'api'), 
-                    attributes: configurations.implementation.attributes,
+                    attributes: testAttributes,
                     capabilities: [new TestCapability(group:'org.test', name: 'test', version: '1')]))
 
             publishing {
@@ -498,7 +695,7 @@ class TestCapability implements Capability {
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
-                    attributes: configurations.implementation.attributes))
+                    attributes: testAttributes))
 
             dependencies {
                 implementation("org:foo:1.0") {
@@ -558,7 +755,7 @@ class TestCapability implements Capability {
                     usage: objects.named(Usage, 'api'), 
                     dependencies: configurations.implementation.allDependencies, 
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
-                    attributes: configurations.implementation.attributes))
+                    attributes: testAttributes))
 
             dependencies {
                 implementation("org:platform:1.0") {
@@ -639,6 +836,11 @@ class TestCapability implements Capability {
             version = '1.0'
 
             def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'api',
+                    usage: objects.named(Usage, 'api'), 
+                    dependencies: configurations.implementation.allDependencies, 
+                    attributes: testAttributes))
 
             publishing {
                 repositories {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
@@ -134,7 +134,7 @@ class ExtraComp implements org.gradle.api.internal.component.SoftwareComponentIn
 }
 
 project(":project3") {
-    def e1 = new ExtraComp()
+    def e1 = new ExtraComp(variants: [components.java])
     def e2 = new ExtraComp(variants: [e1, components.java])
 
     publishing {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -1268,4 +1268,26 @@ include(':platform')
         failure.assertHasCause("Variant for configuration annotationProcessor does not exist in component java")
     }
 
+    def "fails if trying to publish a component with all variants filtered"() {
+        createBuildScripts("""
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java                        
+                    }
+                }
+            }            
+            configurations {
+                components.java.withVariantsFromConfiguration(apiElements) { skip() }
+                components.java.withVariantsFromConfiguration(runtimeElements) { skip() }                
+            }
+""")
+
+        when:
+        fails "publish"
+
+        then:
+        failure.assertHasCause("""Invalid publication 'maven':
+  - This publication must publish at least one variant""")
+    }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -134,7 +134,7 @@ class ExtraComp implements org.gradle.api.internal.component.SoftwareComponentIn
 }
 
 project(":project3") {
-    def c1 = new ExtraComp()
+    def c1 = new ExtraComp(variants: [components.java])
     def c2 = new ExtraComp(variants: [c1, components.java])
     publishing {
         publications {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -39,7 +39,6 @@ import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
-import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -141,7 +140,6 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final Set<MavenDependency> apiDependencyConstraints = new LinkedHashSet<MavenDependency>();
     private final Set<MavenDependency> importDependencyConstraints = new LinkedHashSet<MavenDependency>();
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
-    private final FeaturePreviews featurePreviews;
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final VersionMappingStrategyInternal versionMappingStrategy;
     private final PlatformSupport platformSupport;
@@ -161,7 +159,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     public DefaultMavenPublication(
         String name, MutableMavenProjectIdentity projectIdentity, NotationParser<Object, MavenArtifact> mavenArtifactParser, Instantiator instantiator,
         ObjectFactory objectFactory, ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-        FeaturePreviews featurePreviews, ImmutableAttributesFactory immutableAttributesFactory,
+        ImmutableAttributesFactory immutableAttributesFactory,
         CollectionCallbackActionDecorator collectionCallbackActionDecorator, VersionMappingStrategyInternal versionMappingStrategy,
         PlatformSupport platformSupport) {
         this.name = name;
@@ -175,7 +173,6 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         derivedArtifacts = new DefaultPublicationArtifactSet<>(MavenArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
         publishableArtifacts = new CompositePublicationArtifactSet<>(MavenArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         pom = instantiator.newInstance(DefaultMavenPom.class, this, instantiator, objectFactory);
-        this.featurePreviews = featurePreviews;
     }
 
     @Override

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -552,8 +552,8 @@ class DefaultMavenPublicationTest extends Specification {
     def createPublication() {
         def instantiator = TestUtil.instantiatorFactory().decorateLenient()
         def objectFactory = TestUtil.objectFactory()
-        def publication = new DefaultMavenPublication("pub-name", module, notationParser, instantiator, objectFactory, projectDependencyResolver, TestFiles.fileCollectionFactory(),
-            featurePreviews, AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP, Mock(VersionMappingStrategyInternal), DependencyManagementTestUtil.platformSupport())
+        def publication = new DefaultMavenPublication("pub-name", module, notationParser, instantiator, objectFactory, projectDependencyResolver, TestFiles.fileCollectionFactory()
+            , AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP, Mock(VersionMappingStrategyInternal), DependencyManagementTestUtil.platformSupport())
         publication.setPomGenerator(createArtifactGenerator(pomFile))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(gradleMetadataFile))
         return publication

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -20,8 +20,9 @@ import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.plugins.internal.AbstractUsageContext;
@@ -36,10 +37,10 @@ public class WebApplication implements SoftwareComponentInternal {
     private final String variantName;
 
     @Inject
-    public WebApplication(PublishArtifact warArtifact, String variantName) {
+    public WebApplication(PublishArtifact warArtifact, String variantName, AttributeContainer attributes) {
         this.warArtifact = warArtifact;
         this.variantName = variantName;
-        this.webArchiveUsage = new WebArchiveUsageContext();
+        this.webArchiveUsage = new WebArchiveUsageContext(attributes);
     }
 
     @Override
@@ -53,8 +54,8 @@ public class WebApplication implements SoftwareComponentInternal {
     }
 
     private class WebArchiveUsageContext extends AbstractUsageContext {
-        public WebArchiveUsageContext() {
-            super(ImmutableAttributes.EMPTY, Collections.singleton(warArtifact));
+        public WebArchiveUsageContext(AttributeContainer attributes) {
+            super(((AttributeContainerInternal)attributes).asImmutable(), Collections.singleton(warArtifact));
         }
 
         @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -22,8 +22,11 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.java.WebApplication;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.model.ObjectFactory;
@@ -46,10 +49,12 @@ public class WarPlugin implements Plugin<Project> {
     public static final String WEB_APP_GROUP = "web application";
 
     private final ObjectFactory objectFactory;
+    private final ImmutableAttributesFactory attributesFactory;
 
     @Inject
-    public WarPlugin(ObjectFactory objectFactory) {
+    public WarPlugin(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory) {
         this.objectFactory = objectFactory;
+        this.attributesFactory = attributesFactory;
     }
 
     @Override
@@ -112,6 +117,8 @@ public class WarPlugin implements Plugin<Project> {
     }
 
     private void configureComponent(Project project, PublishArtifact warArtifact) {
-        project.getComponents().add(objectFactory.newInstance(WebApplication.class, warArtifact, "master"));
+        AttributeContainer attributes = attributesFactory.mutable()
+            .attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        project.getComponents().add(objectFactory.newInstance(WebApplication.class, warArtifact, "master", attributes));
     }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -16,10 +16,15 @@
 
 package org.gradle.api.publish.internal;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Strings;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.stream.JsonWriter;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Named;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.DependencyConstraint;
@@ -47,10 +52,12 @@ import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal;
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.util.GUtil;
 import org.gradle.util.GradleVersion;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
@@ -85,6 +92,7 @@ public class GradleModuleMetadataWriter {
     }
 
     public void generateTo(PublicationInternal publication, Collection<? extends PublicationInternal> publications, Writer writer) throws IOException {
+        InvalidPublicationChecker checker = new InvalidPublicationChecker(publication.getName());
         // Collect a map from component to coordinates. This might be better to move to the component or some publications model
         Map<SoftwareComponent, ComponentData> coordinates = new HashMap<SoftwareComponent, ComponentData>();
         collectCoordinates(publications, coordinates);
@@ -97,9 +105,10 @@ public class GradleModuleMetadataWriter {
         JsonWriter jsonWriter = new JsonWriter(writer);
         jsonWriter.setHtmlSafe(false);
         jsonWriter.setIndent("  ");
-        writeComponentWithVariants(publication, publication.getComponent(), coordinates, owners, jsonWriter);
+        writeComponentWithVariants(publication, publication.getComponent(), coordinates, owners, jsonWriter, checker);
         jsonWriter.flush();
         writer.append('\n');
+        checker.validate();
     }
 
     private void collectOwners(Collection<? extends PublicationInternal> publications, Map<SoftwareComponent, SoftwareComponent> owners) {
@@ -123,12 +132,12 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void writeComponentWithVariants(PublicationInternal publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, Map<SoftwareComponent, SoftwareComponent> owners, JsonWriter jsonWriter) throws IOException {
+    private void writeComponentWithVariants(PublicationInternal publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, Map<SoftwareComponent, SoftwareComponent> owners, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         jsonWriter.beginObject();
         writeFormat(jsonWriter);
         writeIdentity(publication.getCoordinates(), publication.getAttributes(), component, componentCoordinates, owners, jsonWriter);
         writeCreator(jsonWriter);
-        writeVariants(publication, component, componentCoordinates, jsonWriter);
+        writeVariants(publication, component, componentCoordinates, jsonWriter, checker);
         jsonWriter.endObject();
     }
 
@@ -203,9 +212,10 @@ public class GradleModuleMetadataWriter {
         }
     }
 
-    private void writeVariants(PublicationInternal publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, JsonWriter jsonWriter) throws IOException {
+    private void writeVariants(PublicationInternal publication, SoftwareComponent component, Map<SoftwareComponent, ComponentData> componentCoordinates, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         boolean started = false;
         for (UsageContext usageContext : ((SoftwareComponentInternal) component).getUsages()) {
+            checker.registerVariant(usageContext.getName(), usageContext.getAttributes(),  usageContext.getCapabilities());
             if (!started) {
                 jsonWriter.name("variants");
                 jsonWriter.beginArray();
@@ -226,6 +236,7 @@ public class GradleModuleMetadataWriter {
                 assert childCoordinates != null;
                 if (childComponent instanceof SoftwareComponentInternal) {
                     for (UsageContext usageContext : ((SoftwareComponentInternal) childComponent).getUsages()) {
+                        checker.registerVariant(usageContext.getName(), usageContext.getAttributes(),  usageContext.getCapabilities());
                         if (!started) {
                             jsonWriter.name("variants");
                             jsonWriter.beginArray();
@@ -571,6 +582,85 @@ public class GradleModuleMetadataWriter {
         private ComponentData(ModuleVersionIdentifier coordinates, ImmutableAttributes attributes) {
             this.coordinates = coordinates;
             this.attributes = attributes;
+        }
+    }
+
+    @NotThreadSafe
+    public static class InvalidPublicationChecker {
+        private final String publicationName;
+        private final BiMap<String, VariantIdentity> variants = HashBiMap.create();
+        private List<String> errors;
+
+        public InvalidPublicationChecker(String publicationName) {
+            this.publicationName = publicationName;
+        }
+
+        public void registerVariant(String name, AttributeContainer attributes, Set<? extends Capability> capabilities) {
+            if (attributes.isEmpty()) {
+                failWith("Variant '" + name + "' must declare at least one attribute.");
+            }
+            if (variants.containsKey(name)) {
+                failWith("It is invalid to have multiple variants with the same name ('" + name + "')");
+            } else {
+                VariantIdentity identity = new VariantIdentity(attributes, capabilities);
+                if (variants.containsValue(identity)) {
+                    String found = variants.inverse().get(identity);
+                    failWith("Variants '" + found + "' and '" + name + "' have the same attributes and capabilities. Please make sure either attributes or capabilities are different.");
+                } else {
+                    variants.put(name, identity);
+                }
+            }
+        }
+
+        public void validate() {
+            if (variants.isEmpty()) {
+                failWith("This publication must publish at least one variant");
+            }
+            if (errors != null) {
+                TreeFormatter formatter = new TreeFormatter();
+                formatter.node("Invalid publication '" + publicationName + "'");
+                formatter.startChildren();
+                for (String error : errors) {
+                    formatter.node(error);
+                }
+                formatter.endChildren();
+                throw new InvalidUserCodeException(formatter.toString());
+            }
+        }
+
+        private void failWith(String message) {
+            if (errors == null) {
+                errors = Lists.newArrayList();
+            }
+            errors.add(message);
+        }
+
+        private static final class VariantIdentity {
+            private final AttributeContainer attributes;
+            private final Set<? extends Capability> capabilities;
+
+            private VariantIdentity(AttributeContainer attributes, Set<? extends Capability> capabilities) {
+                this.attributes = attributes;
+                this.capabilities = capabilities;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                VariantIdentity that = (VariantIdentity) o;
+                return Objects.equal(attributes, that.attributes) &&
+                    Objects.equal(capabilities, that.capabilities);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hashCode(attributes, capabilities);
+            }
         }
     }
 }


### PR DESCRIPTION
### Context

This commit introduces validation when generating Gradle
Module Metadata:

- check that there's at least one variant published
- each variant must have at least one attribute
- there shouldn't be duplicate variant names
- each variant must have a different (attributes,capabilities)
combination

Closes #10736

