### PR TITLE
Improved performance of logging for org.gradle.process.internal.DefaultExecHandle

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -64,6 +64,8 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
 
     private static final Logger LOGGER = Logging.getLogger(DefaultExecHandle.class);
 
+    private static final Joiner ARGUMENT_JOINER = Joiner.on(' ').useForNull("null");
+
     private final String displayName;
 
     /**
@@ -252,8 +254,8 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
 
     @Override
     public ExecHandle start() {
-        LOGGER.info("Starting process '{}'. Working directory: {} Command: {}",
-                displayName, directory, command + ' ' + Joiner.on(' ').useForNull("null").join(arguments));
+        LOGGER.info("Starting process '{}'. Working directory: {} Command: {} {}",
+                displayName, directory, command, ARGUMENT_JOINER.join(arguments));
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Environment for process '{}': {}", displayName, environment);
         }


### PR DESCRIPTION


Signed-off-by: Ross Goldberg <ross.goldberg@gmail.com>

### Context
`DefaultExecHandle` contained some inefficient logging, repeatedly creating a `Joiner`, and concatenating `String`s instead of using separate placeholders in the formatted message.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
