### PR TITLE
Fix duplicate classes on classpath using test fixtures

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -515,7 +515,7 @@ hamcrest-core-1.3.jar
                 if (it.absolutePath.contains('intTestHomeDir')) {
                     println it.name
                 } else {
-                    println it.absolutePath.substring(it.absolutePath.lastIndexOf('build') + 6)
+                    println it.absolutePath.substring(it.absolutePath.lastIndexOf('build') + 6).replace(File.separatorChar, (char) '/')
                 }
             }
 


### PR DESCRIPTION
This commit works around duplicate classes found on compile
and runtime test classpath whenever the "test fixtures"
plugin is used.

This is due to the fact the Java plugin systematically adds
the main source set output to the test compile and runtime
classpath. But if we have test fixtures, they themselves
depend on the main component, so it ends up adding them
twice, possibly once as a jar and once as a class directory.

Fixes #10872
