### PR TITLE
Disable auto apply for scan plugin (temporally)

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.scan.config.fixtures.BuildScanPluginFixture
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedBuildScanPlugin
 import org.gradle.util.VersionNumber
+import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -28,6 +29,7 @@ import static org.gradle.internal.scan.config.fixtures.BuildScanPluginFixture.BU
 import static org.gradle.internal.scan.config.fixtures.BuildScanPluginFixture.FULLY_QUALIFIED_DUMMY_BUILD_SCAN_PLUGIN_IMPL_CLASS
 import static org.gradle.internal.scan.config.fixtures.BuildScanPluginFixture.PUBLISHING_BUILD_SCAN_MESSAGE_PREFIX
 
+@Ignore("Scan plugin auto application temporally ignored - see https://github.com/gradle/gradle/pull/10783")
 class BuildScanAutoApplyIntegrationTest extends AbstractIntegrationSpec {
     private static final String BUILD_SCAN_PLUGIN_AUTO_APPLY_VERSION = AutoAppliedBuildScanPlugin.VERSION
     private static final String BUILD_SCAN_PLUGIN_MINIMUM_VERSION = BuildScanPluginCompatibility.MIN_SUPPORTED_VERSION.toString()

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyKotlinIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyKotlinIntegrationTest.groovy
@@ -20,12 +20,14 @@ import org.gradle.integtests.fixtures.KotlinScriptIntegrationTest
 import org.gradle.internal.scan.config.fixtures.BuildScanPluginFixture
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedBuildScanPlugin
 import org.gradle.util.Requires
+import spock.lang.Ignore
 
 import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOption
 import static org.gradle.internal.scan.config.fixtures.BuildScanPluginFixture.PUBLISHING_BUILD_SCAN_MESSAGE_PREFIX
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
 @Requires([KOTLIN_SCRIPT])
+@Ignore("Scan plugin auto application temporally ignored - see https://github.com/gradle/gradle/pull/10783")
 class BuildScanAutoApplyKotlinIntegrationTest extends KotlinScriptIntegrationTest {
 
     private final BuildScanPluginFixture fixture = new BuildScanPluginFixture(testDirectory, mavenRepo, createExecuter())

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/api/artifacts/transform/ArtifactTransformBuildScanIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/api/artifacts/transform/ArtifactTransformBuildScanIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.api.artifacts.transform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.scan.config.fixtures.BuildScanPluginFixture
+import spock.lang.Ignore
 
+@Ignore("Scan plugin auto application temporally ignored - see https://github.com/gradle/gradle/pull/10783")
 class ArtifactTransformBuildScanIntegrationTest extends AbstractIntegrationSpec {
     def fixture = new BuildScanPluginFixture(testDirectory, mavenRepo, createExecuter())
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -20,12 +20,10 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.Requires
-import spock.lang.Ignore
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
 @Requires([KOTLIN_SCRIPT])
-@Ignore("Scan plugin auto application temporally ignored - see https://github.com/gradle/gradle/pull/10783")
 class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
 
     @Override

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -20,10 +20,12 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.Requires
+import spock.lang.Ignore
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
 @Requires([KOTLIN_SCRIPT])
+@Ignore("Scan plugin auto application temporally ignored - see https://github.com/gradle/gradle/pull/10783")
 class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
 
     @Override

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -33,9 +33,11 @@ import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertNotEquals
+import org.junit.Ignore
 import org.junit.Test
 
 
+@Ignore("Scan plugin auto application temporally ignored - see https://github.com/gradle/gradle/pull/10783")
 class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/autoapply/AutoAppliedPluginsFunctionalTest.groovy
@@ -22,12 +22,14 @@ import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.Ignore
 import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.BuildScanUserInputFixture.*
 
 @Requires(TestPrecondition.ONLINE)
 @LeaksFileHandles
+@Ignore("Scan plugin auto application temporally ignored - see https://github.com/gradle/gradle/pull/10783")
 class AutoAppliedPluginsFunctionalTest extends AbstractPluginIntegrationTest {
 
     private static final String BUILD_SCAN_LICENSE_QUESTION = 'Publishing a build scan to scans.gradle.com requires accepting the Gradle Terms of Service defined at https://gradle.com/terms-of-service. Do you accept these terms?'

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -56,9 +56,12 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
         return buildDefinition.getInjectedPluginRequests();
     }
 
+    // We temporally disable auto apply functionality to fix a chicken egg problem with the gradle enterprise plugin that is
+    //    converted to be a settings plugin
     private boolean shouldApplyScanPlugin(Project target) {
-        StartParameter startParameter = buildDefinition.getStartParameter();
-        return startParameter.isBuildScan() && target.getParent() == null && target.getGradle().getParent() == null;
+//        StartParameter startParameter = buildDefinition.getStartParameter();
+//        return startParameter.isBuildScan() && target.getParent() == null && target.getGradle().getParent() == null;
+        return false;
     }
 
     private static DefaultPluginRequest createScanPluginRequest() {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -16,7 +16,6 @@
 
 package org.gradle.plugin.management.internal.autoapply;
 
-import org.gradle.StartParameter;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;


### PR DESCRIPTION
<!--- The issue this PR addresses -->

### Context
- This is required to fix the transition from the scan plugin being a settings plugin.
The plan is to 

- Ge build needs to build against a gradle snapshot where auto application is disabled so we can make the transition of the scan plugin to the gradle enterprise gradle plugin that will provide functionality to have deal with --scan + settings gradle plugin. 
- Then we can reenable the auto apply mechanism for --scan

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
