### PR TITLE
Fix extending JavaCompile deprecation message

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -142,7 +142,7 @@ public class JavaCompile extends AbstractCompile {
     @Deprecated
     @TaskAction
     protected void compile(@SuppressWarnings("deprecation") org.gradle.api.tasks.incremental.IncrementalTaskInputs inputs) {
-        DeprecationLogger.nagUserOfDeprecatedThing("Extending the JavaCompile task", "Configure the task instead");
+        DeprecationLogger.nagUserOfDeprecated("Extending the JavaCompile task", "Configure the task instead.");
         compile((InputChanges) inputs);
     }
 


### PR DESCRIPTION
and assert that newer versions of the Android plugin don't do this.