### PR TITLE
Differentiate between slow regression tests and performance experiments

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
@@ -15,8 +15,8 @@ import model.PerformanceTestType
 import model.Stage
 
 class PerformanceTestCoordinator(model: CIBuildModel, type: PerformanceTestType, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
-    uuid = type.asId(model)
-    id = AbsoluteId(uuid)
+    uuid = type.asUuid(model)
+    id = AbsoluteId(type.asId(model))
     name = "Performance ${type.name.capitalize()} Coordinator - Linux"
 
     applyPerformanceTestSettings(timeout = type.timeout)

--- a/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
@@ -17,11 +17,11 @@ import model.Stage
 class PerformanceTestCoordinator(model: CIBuildModel, type: PerformanceTestType, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
     uuid = type.asUuid(model)
     id = AbsoluteId(type.asId(model))
-    name = "Performance ${type.name.capitalize()} Coordinator - Linux"
+    name = "${type.displayName} Coordinator - Linux"
 
     applyPerformanceTestSettings(timeout = type.timeout)
 
-    if (type in listOf(PerformanceTestType.test, PerformanceTestType.experiment)) {
+    if (type in listOf(PerformanceTestType.test, PerformanceTestType.slow)) {
         features {
             publishBuildStatusToGithub(model)
         }

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -81,7 +81,7 @@ data class CIBuildModel(
         Stage(StageNames.HISTORICAL_PERFORMANCE,
             trigger = Trigger.weekly,
             performanceTests = listOf(
-                PerformanceTestType.historical, PerformanceTestType.flakinessDetection)),
+                PerformanceTestType.historical, PerformanceTestType.flakinessDetection, PerformanceTestType.experiment)),
         Stage(StageNames.EXPERIMENTAL,
             trigger = Trigger.never,
             runsIndependent = true,
@@ -399,8 +399,9 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
 enum class PerformanceTestType(val taskId: String, val displayName: String, val timeout: Int, val defaultBaselines: String = "", val extraParameters: String = "", val uuid: String? = null) {
     test("PerformanceTest", "Performance Regression Test", 420, "defaults"),
     slow("SlowPerformanceTest", "Slow Performance Regression Test", 420, "defaults", uuid = "PerformanceExperimentCoordinator"),
+    experiment("PerformanceExperiment", "Slow Performance Regression Test", 420, "defaults", uuid = "PerformanceExperimentOnlyCoordinator"),
     flakinessDetection("FlakinessDetection", "Flakiness Detection Performance Test", 420, "flakiness-detection-commit"),
-    historical("FullPerformanceTest", "Historical Performance Test", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
+    historical("HistoricalPerformanceTest", "Historical Performance Test", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
 
     fun asId(model: CIBuildModel): String =
         "${model.projectPrefix}Performance${name.capitalize()}Coordinator"

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -41,7 +41,7 @@ data class CIBuildModel(
             specificBuilds = listOf(
                 SpecificBuild.CompileAll, SpecificBuild.SanityCheck),
             functionalTests = listOf(
-                TestCoverage(1, TestType.quick, Os.linux, common.JvmCategory.MAX_VERSION.version, vendor = common.JvmCategory.MAX_VERSION.vendor)), omitsSlowProjects = true),
+                TestCoverage(1, TestType.quick, Os.linux, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)), omitsSlowProjects = true),
         Stage(StageNames.QUICK_FEEDBACK,
             functionalTests = listOf(
                 TestCoverage(2, TestType.quick, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor)),
@@ -396,15 +396,18 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     forceRealizeDependencyManagement(false, true, false)
 }
 
-enum class PerformanceTestType(val taskId: String, val timeout: Int, val defaultBaselines: String = "", val extraParameters: String = "") {
+enum class PerformanceTestType(val taskId: String, val timeout: Int, val defaultBaselines: String = "", val extraParameters: String = "", val uuid: String? = null) {
     test("PerformanceTest", 420, "defaults"),
-    experiment("PerformanceExperiment", 420, "defaults"),
+    // TODO: Rename to `slow`
+    experiment("SlowPerformanceTest", 420, "defaults", uuid = "PerformanceExperimentCoordinator"),
     flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit"),
     historical("FullPerformanceTest", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
 
-    fun asId(model: CIBuildModel): String {
-        return "${model.projectPrefix}Performance${name.capitalize()}Coordinator"
-    }
+    fun asId(model: CIBuildModel): String =
+        "${model.projectPrefix}Performance${name.capitalize()}Coordinator"
+
+    fun asUuid(model: CIBuildModel): String =
+        uuid?.let { model.projectPrefix + it } ?: asId(model)
 }
 
 enum class Trigger {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -77,7 +77,7 @@ data class CIBuildModel(
                 TestCoverage(14, TestType.platform, Os.macos, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(15, TestType.forceRealizeDependencyManagement, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor)),
             performanceTests = listOf(
-                PerformanceTestType.experiment)),
+                PerformanceTestType.slow)),
         Stage(StageNames.HISTORICAL_PERFORMANCE,
             trigger = Trigger.weekly,
             performanceTests = listOf(
@@ -396,12 +396,11 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     forceRealizeDependencyManagement(false, true, false)
 }
 
-enum class PerformanceTestType(val taskId: String, val timeout: Int, val defaultBaselines: String = "", val extraParameters: String = "", val uuid: String? = null) {
-    test("PerformanceTest", 420, "defaults"),
-    // TODO: Rename to `slow`
-    experiment("SlowPerformanceTest", 420, "defaults", uuid = "PerformanceExperimentCoordinator"),
-    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit"),
-    historical("FullPerformanceTest", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
+enum class PerformanceTestType(val taskId: String, val displayName: String, val timeout: Int, val defaultBaselines: String = "", val extraParameters: String = "", val uuid: String? = null) {
+    test("PerformanceTest", "Performance Regression Test", 420, "defaults"),
+    slow("SlowPerformanceTest", "Slow Performance Regression Test", 420, "defaults", uuid = "PerformanceExperimentCoordinator"),
+    flakinessDetection("FlakinessDetection", "Flakiness Detection Performance Test", 420, "flakiness-detection-commit"),
+    historical("FullPerformanceTest", "Historical Performance Test", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
 
     fun asId(model: CIBuildModel): String =
         "${model.projectPrefix}Performance${name.capitalize()}Coordinator"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,10 @@ buildTypes {
         tasks("performance:distributedFullPerformanceTest")
     }
 
+    create("distributedHistoricalPerformanceTests") {
+        tasks("performance:distributedHistoricalPerformanceTest")
+    }
+
     create("distributedFlakinessDetections") {
         tasks("performance:distributedFlakinessDetection")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,10 +105,6 @@ buildTypes {
         tasks("performance:distributedPerformanceExperiment")
     }
 
-    create("distributedFullPerformanceTests") {
-        tasks("performance:distributedFullPerformanceTest")
-    }
-
     create("distributedHistoricalPerformanceTests") {
         tasks("performance:distributedHistoricalPerformanceTest")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,10 @@ buildTypes {
         tasks("performance:distributedPerformanceTest")
     }
 
+    create("distributedSlowPerformanceTests") {
+        tasks("performance:distributedSlowPerformanceTest")
+    }
+
     create("distributedPerformanceExperiments") {
         tasks("performance:distributedPerformanceExperiment")
     }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -290,11 +290,6 @@ class PerformanceTestPlugin : Plugin<Project> {
             channel = "experiments"
             retryFailedScenarios()
         }
-        create("distributedFullPerformanceTest", DistributedPerformanceTest::class) {
-            configuredBaselines.set(Config.baseLineList)
-            checks = "none"
-            channel = "historical"
-        }
         create("distributedHistoricalPerformanceTest", DistributedPerformanceTest::class) {
             (options as JUnitOptions).excludeCategories(performanceExperimentCategory)
             configuredBaselines.set(Config.baseLineList)

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -295,6 +295,12 @@ class PerformanceTestPlugin : Plugin<Project> {
             checks = "none"
             channel = "historical"
         }
+        create("distributedHistoricalPerformanceTest", DistributedPerformanceTest::class) {
+            (options as JUnitOptions).excludeCategories(performanceExperimentCategory)
+            configuredBaselines.set(Config.baseLineList)
+            checks = "none"
+            channel = "historical"
+        }
         create("distributedFlakinessDetection", DistributedPerformanceTest::class) {
             (options as JUnitOptions).includeCategories(performanceRegressionTestCategory)
             distributedPerformanceReporter.reportGeneratorClass = "org.gradle.performance.results.report.FlakinessReportGenerator"

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -72,6 +72,14 @@ private
 const val performanceExperimentCategory = "org.gradle.performance.categories.PerformanceExperiment"
 
 
+private
+const val performanceRegressionTestCategory = "org.gradle.performance.categories.PerformanceRegressionTest"
+
+
+private
+const val slowPerformanceRegressionTestCategory = "org.gradle.performance.categories.SlowPerformanceRegressionTest"
+
+
 @Suppress("unused")
 class PerformanceTestPlugin : Plugin<Project> {
 
@@ -230,7 +238,14 @@ class PerformanceTestPlugin : Plugin<Project> {
         }
 
         create("performanceTest") {
-            (options as JUnitOptions).excludeCategories(performanceExperimentCategory)
+            (options as JUnitOptions).apply {
+                includeCategories(performanceRegressionTestCategory)
+                excludeCategories(slowPerformanceRegressionTestCategory)
+            }
+        }
+
+        create("slowPerformanceTest") {
+            (options as JUnitOptions).includeCategories(slowPerformanceRegressionTestCategory)
         }
 
         create("performanceExperiment") {
@@ -258,7 +273,15 @@ class PerformanceTestPlugin : Plugin<Project> {
         }
 
         create("distributedPerformanceTest", DistributedPerformanceTest::class) {
-            (options as JUnitOptions).excludeCategories(performanceExperimentCategory)
+            (options as JUnitOptions).apply {
+                includeCategories(performanceRegressionTestCategory)
+                excludeCategories(slowPerformanceRegressionTestCategory)
+            }
+            channel = "commits"
+            retryFailedScenarios()
+        }
+        create("distributedSlowPerformanceTest", DistributedPerformanceTest::class) {
+            (options as JUnitOptions).includeCategories(slowPerformanceRegressionTestCategory)
             channel = "commits"
             retryFailedScenarios()
         }
@@ -273,7 +296,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             channel = "historical"
         }
         create("distributedFlakinessDetection", DistributedPerformanceTest::class) {
-            (options as JUnitOptions).excludeCategories(performanceExperimentCategory)
+            (options as JUnitOptions).includeCategories(performanceRegressionTestCategory)
             distributedPerformanceReporter.reportGeneratorClass = "org.gradle.performance.results.report.FlakinessReportGenerator"
             repeatScenarios(3)
             checks = "none"

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/categories/PerformanceExperiment.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/categories/PerformanceExperiment.java
@@ -20,5 +20,5 @@ package org.gradle.performance.categories;
  * A performance test that is only there for informational purposes, e.g. comparing
  * two different ways of building a project.
  */
-public interface PerformanceExperiment extends PerformanceRegressionTest {
+public interface PerformanceExperiment extends PerformanceTest {
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/categories/SlowPerformanceRegressionTest.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/categories/SlowPerformanceRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,5 @@
 
 package org.gradle.performance.categories;
 
-/**
- * A performance test that compares Gradle's current performance against
- * some baseline and fails if it is slower.
- */
-public interface PerformanceRegressionTest extends PerformanceTest {
-
+public interface SlowPerformanceRegressionTest extends PerformanceRegressionTest {
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/JavaLibraryPluginPerformanceTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.performance.experiment.java
 
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.performance.AbstractCrossBuildPerformanceTest
-import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.SlowPerformanceRegressionTest
 import org.gradle.performance.results.BaselineVersion
 import org.gradle.performance.results.CrossBuildPerformanceResults
 import org.junit.experimental.categories.Category
@@ -26,7 +26,7 @@ import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
 
-@Category(PerformanceExperiment)
+@Category(SlowPerformanceRegressionTest)
 class JavaLibraryPluginPerformanceTest extends AbstractCrossBuildPerformanceTest {
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/ParallelBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/experiment/java/ParallelBuildPerformanceTest.groovy
@@ -21,8 +21,8 @@ import org.gradle.performance.categories.PerformanceExperiment
 import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
-import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
+import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
 @Category(PerformanceExperiment)
 class ParallelBuildPerformanceTest extends AbstractCrossBuildPerformanceTest {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.performance.regression.android
 
 import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
-import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.SlowPerformanceRegressionTest
 import org.gradle.performance.fixture.GradleProfilerCrossVersionPerformanceTestRunner
 import org.gradle.profiler.InvocationSettings
 import org.gradle.profiler.mutations.AbstractCleanupMutator
@@ -78,7 +78,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         SANTA_TRACKER       | true     | null       | null | 'assembleDebug'
     }
 
-    @Category(PerformanceExperiment)
+    @Category(SlowPerformanceRegressionTest)
     @Unroll
     def "clean #tasks on #testProject with clean transforms cache"() {
         given:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.performance.regression.inception
 
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
-import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.SlowPerformanceRegressionTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 import org.gradle.performance.fixture.BuildExperimentListenerAdapter
 import org.junit.experimental.categories.Category
@@ -76,7 +76,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionGradleInternalP
         'help' | _
     }
 
-    @Category(PerformanceExperiment)
+    @Category(SlowPerformanceRegressionTest)
     @Unroll
     def "buildSrc api change in #testProject comparing gradle"() {
         given:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.performance.regression.java
 
 import org.apache.commons.io.FileUtils
 import org.gradle.performance.AbstractCrossVersionGradleInternalPerformanceTest
-import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.SlowPerformanceRegressionTest
 import org.gradle.performance.fixture.BuildExperimentInvocationInfo
 import org.gradle.performance.fixture.BuildExperimentListener
 import org.gradle.performance.fixture.BuildExperimentListenerAdapter
@@ -30,7 +30,7 @@ import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
-@Category(PerformanceExperiment)
+@Category(SlowPerformanceRegressionTest)
 class JavaFirstUsePerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.performance.regression.nativeplatform
 
 import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
-import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.SlowPerformanceRegressionTest
 import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
-@Category(PerformanceExperiment)
+@Category(SlowPerformanceRegressionTest)
 class NativeCleanBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
         runner.minimumVersion = '4.1' // minimum version that contains new C++ plugins

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.performance.regression.nativeplatform
 
 import org.gradle.initialization.ParallelismBuildOptions
 import org.gradle.performance.AbstractCrossVersionGradleProfilerPerformanceTest
-import org.gradle.performance.categories.PerformanceExperiment
+import org.gradle.performance.categories.SlowPerformanceRegressionTest
 import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
-@Category(PerformanceExperiment)
+@Category(SlowPerformanceRegressionTest)
 class SwiftCleanBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
 
     def setup() {


### PR DESCRIPTION
Performance experiments should only run once a week, while slow performance regression should run at least every day if not more often.