### PR TITLE
Dependency locking: support for deactivate locks on configurations

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -110,6 +110,15 @@ public interface ResolutionStrategy {
     ResolutionStrategy activateDependencyLocking();
 
     /**
+     * Deactivates dependency locking support in Gradle.
+     *
+     * @return this resolution strategy instance
+     * @since 6.0
+     */
+    ResolutionStrategy deactivateDependencyLocking();
+
+
+    /**
      * Allows forcing certain versions of dependencies, including transitive dependencies.
      * <b>Appends</b> new forced modules to be considered when resolving dependencies.
      * <p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -115,6 +115,7 @@ public interface ResolutionStrategy {
      * @return this resolution strategy instance
      * @since 6.0
      */
+    @Incubating
     ResolutionStrategy deactivateDependencyLocking();
 
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -32,4 +32,15 @@ public interface DependencyLockingHandler {
      *
      */
     void lockAllConfigurations();
+
+    /**
+     * Convenience method for doing:
+     *
+     * configurations.all {
+     *     resolutionStrategy.deactivateDependencyLocking()
+     * }
+     *
+     * @since 6.0
+     */
+    void unlockAllConfigurations();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyLockingHandler.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.artifacts.dsl;
 
+import org.gradle.api.Incubating;
+
 /**
  * A {@code DependencyLockingHandler} manages the behaviour and configuration of dependency locking.
  *
@@ -42,5 +44,6 @@ public interface DependencyLockingHandler {
      *
      * @since 6.0
      */
+    @Incubating
     void unlockAllConfigurations();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -133,6 +133,14 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     @Override
+    public ResolutionStrategy deactivateDependencyLocking() {
+        mutationValidator.validateMutation(STRATEGY);
+        dependencyLockingEnabled = false;
+        return this;
+    }
+
+
+    @Override
     public void sortArtifacts(SortOrder sortOrder) {
         this.sortOrder = sortOrder;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingHandler.java
@@ -30,6 +30,15 @@ public class DefaultDependencyLockingHandler implements DependencyLockingHandler
         }
     };
 
+
+    private static final Action<Configuration> DEACTIVATE_LOCKING = new Action<Configuration>() {
+        @Override
+        public void execute(Configuration configuration) {
+            configuration.getResolutionStrategy().deactivateDependencyLocking();
+        }
+    };
+
+
     private final ConfigurationContainer configurationContainer;
 
     public DefaultDependencyLockingHandler(ConfigurationContainer configurationContainer) {
@@ -39,5 +48,10 @@ public class DefaultDependencyLockingHandler implements DependencyLockingHandler
     @Override
     public void lockAllConfigurations() {
         configurationContainer.all(ACTIVATE_LOCKING);
+    }
+
+    @Override
+    public void unlockAllConfigurations() {
+        configurationContainer.all(DEACTIVATE_LOCKING);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -287,4 +287,12 @@ class DefaultResolutionStrategySpec extends Specification {
         true            | dependencyLockingProvider
         false           | NoOpDependencyLockingProvider.instance
     }
+
+    def 'Does not provide DependencyLockingProvider when deactivatingLocking'() {
+        when:
+        strategy.deactivateDependencyLocking()
+
+        then:
+        strategy.dependencyLockingProvider.is( NoOpDependencyLockingProvider.instance)
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingHandlerTest.groovy
@@ -45,4 +45,24 @@ class DefaultDependencyLockingHandlerTest extends Specification {
         1 * strategy.activateDependencyLocking()
     }
 
+    def 'deactivates dependency locking on configurations'() {
+        given:
+        ConfigurationContainer container = Mock()
+        Configuration configuration = Mock()
+        ResolutionStrategy strategy = Mock()
+        @Subject
+        def handler = new DefaultDependencyLockingHandler(container)
+
+        when:
+        handler.unlockAllConfigurations()
+
+        then:
+        1 * container.all(_ as Action) >> { Action action ->
+            action.execute(configuration)
+        }
+
+        1 * configuration.getResolutionStrategy() >> strategy
+        1 * strategy.deactivateDependencyLocking()
+    }
+
 }

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
@@ -49,6 +49,12 @@ include::sample[dir="userguide/dependencyManagement/dependencyLocking/lockingAll
 include::sample[dir="userguide/dependencyManagement/dependencyLocking/lockingAllConfigurations/kotlin",files="build.gradle.kts[tags=locking-all]"]
 ====
 
+.Unocking a specific configuration
+====
+include::sample[dir="userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/groovy",files="build.gradle[tags=unlocking-one]"]
+include::sample[dir="userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/kotlin",files="build.gradle.kts[tags=unlocking-one]"]
+====
+
 [NOTE]
 ====
 Only configurations that can be resolved will have lock state attached to them.

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/groovy/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+
+// tag::locking-one[]
+configurations {
+    compileClasspath {
+        resolutionStrategy.deactivateDependencyLocking()
+    }
+}
+// end::locking-one[]
+
+// tag::locking-deps[]
+dependencies {
+    implementation 'org.springframework:spring-beans:[5.0,6.0)'
+}
+// end::locking-deps[]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/groovy/settings.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = 'unlocking-one-configuration'

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/kotlin/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::locking-one[]
+configurations.compileClasspath {
+    resolutionStrategy.deactivateDependencyLocking()
+}
+// end::locking-one[]
+
+// tag::locking-deps[]
+dependencies {
+    implementation("org.springframework:spring-beans:[5.0,6.0)")
+}
+// end::locking-deps[]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/kotlin/settings.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "unlocking-one-configuration"

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/locking-one.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/dependencyLocking/unlockingSingleConfiguration/locking-one.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: tasks
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: tasks
+}]


### PR DESCRIPTION
### Context
1) folks are curious if they can remove an entire configuration from being locked, i.e. a configuration added by a plugin that may have been activated for locking

2) in the nebula-dependency-recommender-plugin, we create copies of a configuration, and those copies persist the dependency locking state of their parent dependency. This means that when the change to rename all copies as configNameCopy1 incrementally[2], we have up to 40+ locked copy configurations, with Gradle 5.6 [3].

[1]https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.ResolutionStrategy.html#org.gradle.api.artifacts.ResolutionStrategy:activateDependencyLocking()
[2]https://github.com/gradle/gradle/pull/9638/files
[3]https://docs.gradle.org/5.6/userguide/upgrading_version_5.html#configuration_copies_have_unique_names

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
