### PR TITLE
Fix test expectation

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
@@ -61,6 +61,11 @@ public class ErrorsOnStdoutScrapingExecutionResult implements ExecutionResult {
     }
 
     @Override
+    public String getOutputLineThatContains(String text) {
+        return delegate.getOutputLineThatContains(text);
+    }
+
+    @Override
     public ExecutionResult assertHasErrorOutput(String expectedOutput) {
         assertContentContains(getOutput(), expectedOutput, "Build output");
         return this;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -67,6 +67,15 @@ public interface ExecutionResult {
     String getError();
 
     /**
+     * Retrieves the first output line that contains the passed in text.
+     *
+     * Fails with an assertion if no output line contains the given text.
+     *
+     * @param text the text to match
+     */
+    String getOutputLineThatContains(String text);
+
+    /**
      * Asserts that this result includes the given error log message. Does not consider any text in or following the build result message (use {@link #assertHasPostBuildOutput(String)} instead).
      *
      * @param expectedOutput The expected log message, with line endings normalized to a newline character.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -562,6 +562,11 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         }
 
         @Override
+        public String getOutputLineThatContains(String text) {
+            return outputResult.getOutputLineThatContains(text);
+        }
+
+        @Override
         public ExecutionResult assertTasksExecutedInOrder(Object... taskPaths) {
             Set<String> expected = TaskOrderSpecs.exact(taskPaths).getTasks();
             assertTasksExecuted(expected);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -215,6 +216,18 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     @Override
     public String getError() {
         return error.withNormalizedEol();
+    }
+
+    @Override
+    public String getOutputLineThatContains(String text) {
+        Optional<String> foundLine = getMainContent().getLines().stream()
+            .filter(line -> line.contains(text))
+            .findFirst();
+        return foundLine.orElseGet(() -> {
+            failOnMissingOutput("Did not find expected text in build output.", "Build output", text, text);
+            // never returned
+            return "";
+        });
     }
 
     public List<String> getExecutedTasks() {

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperLoggingIntegrationTest.groovy
@@ -122,6 +122,6 @@ class WrapperLoggingIntegrationTest extends AbstractWrapperIntegrationSpec {
         result = wrapperExecuter.run()
 
         then:
-        outputContains("........10%.........20%.........30%.........40%.........50%.........60%.........70%.........80%.........90%.........100%")
+        result.getOutputLineThatContains("10%").replaceAll("\\.+", "|") == '|10%|20%|30%|40%|50%|60%|70%|80%|90%|100%'
     }
 }


### PR DESCRIPTION
Instead of comparing output that contains irrelevant dots, we strip them
before asserting that we have the expected percentage values

Added a method that allows to query the output for a line containing a
given String