### PR TITLE
use buildscript repos for javaagent dependencies

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -93,11 +93,11 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * Creates the configurations used by plugin.
      */
     private void addJacocoConfigurations() {
-        Configuration agentConf = project.getConfigurations().create(AGENT_CONFIGURATION_NAME);
+        Configuration agentConf = project.getBuildscript().getConfigurations().create(AGENT_CONFIGURATION_NAME);
         agentConf.setVisible(false);
         agentConf.setTransitive(true);
         agentConf.setDescription("The Jacoco agent to use to get coverage data.");
-        Configuration antConf = project.getConfigurations().create(ANT_CONFIGURATION_NAME);
+        Configuration antConf = project.getBuildscript().getConfigurations().create(ANT_CONFIGURATION_NAME);
         antConf.setVisible(false);
         antConf.setTransitive(true);
         antConf.setDescription("The Jacoco ant tasks to use to get execute Gradle tasks.");
@@ -110,12 +110,12 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * @param extension the extension that has the tool version to use
      */
     private void configureAgentDependencies(JacocoAgentJar jacocoAgentJar, final JacocoPluginExtension extension) {
-        final Configuration config = project.getConfigurations().getAt(AGENT_CONFIGURATION_NAME);
+        final Configuration config = project.getBuildscript().getConfigurations().getAt(AGENT_CONFIGURATION_NAME);
         jacocoAgentJar.setAgentConf(config);
         config.defaultDependencies(new Action<DependencySet>() {
             @Override
             public void execute(DependencySet dependencies) {
-                dependencies.add(project.getDependencies().create("org.jacoco:org.jacoco.agent:" + extension.getToolVersion()));
+                dependencies.add(project.getBuildscript().getDependencies().create("org.jacoco:org.jacoco.agent:" + extension.getToolVersion()));
             }
         });
     }
@@ -127,7 +127,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * @param extension the JacocoPluginExtension
      */
     private void configureTaskClasspathDefaults(final JacocoPluginExtension extension) {
-        final Configuration config = this.project.getConfigurations().getAt(ANT_CONFIGURATION_NAME);
+        final Configuration config = this.project.getBuildscript().getConfigurations().getAt(ANT_CONFIGURATION_NAME);
         project.getTasks().withType(JacocoBase.class).configureEach(new Action<JacocoBase>() {
             @Override
             public void execute(JacocoBase task) {
@@ -137,7 +137,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
         config.defaultDependencies(new Action<DependencySet>() {
             @Override
             public void execute(DependencySet dependencies) {
-                dependencies.add(project.getDependencies().create("org.jacoco:org.jacoco.ant:" + extension.getToolVersion()));
+                dependencies.add(project.getBuildscript().getDependencies().create("org.jacoco:org.jacoco.ant:" + extension.getToolVersion()));
             }
         });
     }

--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
@@ -52,7 +52,7 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
     def 'jacoco task extension can be configured. includeNoLocationClasses: #includeNoLocationClassesValue'() {
         given:
         project.apply plugin: 'java'
-        RepoScriptBlockUtil.configureJcenter(project.repositories)
+        RepoScriptBlockUtil.configureJcenter(project.buildscript.repositories)
         def testTask = project.tasks.getByName('test')
         JacocoTaskExtension extension = testTask.extensions.getByType(JacocoTaskExtension)
 
@@ -108,5 +108,17 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
         jacocoTestCoverageVerificationTask.group == LifecycleBasePlugin.VERIFICATION_GROUP
         jacocoTestReportTask.description == 'Generates code coverage report for the test task.'
         jacocoTestCoverageVerificationTask.description == 'Verifies code coverage metrics based on specified rules for the test task.'
+    }
+
+    @Issue("gradle/gradle#10837")
+    def "declares configurations on buildscript scope"() {
+        given:
+        project.apply plugin: 'jacoco'
+
+        expect:
+        project.getConfigurations().findByName(JacocoPlugin.AGENT_CONFIGURATION_NAME) == null
+        project.getConfigurations().findByName(JacocoPlugin.ANT_CONFIGURATION_NAME) == null
+        project.getBuildscript().getConfigurations().getByName(JacocoPlugin.AGENT_CONFIGURATION_NAME) != null
+        project.getBuildscript().getConfigurations().getByName(JacocoPlugin.ANT_CONFIGURATION_NAME) != null
     }
 }

--- a/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JavaProjectUnderTest.groovy
+++ b/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JavaProjectUnderTest.groovy
@@ -38,6 +38,10 @@ class JavaProjectUnderTest {
             apply plugin: 'java'
             apply plugin: 'jacoco'
 
+            buildscript {
+                ${mavenCentralRepository()}
+            }
+
             ${mavenCentralRepository()}
 
             dependencies {


### PR DESCRIPTION
Fixes #10837 

### Context
Jacoco jars are a build only dependency and most builds won't need them for the actual projects code. For restrictive environments they may not be available in the normal repositories, but are free to be used on special build repositories. This is currently not possible.
Moving the dependencies from the project to the buildscript will make that possible.

## Comment
Fixing the integration tests was interesting and extending the `subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JavaProjectUnderTest.groovy` is quiet a big thing. This also means that all projects in the future will need to declare some kind of buildscript repository or the jacoco jars will be available through the plugin portal right?

I'm not sure this is desireable and where it should be documented?

Also the validations in `subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy` seem a bit off, but the `buildEnvironment` task does not output any other configurations then `classpath`. The custom task on the other hand could not find the `jacocoAgent` configuration if I told him to list only that.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

