### PR TITLE
Emit lower bound for generic types of Kotlin DSL accessors

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/reflect/TypeOf.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/reflect/TypeOf.java
@@ -208,6 +208,7 @@ public abstract class TypeOf<T> {
      * Returns the first declared lower-bound of the wildcard type expression represented by this type.
      *
      * @return null if no lower-bound has been explicitly declared.
+     * @since 6.0
      */
     @Nullable
     public TypeOf<?> getLowerBound() {
@@ -256,7 +257,7 @@ public abstract class TypeOf<T> {
      * </p>
      *
      * @since 5.0
-     * 
+     *
      * @return Underlying Java Class of this type.
      */
     @Incubating

--- a/subprojects/core-api/src/main/java/org/gradle/api/reflect/TypeOf.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/reflect/TypeOf.java
@@ -205,6 +205,16 @@ public abstract class TypeOf<T> {
     }
 
     /**
+     * Returns the first declared lower-bound of the wildcard type expression represented by this type.
+     *
+     * @return null if no lower-bound has been explicitly declared.
+     */
+    @Nullable
+    public TypeOf<?> getLowerBound() {
+        return nullableTypeOf(type.getLowerBound());
+    }
+
+    /**
      * Is this type assignable from the given type?
      *
      * @param type the given type

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -171,6 +171,12 @@
             "member": "Method org.gradle.kotlin.dsl.ComponentMetadataHandlerExtensionsKt.withModule(org.gradle.api.artifacts.dsl.ComponentMetadataHandler,java.lang.Object,org.gradle.api.Action)",
             "acceptation": "Reified versions of methods that are already de-incubated",
             "changes": []
+        },
+        {
+            "type": "org.gradle.api.reflect.TypeOf",
+            "member": "Method org.gradle.api.reflect.TypeOf.getLowerBound()",
+            "acceptation": "It goes with the already public API, getUpperBound",
+            "changes": []
         }
     ]
 }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaLambdaAccessorsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaLambdaAccessorsIntegrationTest.kt
@@ -194,12 +194,6 @@ class ProjectSchemaLambdaAccessorsIntegrationTest : AbstractPluginIntegrationTes
     @Issue("https://github.com/gradle/gradle/issues/10772")
     fun `accessors to **typed** kotlin lambda extensions are typed`() {
 
-        // TODO:kotlin-dsl Remove once above issue is fixed
-        exceptionRule.apply {
-            expect(ComparisonFailure::class.java)
-            expectMessage(containsString("lambdaExtension: kotlin.jvm.functions.Function1<? super java.lang.Object, ? extends java.lang.String>"))
-        }
-
         requireGradleDistributionOnEmbeddedExecuter()
 
         withDefaultSettings()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -758,7 +758,7 @@ val TypeOf<*>.builder: KmTypeBuilder
             classOf(parameterizedTypeDefinition.concreteClass),
             actualTypeArguments.map { it.builder }
         )
-        isWildcard -> upperBound?.builder ?: KotlinType.any
+        isWildcard -> (upperBound ?: lowerBound)?.builder ?: KotlinType.any
         else -> classOf(concreteClass)
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStrings.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStrings.kt
@@ -26,7 +26,7 @@ fun kotlinTypeStringFor(type: TypeOf<*>): String = type.run {
         isParameterized ->
             "$parameterizedTypeDefinition<${actualTypeArguments.joinToString(transform = ::kotlinTypeStringFor)}>"
         isWildcard ->
-            upperBound?.let(::kotlinTypeStringFor) ?: "Any"
+            (upperBound ?: lowerBound)?.let(::kotlinTypeStringFor) ?: "Any"
         else ->
             toString().let { primitiveTypeStrings[it] ?: it }
     }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
@@ -34,6 +34,14 @@ class KotlinTypeStringTest {
     }
 
     @Test
+    fun `#kotlinTypeStringFor Java function type`() {
+        assertThat(
+            kotlinTypeStringFor(typeOf<java.util.function.Function<String, String>>()),
+            equalTo("java.util.function.Function<String, String>")
+        )
+    }
+
+    @Test
     fun `#kotlinTypeStringFor primitive type`() {
         assertPrimitiveTypeName<Boolean>(java.lang.Boolean.TYPE)
         assertPrimitiveTypeName<Char>(java.lang.Character.TYPE)

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStringTest.kt
@@ -26,6 +26,14 @@ class KotlinTypeStringTest {
     }
 
     @Test
+    fun `#kotlinTypeStringFor Kotlin function type`() {
+        assertThat(
+            kotlinTypeStringFor(typeOf<(String) -> String>()),
+            equalTo("kotlin.jvm.functions.Function1<String, String>")
+        )
+    }
+
+    @Test
     fun `#kotlinTypeStringFor primitive type`() {
         assertPrimitiveTypeName<Boolean>(java.lang.Boolean.TYPE)
         assertPrimitiveTypeName<Char>(java.lang.Character.TYPE)


### PR DESCRIPTION
Fixes #10772