### PR TITLE
Cleanup of Worker API internals

### DIFF
--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorkerRequirement.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorkerRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,17 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.IsolationMode;
+import java.io.File;
 
-public interface WorkerFactory {
-    BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement);
+public abstract class AbstractWorkerRequirement implements WorkerRequirement {
+    private final File workerDirectory;
 
-    IsolationMode getIsolationMode();
+    public AbstractWorkerRequirement(File workerDirectory) {
+        this.workerDirectory = workerDirectory;
+    }
+
+    @Override
+    public File getWorkerDirectory() {
+        return workerDirectory;
+    }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ActionExecutionSpecFactory.java
@@ -19,10 +19,8 @@ package org.gradle.workers.internal;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
 
-import java.io.File;
-
 public interface ActionExecutionSpecFactory {
     <T extends WorkParameters> TransportableActionExecutionSpec<T> newTransportableSpec(ActionExecutionSpec<T> spec);
-    <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure, File baseDir, boolean usesInternalServices);
+    <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, WorkerRequirement workerRequirement, boolean usesInternalServices);
     <T extends WorkParameters> SimpleActionExecutionSpec<T> newSimpleSpec(ActionExecutionSpec<T> spec);
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultActionExecutionSpecFactory.java
@@ -27,7 +27,6 @@ import org.gradle.workers.WorkParameters;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 
 public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFactory {
     private final IsolatableFactory isolatableFactory;
@@ -51,8 +50,9 @@ public class DefaultActionExecutionSpecFactory implements ActionExecutionSpecFac
     }
 
     @Override
-    public <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, ClassLoaderStructure classLoaderStructure, File baseDir, boolean usesInternalServices) {
-        return new IsolatedParametersActionExecutionSpec<T>(implementationClass, displayName, isolatableFactory.isolate(params), classLoaderStructure, baseDir, usesInternalServices);
+    public <T extends WorkParameters> IsolatedParametersActionExecutionSpec<T> newIsolatedSpec(String displayName, Class<? extends WorkAction<T>> implementationClass, T params, WorkerRequirement workerRequirement, boolean usesInternalServices) {
+        ClassLoaderStructure classLoaderStructure = workerRequirement instanceof IsolatedClassLoaderWorkerRequirement ? ((IsolatedClassLoaderWorkerRequirement) workerRequirement).getClassLoaderStructure() : null;
+        return new IsolatedParametersActionExecutionSpec<T>(implementationClass, displayName, isolatableFactory.isolate(params), classLoaderStructure, workerRequirement.getWorkerDirectory(), usesInternalServices);
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/FixedClassLoaderWorkerRequirement.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/FixedClassLoaderWorkerRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,17 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.IsolationMode;
+import java.io.File;
 
-public interface WorkerFactory {
-    BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement);
+public class FixedClassLoaderWorkerRequirement extends AbstractWorkerRequirement {
+    private final ClassLoader contextClassLoader;
 
-    IsolationMode getIsolationMode();
+    public FixedClassLoaderWorkerRequirement(File workerDirectory, ClassLoader contextClassLoader) {
+        super(workerDirectory);
+        this.contextClassLoader = contextClassLoader;
+    }
+
+    public ClassLoader getContextClassLoader() {
+        return contextClassLoader;
+    }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ForkedWorkerRequirement.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ForkedWorkerRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,17 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.IsolationMode;
+import java.io.File;
 
-public interface WorkerFactory {
-    BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement);
+public class ForkedWorkerRequirement extends IsolatedClassLoaderWorkerRequirement {
+    private final DaemonForkOptions forkOptions;
 
-    IsolationMode getIsolationMode();
+    public ForkedWorkerRequirement(File workerDirectory, DaemonForkOptions forkOptions) {
+        super(workerDirectory, forkOptions.getClassLoaderStructure());
+        this.forkOptions = forkOptions;
+    }
+
+    public DaemonForkOptions getForkOptions() {
+        return forkOptions;
+    }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassLoaderWorkerRequirement.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassLoaderWorkerRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,17 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.IsolationMode;
+import java.io.File;
 
-public interface WorkerFactory {
-    BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement);
+public class IsolatedClassLoaderWorkerRequirement extends AbstractWorkerRequirement {
+    private final ClassLoaderStructure classLoaderStructure;
 
-    IsolationMode getIsolationMode();
+    public IsolatedClassLoaderWorkerRequirement(File workerDirectory, ClassLoaderStructure classLoaderStructure) {
+        super(workerDirectory);
+        this.classLoaderStructure = classLoaderStructure;
+    }
+
+    public ClassLoaderStructure getClassLoaderStructure() {
+        return classLoaderStructure;
+    }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -42,14 +42,15 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
     }
 
     @Override
-    public BuildOperationAwareWorker getWorker(final DaemonForkOptions forkOptions) {
+    public BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement) {
         return new AbstractWorker(buildOperationExecutor) {
             @Override
             public DefaultWorkResult execute(ActionExecutionSpec spec, BuildOperationRef parentBuildOperation) {
                 return executeWrappedInBuildOperation(spec, parentBuildOperation, workSpec -> {
                     ServiceRegistry workServices = new WorkerPublicServicesBuilder(internalServices).withInternalServicesVisible(workSpec.isInternalServicesRequired()).build();
                     ClassLoader workerInfrastructureClassloader = classLoaderRegistry.getPluginsClassLoader();
-                    ClassLoader workerClassLoader = IsolatedClassloaderWorker.createIsolatedWorkerClassloader(forkOptions.getClassLoaderStructure(), workerInfrastructureClassloader, legacyTypesSupport);
+                    ClassLoaderStructure classLoaderStructure = ((IsolatedClassLoaderWorkerRequirement)workerRequirement).getClassLoaderStructure();
+                    ClassLoader workerClassLoader = IsolatedClassloaderWorker.createIsolatedWorkerClassloader(classLoaderStructure, workerInfrastructureClassloader, legacyTypesSupport);
                     Worker worker = new IsolatedClassloaderWorker(workerClassLoader, workServices, actionExecutionSpecFactory, instantiatorFactory);
                     return worker.execute(workSpec);
                 });

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -46,15 +46,12 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
         return new AbstractWorker(buildOperationExecutor) {
             @Override
             public DefaultWorkResult execute(ActionExecutionSpec spec, BuildOperationRef parentBuildOperation) {
-                return executeWrappedInBuildOperation(spec, parentBuildOperation, new Work() {
-                    @Override
-                    public DefaultWorkResult execute(ActionExecutionSpec spec) {
-                        ServiceRegistry workServices = new WorkerPublicServicesBuilder(internalServices).withInternalServicesVisible(spec.isInternalServicesRequired()).build();
-                        ClassLoader workerInfrastructureClassloader = classLoaderRegistry.getPluginsClassLoader();
-                        ClassLoader workerClassLoader = IsolatedClassloaderWorker.createIsolatedWorkerClassloader(forkOptions.getClassLoaderStructure(), workerInfrastructureClassloader, legacyTypesSupport);
-                        Worker worker = new IsolatedClassloaderWorker(workerClassLoader, workServices, actionExecutionSpecFactory, instantiatorFactory);
-                        return worker.execute(spec);
-                    }
+                return executeWrappedInBuildOperation(spec, parentBuildOperation, workSpec -> {
+                    ServiceRegistry workServices = new WorkerPublicServicesBuilder(internalServices).withInternalServicesVisible(workSpec.isInternalServicesRequired()).build();
+                    ClassLoader workerInfrastructureClassloader = classLoaderRegistry.getPluginsClassLoader();
+                    ClassLoader workerClassLoader = IsolatedClassloaderWorker.createIsolatedWorkerClassloader(forkOptions.getClassLoaderStructure(), workerInfrastructureClassloader, legacyTypesSupport);
+                    Worker worker = new IsolatedClassloaderWorker(workerClassLoader, workServices, actionExecutionSpecFactory, instantiatorFactory);
+                    return worker.execute(workSpec);
                 });
             }
         };

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -44,9 +44,9 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
     }
 
     @Override
-    public BuildOperationAwareWorker getWorker(final DaemonForkOptions forkOptions) {
+    public BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement) {
         final WorkerExecutor workerExecutor = this.workerExecutor;
-        final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        final ClassLoader contextClassLoader = ((FixedClassLoaderWorkerRequirement)workerRequirement).getContextClassLoader();
         return new AbstractWorker(buildOperationExecutor) {
             @Override
             public DefaultWorkResult execute(ActionExecutionSpec spec, BuildOperationRef parentBuildOperation) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -50,28 +50,25 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
         return new AbstractWorker(buildOperationExecutor) {
             @Override
             public DefaultWorkResult execute(ActionExecutionSpec spec, BuildOperationRef parentBuildOperation) {
-                return executeWrappedInBuildOperation(spec, parentBuildOperation, new Work() {
-                    @Override
-                    public DefaultWorkResult execute(ActionExecutionSpec spec) {
-                        DefaultWorkResult result;
-                        try {
-                            DefaultServiceRegistry serviceRegistry = new WorkerPublicServicesBuilder(parent).withInternalServicesVisible(spec.isInternalServicesRequired()).build();
-                            serviceRegistry.add(WorkerExecutor.class, workerExecutor);
-                            WorkerProtocol workerServer = new DefaultWorkerServer(serviceRegistry, parent.get(InstantiatorFactory.class));
-                            result = ClassLoaderUtils.executeInClassloader(contextClassLoader, new Factory<DefaultWorkResult>() {
-                                @Nullable
-                                @Override
-                                public DefaultWorkResult create() {
-                                    return workerServer.execute(spec);
-                                }
-                            });
-                        } finally {
-                            //TODO the async work tracker should wait for children of an operation to finish first.
-                            //It should not be necessary to call it here.
-                            workerExecutor.await();
-                        }
-                        return result;
+                return executeWrappedInBuildOperation(spec, parentBuildOperation, workSpec -> {
+                    DefaultWorkResult result;
+                    try {
+                        DefaultServiceRegistry serviceRegistry = new WorkerPublicServicesBuilder(parent).withInternalServicesVisible(workSpec.isInternalServicesRequired()).build();
+                        serviceRegistry.add(WorkerExecutor.class, workerExecutor);
+                        WorkerProtocol workerServer = new DefaultWorkerServer(serviceRegistry, parent.get(InstantiatorFactory.class));
+                        result = ClassLoaderUtils.executeInClassloader(contextClassLoader, new Factory<DefaultWorkResult>() {
+                            @Nullable
+                            @Override
+                            public DefaultWorkResult create() {
+                                return workerServer.execute(workSpec);
+                            }
+                        });
+                    } finally {
+                        //TODO the async work tracker should wait for children of an operation to finish first.
+                        //It should not be necessary to call it here.
+                        workerExecutor.await();
                     }
+                    return result;
                 });
             }
         };

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -22,7 +22,6 @@ import org.gradle.api.Transformer;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.specs.Spec;
 import org.gradle.initialization.SessionLifecycleListener;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.Stoppable;
@@ -38,7 +37,6 @@ import org.gradle.process.internal.worker.WorkerProcess;
 import org.gradle.util.CollectionUtils;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -42,6 +42,8 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
+import static java.util.Comparator.*;
+
 public class WorkerDaemonClientsManager implements Stoppable {
 
     private static final Logger LOGGER = Logging.getLogger(WorkerDaemonClientsManager.class);
@@ -146,13 +148,8 @@ public class WorkerDaemonClientsManager implements Stoppable {
      */
     public void selectIdleClientsToStop(Transformer<List<WorkerDaemonClient>, List<WorkerDaemonClient>> selectionFunction) {
         synchronized (lock) {
-            List<WorkerDaemonClient> sortedClients = CollectionUtils.sort(idleClients, new Comparator<WorkerDaemonClient>() {
-                @Override
-                public int compare(WorkerDaemonClient o1, WorkerDaemonClient o2) {
-                    return Integer.compare(o1.getUses(), o2.getUses());
-                }
-            });
-            List<WorkerDaemonClient> clientsToStop = selectionFunction.transform(new ArrayList<WorkerDaemonClient>(sortedClients));
+            List<WorkerDaemonClient> sortedClients = CollectionUtils.sort(idleClients, comparingInt(WorkerDaemonClient::getUses));
+            List<WorkerDaemonClient> clientsToStop = selectionFunction.transform(new ArrayList<>(sortedClients));
             if (!clientsToStop.isEmpty()) {
                 stopWorkers(clientsToStop);
             }
@@ -192,12 +189,7 @@ public class WorkerDaemonClientsManager implements Stoppable {
         @Override
         public void beforeComplete() {
             synchronized (lock) {
-                List<WorkerDaemonClient> sessionScopedClients = CollectionUtils.filter(allClients, new Spec<WorkerDaemonClient>() {
-                    @Override
-                    public boolean isSatisfiedBy(WorkerDaemonClient client) {
-                        return client.getKeepAliveMode() == KeepAliveMode.SESSION;
-                    }
-                });
+                List<WorkerDaemonClient> sessionScopedClients = CollectionUtils.filter(allClients, client -> client.getKeepAliveMode() == KeepAliveMode.SESSION);
                 stopWorkers(sessionScopedClients);
             }
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonExpiration.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonExpiration.java
@@ -71,7 +71,7 @@ public class WorkerDaemonExpiration implements MemoryHolder {
         @Override
         public List<WorkerDaemonClient> transform(List<WorkerDaemonClient> idleClients) {
             int notExpirable = 0;
-            List<WorkerDaemonClient> toExpire = new ArrayList<WorkerDaemonClient>();
+            List<WorkerDaemonClient> toExpire = new ArrayList<>();
             for (WorkerDaemonClient idleClient : idleClients) {
                 if (idleClient.isNotExpirable()) {
                     notExpirable++;

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -35,7 +35,7 @@ public class WorkerDaemonFactory implements WorkerFactory {
     }
 
     @Override
-    public BuildOperationAwareWorker getWorker(final DaemonForkOptions forkOptions) {
+    public BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement) {
         return new AbstractWorker(buildOperationExecutor) {
             @Override
             public DefaultWorkResult execute(ActionExecutionSpec spec, BuildOperationRef parentBuildOperation) {
@@ -48,6 +48,7 @@ public class WorkerDaemonFactory implements WorkerFactory {
             }
 
             private WorkerDaemonClient reserveClient() {
+                DaemonForkOptions forkOptions = ((ForkedWorkerRequirement)workerRequirement).getForkOptions();
                 WorkerDaemonClient client = clientsManager.reserveIdleClient(forkOptions);
                 if (client == null) {
                     client = clientsManager.reserveNewClient(WorkerDaemonServer.class, forkOptions);

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonFactory.java
@@ -41,12 +41,7 @@ public class WorkerDaemonFactory implements WorkerFactory {
             public DefaultWorkResult execute(ActionExecutionSpec spec, BuildOperationRef parentBuildOperation) {
                 final WorkerDaemonClient client = reserveClient();
                 try {
-                    return executeWrappedInBuildOperation(spec, parentBuildOperation, new Work() {
-                        @Override
-                        public DefaultWorkResult execute(ActionExecutionSpec spec) {
-                            return client.execute(spec);
-                        }
-                    });
+                    return executeWrappedInBuildOperation(spec, parentBuildOperation, client::execute);
                 } finally {
                     clientsManager.release(client);
                 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
@@ -80,14 +80,11 @@ public class WorkerDaemonStarter {
     }
 
     private static Iterable<File> toFiles(VisitableURLClassLoader.Spec spec) {
-        return CollectionUtils.collect(spec.getClasspath(), new Transformer<File, URL>() {
-            @Override
-            public File transform(URL url) {
-                try {
-                    return new File(url.toURI());
-                } catch (URISyntaxException e) {
-                    throw UncheckedException.throwAsUncheckedException(e);
-                }
+        return CollectionUtils.collect(spec.getClasspath(), url -> {
+            try {
+                return new File(url.toURI());
+            } catch (URISyntaxException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
             }
         });
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
@@ -17,7 +17,6 @@
 package org.gradle.workers.internal;
 
 import org.gradle.api.Action;
-import org.gradle.api.Transformer;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -34,7 +33,6 @@ import org.gradle.util.CollectionUtils;
 
 import java.io.File;
 import java.net.URISyntaxException;
-import java.net.URL;
 
 public class WorkerDaemonStarter {
     private final static Logger LOG = Logging.getLogger(WorkerDaemonStarter.class);

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerRequirement.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,8 @@
 
 package org.gradle.workers.internal;
 
-import org.gradle.workers.IsolationMode;
+import java.io.File;
 
-public interface WorkerFactory {
-    BuildOperationAwareWorker getWorker(WorkerRequirement workerRequirement);
-
-    IsolationMode getIsolationMode();
+public interface WorkerRequirement {
+    File getWorkerDirectory();
 }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -71,7 +71,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         _ * instantiator.newInstance(DefaultProcessWorkerSpec, _) >> { args -> new DefaultProcessWorkerSpec(args[1][0], objectFactory) }
         _ * instantiator.newInstance(DefaultWorkerExecutor.DefaultWorkQueue, _, _) >> { args -> new DefaultWorkerExecutor.DefaultWorkQueue(args[1][0], args[1][1]) }
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator, temporaryFolder.root)
-        _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
+        _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 
     @Unroll

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -75,7 +75,7 @@ class DefaultWorkerExecutorTest extends Specification {
         _ * instantiator.newInstance(DefaultProcessWorkerSpec, _) >> { args -> new DefaultProcessWorkerSpec(args[1][0], objectFactory) }
         _ * instantiator.newInstance(DefaultWorkerExecutor.DefaultWorkQueue, _, _) >> { args -> new DefaultWorkerExecutor.DefaultWorkQueue(args[1][0], args[1][1]) }
         workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, inProcessWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator, temporaryFolder.testDirectory)
-        _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
+        _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 
     def "worker configuration fork property defaults to AUTO"() {
@@ -124,7 +124,7 @@ class DefaultWorkerExecutorTest extends Specification {
         }
 
         when:
-        def daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration, null)
+        def daemonForkOptions = workerExecutor.getWorkerRequirement(runnable.class, configuration, null).forkOptions
 
         then:
         daemonForkOptions.javaForkOptions.minHeapSize == "128m"
@@ -142,13 +142,13 @@ class DefaultWorkerExecutorTest extends Specification {
         configuration.classpath.from([foo])
 
         when:
-        DaemonForkOptions daemonForkOptions = workerExecutor.getDaemonForkOptions(runnable.class, configuration, null)
+        IsolatedClassLoaderWorkerRequirement requirement = workerExecutor.getWorkerRequirement(runnable.class, configuration, null)
 
         then:
         1 * classLoaderStructureProvider.getInProcessClassLoaderStructure(_, _) >> { args -> new HierarchicalClassLoaderStructure(new VisitableURLClassLoader.Spec("test", args[0].collect { it.toURI().toURL() }))}
 
         and:
-        daemonForkOptions.classLoaderStructure.spec.classpath.contains(foo.toURI().toURL())
+        requirement.classLoaderStructure.spec.classpath.contains(foo.toURI().toURL())
     }
 
     def "executor executes a given work action in a daemon"() {

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
@@ -33,6 +33,7 @@ class WorkerDaemonFactoryTest extends Specification {
 
     def workingDir = new File("some-dir")
     def options = Stub(DaemonForkOptions)
+    def requirement = new ForkedWorkerRequirement(workingDir, options)
     def spec = Stub(ActionExecutionSpec)
 
     def setup() {
@@ -41,7 +42,7 @@ class WorkerDaemonFactoryTest extends Specification {
 
     def "getting a worker daemon does not assume client use"() {
         when:
-        factory.getWorker(options);
+        factory.getWorker(requirement);
 
         then:
         0 * clientsManager._
@@ -49,7 +50,7 @@ class WorkerDaemonFactoryTest extends Specification {
 
     def "new client is created when daemon is executed and no idle clients found"() {
         when:
-        factory.getWorker(options).execute(spec)
+        factory.getWorker(requirement).execute(spec)
 
         then:
         1 * clientsManager.reserveIdleClient(options) >> null
@@ -67,7 +68,7 @@ class WorkerDaemonFactoryTest extends Specification {
 
     def "idle client is reused when daemon is executed"() {
         when:
-        factory.getWorker(options).execute(spec)
+        factory.getWorker(requirement).execute(spec)
 
         then:
         1 * clientsManager.reserveIdleClient(options) >> client
@@ -82,7 +83,7 @@ class WorkerDaemonFactoryTest extends Specification {
 
     def "client is released even if execution fails"() {
         when:
-        factory.getWorker(options).execute(spec)
+        factory.getWorker(requirement).execute(spec)
 
         then:
         1 * clientsManager.reserveIdleClient(options) >> client
@@ -98,7 +99,7 @@ class WorkerDaemonFactoryTest extends Specification {
 
     def "build operation is started and finished when client is executed"() {
         when:
-        factory.getWorker(options).execute(spec)
+        factory.getWorker(requirement).execute(spec)
 
         then:
         1 * clientsManager.reserveIdleClient(options) >> client
@@ -107,7 +108,7 @@ class WorkerDaemonFactoryTest extends Specification {
 
     def "build worker operation is finished even if worker fails"() {
         when:
-        factory.getWorker(options).execute(spec)
+        factory.getWorker(requirement).execute(spec)
 
         then:
         1 * clientsManager.reserveIdleClient(options) >> client


### PR DESCRIPTION
Does two things:

- Does some cleanup to use lambdas where possible in the Worker API classes
- Aligns no-isolation workers with isolated workers by introducing a `WorkerRequirement` abstraction that allows the context classloader to be passed along without the need for a wrapper worker class.

Fixes #10357 

