### PR TITLE
Document legacy Ivy and `ivy-publish` differences

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.SourceSet.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.SourceSet.xml
@@ -39,7 +39,7 @@
             </tr>
             <tr>
                 <td>runtimeClasspath</td>
-                <td><literal>sourceSet.output + project.configurations.runtime</literal> (or <literal>sourceSet.output + project.configurations.testRuntime</literal> for the <literal>test</literal> source set).</td>
+                <td><literal>sourceSet.output + project.configurations.runtimeClasspath</literal> (or <literal>sourceSet.output + project.configurations.testRuntimeClasspath</literal> for the <literal>test</literal> source set).</td>
             </tr>
         </table>
     </section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.War.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.War.xml
@@ -14,7 +14,7 @@
             </tr>
             <tr>
                 <td>classpath</td>
-                <td><literal>project.configurations.runtime - project.configurations.providedRuntime</literal></td>
+                <td><literal>project.sourceSets.main.runtimeClasspath - project.configurations.providedRuntime</literal></td>
             </tr>
             <tr>
                 <td>webXml</td>

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseWtpComponent.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseWtpComponent.xml
@@ -21,7 +21,7 @@
             </tr>
             <tr>
                 <td>libConfigurations</td>
-                <td><literal>[project.configurations.runtime]</literal></td>
+                <td><literal>[project.configurations.runtimeClasspath]</literal></td>
                 <td><literal>[project.configurations.earlib]</literal></td>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
@@ -24,9 +24,9 @@
                 <td><literal>[:]</literal></td>
                 <td>
                     <itemizedlist>
-                        <listitem><literal>COMPILE</literal> -> <literal>project.configurations.compile</literal></listitem>
-                        <listitem><literal>RUNTIME</literal> -> <literal>project.configurations.runtime - project.configurations.compile</literal></listitem>
-                        <listitem><literal>TEST</literal> -> <literal>project.configurations.testRuntime - project.configurations.runtime</literal></listitem>
+                        <listitem><literal>COMPILE</literal> -> <literal>project.configurations.compileClasspath</literal></listitem>
+                        <listitem><literal>RUNTIME</literal> -> <literal>project.configurations.runtimeClasspath - project.configurations.compileClasspath</literal></listitem>
+                        <listitem><literal>TEST</literal> -> <literal>project.configurations.testRuntimeClasspath - project.configurations.runtimeClasspath</literal></listitem>
                         <listitem><literal>PROVIDED</literal></listitem>
                     </itemizedlist>
                 </td>

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/rich_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/rich_versions.adoc
@@ -8,7 +8,9 @@ The terms and their meaning are explained below, from the strongest to the weake
 `strictly`::
 Any version not matched by this version notation will be excluded.
 This is the strongest version declaration.
-It will cause dependency resolution to fail if no version acceptable by this clause can be selected.
+On a declared dependency, a `strictly` can downgrade a version.
+When on a transitive dependency, it will cause dependency resolution to fail if no version acceptable by this clause can be selected.
+See <<controlling_transitive_dependencies.adoc#sec:enforcing_dependency_version,overriding dependency version>> for details.
 This term supports dynamic versions.
 +
 When defined, overrides previous `require` declaration and clears previous `reject`.
@@ -44,14 +46,14 @@ The following table illustrates a number of use cases and how to combine the dif
 |===
 | Which version(s) of this dependency are acceptable? | `strictly` | `require` | `prefer` | `rejects` | Selection result
 
-| Tested with version `1.5`, believe all future versions should work
+| Tested with version `1.5`, believe all future versions should work.
 |
 | 1.5
 |
 |
 | Any version starting from `1.5`, equivalent of `org:foo:1.5`. An upgrade to `2.4` is accepted.
 
-| Tested with `1.5`, soft constraint upgrades according to semantic versioning
+| Tested with `1.5`, soft constraint upgrades according to semantic versioning.
 |
 | [1.0, 2.0[
 | 1.5
@@ -59,58 +61,62 @@ The following table illustrates a number of use cases and how to combine the dif
 | Any version between `1.0` and `2.0`, `1.5` if nobody else cares. An upgrade to `2.4` is accepted. +
 🔒
 
-| Tested with `1.5`, but follows semantic versioning
+| Tested with `1.5`, but follows semantic versioning.
 | [1.0, 2.0[
 |
 | 1.5
 |
 | Any version between `1.0` and `2.0` excluded, `1.5` if nobody else cares. +
+Overwrites versions from transitive dependencies. +
 🔒
 
-| Same as above, with `1.4` known broken
+| Same as above, with `1.4` known broken.
 | [1.0, 2.0[
 |
 | 1.5
 | 1.4
 | Any version between `1.0` and `2.0` excluded except for `1.4`, `1.5` if nobody else cares. +
+Overwrites versions from transitive dependencies. +
 🔒
 
-| No opinion, works with `1.5`
+| No opinion, works with `1.5`.
 |
 |
 | 1.5
 |
-| `1.5` if no other opinion, any otherwise
+| `1.5` if no other opinion, any otherwise.
 
-| No opinion, prefer latest release
+| No opinion, prefer latest release.
 |
 |
 | `latest.release`
 |
-| The latest release at build time +
+| The latest release at build time. +
 🔒
 
-| On the edge, latest release, no downgrade
+| On the edge, latest release, no downgrade.
 |
 | `latest.release`
 |
 |
-| The latest release at build time +
+| The latest release at build time. +
 🔒
 
-| No other version than 1.5
+| No other version than 1.5.
 | 1.5
 |
 |
 |
-| 1.5, or failure if another `strict` or higher `require` constraint disagrees
+| 1.5, or failure if another `strict` or higher `require` constraint disagrees. +
+Overwrites versions from transitive dependencies.
 
-| `1.5` or a patch version of it exclusively
+| `1.5` or a patch version of it exclusively.
 | [1.5,1.6[
 |
 |
 |
-| Latest `1.5.x` patch release, or failure if another `strict` or higher `require` constraint disagrees +
+| Latest `1.5.x` patch release, or failure if another `strict` or higher `require` constraint disagrees. +
+Overwrites versions from transitive dependencies. +
 🔒
 |===
 
@@ -118,8 +124,9 @@ Lines annotated with a lock (🔒) indicate that leveraging <<dependency_locking
 Another concept that relates with rich version declaration is the ability to publish <<publishing_maven.adoc#publishing_maven:resolved_dependencies,resolved versions>> instead of declared ones.
 
 
-Using `strictly`, especially for a library, must be a well thought process as it can have a serious impact on downstream consumers.
+Using `strictly`, especially for a library, must be a well thought process as it has an impact on downstream consumers.
 At the same time, used correctly, it will help consumers understand what combination of libraries do not work together in their context.
+See <<controlling_transitive_dependencies.adoc#sec:enforcing_dependency_version,overriding dependency version>> for more information.
 
 
 [NOTE]

--- a/subprojects/docs/src/docs/userguide/publishing_ivy.adoc
+++ b/subprojects/docs/src/docs/userguide/publishing_ivy.adoc
@@ -195,3 +195,21 @@ include::{samplesPath}/ivy-publish/java-multi-project/output-ivy.xml[]
 Note that `«PUBLICATION-TIME-STAMP»` in this example Ivy module descriptor will be the timestamp of when the descriptor was generated.
 ====
 
+[[sec:pub_ivy:legacy_migration]]
+== Migrating from legacy Ivy publication
+
+If you are migrating a project that used to rely on the <<artifact_management.adoc#,legacy publishing>> support, you will find the differences between the two solutions below.
+
+=== Configurations marked as non transitive
+
+When a configuration is marked as `transitive = false`, this is not mapped to Ivy.
+
+Gradle will emit a warning that such a configuration is published. The recommendation, if this really needs to be published, is to use dependency level `transitive = false`.
+
+=== Forced dependencies are not mapped
+
+While Ivy supports the concept of a https://ant.apache.org/ivy/history/latest-milestone/ivyfile/dependency.html#_forcing_revision[`force` on a dependency], Gradle will not map its own deprecated `force` declarations to it.
+
+Instead, it is recommended to replace the Gradle `force` with a <<rich_versions.adoc#sec:strict-version,`strictly` version>>, which provides <<controlling_transitive_dependencies.adoc#sec:enforcing_dependency_version,better semantics>> and is supported by the Gradle Module Metadata format.
+
+Note that if you absolutely need to publish a force, you can still <<#sec:modifying_the_generated_module_descriptor,modify the produced `ivy.xml`>>.

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -306,4 +306,39 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         module2.assertPublished()
     }
 
+    def "warns when trying to publish a transitive = false variant"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java'
+
+            group = 'group'
+            version = '1.0'
+
+            configurations {
+                apiElements {
+                    transitive = false
+                }
+            }
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+
+        when:
+        executer.withStackTraceChecksDisabled()
+        succeeds 'publish'
+
+        then: "build warned about transitive = true variant"
+        outputContains("Publication ignores 'transitive = false' at configuration level.")
+    }
 }


### PR DESCRIPTION
* Warn when publishing a non transitive variant
* Document that `force` is not published with `ivy-publish`
* Misc documentation fixes