### PR TITLE
Explicitly test for deprecation warning messages

### DIFF
--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
@@ -200,7 +200,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         file("in.txt").text = "in"
 
         when:
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarning("Changing the value for a FileCollection with a final value has been deprecated. This will fail with an error in Gradle 7.0.")
         run("merge")
 
         then:
@@ -224,7 +224,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         file("in.txt").text = "in"
 
         when:
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarning("Changing the value for a FileCollection with a final value has been deprecated. This will fail with an error in Gradle 7.0.")
         run("show")
 
         then:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -152,7 +152,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     private boolean renderWelcomeMessage;
 
     private int expectedGenericDeprecationWarnings;
-    private List<String> expectedDeprecationWarnings = new ArrayList<>();
+    private final List<String> expectedDeprecationWarnings = new ArrayList<>();
     private boolean eagerClassLoaderCreationChecksOn = true;
     private boolean stackTraceChecksOn = true;
 
@@ -1136,9 +1136,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
     protected Action<ExecutionResult> getResultAssertion() {
         return new Action<ExecutionResult>() {
-            List<String> expectedDeprecationWarnings = AbstractGradleExecuter.this.expectedDeprecationWarnings;
-            boolean expectStackTraces = !AbstractGradleExecuter.this.stackTraceChecksOn;
-            boolean checkDeprecations = AbstractGradleExecuter.this.checkDeprecations;
+            private int expectedGenericDeprecationWarnings = AbstractGradleExecuter.this.expectedGenericDeprecationWarnings;
+            private final List<String> expectedDeprecationWarnings = new ArrayList<>(AbstractGradleExecuter.this.expectedDeprecationWarnings);
+            private final boolean expectStackTraces = !AbstractGradleExecuter.this.stackTraceChecksOn;
+            private final boolean checkDeprecations = AbstractGradleExecuter.this.checkDeprecations;
 
             @Override
             public void execute(ExecutionResult executionResult) {
@@ -1161,7 +1162,12 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
                 if (!expectedDeprecationWarnings.isEmpty()) {
                     throw new AssertionError(String.format("Expected the following deprecation warnings:%n%s",
-                        expectedDeprecationWarnings.stream().map(warning -> " - " + warning).collect(Collectors.joining("\n"))));
+                        expectedDeprecationWarnings.stream()
+                            .map(warning -> " - " + warning)
+                            .collect(Collectors.joining("\n"))));
+                }
+                if (expectedGenericDeprecationWarnings > 0) {
+                    throw new AssertionError(String.format("Expected %d more deprecation warnings", expectedGenericDeprecationWarnings));
                 }
             }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -284,6 +284,11 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter expectDeprecationWarning();
 
     /**
+     * Expects exactly the given deprecation warning.
+     */
+    GradleExecuter expectDeprecationWarning(String warning);
+
+    /**
      * Expects exactly the given number of deprecation warnings. If fewer or more warnings are produced during
      * the execution, the assertion fails.
      */

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyRemoteLegacyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyRemoteLegacyPublishIntegrationTest.groovy
@@ -44,7 +44,9 @@ abstract class AbstractIvyRemoteLegacyPublishIntegrationTest extends AbstractInt
     @Issue("GRADLE-3440")
     void "can publish using uploadArchives"() {
         // We expect 'The compile/runtime configuration has been deprecated for removal.' for using this legacy mechanism in the traditional way.
-        executer.expectDeprecationWarnings(3)
+        executer.expectDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation configuration instead.")
+        executer.expectDeprecationWarning("The runtime configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the runtimeOnly configuration instead.")
+        executer.expectDeprecationWarning("The uploadArchives task has been deprecated. This is scheduled to be removed in Gradle 7.0. Use the 'ivy-publish' plugin instead")
 
         given:
         settingsFile << 'rootProject.name = "publish"'
@@ -144,7 +146,7 @@ uploadArchives {
         module.jar.expectUploadBroken()
 
         when:
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarning("The uploadArchives task has been deprecated. This is scheduled to be removed in Gradle 7.0. Use the 'ivy-publish' plugin instead")
         fails 'uploadArchives'
 
         then:

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -152,7 +152,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
 
         when:
-        executer.expectDeprecationWarnings(1)
+        executer.expectDeprecationWarning("The DeprecatedPlugin plugin has been deprecated. This is scheduled to be removed in ${GradleVersion.current().nextMajor}. Consider using the Foobar plugin instead.")
         executer.withWarningMode(WarningMode.Fail)
 
         then:

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/external/AbstractMultiVersionPlayExternalContinuousBuildIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/external/AbstractMultiVersionPlayExternalContinuousBuildIntegrationTest.groovy
@@ -40,7 +40,7 @@ abstract class AbstractMultiVersionPlayExternalContinuousBuildIntegrationTest ex
     def setup() {
         buildFile << playPlatformConfiguration(version.toString())
         executer.withPluginRepositoryMirror()
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarning("The ProjectLayout.configurableFiles() method has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the ObjectFactory.fileCollection() method instead.")
     }
 
     private static String playPlatformConfiguration(String version) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/DistributionPluginIntegrationTest.groovy
@@ -80,7 +80,8 @@ class DistributionPluginIntegrationTest extends WellBehavedPluginTest {
             }
             """
         then:
-        executer.expectDeprecationWarnings(2)
+        executer.expectDeprecationWarning("The maven plugin has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the maven-publish plugin instead.")
+        executer.expectDeprecationWarning("The uploadArchives task has been deprecated. This is scheduled to be removed in Gradle 7.0. Use the 'maven-publish' plugin instead")
         succeeds("uploadArchives")
         file("repo/org/acme/TestProject/1.0/TestProject-1.0.zip").assertIsFile()
 


### PR DESCRIPTION
Instead of testing for the number of times `deprecated` appears on the output, we now check if the given message appears explicitly.