### PR TITLE
Steer users away from applying java directly

### DIFF
--- a/subprojects/docs/src/docs/userguide/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/building_java_projects.adoc
@@ -471,3 +471,12 @@ The platform has no source and no artifact of its own.
 It maps in the Maven world to a https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management[BOM].
 
 The support comes via the <<java_platform_plugin.adoc#,Java Platform plugin>>, which sets up the different configurations and publication components.
+
+[[sec:building_jvm_lang]]
+== Building other JVM language projects
+
+If you want to leverage the multi language aspect of the JVM, most of what was described here will still apply.
+
+Gradle itself provides <<groovy_plugin.adoc#,Groovy>> and <<scala_plugin.adoc#,Scala>> plugins. Note that these can be further enhanced by combining them with the `java-library` plugin.
+
+And beyond core Gradle, there are other https://plugins.gradle.org/search?term=jvm[great plugins] for more JVM languages!

--- a/subprojects/docs/src/docs/userguide/groovy_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/groovy_plugin.adoc
@@ -15,7 +15,13 @@
 [[groovy_plugin]]
 = The Groovy Plugin
 
-The Groovy plugin extends the Java plugin to add support for Groovy projects. It can deal with Groovy code, mixed Groovy and Java code, and even pure Java code (although we don't necessarily recommend to use it for the latter). The plugin supports _joint compilation_, which allows you to freely mix and match Groovy and Java code, with dependencies in both directions. For example, a Groovy class can extend a Java class that in turn extends a Groovy class. This makes it possible to use the best language for the job, and to rewrite any class in the other language if needed.
+The Groovy plugin extends the <<java_plugin.adoc#,Java plugin>> to add support for https://groovy-lang.org/[Groovy] projects.
+It can deal with Groovy code, mixed Groovy and Java code, and even pure Java code (although we don't necessarily recommend to use it for the latter).
+The plugin supports _joint compilation_, which allows you to freely mix and match Groovy and Java code, with dependencies in both directions.
+For example, a Groovy class can extend a Java class that in turn extends a Groovy class.
+This makes it possible to use the best language for the job, and to rewrite any class in the other language if needed.
+
+Note that if you want to benefit from the <<java_library_plugin.adoc#sec:java_library_separation,API / implementation separation>>, you can also apply the `java-library` plugin to your Groovy project.
 
 
 [[sec:groovy_usage]]

--- a/subprojects/docs/src/docs/userguide/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_plugin.adoc
@@ -15,7 +15,16 @@
 [[java_plugin]]
 = The Java Plugin
 
-The Java plugin adds Java compilation along with testing and bundling capabilities to a project. It serves as the basis for many of the other JVM language Gradle plugins. You can find a comprehensive introduction and overview to the Java Plugin in the <<building_java_projects.adoc#building_java_projects,Building Java Projects>> chapter.
+The Java plugin adds Java compilation along with testing and bundling capabilities to a project.
+It serves as the basis for many of the other JVM language Gradle plugins.
+You can find a comprehensive introduction and overview to the Java Plugin in the <<building_java_projects.adoc#building_java_projects,Building Java Projects>> chapter.
+
+[NOTE]
+====
+As indicated above, this plugin adds basic building blocks for working with JVM projects.
+Its feature set has been superseded by other plugins, offering more features based on your project type.
+Instead of applying it directly to your project, you should look into the `java-library` or `java-application` plugins or one of the supported alternative JVM language.
+====
 
 [[sec:java_usage]]
 == Usage

--- a/subprojects/docs/src/docs/userguide/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/scala_plugin.adoc
@@ -15,7 +15,13 @@
 [[scala_plugin]]
 = The Scala Plugin
 
-The Scala plugin extends the Java plugin to add support for Scala projects. It can deal with Scala code, mixed Scala and Java code, and even pure Java code (although we don't necessarily recommend to use it for the latter). The plugin supports _joint compilation_, which allows you to freely mix and match Scala and Java code, with dependencies in both directions. For example, a Scala class can extend a Java class that in turn extends a Scala class. This makes it possible to use the best language for the job, and to rewrite any class in the other language if needed.
+The Scala plugin extends the <<java_plugin.adoc#,Java plugin>> to add support for https://www.scala-lang.org/[Scala] projects.
+It can deal with Scala code, mixed Scala and Java code, and even pure Java code (although we don't necessarily recommend to use it for the latter).
+The plugin supports _joint compilation_, which allows you to freely mix and match Scala and Java code, with dependencies in both directions.
+For example, a Scala class can extend a Java class that in turn extends a Scala class.
+This makes it possible to use the best language for the job, and to rewrite any class in the other language if needed.
+
+Note that if you want to benefit from the <<java_library_plugin.adoc#sec:java_library_separation,API / implementation separation>>, you can also apply the `java-library` plugin to your Scala project.
 
 
 [[sec:scala_usage]]


### PR DESCRIPTION
Updates to the documentation to highlight better the interest of the
`java-library` plugin.