### PR TITLE
Split cross version tests by task

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -261,11 +261,7 @@ data class SubprojectSplit(val subproject: GradleSubproject, val total: Int) : B
     private fun getName(number: Int) = if (number == 1) subproject.name else "${subproject.name}_$number"
 
     override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage) =
-        if (testCoverage.testType.supportTestSplit) {
-            (1..total).map { createFunctionalTestsFor(model, stage, testCoverage, getName(it), "-PtestSplit=$it/$total") }
-        } else {
-            listOf(createFunctionalTestsFor(model, stage, testCoverage, getName(1), ""))
-        }
+        (1..total).map { createFunctionalTestsFor(model, stage, testCoverage, getName(it), "-PtestSplit=$it/$total") }
 
     private fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage, name: String, parameter: String): FunctionalTest = FunctionalTest(model,
         testCoverage.asConfigurationId(model, name),
@@ -395,7 +391,7 @@ data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val t
     }
 }
 
-enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val timeout: Int = 180, val supportTestSplit: Boolean = true) {
+enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val timeout: Int = 180) {
     // Include cross version tests, these take care of selecting a very small set of versions to cover when run as part of this stage, including the current version
     quick(true, true, true, 60),
     // Include cross version tests, these take care of selecting a very small set of versions to cover when run as part of this stage, including the current version
@@ -403,7 +399,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     // Cross version tests select a small set of versions to cover when run as part of this stage
     quickFeedbackCrossVersion(false, false, true),
     // Cross version tests select all versions to cover when run as part of this stage
-    allVersionsCrossVersion(false, true, true, 240, false),
+    allVersionsCrossVersion(false, true, true, 240),
     parallel(false, true, false),
     noDaemon(false, true, false, 240),
     soak(false, false, false),

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -159,12 +159,6 @@ class CIConfigIntegrationTests {
                 // e.g. core
                 val projectName = projectNameWithSplit.substringBefore('_')
 
-                if (it.name.contains("AllVersionsCrossVersion")) {
-                    // No split for AllVersionsCrossVersion
-                    assertTrue(projectName == projectNameWithSplit)
-                    return@forEach
-                }
-
                 val numberOfSplits = largeSubprojects.find { it.subproject.name == projectName }!!.total
                 val runnerStep = it.steps.items.find { it.name == "GRADLE_RUNNER" } as GradleBuildStep
                 if (projectNameWithSplit.contains("_")) {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/CrossVersionTestsPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/CrossVersionTestsPlugin.kt
@@ -15,6 +15,7 @@
  */
 package org.gradle.gradlebuild.test.integrationtests
 
+import com.google.common.collect.MultimapBuilder
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -87,9 +88,12 @@ class CrossVersionTestsPlugin : Plugin<Project> {
         }
         val currentSplit = testSplit.split("/")[0].toInt()
         val numberOfSplits = testSplit.split("/")[1].toInt()
-        val buckets = Array(numberOfSplits) { mutableListOf<String>() }
+        val buckets = MultimapBuilder.SetMultimapBuilder
+            .hashKeys()
+            .arrayListValues()
+            .build<Int, String>()
         for ((index, version) in allTestVersions.withIndex()) {
-            buckets[index % numberOfSplits].add(version)
+            buckets.put(index % numberOfSplits, version)
         }
         return buckets[currentSplit - 1]
     }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -84,7 +84,7 @@ fun Project.createTasks(sourceSet: SourceSet, testType: TestType) {
 internal
 fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet, testType: TestType, extraConfig: Action<IntegrationTest>): TaskProvider<IntegrationTest> =
     tasks.register(name, IntegrationTest::class) {
-        configureTestSplitIfNecessary(sourceSet)
+        configureTestSplitIfNecessary(sourceSet, testType)
         description = "Runs ${testType.prefix} with $executer executer"
         systemProperties["org.gradle.integtest.executer"] = executer
         addDebugProperties()
@@ -96,9 +96,10 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
 
 
 private
-fun DistributionTest.configureTestSplitIfNecessary(sourceSet: SourceSet) {
+fun DistributionTest.configureTestSplitIfNecessary(sourceSet: SourceSet, testType: TestType) {
     val testSplit = project.stringPropertyOrEmpty("testSplit")
-    if (testSplit.isBlank()) {
+    if (testSplit.isBlank() || testType == TestType.CROSSVERSION) {
+        // Cross version tests are splitted by tasks
         return
     }
 


### PR DESCRIPTION
### Context

We didn't split cross version tests before, because some of them have own test class split. However, we see large cross version test timeout frequently: https://builds.gradle.org/viewLog.html?buildId=27174833&buildTypeId=Gradle_Check_AllVersionsCrossVersion_11_toolingApi

This PR splits cross version tests by task, not by test class. For example, for version [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7]:

- -PtestSplit=1/3: [1.0, 1.3, 1.6]
- -PtestSplit=2/3: [1.1, 1.4, 1.7]
- -PtestSplit=3/3: [1.2, 1.5]