### PR TITLE
Decrease number of list object creations in large dependency graphs

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -171,7 +171,7 @@ public class NodeState implements DependencyGraphNode {
 
     @Override
     public List<EdgeState> getIncomingEdges() {
-        return ImmutableList.copyOf(incomingEdges);
+        return incomingEdges;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -20,9 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
@@ -74,7 +72,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
                                          ImmutableAttributes attributes,
                                          Factory<List<ModuleDependencyMetadata>> configDependenciesFactory,
                                          DependencyFilter dependencyFilter,
-                                         List<Capability> capabilities,
+                                         CapabilitiesMetadata capabilities,
                                          boolean mavenArtifactDiscovery) {
         super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependenciesFactory, ImmutableCapabilities.of(capabilities), mavenArtifactDiscovery);
         this.componentMetadataRules = componentMetadataRules;
@@ -246,7 +244,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
     public class Builder {
         private String name = DefaultConfigurationMetadata.this.getName();
         private DependencyFilter dependencyFilter = DefaultConfigurationMetadata.this.dependencyFilter;
-        private List<Capability> capabilities;
+        private CapabilitiesMetadata capabilities;
         private ImmutableAttributes attributes;
         private ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
 
@@ -281,7 +279,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
             return this;
         }
 
-        Builder withCapabilities(List<Capability> capabilities) {
+        Builder withCapabilities(CapabilitiesMetadata capabilities) {
             this.capabilities = capabilities;
             return this;
         }
@@ -299,7 +297,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
                     attributes == null ? DefaultConfigurationMetadata.super.getAttributes() : attributes,
                     lazyConfigDependencies(),
                     dependencyFilter,
-                    capabilities == null ? Cast.uncheckedCast(DefaultConfigurationMetadata.this.getCapabilities().getCapabilities()) : capabilities,
+                    capabilities == null ? DefaultConfigurationMetadata.this.getCapabilities() : capabilities,
                     DefaultConfigurationMetadata.super.requiresMavenArtifactDiscovery()
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -26,6 +26,13 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
 
     private final ImmutableList<? extends Capability> capabilities;
 
+    public static ImmutableCapabilities of(CapabilitiesMetadata capabilities) {
+        if (capabilities instanceof ImmutableCapabilities) {
+            return (ImmutableCapabilities) capabilities;
+        }
+        return of(capabilities.getCapabilities());
+    }
+
     public static ImmutableCapabilities of(List<? extends Capability> capabilities) {
         if (capabilities.isEmpty()) {
             return EMPTY;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -18,14 +18,12 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.maven.DefaultMavenModuleResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 
 import java.util.Collections;
-import java.util.List;
 
 public class JavaEcosystemVariantDerivationStrategy implements VariantDerivationStrategy {
     @Override
@@ -42,7 +40,7 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
             DefaultConfigurationMetadata compileConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("compile");
             DefaultConfigurationMetadata runtimeConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("runtime");
             ModuleComponentIdentifier componentId = md.getId();
-            List<Capability> shadowedPlatformCapability = buildShadowPlatformCapability(componentId);
+            ImmutableCapabilities shadowedPlatformCapability = buildShadowPlatformCapability(componentId);
             return ImmutableList.of(
                     // When deriving variants for the Java ecosystem, we actually have 2 components "mixed together": the library and the platform
                     // and there's no way to figure out what was the intent when it was published. So we derive variants, but we also need
@@ -60,13 +58,14 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
         return null;
     }
 
-    private List<Capability> buildShadowPlatformCapability(ModuleComponentIdentifier componentId) {
-        return Collections.singletonList(
+    private ImmutableCapabilities buildShadowPlatformCapability(ModuleComponentIdentifier componentId) {
+        return ImmutableCapabilities.of(Collections.singletonList(
                 new DefaultShadowedCapability(new ImmutableCapability(
                         componentId.getGroup(),
                         componentId.getModule(),
                         componentId.getVersion()
                 ), "-derived-platform")
+            )
         );
     }
 
@@ -78,7 +77,7 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
                 .build();
     }
 
-    private static ConfigurationMetadata platformWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage, boolean enforcedPlatform, List<Capability> shadowedPlatformCapability) {
+    private static ConfigurationMetadata platformWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage, boolean enforcedPlatform, ImmutableCapabilities shadowedPlatformCapability) {
         ImmutableAttributes attributes = attributesFactory.platformWithUsage(originAttributes, usage, enforcedPlatform);
         String prefix = enforcedPlatform ? "enforced-platform-" : "platform-";
         DefaultConfigurationMetadata.Builder builder = conf.mutate()


### PR DESCRIPTION
This reduces the amount of lists created in two code path that are hit for almost every dependency visited.