### PR TITLE
Add missing references to fail warning mode

### DIFF
--- a/subprojects/docs/src/docs/userguide/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/build_environment.adoc
@@ -65,7 +65,7 @@ Specifies the JVM arguments used for the Gradle Daemon. The setting is particula
 When set to quiet, warn, lifecycle, info, or debug, Gradle will use this log level. The values are not case sensitive. The `lifecycle` level is the default. See <<logging.adoc#sec:choosing_a_log_level,Choosing a log level>>.
 `org.gradle.parallel=(true,false)`::
 When configured, Gradle will fork up to `org.gradle.workers.max` JVMs to execute projects in parallel. To learn more about parallel task execution, see link:https://guides.gradle.org/performance/#parallel_execution[the Gradle performance guide].
-`org.gradle.warning.mode=(all,none,summary)`::
+`org.gradle.warning.mode=(all,fail,summary,none)`::
 When set to `all`, `summary` or `none`, Gradle will use different warning type display. See <<command_line_interface.adoc#sec:command_line_logging,Command-line logging options>> for details.
 `org.gradle.workers.max=(max # of worker processes)`::
 When configured, Gradle will use a maximum of the given number of workers. Default is number of CPU processors. See also <<command_line_interface.adoc#sec:command_line_performance, performance command-line options>>.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -423,7 +423,7 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter withConsole(ConsoleOutput consoleOutput);
 
     /**
-     * Executes the build with {@code "--warning-mode=none, summary, all"} argument.
+     * Executes the build with {@code "--warning-mode=none, summary, fail, all"} argument.
      *
      * @see WarningMode
      */

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -178,7 +178,7 @@ public class LoggingConfigurationBuildOptions {
         public static final String GRADLE_PROPERTY = "org.gradle.warning.mode";
 
         public WarningsOption() {
-            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which mode of warnings to generate. Values are 'all', 'summary'(default) or 'none'"));
+            super(GRADLE_PROPERTY, CommandLineOptionConfiguration.create(LONG_OPTION, "Specifies which mode of warnings to generate. Values are 'all', 'fail', 'summary'(default) or 'none'"));
         }
 
         @Override


### PR DESCRIPTION
~~Opened against `release` so that it makes it in a potential `5.6.3` as well.~~
Will be fixed on `master`