### PR TITLE
Set empty REPO_MIRROR_URLS for macos

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -14,6 +14,7 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2018_2.FailureAction
+import jetbrains.buildServer.configs.kotlin.v2018_2.Parameter
 import jetbrains.buildServer.configs.kotlin.v2018_2.ProjectFeatures
 import jetbrains.buildServer.configs.kotlin.v2018_2.buildFeatures.commitStatusPublisher
 import model.CIBuildModel
@@ -164,6 +165,10 @@ fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTas
 }
 
 fun applyTestDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTasks: String, notQuick: Boolean = false, os: Os = Os.linux, extraParameters: String = "", timeout: Int = 90, extraSteps: BuildSteps.() -> Unit = {}, daemon: Boolean = true) {
+    if (os == Os.macos) {
+        buildType.params.param("env.REPO_MIRROR_URLS", "")
+    }
+
     buildType.applyDefaultSettings(os, timeout)
 
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)

--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -14,7 +14,6 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2018_2.FailureAction
-import jetbrains.buildServer.configs.kotlin.v2018_2.Parameter
 import jetbrains.buildServer.configs.kotlin.v2018_2.ProjectFeatures
 import jetbrains.buildServer.configs.kotlin.v2018_2.buildFeatures.commitStatusPublisher
 import model.CIBuildModel

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import projects.FunctionalTestProject
 import projects.RootProject
 import projects.StageProject
 import java.io.File
@@ -27,6 +28,16 @@ class CIConfigIntegrationTests {
         val rootProject = RootProject(model)
         assertEquals(rootProject.subProjects.size, model.stages.size + 1)
         assertEquals(rootProject.buildTypes.size, model.stages.size)
+    }
+
+    @Test
+    fun macBuildsHasEmptyRepoMirrorUrlsParam() {
+        val model = CIBuildModel()
+        val rootProject = RootProject(model)
+        val readyForRelease = rootProject.searchSubproject("Gradle_Check_Stage_ReadyforRelease")
+        val macBuilds = readyForRelease.subProjects.filter { it.name.contains("Macos") }.flatMap { (it as FunctionalTestProject).functionalTests }
+        assertTrue(macBuilds.isNotEmpty())
+        assertTrue(macBuilds.all { it.params.findRawParam("env.REPO_MIRROR_URLS")!!.value == "" })
     }
 
     @Test


### PR DESCRIPTION

### Context

This is a follow-up of https://github.com/gradle/gradle/pull/10824#discussion_r326988751 discussion.