### PR TITLE
Mapping of dependencyManagement elements in POM files

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
@@ -29,7 +29,7 @@ class MavenPom {
             def scopesByDependency = ArrayListMultimap.create()
 
             pom.dependencies.dependency.each { dep ->
-                def scope = createScope(dep.scope)
+                def scope = createScope(dep.scope, 'compile')
                 MavenDependency mavenDependency = createDependency(dep)
                 if (mavenDependency.optional) {
                     scope.optionalDependencies[mavenDependency.getKey()] = mavenDependency
@@ -40,7 +40,7 @@ class MavenPom {
             }
 
             pom.dependencyManagement.dependencies.dependency.each { dep ->
-                def scope = createScope(dep.scope)
+                def scope = createScope(dep.scope, 'no_scope')
                 MavenDependency mavenDependency = createDependency(dep)
                 scope.dependencyManagement[mavenDependency.getKey()] = mavenDependency
             }
@@ -154,8 +154,8 @@ class MavenPom {
         )
     }
 
-    private MavenScope createScope(def scopeElement) {
-        def scopeName = scopeElement ? scopeElement.text() : 'runtime'
+    private MavenScope createScope(def scopeElement, String defaultScope) {
+        def scopeName = scopeElement ? scopeElement.text() : defaultScope
         def scope = scopes[scopeName]
         if (!scope) {
             scope = new MavenScope(name: scopeName)

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
@@ -277,12 +277,11 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
         javaLibrary.assertPublished()
 
         javaLibrary.parsedPom.packaging == null // 'jar' packaging
-        javaLibrary.parsedPom.scopes.keySet() == ["compile", "runtime"] as Set
+        javaLibrary.parsedPom.scopes.keySet() == ["compile", "no_scope", "runtime"] as Set
         javaLibrary.parsedPom.scopes.compile.assertDependsOn("org.springframework:spring-core:1.2.9")
-        javaLibrary.parsedPom.scopes.compile.assertDependencyManagement("commons-logging:commons-logging:1.1")
 
         javaLibrary.parsedPom.scopes.runtime.assertDependsOn("org.apache.commons:commons-compress:1.5")
-        javaLibrary.parsedPom.scopes.runtime.assertDependencyManagement("commons-logging:commons-logging:1.2", "org.tukaani:xz:1.6")
+        javaLibrary.parsedPom.scopes.no_scope.assertDependencyManagement("commons-logging:commons-logging:1.1", "commons-logging:commons-logging:1.2", "org.tukaani:xz:1.6")
 
         and:
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
@@ -433,9 +432,9 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
         then:
         javaLibrary.assertPublished()
 
-        javaLibrary.parsedPom.scopes.keySet() == ["runtime"] as Set
+        javaLibrary.parsedPom.scopes.keySet() == ["no_scope", "runtime"] as Set
         javaLibrary.parsedPom.scopes.runtime.assertDependsOn("commons-collections:commons-collections:")
-        javaLibrary.parsedPom.scopes.runtime.assertDependencyManagement("commons-collections:commons-collections:3.2.2")
+        javaLibrary.parsedPom.scopes.no_scope.assertDependencyManagement("commons-collections:commons-collections:3.2.2")
 
         and:
         javaLibrary.parsedModuleMetadata.variant("apiElements") {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaPlatformIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaPlatformIntegTest.groovy
@@ -82,13 +82,10 @@ class MavenPublishJavaPlatformIntegTest extends AbstractMavenPublishIntegTest {
             constraint("org.test:bar:1.0")
             noMoreDependencies()
         }
-        javaPlatform.parsedPom.scope('compile') {
+        javaPlatform.parsedPom.scopes.keySet() == ['no_scope'] as Set
+        javaPlatform.parsedPom.scope('no_scope') {
             assertNoDependencies()
-            assertDependencyManagement("org.test:foo:1.0")
-        }
-        javaPlatform.parsedPom.scope('runtime') {
-            assertNoDependencies()
-            assertDependencyManagement("org.test:bar:1.0")
+            assertDependencyManagement("org.test:bar:1.0", "org.test:foo:1.0")
         }
     }
 
@@ -130,13 +127,10 @@ class MavenPublishJavaPlatformIntegTest extends AbstractMavenPublishIntegTest {
             constraint("org.gradle.test:utils:1.9")
             noMoreDependencies()
         }
-        javaPlatform.parsedPom.scope('compile') {
+        javaPlatform.parsedPom.scopes.keySet() == ['no_scope'] as Set
+        javaPlatform.parsedPom.scope('no_scope') {
             assertNoDependencies()
-            assertDependencyManagement("org.gradle.test:core:1.9")
-        }
-        javaPlatform.parsedPom.scope('runtime') {
-            assertNoDependencies()
-            assertDependencyManagement("org.gradle.test:utils:1.9")
+            assertDependencyManagement("org.gradle.test:core:1.9", "org.gradle.test:utils:1.9")
         }
     }
 
@@ -185,8 +179,13 @@ class MavenPublishJavaPlatformIntegTest extends AbstractMavenPublishIntegTest {
             dependency("org.test:foo:1.1")
             noMoreDependencies()
         }
+        javaPlatform.parsedPom.scopes.keySet() == ['compile', 'no_scope'] as Set
         javaPlatform.parsedPom.scope('compile') {
             assertDependsOn("org.test:foo:1.1")
+            assertNoDependencyManagement()
+        }
+        javaPlatform.parsedPom.scope('no_scope') {
+            assertNoDependencies()
             assertDependencyManagement("org.test:foo:1.1")
         }
         javaPlatform.parsedPom.hasNoScope('runtime')

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -459,7 +459,7 @@ project(":library") {
         then:
         platformModule.parsedPom.packaging == 'pom'
         platformModule.parsedPom.scopes.compile.assertDependsOn("org.test:foo:1.0")
-        platformModule.parsedPom.scopes.compile.assertDependencyManagement("org.test:bar:1.1")
+        platformModule.parsedPom.scopes.no_scope.assertDependencyManagement("org.test:bar:1.1")
         platformModule.parsedModuleMetadata.variant('apiElements') {
             dependency("org.test:foo:1.0").exists()
             constraint("org.test:bar:1.1").exists()

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -496,7 +496,6 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
             assert it.groupId.text() == 'org.test'
             assert it.artifactId.text() == 'bar'
             assert it.version.text() == '1.0'
-            assert it.scope.text() == 'compile'
         }
         dependencies[1].with {
             assert it.groupId.text() == 'org.test'

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
@@ -349,7 +349,10 @@ public class MavenPomFileGenerator {
         if (type != null) {
             mavenDependency.setType(type);
         }
-        mavenDependency.setScope(scope);
+        // Only publish the import scope, others have too different meanings than what Gradle expresses
+        if ("import".equals(scope)) {
+            mavenDependency.setScope(scope);
+        }
 
         DependencyManagement dependencyManagement = model.getDependencyManagement();
         if (dependencyManagement == null) {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
@@ -115,7 +115,7 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
         def barMarker = mavenRepo.module('com.example.bar', 'com.example.bar' + PLUGIN_MARKER_SUFFIX, '1.0')
         [fooMarker, barMarker].each { marker ->
             marker.assertPublished()
-            assert marker.parsedPom.scopes['runtime'].expectDependency('com.example:plugins:1.0')
+            assert marker.parsedPom.scopes['compile'].expectDependency('com.example:plugins:1.0')
         }
         with(fooMarker.parsedPom) {
             it.name == 'The Foo Plugin'


### PR DESCRIPTION
The semantics between the configuration of a constraint in Gradle and the scope
of a declaration in `dependencyManagement` in Maven are fundamentally
different.
Given this, Gradle will no longer attempt to define a scope for
`dependencyManagement` entries when creating POM files.
The only exception is the `import` scope as it carries special meaning.