### PR TITLE
Add error message in case GMM doesn't declare variants

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
@@ -21,12 +21,13 @@ import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.gradle.GradleFileModuleAdapter
+import spock.lang.Issue
 
+@RequiredFeatures([
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+])
 class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    ])
     def "can resolve if component gav information is missing"() {
         GradleFileModuleAdapter.printComponentGAV = false
         buildFile << """
@@ -57,9 +58,6 @@ class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDepen
         GradleFileModuleAdapter.printComponentGAV = true
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    ])
     def "fails with proper error if a mandatory attribute is not defined"() {
         buildFile << """
             dependencies {
@@ -84,5 +82,32 @@ class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDepen
         then:
         fails ":checkDeps"
         failure.assertHasCause("missing 'url' at /variants[0]/files[0]")
+    }
+
+    @Issue("gradle/gradle#7888")
+    def "fails with reasonable error message if Gradle Module Metadata doesn't declare any variant"() {
+        buildFile << """
+            dependencies {
+                conf 'org.test:projectA:1.1'
+            }
+        """
+
+        when:
+        repository {
+            'org.test:projectA:1.1' {
+                withModule {
+                    withoutDefaultVariants()
+                }
+            }
+        }
+        repositoryInteractions {
+            'org.test:projectA:1.1' {
+                expectGetMetadata()
+            }
+        }
+
+        then:
+        fails ":checkDeps"
+        failure.assertHasCause("Gradle Module Metadata for module org.test:projectA:1.1 is invalid because it doesn't declare any variant")
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
@@ -38,4 +38,6 @@ interface Module {
     Module withVariant(String name, @DelegatesTo(value=VariantMetadataSpec.class, strategy = Closure.DELEGATE_FIRST) groovy.lang.Closure<?> action)
 
     Map<String, String> getAttributes()
+
+    Module withoutDefaultVariants()
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -144,6 +144,12 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         return this
     }
 
+    @Override
+    IvyModule withoutDefaultVariants() {
+        variants.clear()
+        return this
+    }
+
     IvyFileModule withXml(Closure action) {
         transformer.addAction(action);
         return this

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -717,4 +717,10 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         action()
         return this
     }
+
+    @Override
+    MavenModule withoutDefaultVariants() {
+        variants.clear()
+        this
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -292,4 +292,10 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     public Map<String, String> getAttributes() {
         return backingModule.getAttributes();
     }
+
+    @Override
+    public T withoutDefaultVariants() {
+        backingModule.withoutDefaultVariants();
+        return t();
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -267,4 +267,10 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
     public Map<String, String> getAttributes() {
         return backingModule.getAttributes();
     }
+
+    @Override
+    public T withoutDefaultVariants() {
+        backingModule.withoutDefaultVariants();
+        return t();
+    }
 }


### PR DESCRIPTION
### Context

This commit validates that published Gradle Module Metadata
declares at least one variant when resolved. This is the
counterpart to validation at publication time, but this time
when resolving, in case a user/plugin generates module metadata
in a non-Gradle compatible way.

Fixes #7888 	