### PR TITLE
Improvement: Add link to adoc source file to generated html

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -280,28 +280,17 @@ def dslHtml = tasks.register("dslHtml", Docbook2Xhtml) {
     ext.entryPoint = "$destDir/index.html"
 }
 
-def userguideAddSourceLinks = tasks.register("userguideAddSourceLinks", Sync) {
-    def adocDir = file("${buildDir}/adocs")
-
-    into(adocDir)
-    from("src/docs/userguide") {
-        include("**/*.adoc")
-    }
-    doLast {
-        fileTree(adocDir).each {
-            if (it.name != 'userguide_single.adoc') {
-                it.text = ":description: ${it.path - adocDir.path}\n\n${it.text}"
-            }
-        }
-    }
-}
-
 def userguideFlattenSources = tasks.register("userguideFlattenSources", Sync) {
-    dependsOn css, samples, defaultImports, userguideAddSourceLinks
+    dependsOn css, samples, defaultImports
     finalizedBy("checkDeadInternalLinks")
 
     duplicatesStrategy = DuplicatesStrategy.FAIL
     into("${buildDir}/userguide-resources")
+
+    def adocDir = file("src/docs/userguide")
+    def adocFiles = fileTree(adocDir).matching {
+        include "**/*.adoc"
+    }
     from("src/docs/css") {
         into("css")
     }
@@ -314,7 +303,14 @@ def userguideFlattenSources = tasks.register("userguideFlattenSources", Sync) {
     from(generatedResourcesDir) {
         into(generatedResourcesDir.name)
     }
-    from { fileTree(userguideAddSourceLinks.get().destinationDir).files }
+    from adocFiles.files
+
+    doLast {
+        adocFiles.each { adocFile ->
+            file("${buildDir}/userguide-resources/${adocFile.name.substring(0, adocFile.name.length() - 5)}-docinfo.html").text =
+                """<meta name="adoc-src-path" content="${adocFile.path - adocDir.path}">"""
+        }
+    }
 }
 
 def userguideSinglePage = tasks.register("userguideSinglePage", CacheableAsciidoctorTask) {
@@ -422,6 +418,7 @@ tasks.withType(CacheableAsciidoctorTask).configureEach {
         sectlinks           : true,
         linkattrs           : true,
         reproducible        : '',
+        docinfo             : '',
         lang                : 'en-US',
         encoding            : 'utf-8',
         idprefix            : '',


### PR DESCRIPTION
This is a follow up to #10841.

Instead of using the 'description' tag, which is a standardised
tag other tools might read and display as page description,
we now use a custom name (adoc-src-path).
This also simplifies the build (and partly reverts #10841) as we
now use the 'docinfo' configuration of asciidoc to generate and include
a custom html header file for each 'adoc' file. Instead of modifying
the adoc files themselves.