### PR TITLE
Move Software Model Check task to base plugin

### DIFF
--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
@@ -172,4 +172,24 @@ model {
         expect:
         succeeds "verify"
     }
+
+    def "binary has check task"() {
+        given:
+        buildFile << '''
+model {
+    tasks {
+        verify(Task) {
+            doLast {
+                def binaries = $.components.mylib.binaries
+                assert binaries.main.checkTask != null
+                assert binaries.test.checkTask != null
+            }
+        }
+    }
+}
+'''
+
+        expect:
+        succeeds "verify"
+    }
 }

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
@@ -60,6 +60,7 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
                                  ⤷ ComponentModelBasePlugin.PluginRules.AttachInputs#initializeBinarySourceSets(ModelMap<BinarySpec>) > withType()
                                  ⤷ BinaryBasePlugin.Rules#defineBuildLifecycleTask(BinarySpecInternal, NamedEntityInstantiator<Task>)
                                  ⤷ BinaryBasePlugin.Rules#addSourceSetsOwnedByBinariesToTheirInputs(BinarySpecInternal)
+                                 ⤷ ComponentModelBasePlugin.PluginRules#defineBinariesCheckTasks(BinarySpecInternal, NamedEntityInstantiator<Task>)
                             + sources
                                   | Type:   	org.gradle.model.ModelMap<org.gradle.language.base.LanguageSourceSet>
                                   | Creator: 	myComponent(UnmanagedComponent) { ... } @ build.gradle line 89, column 9 > create(myBinary)
@@ -125,6 +126,7 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
                                  ⤷ ComponentModelBasePlugin.PluginRules.AttachInputs#initializeBinarySourceSets(ModelMap<BinarySpec>) > withType()
                                  ⤷ BinaryBasePlugin.Rules#defineBuildLifecycleTask(BinarySpecInternal, NamedEntityInstantiator<Task>)
                                  ⤷ BinaryBasePlugin.Rules#addSourceSetsOwnedByBinariesToTheirInputs(BinarySpecInternal)
+                                 ⤷ ComponentModelBasePlugin.PluginRules#defineBinariesCheckTasks(BinarySpecInternal, NamedEntityInstantiator<Task>)
                             + data
                                   | Type:   	java.lang.String
                                   | Value:  	my binary

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
@@ -18,12 +18,14 @@ package org.gradle.language.base.plugins;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.tasks.TaskContainer;
@@ -49,6 +51,7 @@ import org.gradle.model.RuleSource;
 import org.gradle.model.RuleTarget;
 import org.gradle.model.Rules;
 import org.gradle.model.internal.core.Hidden;
+import org.gradle.model.internal.core.NamedEntityInstantiator;
 import org.gradle.platform.base.ApplicationSpec;
 import org.gradle.platform.base.BinaryContainer;
 import org.gradle.platform.base.BinarySpec;
@@ -228,6 +231,27 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
                 File baseDir = projectIdentifier.getProjectDir();
                 String defaultSourceDir = Joiner.on(File.separator).skipNulls().join(baseDir.getPath(), "src", emptyToNull(languageSourceSet.getParentName()), emptyToNull(languageSourceSet.getName()));
                 languageSourceSet.getSource().srcDir(defaultSourceDir);
+            }
+        }
+
+        @Finalize
+        public void defineBinariesCheckTasks(@Each BinarySpecInternal binary, NamedEntityInstantiator<Task> taskInstantiator) {
+            if (binary.isLegacyBinary()) {
+                return;
+            }
+            TaskInternal binaryLifecycleTask = taskInstantiator.create(binary.getNamingScheme().getTaskName("check"), DefaultTask.class);
+            binaryLifecycleTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+            binaryLifecycleTask.setDescription("Check " + binary);
+            binary.setCheckTask(binaryLifecycleTask);
+        }
+
+        @Finalize
+        void copyBinariesCheckTasksToTaskContainer(TaskContainer tasks, BinaryContainer binaries) {
+            for (BinarySpec binary : binaries) {
+                Task checkTask = binary.getCheckTask();
+                if (checkTask != null) {
+                    ((TaskContainerInternal)tasks).addInternal(checkTask);
+                }
             }
         }
 

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.tasks.TaskContainer;

--- a/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
@@ -22,7 +22,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.language.base.plugins.ComponentModelBasePlugin;
-import org.gradle.model.Each;
 import org.gradle.model.Finalize;
 import org.gradle.model.Model;
 import org.gradle.model.ModelMap;

--- a/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/testing/base/plugins/TestingModelBasePlugin.java
@@ -17,16 +17,11 @@
 package org.gradle.testing.base.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.tasks.TaskContainerInternal;
-import org.gradle.api.tasks.TaskContainer;
 import org.gradle.language.base.plugins.ComponentModelBasePlugin;
-import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.model.Each;
 import org.gradle.model.Finalize;
 import org.gradle.model.Model;
@@ -34,7 +29,6 @@ import org.gradle.model.ModelMap;
 import org.gradle.model.Mutate;
 import org.gradle.model.Path;
 import org.gradle.model.RuleSource;
-import org.gradle.model.internal.core.NamedEntityInstantiator;
 import org.gradle.platform.base.BinaryContainer;
 import org.gradle.platform.base.BinarySpec;
 import org.gradle.platform.base.ComponentType;
@@ -74,27 +68,6 @@ public class TestingModelBasePlugin implements Plugin<Project> {
             for (TestSuiteSpec testSuite : testSuites.values()) {
                 for (BinarySpecInternal binary : testSuite.getBinaries().withType(BinarySpecInternal.class).values()) {
                     binaries.put(binary.getProjectScopedName(), binary);
-                }
-            }
-        }
-
-        @Finalize
-        public void defineBinariesCheckTasks(@Each BinarySpecInternal binary, NamedEntityInstantiator<Task> taskInstantiator) {
-            if (binary.isLegacyBinary()) {
-                return;
-            }
-            TaskInternal binaryLifecycleTask = taskInstantiator.create(binary.getNamingScheme().getTaskName("check"), DefaultTask.class);
-            binaryLifecycleTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-            binaryLifecycleTask.setDescription("Check " + binary);
-            binary.setCheckTask(binaryLifecycleTask);
-        }
-
-        @Finalize
-        void copyBinariesCheckTasksToTaskContainer(TaskContainer tasks, BinaryContainer binaries) {
-            for (BinarySpec binary : binaries) {
-                Task checkTask = binary.getCheckTask();
-                if (checkTask != null) {
-                    ((TaskContainerInternal)tasks).addInternal(checkTask);
                 }
             }
         }


### PR DESCRIPTION
Previously, a check task was only added if the testing base was added, causing confusion to users who wanted to add their own check tasks which are not directly unit tests.

Fixes #10851 

### Context
The check tasks shouldn't be dependent on the testing base being added, theyre not in both the new native setup or in Java code builds.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
