### PR TITLE
De-incubate latest dependency management APIs for 6.0

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 
@@ -81,7 +80,6 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      *
      * @since 6.0
      */
-    @Incubating
     void addVariant(String name, Action<? super VariantMetadata> action);
 
     /**
@@ -105,7 +103,6 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      *
      * @since 6.0
      */
-    @Incubating
     void addVariant(String name, String base, Action<? super VariantMetadata> action);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVariantFilesMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVariantFilesMetadata.java
@@ -17,14 +17,12 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 
 /**
  * Mutable information about the files that belong to a variant.
  *
  * @since 6.0
  */
-@Incubating
 public interface MutableVariantFilesMetadata {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantFileMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VariantFileMetadata.java
@@ -16,14 +16,11 @@
 
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 /**
  * Part of a component variant's metadata representing a file and its location.
  *
  * @since 6.0
  */
-@Incubating
 public interface VariantFileMetadata {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/DocsType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/DocsType.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
@@ -26,7 +25,6 @@ import org.gradle.api.Named;
  *
  * @since 5.6
  */
-@Incubating
 public interface DocsType extends Named {
     Attribute<DocsType> DOCS_TYPE_ATTRIBUTE = Attribute.of("org.gradle.docstype", DocsType.class);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/LibraryElements.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/LibraryElements.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.api.Named;
  *
  * @since 5.6
  */
-@Incubating
 public interface LibraryElements extends Named {
     Attribute<LibraryElements> LIBRARY_ELEMENTS_ATTRIBUTE = Attribute.of("org.gradle.libraryelements", LibraryElements.class);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
@@ -16,7 +16,6 @@
 package org.gradle.api.component;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 
 /**
@@ -45,7 +44,6 @@ public interface AdhocComponentWithVariants extends SoftwareComponent {
      *
      * @since 6.0
      */
-    @Incubating
     void withVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action);
 
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -183,6 +183,96 @@
             "member": "Method org.gradle.StartParameter.doUseEmptySettings()",
             "acceptation": "Method added to work around the deprecation of useEmptySettings(). Users are not intended to extend the StartParameter class.",
             "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.ComponentMetadataDetails",
+            "member": "Method org.gradle.api.artifacts.ComponentMetadataDetails.addVariant(java.lang.String,org.gradle.api.Action)",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.ComponentMetadataDetails",
+            "member": "Method org.gradle.api.artifacts.ComponentMetadataDetails.addVariant(java.lang.String,java.lang.String,org.gradle.api.Action)",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.MutableVariantFilesMetadata",
+            "member": "Class org.gradle.api.artifacts.MutableVariantFilesMetadata",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.MutableVariantFilesMetadata",
+            "member": "Method org.gradle.api.artifacts.MutableVariantFilesMetadata.addFile(java.lang.String)",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.MutableVariantFilesMetadata",
+            "member": "Method org.gradle.api.artifacts.MutableVariantFilesMetadata.addFile(java.lang.String,java.lang.String)",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.MutableVariantFilesMetadata",
+            "member": "Method org.gradle.api.artifacts.MutableVariantFilesMetadata.removeAllFiles()",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.VariantFileMetadata",
+            "member": "Class org.gradle.api.artifacts.VariantFileMetadata",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.VariantFileMetadata",
+            "member": "Method org.gradle.api.artifacts.VariantFileMetadata.getName()",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.VariantFileMetadata",
+            "member": "Method org.gradle.api.artifacts.VariantFileMetadata.getUrl()",
+            "acceptation": "Method added to complete component metadata rules functionality that is de-incubated in 6.0",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.publish.ivy.IvyPublication",
+            "member": "Method org.gradle.api.publish.ivy.IvyPublication.suppressAllIvyMetadataWarnings()",
+            "acceptation": "Method added to complete GMM publishing functionality that is the default in 6.0",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.publish.ivy.IvyPublication",
+            "member": "Method org.gradle.api.publish.ivy.IvyPublication.suppressIvyMetadataWarningsFor(java.lang.String)",
+            "acceptation": "Method added to complete GMM publishing functionality that is the default in 6.0",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.publish.maven.MavenPublication",
+            "member": "Method org.gradle.api.publish.maven.MavenPublication.suppressAllPomMetadataWarnings()",
+            "acceptation": "Method added to complete GMM publishing functionality that is the default in 6.0",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.publish.maven.MavenPublication",
+            "member": "Method org.gradle.api.publish.maven.MavenPublication.suppressPomMetadataWarningsFor(java.lang.String)",
+            "acceptation": "Method added to complete GMM publishing functionality that is the default in 6.0",
+            "changes": [
+                "Method added to interface"
+            ]
         }
     ]
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -370,7 +369,6 @@ public interface IvyPublication extends Publication {
      *
      * @since 6.0
      */
-    @Incubating
     void suppressIvyMetadataWarningsFor(String variantName);
 
     /**
@@ -380,6 +378,5 @@ public interface IvyPublication extends Publication {
      *
      * @since 6.0
      */
-    @Incubating
     void suppressAllIvyMetadataWarnings();
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPublication.java
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -323,7 +322,6 @@ public interface MavenPublication extends Publication {
      *
      * @since 6.0
      */
-    @Incubating
     void suppressPomMetadataWarningsFor(String variantName);
 
 
@@ -334,6 +332,5 @@ public interface MavenPublication extends Publication {
      *
      * @since 6.0
      */
-    @Incubating
     void suppressAllPomMetadataWarnings();
 }


### PR DESCRIPTION
These are APIs that complete features which are fully implemented and
de-incubated in Gradle 6.
