### PR TITLE
Support for VS2019 and CI failure fix due to VS2019

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -260,10 +260,16 @@ Gradle now reports the progress of the distribution downloaded.
 
 Initially contributed by [Artur Dryomov](https://github.com/ming13).
 
+## Features for native developers
+
 ### IntelliSense support for C++17 and latest C++ standard within Visual Studio
 
 Gradle will now generate IDE solution honoring the C++17 `/std:cpp17` and latest C++ standard `/std:cpplatest` compiler flag.
 The Visual Studio IntelliSense will help you write great code with those new standard.
+
+### Support for Visual Studio 2019
+
+Gradle now officially supports building application and libraries with Visual Studio 2019.
 
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/docs/userguide/building_cpp_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/building_cpp_projects.adoc
@@ -153,12 +153,12 @@ When you build a native binary, Gradle will attempt to locate a tool chain insta
 Gradle select the first tool chain that can build for the target operating system and architecture.
 In the future, Gradle will consider source and ABI compatibility when selecting a tool chain.
 
-Gradle has general support for the three major tool chains on major operating system: Clang footnote:[Installed with Xcode on macOS], GCC footnote:[Installed through Cygwin and MinGW for 32- and 64-bits architecture on Windows] and Visual {cpp} footnote:[Installed with Visual Studio 2010 to 2017] (Windows-only).
+Gradle has general support for the three major tool chains on major operating system: Clang footnote:[Installed with Xcode on macOS], GCC footnote:[Installed through Cygwin and MinGW for 32- and 64-bits architecture on Windows] and Visual {cpp} footnote:[Installed with Visual Studio 2010 to 2019] (Windows-only).
 GCC and Clang installed using Macports and Homebrew have been reported to work fine, but this isn’t tested continuously.
 
 ==== Windows
 
-To build on Windows, install a compatible version of Visual Studio[4].
+To build on Windows, install a compatible version of Visual Studio.
 The {cpp} plugins will discover the Visual Studio installations and select the latest version.
 There is no need to mess around with environment variables or batch scripts.
 This works fine from a Cygwin shell or the Windows command-line.

--- a/subprojects/docs/src/docs/userguide/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native_software.adoc
@@ -80,7 +80,7 @@ The following tool chains are supported:
 
 | Windows
 | https://visualstudio.microsoft.com/[Visual C++]
-| Windows XP and later, Visual C++ 2010/2012/2013/2015/2017.
+| Windows XP and later, Visual C++ 2010/2012/2013/2015/2017/2019.
 
 | Windows
 | http://gcc.gnu.org/[GCC] with http://cygwin.com[Cygwin 32 and Cygwin 64]

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/fixtures/MSBuildVersionLocator.java
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/fixtures/MSBuildVersionLocator.java
@@ -60,6 +60,12 @@ public class MSBuildVersionLocator {
             msbuild = new TestFile("C:/program files (x86)/MSBuild/" + vsVersion.getMajor() + ".0/Bin/MSBuild.exe");
         }
 
+        // There is some value to the other ways to locate MSBuild (aka matching the MSBuild installation with the VS installation), this is a last chance to try and locate a usable MSBuild installation which will just try to get the latest available MSBuild. We can refine this later.
+        if (!msbuild.exists()) {
+            vsWhereOutput = new TestFile(vswhere).exec("-latest", "-requires", "Microsoft.Component.MSBuild", "-find", "MSBuild\\**\\Bin\\MSBuild.exe");
+            msbuild = new TestFile(vsWhereOutput.getOut().trim());
+        }
+
         if (!msbuild.exists()) {
             throw new IllegalStateException(String.format("This test requires MSBuild %s to be installed. Expected it to be installed at %s.", vsVersion.getMajor(), msbuild));
         }

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -424,7 +424,7 @@ model {
             return DumpbinBinaryInfo.findVisualStudio() ? new DumpbinBinaryInfo(file) : new FileArchOnlyBinaryInfo(file)
         }
         if (ReadelfBinaryInfo.canUseReadelf()) {
-            return new ReadelfBinaryInfo(file)
+            return new ReadelfBinaryInfo(file, toolchainUnderTest.runtimeEnv)
         } else {
             return new FileArchOnlyBinaryInfo(file)
         }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -68,6 +68,7 @@ import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISU
 import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2013;
 import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2015;
 import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2017;
+import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2019;
 
 public class AvailableToolChains {
     private static final Comparator<ToolChainCandidate> LATEST_RELEASED_FIRST = Collections.reverseOrder(new Comparator<ToolChainCandidate>() {
@@ -926,6 +927,10 @@ public class AvailableToolChains {
                     return version.equals(VISUALSTUDIO_2017.getVersion());
                 case VISUALCPP_2017_OR_NEWER:
                     return version.compareTo(VISUALSTUDIO_2017.getVersion()) >= 0;
+                case VISUALCPP_2019:
+                    return version.equals(VISUALSTUDIO_2019.getVersion());
+                case VISUALCPP_2019_OR_NEWER:
+                    return version.compareTo(VISUALSTUDIO_2019.getVersion()) >= 0;
                 default:
                     return false;
             }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeBinaryFixture.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeBinaryFixture.groovy
@@ -158,10 +158,10 @@ class NativeBinaryFixture {
         }
         if (OperatingSystem.current().isWindows()) {
             if (toolChain.meets(ToolChainRequirement.GCC)) {
-                return new DumpbinGccProducedBinaryInfo(file)
+                return new DumpbinGccProducedBinaryInfo(file, toolChain.runtimeEnv)
             }
             return new DumpbinBinaryInfo(file)
         }
-        return new ReadelfBinaryInfo(file)
+        return new ReadelfBinaryInfo(file, toolChain.runtimeEnv)
     }
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
@@ -35,6 +35,10 @@ public enum ToolChainRequirement {
     VISUALCPP_2017,
     // Any available Visual Studio >= 2017
     VISUALCPP_2017_OR_NEWER,
+    // Exactly Visual Studio 2019
+    VISUALCPP_2019,
+    // Any available Visual Studio >= 2019
+    VISUALCPP_2019_OR_NEWER,
     // Any windows GCC compatible implementation (mingw, cygwin)
     WINDOWS_GCC,
     // Any available GCC implementation (including mingw, cygwin, but not clang)

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/NMToolFixture.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/NMToolFixture.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.binaryinfo
+
+import org.gradle.internal.os.OperatingSystem
+
+class NMToolFixture {
+    private final List<String> environments
+
+    private NMToolFixture(List<String> environments) {
+        this.environments = environments
+    }
+    
+    static NMToolFixture of(List<String> environments) {
+        return new NMToolFixture(environments)
+    }
+
+    private findExe(String exe) {
+        // *nix OS correctly handle search inside the process's PATH environment variable
+        if (!OperatingSystem.current().windows) {
+            return exe
+        }
+
+        // Windows need to use cmd /c to correctly search inside the process's PATH environment variable
+        return "cmd /c ${exe}"
+    }
+
+    List<BinaryInfo.Symbol> listSymbols(File binaryFile) {
+        def process = "${findExe('nm')} -a -f posix ${binaryFile.absolutePath}".execute(environments, null)
+        def lines = process.inputStream.readLines()
+        return lines.collect { line ->
+            // Looks like on Linux:
+            // _main t 0 0
+            //
+            // Looks like on Windows (MinGW):
+            // main T 0000000000401550
+            def splits = line.split(' ')
+            String name = splits[0]
+            char type = splits[1].getChars()[0]
+            return new BinaryInfo.Symbol(name, type, Character.isUpperCase(type))
+        }
+    }
+}

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/NMToolFixture.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/binaryinfo/NMToolFixture.groovy
@@ -32,15 +32,15 @@ class NMToolFixture {
     private findExe(String exe) {
         // *nix OS correctly handle search inside the process's PATH environment variable
         if (!OperatingSystem.current().windows) {
-            return exe
+            return [exe]
         }
 
         // Windows need to use cmd /c to correctly search inside the process's PATH environment variable
-        return "cmd /c ${exe}"
+        return ["cmd", "/c", exe]
     }
 
     List<BinaryInfo.Symbol> listSymbols(File binaryFile) {
-        def process = "${findExe('nm')} -a -f posix ${binaryFile.absolutePath}".execute(environments, null)
+        def process = (findExe('nm') + ['-a', '-f', 'posix', binaryFile.absolutePath]).execute(environments, null)
         def lines = process.inputStream.readLines()
         return lines.collect { line ->
             // Looks like on Linux:

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/msvcpp/VisualStudioVersion.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/msvcpp/VisualStudioVersion.java
@@ -22,7 +22,8 @@ public enum VisualStudioVersion {
     VISUALSTUDIO_2012("11.0", "2012"),
     VISUALSTUDIO_2013("12.0", "2013"),
     VISUALSTUDIO_2015("14.0", "2015"),
-    VISUALSTUDIO_2017("15.0", "2017");
+    VISUALSTUDIO_2017("15.0", "2017"),
+    VISUALSTUDIO_2019("16.0", "2019");
 
     private final VersionNumber version;
     private final String year;


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-native-private/issues/196, https://github.com/gradle/dev-infrastructure/issues/354 and https://github.com/gradle/dev-infrastructure/issues/353

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fvs2019)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
