### PR TITLE
Fix snapshot handling with Gradle Module Metadata

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -22,10 +22,13 @@ import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ComponentMetadataListerDetails;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
@@ -43,6 +46,8 @@ import org.gradle.api.internal.artifacts.repositories.metadata.MetadataSource;
 import org.gradle.api.internal.artifacts.repositories.metadata.RedirectingGradleMetadataModuleMetadataSource;
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceArtifactResolver;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver;
+import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
+import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.file.FileResolver;
@@ -51,10 +56,16 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
+import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
+import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
@@ -274,13 +285,16 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         ImmutableList.Builder<MetadataSource<?>> sources = ImmutableList.builder();
         // Don't list versions for gradleMetadata if maven-metadata.xml will be checked.
         boolean listVersionsForGradleMetadata = !metadataSources.mavenPom;
-        DefaultGradleModuleMetadataSource gradleModuleMetadataSource = new DefaultGradleModuleMetadataSource(getMetadataParser(), metadataFactory, listVersionsForGradleMetadata);
+        MetadataSource<MutableModuleComponentResolveMetadata> gradleModuleMetadataSource =
+            new MavenSnapshotDecoratingSource(
+                new DefaultGradleModuleMetadataSource(getMetadataParser(), metadataFactory, listVersionsForGradleMetadata)
+            );
         if (metadataSources.gradleMetadata) {
             sources.add(gradleModuleMetadataSource);
         }
         if (metadataSources.mavenPom) {
             DefaultMavenPomMetadataSource pomMetadataSource = new DefaultMavenPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
-            if(metadataSources.ignoreGradleMetadataRedirection) {
+            if (metadataSources.ignoreGradleMetadataRedirection) {
                 sources.add(pomMetadataSource);
             } else {
                 sources.add(new RedirectingGradleMetadataModuleMetadataSource(pomMetadataSource, gradleModuleMetadataSource));
@@ -402,4 +416,33 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         }
     }
 
+    private static class MavenSnapshotDecoratingSource implements MetadataSource<MutableModuleComponentResolveMetadata> {
+        private static final int HASH_ID = 30155977;
+
+        private final MetadataSource<MutableModuleComponentResolveMetadata> delegate;
+
+        private MavenSnapshotDecoratingSource(MetadataSource<MutableModuleComponentResolveMetadata> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult result) {
+            MutableModuleComponentResolveMetadata metadata = delegate.create(repositoryName, componentResolvers, moduleComponentIdentifier, prescribedMetaData, artifactResolver, result);
+            if (metadata != null) {
+                return MavenResolver.processMetaData((MutableMavenModuleResolveMetadata) metadata);
+            }
+            return null;
+        }
+
+        @Override
+        public void listModuleVersions(ModuleDependencyMetadata dependency, ModuleIdentifier module, List<ResourcePattern> ivyPatterns, List<ResourcePattern> artifactPatterns, VersionLister versionLister, BuildableModuleVersionListingResolveResult result) {
+            delegate.listModuleVersions(dependency, module, ivyPatterns, artifactPatterns, versionLister, result);
+        }
+
+        @Override
+        public void appendId(Hasher hasher) {
+            hasher.putInt(HASH_ID);
+            delegate.appendId(hasher);
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/RedirectingGradleMetadataModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/RedirectingGradleMetadataModuleMetadataSource.java
@@ -39,9 +39,9 @@ import java.util.List;
  */
 public class RedirectingGradleMetadataModuleMetadataSource extends AbstractMetadataSource<MutableModuleComponentResolveMetadata> {
     private final MetadataSource<?> delegate;
-    private final DefaultGradleModuleMetadataSource gradleModuleMetadataSource;
+    private final MetadataSource<MutableModuleComponentResolveMetadata> gradleModuleMetadataSource;
 
-    public RedirectingGradleMetadataModuleMetadataSource(MetadataSource<?> delegate, DefaultGradleModuleMetadataSource gradleModuleMetadataSource) {
+    public RedirectingGradleMetadataModuleMetadataSource(MetadataSource<?> delegate, MetadataSource<MutableModuleComponentResolveMetadata> gradleModuleMetadataSource) {
         this.delegate = delegate;
         this.gradleModuleMetadataSource = gradleModuleMetadataSource;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultArtifactIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dsl.ArtifactFile;
+import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
@@ -33,13 +34,27 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
     private final ModuleComponentIdentifier componentIdentifier;
     private final String fileName;
     private final String relativeUrl;
-    private final ModuleComponentFileArtifactIdentifier id;
+    private final ModuleComponentArtifactIdentifier id;
+
+    private IvyArtifactName ivyArtifactName;
 
     public UrlBackedArtifactMetadata(ModuleComponentIdentifier componentIdentifier, String fileName, String relativeUrl) {
         this.componentIdentifier = componentIdentifier;
         this.fileName = fileName;
         this.relativeUrl = relativeUrl;
-        id = new ModuleComponentFileArtifactIdentifier(componentIdentifier, fileName);
+        id = createArtifactId(componentIdentifier, fileName);
+    }
+
+    private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier, String fileName) {
+        if (componentIdentifier instanceof MavenUniqueSnapshotComponentIdentifier) {
+            // This special case is for Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
+            // corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility
+            return new DefaultModuleComponentArtifactIdentifier(
+                componentIdentifier,
+                getName()
+            );
+        }
+        return new ModuleComponentFileArtifactIdentifier(componentIdentifier, fileName);
     }
 
     @Override
@@ -68,12 +83,22 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
 
     @Override
     public IvyArtifactName getName() {
-        ArtifactFile names = new ArtifactFile(relativeUrl, componentIdentifier.getVersion());
-        return new DefaultIvyArtifactName(names.getName(), names.getExtension(), names.getExtension(), names.getClassifier());
+        if (ivyArtifactName == null) {
+            ArtifactFile names = new ArtifactFile(relativeUrl, uniqueVersion());
+            ivyArtifactName = new DefaultIvyArtifactName(names.getName(), names.getExtension(), names.getExtension(), names.getClassifier());
+        }
+        return ivyArtifactName;
     }
 
     @Override
     public TaskDependency getBuildDependencies() {
         return TaskDependencyInternal.EMPTY;
+    }
+
+    private String uniqueVersion() {
+        if (componentIdentifier instanceof MavenUniqueSnapshotComponentIdentifier) {
+            return ((MavenUniqueSnapshotComponentIdentifier) componentIdentifier).getTimestampedVersion();
+        }
+        return componentIdentifier.getVersion();
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -26,20 +26,22 @@ class GradleFileModuleAdapter {
     private final String group
     private final String module
     private final String version
+    private final String publishArtifactVersion
     private final List<VariantMetadataSpec> variants
     private final Map<String, String> attributes
 
-    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadataSpec> variants, Map<String, String> attributes = [:]) {
+    GradleFileModuleAdapter(String group, String module, String version, String publishArtifactVersion, List<VariantMetadataSpec> variants, Map<String, String> attributes = [:]) {
         this.group = group
         this.module = module
         this.version = version
+        this.publishArtifactVersion = publishArtifactVersion
         this.variants = variants
         this.attributes = attributes
     }
 
     void publishTo(TestFile moduleDir) {
         moduleDir.createDir()
-        def file = moduleDir.file("$module-${version}.module")
+        def file = moduleDir.file("$module-${publishArtifactVersion}.module")
         def jsonBuilder = new JsonBuilder()
         jsonBuilder {
             formatVersion GradleModuleMetadataParser.FORMAT_VERSION

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -417,7 +417,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         def defaultArtifacts = artifacts.findAll {!it.undeclared}.collect { moduleArtifact(it) }.collect {
             new FileSpec(it.file.name, it.file.name)
         }
-        GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(organisation, module, revision,
+        GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(organisation, module, revision, revision,
             variants.collect { v ->
                 def artifacts = v.artifacts
                 if (!artifacts && v.useDefaultArtifacts) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -463,7 +463,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         def defaultArtifacts = getArtifact([:]).collect {
             new FileSpec(it.file.name, it.file.name)
         }
-        GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(groupId, artifactId, version,
+        GradleFileModuleAdapter adapter = new GradleFileModuleAdapter(groupId, artifactId, version, publishArtifactVersion,
             variants.collect { v ->
                 def artifacts = v.artifacts
                 if (!artifacts && v.useDefaultArtifacts) {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -110,6 +110,10 @@ abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec imple
             repositories {
                 ivy { 
                     url "${ivyRepo.uri}"
+                    metadataSources {
+                        ${params.resolveModuleMetadata?'gradleMetadata':'ivyDescriptor'}()
+                        ${params.resolveModuleMetadata?'':'ignoreGradleMetadataRedirection()'}
+                    }
                 }
             }
 
@@ -168,8 +172,8 @@ abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec imple
         }
 
         void validate() {
-            singleValidation(true, withModuleMetadataSpec)
             singleValidation(false, withoutModuleMetadataSpec)
+            singleValidation(true, withModuleMetadataSpec)
         }
 
         void singleValidation(boolean withModuleMetadata, SingleArtifactResolutionResultSpec expectationSpec) {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -86,7 +86,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
                 expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
             }
             withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+                expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
             }
         }
 
@@ -165,7 +165,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
                 expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
             }
             withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+                expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
             }
         }
 
@@ -256,7 +256,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
                 expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
             }
             withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
             }
         }
 
@@ -361,7 +361,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
                 expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
             }
             withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
             }
         }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -37,10 +37,16 @@ import org.gradle.internal.xml.XmlTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.stream.Stream;
 
 import static org.apache.maven.artifact.ArtifactUtils.isSnapshot;
 
@@ -206,7 +212,35 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
             }
 
             ExternalResourceName externalResource = new ExternalResourceName(rootUri, path.toString());
-            publish(externalResource, content);
+            publish(externalResource, maybeSubstituteVersion(extension, content));
+        }
+
+        // When publishing unique snapshot versions, we need to tweak the generated
+        // Gradle Module Metadata file in order to replace the URI/file names of the
+        // published files
+        private File maybeSubstituteVersion(String extension, File content) {
+            if ("module".equals(extension) && !artifactVersion.equals(moduleVersion)) {
+                File timestamped = new File(content.getParentFile(), content.getName() + "-" + artifactVersion);
+                if (timestamped.exists()) {
+                    return timestamped;
+                }
+                // we're publishing a timestamped snapshot version so we need to tweak the generated module file
+                try (PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(timestamped), StandardCharsets.UTF_8)))) {
+                    try (Stream<String> lines = Files.lines(content.toPath(), StandardCharsets.UTF_8)) {
+                        lines.forEach(line -> {
+                            if (line.contains("\"url\"") || line.contains("\"name\"")) {
+                                writer.println(line.replace(moduleVersion, artifactVersion));
+                            } else {
+                                writer.println(line);
+                            }
+                        });
+                    }
+                } catch (IOException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+                return timestamped;
+            }
+            return content;
         }
 
         void publish(ExternalResourceName externalResource, File content) {

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -119,6 +119,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
                     url "${mavenRepo.uri}"
                     metadataSources {
                         ${params.resolveModuleMetadata?'gradleMetadata':'mavenPom'}()
+                        ${params.resolveModuleMetadata?'':'ignoreGradleMetadataRedirection()'}
                     }
                 }
                 ${externalRepo}
@@ -175,8 +176,8 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
         }
 
         void validate() {
-            singleValidation(true, withModuleMetadataSpec)
             singleValidation(false, withoutModuleMetadataSpec)
+            singleValidation(true, withModuleMetadataSpec)
         }
 
         void singleValidation(boolean withModuleMetadata, SingleArtifactResolutionResultSpec expectationSpec) {

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -226,6 +226,35 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         file("build", "publications", "ivy", "module.json.asc").text
     }
 
+    def "disallows signing Gradle metadata if version is a snapshot"() {
+        given:
+        buildFile << """
+            apply plugin: 'maven-publish'
+            ${keyInfo.addAsPropertiesScript()}
+
+            version = '1.0-SNAPSHOT'
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+
+            signing {
+                ${signingConfiguration()}
+                sign publishing.publications.maven
+            }
+        """
+
+        when:
+        fails "signMavenPublication"
+
+        then:
+        failure.assertHasCause("Signing Gradle Module Metadata is not supported for snapshot dependencies.")
+    }
+
     def "publishes signature files for Maven publication"() {
         given:
         buildFile << """

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -22,6 +22,7 @@ import org.gradle.api.Buildable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Incubating;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
@@ -105,7 +106,16 @@ public class Sign extends DefaultTask implements SignatureSpec {
     }
 
     private void signArtifact(final PublicationArtifact publicationArtifact) {
+        ensurePublicationArtifactCanBeSigned(publicationArtifact);
         addSignature(new Signature(publicationArtifact, publicationArtifact::getFile, null, null, this, this));
+    }
+
+    private void ensurePublicationArtifactCanBeSigned(PublicationArtifact publicationArtifact) {
+        if (publicationArtifact.getFile().getName().equals("module.json")) {
+            if (String.valueOf(getProject().getVersion()).endsWith("-SNAPSHOT")) {
+                throw new InvalidUserCodeException("Signing Gradle Module Metadata is not supported for snapshot dependencies.");
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This commit fixes a couple of bugs:

1. if Gradle Module Metadata was published and consumed, then
the `changing` flag for the resolved component metadata wouldn't
be set to `true`, which means that snapshot would effectively be
considered as persistent

2. the publish test fixtures were not using the right, timestamped,
version id for the metadata and artifacts in case of unique snapshots,
which caused the resolution to fallback to the POM file

Fixes #10916
