### PR TITLE
Improve error message when build fails because of missing metadata

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -757,6 +757,7 @@ afterEvaluate {
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
   - ${m.pom.file.toURL()}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :buildC""")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -100,6 +100,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
   - ${m.pom.file.toURL()}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :buildSrc""")
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
@@ -176,9 +176,12 @@ class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyReso
         fails ":checkDeps"
 
         and:
+        def format = metadataSource == 'ivyDescriptor' ? 'ivy.xml' :
+            (metadataSource == 'mavenPom' ? 'Maven POM' : 'Gradle module')
         failure.assertHasCause("""Could not find org.test:projectA:1.1.
 Searched in the following locations:
   - ${metadataUri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in '$format' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:""")
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyBrokenRemoteResolveIntegrationTest.groovy
@@ -44,6 +44,7 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${module.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
 
@@ -57,6 +58,7 @@ Required by:
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${module.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
 
@@ -104,11 +106,13 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${moduleA.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
 
@@ -181,12 +185,14 @@ task showMissing { doLast { println configurations.compile.files } }
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${moduleA.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project : > group:projectC:0.99
     project : > project :child1 > group:projectD:1.0GA""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project : > project :child1 > group:projectD:1.0GA""")
 
@@ -236,6 +242,7 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${module.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
 """)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBrokenRemoteResolveIntegrationTest.groovy
@@ -46,6 +46,7 @@ task showMissing { doLast { println configurations.missing.files } }
             .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${module.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
 
@@ -59,6 +60,7 @@ Required by:
             .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${module.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
 
@@ -106,11 +108,13 @@ task showMissing { doLast { println configurations.missing.files } }
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${moduleA.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
 
@@ -183,12 +187,14 @@ task showMissing { doLast { println configurations.compile.files } }
                 .assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${moduleA.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project : > group:projectC:0.99
     project : > project :child1 > group:projectD:1.0GA""")
                 .assertHasCause("""Could not find group:projectB:1.0-milestone-9.
 Searched in the following locations:
   - ${moduleB.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project : > project :child1 > group:projectD:1.0GA""")
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -178,6 +178,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         failure.assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
   - ${module.pomFile.toURL()}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
 """)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -678,6 +678,7 @@ dependencies {
         failure.assertHasCause("""Could not find test:a:1.2.
 Searched in the following locations:
   - ${m.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
     project :""")
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -1034,6 +1034,7 @@ task retrieve(type: Sync) {
         failure.assertHasCause("""Could not find org.gradle.integtests.resolve:projectA:${published.publishArtifactVersion}.
 Searched in the following locations:
   - ${projectA.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
 """)
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
@@ -132,5 +132,25 @@ public class ModuleVersionNotFoundException extends ModuleVersionResolveExceptio
             builder.node(location);
         }
         builder.endChildren();
+        tryHintAboutArtifactSource(builder, locations);
+    }
+
+    // This method should ideally use more data to figure out if the message should be displayed
+    // or not. In particular, the ivy patterns can make it difficult to find out if an Ivy artifact
+    // source should be configured. At this stage, this information is lost, so we do a best effort
+    // based on the file locations.
+    private static void tryHintAboutArtifactSource(TreeFormatter builder, Collection<String> locations) {
+        if (locations.size() == 1) {
+            String singleLocation = locations.iterator().next();
+            boolean isPom = singleLocation.endsWith(".pom");
+            boolean isIvy = singleLocation.contains("ivy-") && singleLocation.endsWith(".xml");
+            boolean isModule = singleLocation.endsWith(".module");
+            String format = isPom ? "Maven POM" : (isIvy ? "ivy.xml" : (isModule ? "Gradle module" : null));
+            if (format != null) {
+                builder.node(
+                    String.format("If the artifact you are trying to retrieve can be found in the repository but without metadata in '%s' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.", format)
+                );
+            }
+        }
     }
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1413,6 +1413,7 @@ org:middle:1.0 FAILED
       - Could not find org:middle:2.0.
         Searched in the following locations:
           - ${mavenRepoURL}/org/middle/2.0/middle-2.0.pom
+        If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 
 org:middle:1.0 -> 2.0 FAILED
 \\--- org:top:1.0
@@ -1580,6 +1581,7 @@ org:leaf:1.0 FAILED
       - Could not find org:leaf:1.0.
         Searched in the following locations:
           - ${ivyRepoURL}/org/leaf/1.0/ivy-1.0.xml
+        If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 
 org:leaf:1.0 FAILED
 \\--- org:top:1.0

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsRepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/maven/MavenGcsRepoErrorsIntegrationTest.groovy
@@ -97,6 +97,7 @@ repositories {
             """Could not find org.gradle:test:1.85.
 Searched in the following locations:
   - ${module.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
 """)
     }

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
@@ -118,6 +118,7 @@ repositories {
                 """Could not find org.gradle:test:1.85.
 Searched in the following locations:
   - ${module.pom.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
 """)
     }

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoErrorsIntegrationTest.groovy
@@ -51,6 +51,7 @@ class IvySftpRepoErrorsIntegrationTest extends AbstractSftpDependencyResolutionT
                 .assertHasCause("""Could not find org.group.name:projectA:1.2.
 Searched in the following locations:
   - ${module.ivy.uri}
+If the artifact you are trying to retrieve can be found in the repository but without metadata in 'ivy.xml' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
 Required by:
 """)
     }


### PR DESCRIPTION
Gradle 6.0 removed the "artifact" metadata source by default.
This means that if a module is published _only_ with an artifact,
previous version of Gradle would find it, but 6.0 would fail with
a module missing exception.

The problem is that it's hard to realize that the issue comes
from the change of this default artifact sources.

This commit tries to improve the situation by recognizing that
a failure is related to not finding metadata, and in this case
would suggest that if the metadata is missing, it is still
possible that the jar is present.

The drawback of this approach is that we're unsure: if, for
some reason, the module is _really_ absent, then we gave a
wrong advice. This means, in particular, in case of wrong
coordinates.

Fixes #10786 


