### PR TITLE
Fix JDK14 failures on Mac agents

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -245,8 +245,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
 
     private
     fun collectMirrorUrls(): Map<String, String> =
-    // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
-        System.getenv("REPO_MIRROR_URLS")?.split(',')?.associate { nameToUrl ->
+        // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
+        System.getenv("REPO_MIRROR_URLS")?.ifBlank { null }?.split(',')?.associate { nameToUrl ->
             val (name, url) = nameToUrl.split(':', limit = 2)
             name to url
         } ?: emptyMap()


### PR DESCRIPTION
### Context

It looks like we installed jdk14 on these systems on Friday, but there aren't any version compatibility rules for it in `DefaultGradleDistribution.worksWith()` so we happily select it as an alternate jdk in some tests.