### PR TITLE
Stricter binary compatibility check of deprecated members

### DIFF
--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -77,65 +77,36 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
         return isAnnotatedWithInject(member)
     }
 
-    boolean isIncubatingOrDeprecated(JApiHasAnnotations member) {
+    protected boolean isIncubating(JApiHasAnnotations member) {
         if (member instanceof JApiClass) {
-            return isIncubatingOrDeprecated((JApiClass) member)
-        } else if (member instanceof JApiMethod) {
-            return isIncubatingOrDeprecatedOrOverride((JApiMethod) member)
-        } else if (member instanceof JApiField) {
-            return isIncubatingOrDeprecated((JApiField) member)
-        } else if (member instanceof JApiConstructor) {
-            return isIncubatingOrDeprecated((JApiConstructor) member)
+            return isIncubatingClass((JApiClass) member)
+        }
+        if (member instanceof JApiMethod) {
+            return isIncubatingOrOverrideMethod((JApiMethod) member)
+        }
+        if (member instanceof JApiField) {
+            return isIncubatingField((JApiField) member)
+        }
+        if (member instanceof JApiConstructor) {
+            return isIncubatingConstructor((JApiConstructor) member)
         }
         return isAnnotatedWithIncubating(member)
     }
 
-    boolean isIncubatingOrDeprecated(JApiClass clazz) {
-        return isAnnotatedWithIncubating(clazz) || isAnnotatedWithDeprecated(clazz)
+    private static boolean isIncubatingClass(JApiClass clazz) {
+        return isAnnotatedWithIncubating(clazz)
     }
 
-    boolean isIncubatingOrDeprecated(JApiField field) {
-        return isAnnotatedWithIncubating(field) || isAnnotatedWithIncubating(field.jApiClass) || isAnnotatedWithDeprecated(field) || isAnnotatedWithDeprecated(field.jApiClass)
+    private boolean isIncubatingOrOverrideMethod(JApiMethod method) {
+        return isAnnotatedWithIncubating(method) || isAnnotatedWithIncubating(method.jApiClass) || isOverride(method)
     }
 
-    boolean isIncubatingOrDeprecated(JApiConstructor constructor) {
-        return isAnnotatedWithIncubating(constructor) || isAnnotatedWithIncubating(constructor.jApiClass) || isAnnotatedWithDeprecated(constructor) || isAnnotatedWithDeprecated(constructor.jApiClass)
+    private static boolean isIncubatingField(JApiField field) {
+        return isAnnotatedWithIncubating(field) || isAnnotatedWithIncubating(field.jApiClass)
     }
 
-    boolean isIncubatingOrDeprecatedOrOverride(JApiMethod method) {
-        return isAnnotatedWithIncubating(method) || isAnnotatedWithIncubating(method.jApiClass) || isOverride(method) || isAnnotatedWithDeprecated(method) || isAnnotatedWithDeprecated(method.jApiClass)
-    }
-
-    boolean isDeprecated(JApiClass clazz) {
-        return isAnnotatedWithDeprecated(clazz)
-    }
-
-    boolean isDeprecated(JApiConstructor constructor) {
-        return isAnnotatedWithDeprecated(constructor) || isAnnotatedWithDeprecated(constructor.jApiClass)
-    }
-
-    boolean isDeprecated(JApiField field) {
-        return isAnnotatedWithDeprecated(field) || isAnnotatedWithDeprecated(field.jApiClass)
-    }
-
-    boolean isDeprecated(JApiMethod method) {
-        return isAnnotatedWithDeprecated(method) || isAnnotatedWithDeprecated(method.jApiClass)
-    }
-
-    boolean isDeprecated(JApiCompatibility member) {
-        if (member instanceof JApiClass) {
-            return isDeprecated(member as JApiClass)
-        }
-        if (member instanceof JApiConstructor) {
-            return isDeprecated(member as JApiConstructor)
-        }
-        if (member instanceof JApiField) {
-            return isDeprecated(member as JApiField)
-        }
-        if (member instanceof JApiMethod) {
-            return isDeprecated(member as JApiMethod)
-        }
-        return false
+    private static boolean isIncubatingConstructor(JApiConstructor constructor) {
+        return isAnnotatedWithIncubating(constructor) || isAnnotatedWithIncubating(constructor.jApiClass)
     }
 
     protected boolean isOverride(JApiMethod method) {

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/BinaryBreakingChangesRule.java
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/BinaryBreakingChangesRule.java
@@ -65,8 +65,8 @@ public class BinaryBreakingChangesRule extends AbstractGradleViolationRule {
                 }
             }
             if (member instanceof JApiHasAnnotations) {
-                if (isIncubatingOrDeprecated((JApiHasAnnotations) member)) {
-                    return Violation.warning(member, "Changed public API (@Incubating/@Deprecated)");
+                if (isIncubating((JApiHasAnnotations) member)) {
+                    return Violation.warning(member, "Changed public API (@Incubating)");
                 }
             }
             return acceptOrReject(member, Violation.notBinaryCompatible(member));

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/IncubatingMissingRule.java
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/IncubatingMissingRule.java
@@ -35,7 +35,7 @@ public class IncubatingMissingRule extends AbstractGradleViolationRule {
     @Override
     public Violation maybeViolation(final JApiCompatibility member) {
         if (member instanceof JApiMethod || member instanceof JApiField || member instanceof JApiClass || member instanceof JApiConstructor) {
-            if (!isIncubatingOrDeprecated((JApiHasAnnotations) member) && !isInject((JApiHasAnnotations) member)) {
+            if (!isIncubating((JApiHasAnnotations) member) && !isInject((JApiHasAnnotations) member)) {
                 return violationError(member);
             }
         }

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/NewIncubatingAPIRule.java
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/NewIncubatingAPIRule.java
@@ -34,7 +34,7 @@ public class NewIncubatingAPIRule extends AbstractGradleViolationRule {
     @Override
     public Violation maybeViolation(final JApiCompatibility member) {
         if (member instanceof JApiMethod || member instanceof JApiField || member instanceof JApiClass) {
-            if (!isIncubatingOrDeprecated((JApiHasAnnotations) member)) {
+            if (!isIncubating((JApiHasAnnotations) member)) {
                 return null;
             }
             if (member instanceof JApiMethod && isOverride((JApiMethod) member)) {

--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
@@ -46,7 +46,6 @@ public class SinceAnnotationMissingRule extends AbstractGradleViolationRule {
 
     private boolean shouldSkipViolationCheckFor(JApiCompatibility member) {
         return !isClassFieldConstructorOrMethod(member) ||
-            isDeprecated(member) ||
             isInject(member) ||
             isOverrideMethod(member) ||
             isKotlinFileFacadeClass(member);

--- a/buildSrc/subprojects/binary-compatibility/src/test/groovy/org/gradle/binarycompatibility/PublicAPIRulesTest.groovy
+++ b/buildSrc/subprojects/binary-compatibility/src/test/groovy/org/gradle/binarycompatibility/PublicAPIRulesTest.groovy
@@ -291,7 +291,7 @@ class PublicAPIRulesTest extends Specification {
     }
 
     @Unroll
-    def "if a new #apiElement is annotated with @Deprecated it does not require @Incubating or @since annotations"() {
+    def "if a new #apiElement is annotated with @Deprecated it does require @Incubating or @since annotations"() {
         given:
         JApiCompatibility jApiType = getProperty(jApiTypeName)
         def incubatingMissingRule = withContext(new IncubatingMissingRule([:]))
@@ -310,8 +310,8 @@ class PublicAPIRulesTest extends Specification {
         """
 
         then:
-        incubatingMissingRule.maybeViolation(jApiType) == null
-        sinceMissingRule.maybeViolation(jApiType) == null
+        incubatingMissingRule.maybeViolation(jApiType).severity == Severity.error
+        sinceMissingRule.maybeViolation(jApiType).severity == Severity.error
 
         where:
         apiElement  | jApiTypeName

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1120,6 +1120,374 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Class org.gradle.api.plugins.quality.FindBugs",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.extraArgs(java.lang.Iterable)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.extraArgs(java.lang.String[])",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getCandidateClassFiles()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getClasses()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getClasspath()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getEffort()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getExcludeBugsFilter()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getExcludeBugsFilterConfig()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getExcludeFilter()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getExcludeFilterConfig()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getExtraArgs()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getFindbugsClasspath()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getIncludeFilter()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getIncludeFilterConfig()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getMaxHeapSize()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getObjectFactory()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getOmitVisitors()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getPluginClasspath()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getReportLevel()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getReports()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getShowProgress()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getSource()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getVisitors()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.getWorkerProcessBuilderFactory()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.reports(groovy.lang.Closure)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.reports(org.gradle.api.Action)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.run()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setClasses(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setClasspath(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setEffort(java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setExcludeBugsFilter(java.io.File)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setExcludeBugsFilterConfig(org.gradle.api.resources.TextResource)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setExcludeFilter(java.io.File)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setExcludeFilterConfig(org.gradle.api.resources.TextResource)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setExtraArgs(java.util.Collection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setFindbugsClasspath(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setIncludeFilter(java.io.File)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setIncludeFilterConfig(org.gradle.api.resources.TextResource)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setMaxHeapSize(java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setOmitVisitors(java.util.Collection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setPluginClasspath(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setReportLevel(java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setShowProgress(boolean)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Method org.gradle.api.plugins.quality.FindBugs.setVisitors(java.util.Collection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugs",
+            "member": "Constructor org.gradle.api.plugins.quality.FindBugs()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -928,6 +928,198 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Class org.gradle.api.plugins.quality.FindBugsExtension",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getEffort()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getExcludeBugsFilter()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getExcludeBugsFilterConfig()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getExcludeFilter()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getExcludeFilterConfig()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getExtraArgs()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getIncludeFilter()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getIncludeFilterConfig()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getOmitVisitors()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getReportLevel()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.getVisitors()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setEffort(java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setExcludeBugsFilter(java.io.File)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setExcludeBugsFilterConfig(org.gradle.api.resources.TextResource)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setExcludeFilter(java.io.File)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setExcludeFilterConfig(org.gradle.api.resources.TextResource)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setExtraArgs(java.util.Collection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setIncludeFilter(java.io.File)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setIncludeFilterConfig(org.gradle.api.resources.TextResource)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setOmitVisitors(java.util.Collection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setReportLevel(java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsExtension.setVisitors(java.util.Collection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsExtension",
+            "member": "Constructor org.gradle.api.plugins.quality.FindBugsExtension(org.gradle.api.Project)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -712,6 +712,102 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Class org.gradle.api.plugins.quality.JDepend",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.getAntBuilder()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.getClassesDirs()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.getJdependClasspath()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.getObjectFactory()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.getReports()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.reports(groovy.lang.Closure)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.reports(org.gradle.api.Action)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.run()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.setClassesDirs(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Method org.gradle.api.plugins.quality.JDepend.setJdependClasspath(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDepend",
+            "member": "Constructor org.gradle.api.plugins.quality.JDepend()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -832,6 +832,102 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Class org.gradle.api.plugins.quality.FindBugsPlugin",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Field DEFAULT_FINDBUGS_VERSION",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.beforeApply()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.configureConfiguration(org.gradle.api.artifacts.Configuration)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.configureForSourceSet(org.gradle.api.tasks.SourceSet,org.gradle.api.plugins.quality.FindBugs)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.configureForSourceSet(org.gradle.api.tasks.SourceSet,java.lang.Object)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.configureTaskDefaults(org.gradle.api.plugins.quality.FindBugs,java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.configureTaskDefaults(java.lang.Object,java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.createExtension()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.getTaskType()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsPlugin.getToolName()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsPlugin",
+            "member": "Constructor org.gradle.api.plugins.quality.FindBugsPlugin()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -417,6 +417,20 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.JavaCompile",
+            "member": "Method org.gradle.api.tasks.compile.JavaCompile.getEffectiveAnnotationProcessorPath()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.JavaCompile",
+            "member": "Method org.gradle.api.tasks.compile.JavaCompile.getSources()",
+            "acceptation": "Deprecated member removed",
+            "changes": []
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -401,6 +401,14 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.testfixtures.ProjectBuilder",
+            "member": "Constructor org.gradle.testfixtures.ProjectBuilder()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor is less accessible"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -337,6 +337,14 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.Nullable",
+            "member": "Class org.gradle.api.Nullable",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -591,6 +591,15 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.plugins.JacocoPlugin",
+            "member": "Method org.gradle.testing.jacoco.plugins.JacocoPlugin.configureDefaultOutputPathForJacocoMerge()",
+            "acceptation": "Deprecated member made private",
+            "changes": [
+                "Method is less accessible",
+                "Method return type has changed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1488,6 +1488,46 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsReports",
+            "member": "Class org.gradle.api.plugins.quality.FindBugsReports",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsReports",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsReports.getEmacs()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsReports",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsReports.getHtml()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsReports",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsReports.getText()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsReports",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsReports.getXml()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -353,6 +353,22 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.tasks.CompatibilityAdapterForTaskInputs",
+            "member": "Class org.gradle.api.tasks.CompatibilityAdapterForTaskInputs",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.CompatibilityAdapterForTaskInputs",
+            "member": "Method org.gradle.api.tasks.CompatibilityAdapterForTaskInputs.property(java.lang.String,java.lang.Object)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -463,6 +463,46 @@
             "changes": [
                 "Method return type has changed"
             ]
+        },
+        {
+            "type": "org.gradle.plugin.devel.tasks.ValidateTaskProperties",
+            "member": "Method org.gradle.plugin.devel.tasks.ValidateTaskProperties.getClassLoaderFactory()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.plugin.devel.tasks.ValidateTaskProperties",
+            "member": "Method org.gradle.plugin.devel.tasks.ValidateTaskProperties.getDocumentationRegistry()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.plugin.devel.tasks.ValidateTaskProperties",
+            "member": "Method org.gradle.plugin.devel.tasks.ValidateTaskProperties.setClasses(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.plugin.devel.tasks.ValidateTaskProperties",
+            "member": "Method org.gradle.plugin.devel.tasks.ValidateTaskProperties.setClasspath(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.plugin.devel.tasks.ValidateTaskProperties",
+            "member": "Method org.gradle.plugin.devel.tasks.ValidateTaskProperties.validateTaskClasses()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -519,6 +519,22 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.plugins.signing.Sign",
+            "member": "Method org.gradle.plugins.signing.Sign.getInputFiles()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.signing.Sign",
+            "member": "Method org.gradle.plugins.signing.Sign.getOutputFiles()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -551,6 +551,46 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoReportBase",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoReportBase.setAdditionalClassDirs(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoReportBase",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoReportBase.setAdditionalSourceDirs(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoReportBase",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoReportBase.setClassDirectories(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoReportBase",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoReportBase.setExecutionData(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoReportBase",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoReportBase.setSourceDirectories(org.gradle.api.file.FileCollection)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -289,6 +289,38 @@
             "changes": [
                 "Abstract method has been added to this class"
             ]
+        },
+        {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Method org.gradle.api.DefaultTask.newInputDirectory()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Method org.gradle.api.DefaultTask.newInputFile()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Method org.gradle.api.DefaultTask.newOutputDirectory()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.DefaultTask",
+            "member": "Method org.gradle.api.DefaultTask.newOutputFile()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -503,6 +503,14 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.language.scala.tasks.AbstractScalaCompile",
+            "member": "Method org.gradle.language.scala.tasks.AbstractScalaCompile.getEffectiveAnnotationProcessorPath()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -345,6 +345,14 @@
             "changes": [
                 "Class has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ExtensionContainer",
+            "member": "Method org.gradle.api.plugins.ExtensionContainer.getSchema()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -600,6 +600,102 @@
                 "Method is less accessible",
                 "Method return type has changed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Class org.gradle.api.plugins.quality.JDependPlugin",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Field DEFAULT_JDEPEND_VERSION",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Field has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.beforeApply()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.configureConfiguration(org.gradle.api.artifacts.Configuration)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.configureForSourceSet(org.gradle.api.tasks.SourceSet,org.gradle.api.plugins.quality.JDepend)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.configureForSourceSet(org.gradle.api.tasks.SourceSet,java.lang.Object)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.configureTaskDefaults(org.gradle.api.plugins.quality.JDepend,java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.configureTaskDefaults(java.lang.Object,java.lang.String)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.createExtension()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.getTaskType()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Method org.gradle.api.plugins.quality.JDependPlugin.getToolName()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependPlugin",
+            "member": "Constructor org.gradle.api.plugins.quality.JDependPlugin()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -409,6 +409,14 @@
             "changes": [
                 "Constructor is less accessible"
             ]
+        },
+        {
+            "type": "org.gradle.api.tasks.SourceSetOutput",
+            "member": "Method org.gradle.api.tasks.SourceSetOutput.isLegacyLayout()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -369,6 +369,38 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.isInteractive()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.isRecompileScripts()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.setInteractive(boolean)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.StartParameter",
+            "member": "Method org.gradle.StartParameter.setRecompileScripts(boolean)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -535,6 +535,22 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.plugins.JacocoTaskExtension",
+            "member": "Method org.gradle.testing.jacoco.plugins.JacocoTaskExtension.isAppend()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.plugins.JacocoTaskExtension",
+            "member": "Method org.gradle.testing.jacoco.plugins.JacocoTaskExtension.setAppend(boolean)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -808,6 +808,30 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependReports",
+            "member": "Class org.gradle.api.plugins.quality.JDependReports",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependReports",
+            "member": "Method org.gradle.api.plugins.quality.JDependReports.getText()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependReports",
+            "member": "Method org.gradle.api.plugins.quality.JDependReports.getXml()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -511,6 +511,14 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.publish.maven.tasks.AbstractPublishToMaven",
+            "member": "Method org.gradle.api.publish.maven.tasks.AbstractPublishToMaven.getLoggingManagerFactory()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -321,6 +321,22 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.dsl.ConventionProperty",
+            "member": "Class org.gradle.api.dsl.ConventionProperty",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.dsl.ConventionProperty",
+            "member": "Constructor org.gradle.api.dsl.ConventionProperty()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -696,6 +696,22 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependExtension",
+            "member": "Class org.gradle.api.plugins.quality.JDependExtension",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.JDependExtension",
+            "member": "Constructor org.gradle.api.plugins.quality.JDependExtension()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Constructor has been removed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -431,6 +431,38 @@
             "member": "Method org.gradle.api.tasks.compile.JavaCompile.getSources()",
             "acceptation": "Deprecated member removed",
             "changes": []
+        },
+        {
+            "type": "org.gradle.caching.configuration.BuildCacheConfiguration",
+            "member": "Method org.gradle.caching.configuration.BuildCacheConfiguration.local(java.lang.Class)",
+            "acceptation": "Local cache configuration is always a DirectoryBuildCache now",
+            "changes": [
+                "Method return type has changed"
+            ]
+        },
+        {
+            "type": "org.gradle.caching.configuration.BuildCacheConfiguration",
+            "member": "Method org.gradle.caching.configuration.BuildCacheConfiguration.local(java.lang.Class,org.gradle.api.Action)",
+            "acceptation": "Local cache configuration is always a DirectoryBuildCache now",
+            "changes": [
+                "Method return type has changed"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.BuildCacheConfigurationExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.BuildCacheConfigurationExtensionsKt.local(org.gradle.caching.configuration.BuildCacheConfiguration)",
+            "acceptation": "Local cache configuration is always a DirectoryBuildCache now",
+            "changes": [
+                "Method return type has changed"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.BuildCacheConfigurationExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.BuildCacheConfigurationExtensionsKt.local(org.gradle.caching.configuration.BuildCacheConfiguration,kotlin.jvm.functions.Function1)",
+            "acceptation": "Local cache configuration is always a DirectoryBuildCache now",
+            "changes": [
+                "Method return type has changed"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1528,6 +1528,30 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsXmlReport",
+            "member": "Class org.gradle.api.plugins.quality.FindBugsXmlReport",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Class has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsXmlReport",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsXmlReport.isWithMessages()",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.quality.FindBugsXmlReport",
+            "member": "Method org.gradle.api.plugins.quality.FindBugsXmlReport.setWithMessages(boolean)",
+            "acceptation": "Deprecated member removed",
+            "changes": [
+                "Method has been removed"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Let binary compatibility check not ignore changes on `@Deprecated` members the way it does it for `@Incubating` members. This change makes that adding deprecated members is an error and that the change must be explicitly accepted. A since annotation is also required when introducing a new member, deprecated or not.

It makes all the deletions of non-incubating deprecated members done for 6.0 fail the check: [compatibility report](https://builds.gradle.org/viewLog.html?buildId=27374053&buildTypeId=Gradle_Check_SanityCheck&tab=report_project951_API_Compatibility_Report&branch_Gradle_Check_Stage_QuickFeedbackLinuxOnly=eskatos%2Fbincompat%2Fdo-not-ignore-deprecated). They were reported as warnings before. It's now required to accept the removals, e.g.:

![image](https://user-images.githubusercontent.com/132773/66065179-22280e80-e547-11e9-9a0b-fa5b46252ccb.png)

The report now also fail when adding a new member in a deprecated type, or changing a deprecated member, which is good.

Modifications or deletions of incubating deprecated members are still reported as warnings.
