### PR TITLE
Deprecate BuildListener#buildStarted and Gradle#buildStarted

### DIFF
--- a/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.profile;
 
-import org.gradle.BuildListener;
 import org.gradle.BuildResult;
 import org.gradle.api.Describable;
 import org.gradle.api.Project;
@@ -30,13 +29,14 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskState;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
 import org.gradle.initialization.BuildCompletionListener;
+import org.gradle.internal.InternalBuildListener;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.time.Clock;
 
 /**
  * Adapts various events to build a {@link BuildProfile} model, and then notifies a {@link ReportGeneratingProfileListener} when the model is ready.
  */
-public class ProfileEventAdapter implements BuildListener, ProjectEvaluationListener, TaskListenerInternal, DependencyResolutionListener, BuildCompletionListener, ArtifactTransformListener {
+public class ProfileEventAdapter implements InternalBuildListener, ProjectEvaluationListener, TaskListenerInternal, DependencyResolutionListener, BuildCompletionListener, ArtifactTransformListener {
     private final BuildStartedTime buildStartedTime;
     private final Clock clock;
     private final ProfileListener listener;

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -319,6 +319,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     }
 
     protected void execute() {
+        executer.expectDeprecationWarnings(2) // Due to LoggingBuildListener
         super.execute(buildA, ":resolveArtifacts", ["-I../gradle-user-home/init.gradle"])
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/BuildAdapter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildAdapter.java
@@ -24,6 +24,7 @@ import org.gradle.api.invocation.Gradle;
  */
 public class BuildAdapter implements BuildListener {
     @Override
+    @Deprecated
     public void buildStarted(Gradle gradle) {
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
@@ -30,6 +30,7 @@ public interface BuildListener {
      *
      * @param gradle The build which is being started. Never null.
      */
+    @Deprecated
     void buildStarted(Gradle gradle);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/internal/InternalBuildListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/InternalBuildListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 package org.gradle.internal;
 
-import org.gradle.BuildAdapter;
+import org.gradle.BuildListener;
 import org.gradle.api.invocation.Gradle;
 
-public class InternalBuildAdapter extends BuildAdapter implements InternalBuildListener {
-
-    // Internal usage of this callback is fine only the public API is being deprecated
-    @Override
-    @SuppressWarnings("deprecation")
-    public void buildStarted(Gradle gradle) {
-    }
+public interface InternalBuildListener extends BuildListener, InternalListener {
+    /**
+     * <p>Called when the build is started.</p>
+     *
+     * @param gradle The build which is being started. Never null.
+     */
+    void buildStarted(Gradle gradle);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -593,6 +593,7 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         initFile << addGradleListeners('init')
 
         when:
+        executer.expectDeprecationWarning()
         run()
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/invocation/BuildStartedDeprecatedIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/invocation/BuildStartedDeprecatedIntegrationTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.invocation
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class BuildStartedDeprecatedIntegrationTest extends AbstractIntegrationSpec {
+    private static final String INIT_FILE_NAME = "init.gradle"
+
+    @Unroll
+    def "shows deprecation warning when adding build listener through Gradle.addBuildListener that override the BuildAdapter#buildStarted after the build was started (#fromScript)"() {
+        def initScriptFile = file(INIT_FILE_NAME).touch()
+        file(scriptFile) << """
+            gradle.addBuildListener(new BuildAdapter() {
+                void buildStarted(Gradle gradle) {
+                    assert false
+                }
+            })
+        """
+
+        executer.usingInitScript(initScriptFile)
+
+        expect:
+        executer.expectDeprecationWarning()
+        run "help"
+        outputContains("BuildListener#buildStarted(Gradle) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
+
+        where:
+        fromScript       | scriptFile
+        "init script"    | INIT_FILE_NAME
+        "setting script" | "settings.gradle"
+        "build script"   | "build.gradle"
+    }
+
+    @Unroll
+    def "shows deprecation warning when adding build listener through Gradle.addListener that override the BuildAdapter#buildStarted after the build was started (#fromScript)"() {
+        def initScriptFile = file(INIT_FILE_NAME).touch()
+        file(scriptFile) << """
+            gradle.addListener(new BuildAdapter() {
+                void buildStarted(Gradle gradle) {
+                    assert false
+                }
+            })
+        """
+
+        executer.usingInitScript(initScriptFile)
+
+        expect:
+        executer.expectDeprecationWarning()
+        run "help"
+        outputContains("BuildListener#buildStarted(Gradle) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
+
+        where:
+        fromScript       | scriptFile
+        "init script"    | INIT_FILE_NAME
+        "setting script" | "settings.gradle"
+        "build script"   | "build.gradle"
+    }
+
+    @Unroll
+    def "shows deprecation warning when adding build listener through Gradle.buildStarted after the build was started (#fromScript)"() {
+        def initScriptFile = file(INIT_FILE_NAME).touch()
+        file(scriptFile) << """
+            gradle.buildStarted { assert false }
+            gradle.buildStarted new Action<Gradle>() {
+                void execute(Gradle g) {
+                    assert false
+                }
+            }
+        """
+
+        executer.usingInitScript(initScriptFile)
+
+        expect:
+        executer.expectDeprecationWarnings(2)
+        run "help"
+        outputContains("Gradle#buildStarted(Action) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
+        outputContains("Gradle#buildStarted(Closure) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
+
+        where:
+        fromScript       | scriptFile
+        "init script"    | INIT_FILE_NAME
+        "setting script" | "settings.gradle"
+        "build script"   | "build.gradle"
+    }
+
+    @Unroll
+    def "does not shows deprecation warning when adding build listener through Gradle.addBuildListener that does not override the BuildAdapter#buildStarted after the build was started (#fromScript)"() {
+        def initScriptFile = file(INIT_FILE_NAME).touch()
+        file(scriptFile) << """
+            gradle.addBuildListener(new BuildAdapter() {
+                void buildFinished(Gradle gradle) {
+                    assert true
+                }
+            })
+        """
+
+        executer.usingInitScript(initScriptFile)
+
+        expect:
+        run "help"
+
+        where:
+        fromScript       | scriptFile
+        "init script"    | INIT_FILE_NAME
+        "setting script" | "settings.gradle"
+        "build script"   | "build.gradle"
+    }
+
+    @Unroll
+    def "does not shows deprecation warning when adding build listener through Gradle.addListener that does not override the BuildAdapter#buildStarted after the build was started (#fromScript)"() {
+        def initScriptFile = file(INIT_FILE_NAME).touch()
+        file(scriptFile) << """
+            gradle.addListener(new BuildAdapter() {
+                void buildFinished(Gradle gradle) {
+                    assert true
+                }
+            })
+        """
+
+        executer.usingInitScript(initScriptFile)
+
+        expect:
+        run "help"
+
+        where:
+        fromScript       | scriptFile
+        "init script"    | INIT_FILE_NAME
+        "setting script" | "settings.gradle"
+        "build script"   | "build.gradle"
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.buildevents;
 
-import org.gradle.BuildListener;
 import org.gradle.BuildResult;
 import org.gradle.StartParameter;
 import org.gradle.api.execution.TaskExecutionGraph;
@@ -26,7 +25,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.initialization.BuildRequestMetaData;
-import org.gradle.internal.InternalListener;
+import org.gradle.internal.InternalBuildListener;
 import org.gradle.internal.logging.format.TersePrettyDurationFormatter;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.time.Clock;
@@ -34,7 +33,7 @@ import org.gradle.internal.time.Clock;
 /**
  * A {@link org.gradle.BuildListener} which logs the build progress.
  */
-public class BuildLogger implements BuildListener, TaskExecutionGraphListener, InternalListener {
+public class BuildLogger implements InternalBuildListener, TaskExecutionGraphListener {
     private final Logger logger;
     private final BuildExceptionReporter exceptionReporter;
     private final BuildResultLogger resultLogger;

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -17,7 +17,9 @@
 package org.gradle.invocation;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import groovy.lang.Closure;
+import org.gradle.BuildAdapter;
 import org.gradle.BuildListener;
 import org.gradle.BuildResult;
 import org.gradle.StartParameter;
@@ -58,6 +60,7 @@ import org.gradle.internal.scan.config.BuildScanConfigInit;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.listener.ClosureBackedMethodInvocationDispatch;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.Path;
 
@@ -336,11 +339,13 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void buildStarted(Closure closure) {
+        DeprecationLogger.nagUserOfDeprecated("Gradle#buildStarted(Closure)");
         buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("buildStarted", closure));
     }
 
     @Override
     public void buildStarted(Action<? super Gradle> action) {
+        DeprecationLogger.nagUserOfDeprecated("Gradle#buildStarted(Action)");
         buildListenerBroadcast.add("buildStarted", action);
     }
 
@@ -400,6 +405,9 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void addListener(Object listener) {
+        if (listener instanceof BuildListener) {
+            nagBuildStartedDeprecationIfOverriden(((BuildListener) listener).getClass());
+        }
         addListener("Gradle.addListener", listener);
     }
 
@@ -425,7 +433,18 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void addBuildListener(BuildListener buildListener) {
+        nagBuildStartedDeprecationIfOverriden(buildListener.getClass());
         addListener("Gradle.addBuildListener", buildListener);
+    }
+
+    private void nagBuildStartedDeprecationIfOverriden(Class<? extends BuildListener> buildListenerClass) {
+        try {
+            if (!ImmutableSet.of(BuildAdapter.class, InternalBuildAdapter.class).contains(buildListenerClass.getMethod("buildStarted", Gradle.class).getDeclaringClass())) {
+                DeprecationLogger.nagUserOfDeprecated("BuildListener#buildStarted(Gradle)");
+            }
+        } catch (NoSuchMethodException e) {
+            assert false; // There's always a method named buildStarted
+        }
     }
 
     @Override

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -72,6 +72,11 @@ Property 'options.configFile' is not annotated with an input or output annotatio
 In Gradle 5.0 we removed the `--no-search-upward` CLI parameter.
 The related APIs in `StartParameter` are now deprecated.
 
+==== `BuildListener#buildStarted` and `Gradle#buildStarted` has been deprecated
+
+These methods currently do not work as expected.
+They are being deprecated to avoid confusion.
+
 === Potential breaking changes
 
 ==== Android Gradle Plugin 3.3 and earlier is not supported anymore

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -71,13 +71,16 @@ class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionAnd
 
     def "android 3.6 minimal build clean assembleDebug"() {
         when:
+        executer.expectDeprecationWarning() // Coming from Android plugin
         instantRun("assembleDebug")
 
         then:
         instantExecution.assertStateStored()
 
         when:
+        executer.expectDeprecationWarning() // Coming from Android plugin
         run 'clean'
+        // Instant execution avoid registering the listener inside Android plugin
         instantRun("assembleDebug")
 
         then:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
@@ -69,12 +69,15 @@ class InstantExecutionSantaTrackerIntegrationTest extends AbstractInstantExecuti
         withAgpNightly()
 
         when:
+        executer.expectDeprecationWarning() // Coming from Android plugin
         instantRun("assembleDebug", "--no-build-cache")
 
         and:
+        executer.expectDeprecationWarning() // Coming from Android plugin
         run 'clean'
 
         then:
+        // Instant execution avoid registering the listener inside Android plugin
         instantRun("assembleDebug", "--no-build-cache")
     }
 }


### PR DESCRIPTION
Registering this callback within an init, settings or build script has
no effect as the build is already started. Those callback are also part
of an older API. Removing it from the public API will prevent further
user confusion.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/7613

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fdeprecate-buildStarted)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
