### PR TITLE
Deprecate afterEvaluate invocation after a project is evaluated

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -409,6 +409,7 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         applyScript(subBuildFile, scriptFile)
 
         when:
+        executer.expectDeprecationWarnings(2)
         run()
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
@@ -30,6 +30,7 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
 
     def "nested afterEvaluate is honored asynchronously"() {
         given:
+
         buildFile << """
             afterEvaluate {
                 println "> Outer"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -997,6 +997,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public void afterEvaluate(Action<? super Project> action) {
         assertMutatingMethodAllowed("afterEvaluate(Action)");
+        maybeNagDeprecationOfAfterEvaluateAfterProjectIsEvaluated("afterEvaluate(Action)");
         evaluationListener.add("afterEvaluate", getListenerBuildOperationDecorator().decorate("Project.afterEvaluate", action));
     }
 
@@ -1009,7 +1010,18 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public void afterEvaluate(Closure closure) {
         assertMutatingMethodAllowed("afterEvaluate(Closure)");
+        maybeNagDeprecationOfAfterEvaluateAfterProjectIsEvaluated("afterEvaluate(Closure)");
         evaluationListener.add(new ClosureBackedMethodInvocationDispatch("afterEvaluate", getListenerBuildOperationDecorator().decorate("Project.afterEvaluate", closure)));
+    }
+
+    private void maybeNagDeprecationOfAfterEvaluateAfterProjectIsEvaluated(String methodPrototype) {
+        if (!state.isUnconfigured() && !state.isConfiguring()) {
+            DeprecationLogger.nagUserOfDiscontinuedMethodInvocation("Project#" + methodPrototype + " when the project is already evaluated", getAdviceOnDeprecationOfAfterEvaluateAfterProjectIsEvaluated());
+        }
+    }
+
+    private static String getAdviceOnDeprecationOfAfterEvaluateAfterProjectIsEvaluated() {
+        return "The configuration given is ignored because the project has already been evaluated. To apply this configuration, remove afterEvaluate.";
     }
 
     @Override

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -273,7 +273,7 @@ In general, users are advised to migrate from `ivy.xml` to the new Gradle Module
 
 ==== Calling afterEvaluate on an evaluated project has been deprecated
 
-Once a project is evaluated, Gradle ignores all configuration passed to `Project#afterEvaluate`.
+Once a project is evaluated, Gradle ignores all configuration passed to `Project#afterEvaluate` and emits a deprecation warning. This scenario will become an error in Gradle 7.0.
 To avoid confusion, this scenario will become an error in Gradle 7.0.
 Until then, a deprecation warning will be shown.
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -274,7 +274,6 @@ In general, users are advised to migrate from `ivy.xml` to the new Gradle Module
 ==== Calling afterEvaluate on an evaluated project has been deprecated
 
 Once a project is evaluated, Gradle ignores all configuration passed to `Project#afterEvaluate` and emits a deprecation warning. This scenario will become an error in Gradle 7.0.
-To avoid confusion, this scenario will become an error in Gradle 7.0.
 Until then, a deprecation warning will be shown.
 
 ==== Miscellaneous

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -274,7 +274,6 @@ In general, users are advised to migrate from `ivy.xml` to the new Gradle Module
 ==== Calling afterEvaluate on an evaluated project has been deprecated
 
 Once a project is evaluated, Gradle ignores all configuration passed to `Project#afterEvaluate` and emits a deprecation warning. This scenario will become an error in Gradle 7.0.
-Until then, a deprecation warning will be shown.
 
 ==== Miscellaneous
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -271,6 +271,12 @@ However, selecting the `default` configuration yields the same result as before.
 Only the `runtime` configuration now contains more information which corresponds to the _runtimeElements_ variant of a Java library.
 In general, users are advised to migrate from `ivy.xml` to the new Gradle Module Metadata format.
 
+==== Calling afterEvaluate on an evaluated project has been deprecated
+
+Once a project is evaluated, Gradle ignores all configuration passed to `Project#afterEvaluate`.
+To avoid confusion, this scenario will become an error in Gradle 7.0.
+Until then, a deprecation warning will be shown.
+
 ==== Miscellaneous
 
 The following breaking changes will appear as deprecation warnings with Gradle 5.6:


### PR DESCRIPTION
Calling afterEvaluate once the project is evaluated has no effect (aka
the action is never called). We are converting the silent ignore of the
action into a deprecation warning which will then become an error in
Gradle 7.0.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/1135

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fdeprecate-afterEvaluate-after-evaluate)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
