### PR TITLE
Add new "reproducible resolution" failure modes

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -110,6 +110,20 @@ public interface ResolutionStrategy {
     ResolutionStrategy failOnChangingVersions();
 
     /**
+     * Configures Gradle to fail the build is the resolution result is expected to be unstable, that is to say that
+     * it includes dynamic versions or changing versions and therefore the result may change depending
+     * on when the build is executed.
+     *
+     * This method is equivalent to calling both {@link #failOnDynamicVersions()} and
+     * {@link #failOnChangingVersions()}.
+     *
+     * @return this resolution strategy
+     * @since 6.1
+     */
+    @Incubating
+    ResolutionStrategy failOnNonReproducibleResolution();
+
+    /**
      * Gradle can resolve conflicts purely by version number or prioritize project dependencies over binary.
      * The default is <b>by version number</b>.<p>
      * This applies to both first level and transitive dependencies. See example below:

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -98,6 +98,18 @@ public interface ResolutionStrategy {
     ResolutionStrategy failOnDynamicVersions();
 
     /**
+     * If this method is called, Gradle will make sure that no changing version participates in resolution.
+     *
+     * This can be used in cases you want to make sure your build is reproducible, <i>without</i> relying on
+     * dependency locking.
+     *
+     * @return this resolution strategy
+     * @since 6.1
+     */
+    @Incubating
+    ResolutionStrategy failOnChangingVersions();
+
+    /**
      * Gradle can resolve conflicts purely by version number or prioritize project dependencies over binary.
      * The default is <b>by version number</b>.<p>
      * This applies to both first level and transitive dependencies. See example below:

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -83,6 +83,21 @@ public interface ResolutionStrategy {
     ResolutionStrategy failOnVersionConflict();
 
     /**
+     * If this method is called, Gradle will make sure that no dynamic version was used in the resulting dependency graph.
+     * In practice, it means that if the resolved dependency graph contains a module and that the versions participating
+     * in the selection of that module contain at least one dynamic version, then resolution will fail if the resolution
+     * result can change because of this version selector.
+     *
+     * This can be used in cases you want to make sure your build is reproducible, <i>without</i> relying on
+     * dependency locking.
+     *
+     * @return this resolution strategy
+     * @since 6.1
+     */
+    @Incubating
+    ResolutionStrategy failOnDynamicVersions();
+
+    /**
      * Gradle can resolve conflicts purely by version number or prioritize project dependencies over binary.
      * The default is <b>by version number</b>.<p>
      * This applies to both first level and transitive dependencies. See example below:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FailOnChangingVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FailOnChangingVersionsResolveIntegrationTest.groovy
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import spock.lang.Unroll
+
+class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        buildFile << """
+            configurations.all {
+                resolutionStrategy.failOnChangingVersions()
+            }
+        """
+    }
+
+    def "fails to resolve a direct changing dependency"() {
+        buildFile << """
+            dependencies {
+                conf('org:test:1.0') {
+                    changing = true
+                }
+            }
+        """
+
+        repository {
+            'org:test:1.0'()
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectGetMetadata()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:test:1.0: Resolution strategy disallows usage of changing versions")
+    }
+
+    def "fails to resolve a transitive changing dependency"() {
+        buildFile << """
+            dependencies {
+                conf('org:test:1.0')
+                components {
+                    withModule('org:testB') {
+                        changing = true
+                    }
+                }
+            }
+        """
+
+        repository {
+            'org:test:1.0' {
+                dependsOn 'org:testB:1.0'
+            }
+            'org:testB:1.0'()
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectGetMetadata()
+            }
+            'org:testB:1.0' {
+                expectGetMetadata()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:testB:1.0: Resolution strategy disallows usage of changing versions")
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    )
+    @Unroll
+    def "can deny a direct snapshot dependency (unique = #unique)"() {
+        buildFile << """
+            dependencies {
+                conf('org:test:1.0-SNAPSHOT')
+            }
+        """
+
+        repository {
+            'org:test:1.0-SNAPSHOT' {
+                withModule {
+                    if (!unique) {
+                        withNonUniqueSnapshots()
+                    }
+                }
+            }
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0-SNAPSHOT' {
+                allowAll()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:test:1.0-SNAPSHOT: Resolution strategy disallows usage of changing versions")
+
+        where:
+        unique << [true, false]
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    )
+    @Unroll
+    def "can deny a transitive snapshot dependency (unique = #unique)"() {
+        buildFile << """
+            dependencies {
+                conf 'org:test:1.0'
+            }
+        """
+
+        repository {
+            'org:test:1.0' {
+                dependsOn 'org:testB:1.0-SNAPSHOT' // oh noes!
+            }
+            'org:testB:1.0-SNAPSHOT' {
+                withModule {
+                    if (!unique) {
+                        withNonUniqueSnapshots()
+                    }
+                }
+            }
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectGetMetadata()
+            }
+            'org:testB:1.0-SNAPSHOT' {
+                allowAll()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:testB:1.0-SNAPSHOT: Resolution strategy disallows usage of changing versions")
+
+        where:
+        unique << [true, false]
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FailOnDynamicVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FailOnDynamicVersionsResolveIntegrationTest.groovy
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import groovy.transform.CompileStatic
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import spock.lang.Unroll
+
+class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        buildFile << """
+            configurations.all {
+                resolutionStrategy.failOnDynamicVersions()
+            }
+        """
+    }
+
+    def "fails to resolve a direct dependency using a dynamic version"() {
+        buildFile << """
+            dependencies {
+                conf 'org:test:1.+'
+            }
+        """
+
+        repository {
+            'org:test:1.0'()
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test' {
+                expectVersionListing()
+            }
+            'org:test:1.0' {
+                expectGetMetadata()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:test:1.+: Resolution strategy disallows usage of dynamic versions")
+    }
+
+    def "fails to resolve a transitive dependency which uses a dynamic version"() {
+        buildFile << """
+            dependencies {
+                conf 'org:test:1.0'
+            }
+        """
+
+        repository {
+            'org:test:1.0' {
+                dependsOn 'org:transitive:1.+'
+            }
+            'org:transitive:1.0'()
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectGetMetadata()
+            }
+            'org:transitive' {
+                expectVersionListing()
+                '1.0' {
+                    expectGetMetadata()
+                }
+            }
+
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:transitive:1.+: Resolution strategy disallows usage of dynamic versions")
+    }
+
+    def "fails if a transitive dynamic selector participates in selection"() {
+        buildFile << """
+            dependencies {
+                conf 'org:test:1.0'
+                conf 'org:testB:1.0'
+            }
+        """
+
+        repository {
+            'org:test:1.0' {
+                dependsOn 'org:transitive:1.+'
+            }
+            'org:testB:1.0' {
+                dependsOn 'org:transitive:1.0'
+            }
+            'org:transitive:1.0'()
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectGetMetadata()
+            }
+            'org:testB:1.0' {
+                expectGetMetadata()
+            }
+            'org:transitive' {
+                expectVersionListing()
+                '1.0' {
+                    expectGetMetadata()
+                }
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:transitive:1.+: Resolution strategy disallows usage of dynamic versions")
+    }
+
+    def "passes if a transitive dynamic selector doesn't participate in selection"() {
+        buildFile << """
+            dependencies {
+                conf 'org:test:1.0'
+                conf 'org:testB:1.0'
+                conf 'org:testC:1.0'
+            }
+           
+        """
+
+        repository {
+            'org:test:1.0' {
+                dependsOn 'org:transitive:1.+'
+            }
+            'org:test:1.1' {
+                dependsOn 'org:transitive:1.0'
+            }
+            'org:testB:1.0' {
+                dependsOn 'org:transitive:1.0'
+            }
+            'org:testC:1.0' {
+                dependsOn 'org:test:1.1'
+            }
+            'org:transitive:1.0'()
+        }
+
+        when:
+        repositoryInteractions {
+            'org:test' {
+                '1.0' {
+                    expectGetMetadata()
+                }
+                '1.1' {
+                    expectResolve()
+                }
+            }
+            'org:testB:1.0' {
+                expectResolve()
+            }
+            'org:testC:1.0' {
+                expectResolve()
+            }
+            'org:transitive' {
+                expectVersionListing()
+                '1.0' {
+                    expectResolve()
+                }
+            }
+        }
+        succeeds ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:test:1.0', 'org:test:1.1') {
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:transitive:1.0')
+                }
+                module('org:testB:1.0') {
+                    module('org:transitive:1.0')
+                }
+                module('org:testC:1.0') {
+                    module('org:test:1.1')
+                }
+            }
+        }
+    }
+
+    def "doesn't fail if selection within range"() {
+        buildFile << """
+            dependencies {
+               conf 'org:test:[1.0, 2.0['
+               conf 'org:testB:1.0'
+            }
+        """
+        repository {
+            'org:test' {
+                '1.0'()
+                '1.1'()
+                '1.2'()
+            }
+            'org:testB:1.0' {
+                dependsOn 'org:test:1.1' // solution within range
+            }
+        }
+        when:
+        repositoryInteractions {
+            'org:test' {
+                expectVersionListing()
+                '1.2' {
+                    expectGetMetadata()
+                }
+                '1.1' {
+                    expectResolve()
+                }
+            }
+            'org:testB:1.0' {
+                expectResolve()
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:test:[1.0, 2.0[', 'org:test:1.1')
+                module('org:testB:1.0') {
+                    module('org:test:1.1')
+                }
+            }
+        }
+    }
+
+    @Unroll
+    def "fails with combination of selectors (#selector1 and #selector2)"() {
+        buildFile << """
+            dependencies {
+               conf 'org:test:$selector1'
+               conf 'org:testB:1.0'
+            }
+        """
+        repository {
+            'org:test' {
+                '1.0'()
+                '1.1'()
+                '1.2'()
+            }
+            'org:testB:1.0' {
+                dependsOn "org:test:$selector2"
+            }
+        }
+        when:
+        repositoryInteractions {
+            'org:test' {
+                expectVersionListing()
+                '1.2' {
+                    expectGetMetadata()
+                }
+                '1.0' {
+                    allowAll()
+                }
+                '1.1' {
+                    allowAll()
+                }
+            }
+            'org:testB:1.0' {
+                expectGetMetadata()
+            }
+        }
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Could not resolve org:test:$selector1: Resolution strategy disallows usage of dynamic versions")
+        failure.assertHasCause("Could not resolve org:test:$selector2: Resolution strategy disallows usage of dynamic versions")
+
+        where:
+        selector1        | selector2
+        '[1.0, 2.0['     | '[1.0, 1.5['
+        latestNotation() | '1.1'
+        '1.+'            | '[1.0, 1.5'
+        '[1.0, 1.5['     | '[1.0, 2.0['
+        '1.1'            | latestNotation()
+        '[1.0, 1.5['     | '1.+'
+        latestNotation() | latestNotation()
+        '1.+'            | '+'
+    }
+
+    @CompileStatic
+    static Closure<String> latestNotation() {
+        { -> GradleMetadataResolveRunner.useIvy() ? "latest.integration" : "latest.release" }
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -943,4 +943,37 @@ configurations {
         then:
         lockfileFixture.verifyLockfile('lockedConf', [])
     }
+
+    @Unroll
+    def "fails if trying to resolve a locked configuration with #flag"() {
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+configurations {
+    lockedConf {
+        resolutionStrategy {
+            $flag()
+        }
+    }
+}
+
+dependencies {
+    lockedConf 'org:foo:1.0'
+}
+"""
+
+        when:
+        fails 'dependencies'
+
+        then:
+        failure.assertHasCause "Resolution strategy has both dependency locking and fail on $desc versions enabled. You must choose between the two modes."
+
+        where:
+        flag                              | desc
+        'failOnDynamicVersions'           | 'dynamic'
+        'failOnChangingVersions'          | 'changing'
+        'failOnNonReproducibleResolution' | 'dynamic'
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsNonReproducibleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsNonReproducibleResolveIntegrationTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.reproducibility
+
+class FailOnChangingVersionsNonReproducibleResolveIntegrationTest extends FailOnChangingVersionsResolveIntegrationTest {
+    @Override
+    String getNotation() {
+        "failOnNonReproducibleResolution"
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsResolveIntegrationTest.groovy
@@ -14,19 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.resolve
+package org.gradle.integtests.resolve.reproducibility
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
 class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
+    String getNotation() {
+        "failOnChangingVersions"
+    }
+
     def setup() {
         buildFile << """
             configurations.all {
-                resolutionStrategy.failOnChangingVersions()
+                resolutionStrategy.$notation()
             }
         """
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsNonReproducibleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsNonReproducibleResolveIntegrationTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.reproducibility
+
+class FailOnDynamicVersionsNonReproducibleResolveIntegrationTest extends FailOnDynamicVersionsResolveIntegrationTest {
+    @Override
+    String getNotation() {
+        "failOnNonReproducibleResolution"
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnDynamicVersionsResolveIntegrationTest.groovy
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.resolve
+package org.gradle.integtests.resolve.reproducibility
 
 import groovy.transform.CompileStatic
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
 class FailOnDynamicVersionsResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
+    String getNotation() {
+        "failOnDynamicVersions"
+    }
+
     def setup() {
         buildFile << """
             configurations.all {
-                resolutionStrategy.failOnDynamicVersions()
+                resolutionStrategy.$notation()
             }
         """
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
@@ -32,4 +32,8 @@ public interface ResolvedVersionConstraint {
     boolean isRejectAll();
     boolean isDynamic();
     boolean isStrict();
+
+    boolean accepts(String version);
+
+    boolean canBeStable();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -94,4 +94,6 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     CapabilitiesResolutionInternal getCapabilitiesResolutionRules();
 
     boolean isFailingOnDynamicVersions();
+
+    boolean isFailingOnChangingVersions();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -92,4 +92,6 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     boolean isDependencyLockingEnabled();
 
     CapabilitiesResolutionInternal getCapabilitiesResolutionRules();
+
+    boolean isFailingOnDynamicVersions();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
@@ -19,9 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.InverseVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.UnionVersionSelector;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 
@@ -131,13 +129,7 @@ public class DefaultResolvedVersionConstraint implements ResolvedVersionConstrai
         if (vs == null) {
             return true;
         }
-        if (vs instanceof VersionRangeSelector) {
-            return true;
-        }
-        if (vs instanceof InverseVersionSelector) {
-            return canBeStable(((InverseVersionSelector) vs).getInverseSelector());
-        }
-        return false;
+        return vs.canShortCircuitWhenVersionAlreadyPreselected();
     }
 
     private boolean doComputeIsDynamic() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/InverseVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/InverseVersionSelector.java
@@ -25,6 +25,10 @@ public class InverseVersionSelector implements VersionSelector {
         this.versionSelector = versionSelector;
     }
 
+    public VersionSelector getInverseSelector() {
+        return versionSelector;
+    }
+
     @Override
     public String getSelector() {
         return "!(" + versionSelector.getSelector() + ")";

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -72,6 +72,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private boolean assumeFluidDependencies;
     private SortOrder sortOrder = SortOrder.DEFAULT;
     private boolean failOnDynamicVersions;
+    private boolean failOnChangingVersions;
 
     private static final String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies";
 
@@ -126,6 +127,13 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     public ResolutionStrategy failOnDynamicVersions() {
         mutationValidator.validateMutation(STRATEGY);
         this.failOnDynamicVersions = true;
+        return this;
+    }
+
+    @Override
+    public ResolutionStrategy failOnChangingVersions() {
+        mutationValidator.validateMutation(STRATEGY);
+        this.failOnChangingVersions = true;
         return this;
     }
 
@@ -286,6 +294,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         if (isFailingOnDynamicVersions()) {
             out.failOnDynamicVersions();
         }
+        if (isFailingOnChangingVersions()) {
+            out.failOnChangingVersions();
+        }
         return out;
     }
 
@@ -311,5 +322,10 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Override
     public boolean isFailingOnDynamicVersions() {
         return failOnDynamicVersions;
+    }
+
+    @Override
+    public boolean isFailingOnChangingVersions() {
+        return failOnChangingVersions;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -138,6 +138,13 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     @Override
+    public ResolutionStrategy failOnNonReproducibleResolution() {
+        failOnChangingVersions();
+        failOnDynamicVersions();
+        return this;
+    }
+
+    @Override
     public void preferProjectModules() {
         conflictResolution = ConflictResolution.preferProjectModules;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -71,6 +71,8 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private boolean dependencyLockingEnabled = false;
     private boolean assumeFluidDependencies;
     private SortOrder sortOrder = SortOrder.DEFAULT;
+    private boolean failOnDynamicVersions;
+
     private static final String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies";
 
     public DefaultResolutionStrategy(DependencySubstitutionRules globalDependencySubstitutionRules,
@@ -117,6 +119,13 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     public ResolutionStrategy failOnVersionConflict() {
         mutationValidator.validateMutation(STRATEGY);
         this.conflictResolution = ConflictResolution.strict;
+        return this;
+    }
+
+    @Override
+    public ResolutionStrategy failOnDynamicVersions() {
+        mutationValidator.validateMutation(STRATEGY);
+        this.failOnDynamicVersions = true;
         return this;
     }
 
@@ -274,6 +283,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         if (isDependencyLockingEnabled()) {
             out.activateDependencyLocking();
         }
+        if (isFailingOnDynamicVersions()) {
+            out.failOnDynamicVersions();
+        }
         return out;
     }
 
@@ -294,5 +306,10 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Override
     public CapabilitiesResolutionInternal getCapabilitiesResolutionRules() {
         return capabilitiesResolution;
+    }
+
+    @Override
+    public boolean isFailingOnDynamicVersions() {
+        return failOnDynamicVersions;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -133,7 +133,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         DefaultCapabilitiesConflictHandler capabilitiesConflictHandler = createCapabilitiesConflictHandler(resolutionStrategy.getCapabilitiesResolutionRules());
 
         DependencySubstitutionApplicator applicator = createDependencySubstitutionApplicator(resolutionStrategy);
-        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, capabilitiesConflictHandler, edgeFilter, attributesSchema, moduleExclusions, buildOperationExecutor, globalRules.getModuleMetadataProcessor().getModuleReplacements(), applicator, componentSelectorConverter, attributesFactory, versionSelectorScheme, versionComparator.asVersionComparator(), versionParser);
+        return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, capabilitiesConflictHandler, edgeFilter, attributesSchema, moduleExclusions, buildOperationExecutor, applicator, componentSelectorConverter, attributesFactory, versionSelectorScheme, versionComparator.asVersionComparator(), versionParser);
     }
 
     private DependencySubstitutionApplicator createDependencySubstitutionApplicator(ResolutionStrategyInternal resolutionStrategy) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
@@ -114,6 +115,9 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     @Override
     public void resolve(ResolveContext resolveContext, List<? extends ResolutionAwareRepository> repositories, GlobalDependencyResolutionRules metadataHandler, Spec<? super DependencyMetadata> edgeFilter, DependencyGraphVisitor graphVisitor, DependencyArtifactsVisitor artifactsVisitor, AttributesSchemaInternal consumerSchema, ArtifactTypeRegistry artifactTypeRegistry) {
         LOGGER.debug("Resolving {}", resolveContext);
+
+        validateResolutionStrategy(resolveContext.getResolutionStrategy());
+
         ComponentResolversChain resolvers = createResolvers(resolveContext, repositories, metadataHandler, artifactTypeRegistry, consumerSchema);
         DependencyGraphBuilder builder = createDependencyGraphBuilder(resolvers, resolveContext.getResolutionStrategy(), metadataHandler, edgeFilter, consumerSchema, moduleExclusions, buildOperationExecutor);
 
@@ -121,6 +125,21 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
 
         // Resolve the dependency graph
         builder.resolve(resolveContext, new CompositeDependencyGraphVisitor(graphVisitor, artifactsGraphVisitor));
+    }
+
+    private static void validateResolutionStrategy(ResolutionStrategyInternal resolutionStrategy) {
+        if (resolutionStrategy.isDependencyLockingEnabled()) {
+            if (resolutionStrategy.isFailingOnDynamicVersions()) {
+                failOnDependencyLockingConflictingWith("fail on dynamic versions");
+            } else if (resolutionStrategy.isFailingOnChangingVersions()) {
+                failOnDependencyLockingConflictingWith("fail on changing versions");
+            }
+        }
+    }
+
+    private static void failOnDependencyLockingConflictingWith(String conflicting) {
+        throw new InvalidUserCodeException("Resolution strategy has both dependency locking and " + conflicting + " enabled. You must choose between the two modes.");
+
     }
 
     private DependencyGraphBuilder createDependencyGraphBuilder(ComponentResolversChain componentSource, ResolutionStrategyInternal resolutionStrategy, GlobalDependencyResolutionRules globalRules, Spec<? super DependencyMetadata> edgeFilter, AttributesSchemaInternal attributesSchema, ModuleExclusions moduleExclusions, BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -34,11 +34,8 @@ import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionApplicator;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.ExactVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
@@ -404,26 +401,6 @@ public class DependencyGraphBuilder {
 
     private static boolean isDynamic(SelectorState selector) {
         return selector.getVersionConstraint().isDynamic();
-    }
-
-    private static boolean isSimpleRangeSelector(ResolvedVersionConstraint rvc) {
-        return isSimpleSelector(rvc, VersionRangeSelector.class);
-    }
-
-    private static boolean isSimpleExactSelector(ResolvedVersionConstraint rvc) {
-        return isSimpleSelector(rvc, ExactVersionSelector.class);
-    }
-
-    private static boolean isSimpleSelector(ResolvedVersionConstraint rvc, Class<? extends VersionSelector> selectorClass) {
-        VersionSelector preferredSelector = rvc.getPreferredSelector();
-        if (preferredSelector != null && !(selectorClass.isAssignableFrom(preferredSelector.getClass()))) {
-            return false;
-        }
-        VersionSelector requireSelector = rvc.getRequiredSelector();
-        if (requireSelector != null && !(selectorClass.isAssignableFrom(requireSelector.getClass()))) {
-            return false;
-        }
-        return true;
     }
 
     private void validateDynamicSelectors(ComponentState selected) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -423,9 +423,6 @@ public class DependencyGraphBuilder {
         if (requireSelector != null && !(selectorClass.isAssignableFrom(requireSelector.getClass()))) {
             return false;
         }
-        if (rvc.getRejectedSelector() != null) {
-            return false;
-        }
         return true;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -83,13 +83,24 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     private final ResolveOptimizations resolveOptimizations;
     private final Map<VersionConstraint, ResolvedVersionConstraint> resolvedVersionConstraints = Maps.newHashMap();
     private final AttributeDesugaring attributeDesugaring;
+    private final boolean denyDynamicSelector;
 
-    public ResolveState(IdGenerator<Long> idGenerator, ComponentResolveResult rootResult, String rootConfigurationName, DependencyToComponentIdResolver idResolver,
-                        ComponentMetaDataResolver metaDataResolver, Spec<? super DependencyMetadata> edgeFilter, AttributesSchemaInternal attributesSchema,
+    public ResolveState(IdGenerator<Long> idGenerator,
+                        ComponentResolveResult rootResult,
+                        String rootConfigurationName,
+                        DependencyToComponentIdResolver idResolver,
+                        ComponentMetaDataResolver metaDataResolver,
+                        Spec<? super DependencyMetadata> edgeFilter,
+                        AttributesSchemaInternal attributesSchema,
                         ModuleExclusions moduleExclusions,
-                        ComponentSelectorConverter componentSelectorConverter, ImmutableAttributesFactory attributesFactory,
-                        DependencySubstitutionApplicator dependencySubstitutionApplicator, VersionSelectorScheme versionSelectorScheme,
-                        Comparator<Version> versionComparator, VersionParser versionParser, ModuleConflictResolver conflictResolver,
+                        ComponentSelectorConverter componentSelectorConverter,
+                        ImmutableAttributesFactory attributesFactory,
+                        DependencySubstitutionApplicator dependencySubstitutionApplicator,
+                        VersionSelectorScheme versionSelectorScheme,
+                        Comparator<Version> versionComparator,
+                        VersionParser versionParser,
+                        ModuleConflictResolver conflictResolver,
+                        boolean denyDynamicSelectorm,
                         int graphSize) {
         this.idGenerator = idGenerator;
         this.idResolver = idResolver;
@@ -117,6 +128,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         root.getComponent().getModule().select(root.getComponent());
         this.replaceSelectionWithConflictResultAction = new ReplaceSelectionWithConflictResultAction(this);
         selectorStateResolver = new SelectorStateResolver<ComponentState>(conflictResolver, this, rootVersion, resolveOptimizations);
+        this.denyDynamicSelector = denyDynamicSelectorm;
         getModule(rootResult.getModuleVersionId().getModule()).setSelectorStateResolver(selectorStateResolver);
     }
 
@@ -262,5 +274,9 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
 
     ResolveOptimizations getResolveOptimizations() {
         return resolveOptimizations;
+    }
+
+    public boolean isDenyDynamicSelector() {
+        return denyDynamicSelector;
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.DependencySubstitutionInternal
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution
 import org.gradle.api.internal.artifacts.configurations.MutationValidator
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
@@ -165,6 +166,7 @@ class DefaultResolutionStrategySpec extends Specification {
         dependencySubstitutions.copy() >> newDependencySubstitutions
 
         strategy.failOnVersionConflict()
+        strategy.failOnDynamicVersions()
         strategy.force("org:foo:1.0")
         strategy.componentSelection.addRule(new NoInputsRuleAction<ComponentSelection>({}))
 
@@ -181,6 +183,8 @@ class DefaultResolutionStrategySpec extends Specification {
 
         strategy.dependencySubstitution == dependencySubstitutions
         copy.dependencySubstitution == newDependencySubstitutions
+
+        ((ResolutionStrategyInternal)copy).isFailingOnDynamicVersions() == ((ResolutionStrategyInternal)strategy).isFailingOnDynamicVersions()
     }
 
     def "configures changing modules cache with jdk5+ units"() {
@@ -220,6 +224,9 @@ class DefaultResolutionStrategySpec extends Specification {
         strategy.setMutationValidator(validator)
 
         when: strategy.failOnVersionConflict()
+        then: 1 * validator.validateMutation(STRATEGY)
+
+        when: strategy.failOnDynamicVersions()
         then: 1 * validator.validateMutation(STRATEGY)
 
         when: strategy.force("org.utils:api:1.3")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -234,6 +234,9 @@ class DefaultResolutionStrategySpec extends Specification {
         when: strategy.failOnChangingVersions()
         then: 1 * validator.validateMutation(STRATEGY)
 
+        when: strategy.failOnNonReproducibleResolution()
+        then: 2 * validator.validateMutation(STRATEGY)
+
         when: strategy.force("org.utils:api:1.3")
         then: 1 * validator.validateMutation(STRATEGY)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -167,6 +167,7 @@ class DefaultResolutionStrategySpec extends Specification {
 
         strategy.failOnVersionConflict()
         strategy.failOnDynamicVersions()
+        strategy.failOnChangingVersions()
         strategy.force("org:foo:1.0")
         strategy.componentSelection.addRule(new NoInputsRuleAction<ComponentSelection>({}))
 
@@ -185,6 +186,7 @@ class DefaultResolutionStrategySpec extends Specification {
         copy.dependencySubstitution == newDependencySubstitutions
 
         ((ResolutionStrategyInternal)copy).isFailingOnDynamicVersions() == ((ResolutionStrategyInternal)strategy).isFailingOnDynamicVersions()
+        ((ResolutionStrategyInternal)copy).isFailingOnChangingVersions() == ((ResolutionStrategyInternal)strategy).isFailingOnChangingVersions()
     }
 
     def "configures changing modules cache with jdk5+ units"() {
@@ -227,6 +229,9 @@ class DefaultResolutionStrategySpec extends Specification {
         then: 1 * validator.validateMutation(STRATEGY)
 
         when: strategy.failOnDynamicVersions()
+        then: 1 * validator.validateMutation(STRATEGY)
+
+        when: strategy.failOnChangingVersions()
         then: 1 * validator.validateMutation(STRATEGY)
 
         when: strategy.force("org.utils:api:1.3")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -122,7 +122,7 @@ class DependencyGraphBuilderTest extends Specification {
         _ * configuration.allDependencies >> Stub(DependencySet)
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, AttributeTestUtil.attributesFactory(), versionSelectorScheme, Stub(Comparator), new VersionParser())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, dependencySubstitutionApplicator, componentSelectorConverter, AttributeTestUtil.attributesFactory(), versionSelectorScheme, Stub(Comparator), new VersionParser())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
@@ -573,7 +573,7 @@ class DependencyGraphBuilderTest extends Specification {
     def "does not include filtered dependencies"() {
         given:
         def spec = { DependencyMetadata dep -> dep.selector.module != 'c' }
-        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, AttributeTestUtil.attributesFactory(), versionSelectorScheme, Stub(Comparator), new VersionParser())
+        builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, spec, attributesSchema, moduleExclusions, buildOperationProcessor, dependencySubstitutionApplicator, componentSelectorConverter, AttributeTestUtil.attributesFactory(), versionSelectorScheme, Stub(Comparator), new VersionParser())
 
         def a = revision('a')
         def b = revision('b')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutionApplicator
@@ -78,7 +79,9 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
 
 class DependencyGraphBuilderTest extends Specification {
-    def configuration = Mock(ConfigurationInternal)
+    def configuration = Mock(ConfigurationInternal) {
+        getResolutionStrategy() >> Stub(ResolutionStrategyInternal)
+    }
     def conflictResolver = Mock(ModuleConflictResolver)
     def idResolver = Mock(DependencyToComponentIdResolver)
     def metaDataResolver = Mock(ComponentMetaDataResolver)

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution-strategy-tuning.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution-strategy-tuning.adoc
@@ -1,0 +1,73 @@
+[[resolution-strategy-safety-nets]]
+= Preventing accidental dependency upgrades
+
+In some situations, you might want to be in total control of the dependency graph.
+In particular, you may want to make sure that:
+
+- the versions declared in a build script actually correspond to the ones being resolved
+- or make sure that dependency resolution is reproducible over time
+
+Gradle provides ways to perform this by configuring the resolution strategy.
+
+[[fail-version-conflict]]
+== Failing on version conflict
+
+There's a version conflict whenever Gradle finds the same module in two different versions in a dependency graph.
+By default, Gradle performs _optimitic upgrades_, meaning that if version `1.1` and `1.3` are found in the graph, we resolve to the highest version, `1.3`.
+However, it is easy to miss that some dependencies are upgraded because of a transitive dependency.
+In the example above, if `1.1` was a version used in your build script and `1.3` a version brough transitively, you could use `1.3` without actually noticing.
+
+To make sure that you are aware of such upgrades, Gradle provides a mode that can be activated in the resolution strategy of a configuration.
+Imagine the following dependencies declaration:
+
+.Direct dependency version not matching a transitive version
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy",files="build.gradle[tags=dependencies]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin",files="build.gradle.kts[tags=dependencies]"]
+====
+
+Then by default Gradle would upgrade `commons-lang3`, but it is possible to _fail_ the build:
+
+.Fail on version conflict
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy",files="build.gradle[tags=fail-on-version-conflict]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-version-conflict]"]
+====
+
+[[reproducible-resolution]]
+== Making sure resolution is reproducible
+
+There are cases where dependency resolution can be _unstable_ over time.
+That is to say that if you build at date D, building at date D+x may give a different resolution result.
+
+This is possible in the following cases:
+
+- dynamic dependency versions are used (version ranges, `latest.release`, `1.+`, ...)
+- or _changing_ versions are used (SNAPSHOTs, fixed version with changing contents, ...)
+
+The recommended way to deal with dynamic versions is to use <<dependency_locking.adoc#dependency-locking,dependency locking>>.
+However, it is possible to prevent the use of dynamic versions altogether, which is an alternate strategy:
+
+.Failing on dynamic versions
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy",files="build.gradle[tags=fail-on-dynamic]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-dynamic]"]
+====
+
+Likewise, it's possible to prevent the use of changing versions by activating this flag:
+
+.Failing on changing versions
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy",files="build.gradle[tags=fail-on-changing]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-changing]"]
+====
+
+It's a good practice to fail on changing versions at release time.
+
+Eventually, it's possible to combine both failing on dynamic versions and changing versions using a single call:
+
+.Failing on non-reproducible resolution
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy",files="build.gradle[tags=fail-on-unstable]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin",files="build.gradle.kts[tags=fail-on-unstable]"]
+====

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -239,6 +239,7 @@
                     <li><a href="dependency_capability_conflict.html">Handling Mutually Exclusive Dependencies</a></li>
                     <li><a href="component_metadata_rules.html">Fixing Metadata</a></li>
                     <li><a href="resolution_rules.html">Customizing Resolution</a></li>
+                    <li><a href="resolution_stategy_tuning.html">Preventing accidental upgrades</a></li>
                 </ul>
             </li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#modeling-features" aria-expanded="false" aria-controls="modeling-features">Producing and Consuming Variants of Libraries</a>

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy/build.gradle
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::dependencies[]
+dependencies {
+    implementation 'org.apache.commons:commons-lang3:3.0'
+    // the following dependency brings lang3 3.8.1 transitively
+    implementation 'com.opencsv:opencsv:4.6'
+}
+// end::dependencies[]
+
+// tag::fail-on-version-conflict[]
+configurations.all {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
+}
+// end::fail-on-version-conflict[]
+
+// tag::fail-on-dynamic[]
+configurations.all {
+    resolutionStrategy {
+        failOnDynamicVersions()
+    }
+}
+// end::fail-on-dynamic[]
+
+// tag::fail-on-changing[]
+configurations.all {
+    resolutionStrategy {
+        failOnChangingVersions()
+    }
+}
+// end::fail-on-changing[]
+
+// tag::fail-on-unstable[]
+configurations.all {
+    resolutionStrategy {
+        failOnNonReproducibleResolution()
+    }
+}
+// end::fail-on-unstable[]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/groovy/settings.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "resolution-strategy"

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin/build.gradle.kts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+   `java-library`
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::dependencies[]
+dependencies {
+    implementation("org.apache.commons:commons-lang3:3.0")
+    // the following dependency brings lang3 3.8.1 transitively
+    implementation("com.opencsv:opencsv:4.6")
+}
+// end::dependencies[]
+
+// tag::fail-on-version-conflict[]
+configurations.all {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
+}
+// end::fail-on-version-conflict[]
+
+// tag::fail-on-dynamic[]
+configurations.all {
+    resolutionStrategy {
+        failOnDynamicVersions()
+    }
+}
+// end::fail-on-dynamic[]
+
+// tag::fail-on-changing[]
+configurations.all {
+    resolutionStrategy {
+        failOnChangingVersions()
+    }
+}
+// end::fail-on-changing[]
+
+// tag::fail-on-unstable[]
+configurations.all {
+    resolutionStrategy {
+        failOnNonReproducibleResolution()
+    }
+}
+// end::fail-on-unstable[]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/kotlin/settings.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "resolution-strategy"

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/resolution-strategy.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/resolutionStrategy/resolution-strategy.sample.conf
@@ -1,0 +1,11 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: dependencies
+    expect-failure: true
+}, {
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: dependencies
+    expect-failure: true
+}]

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
@@ -65,10 +65,10 @@ class UserGuideSamplesIntegrationTest {
     To update a sample test, change the *.sample.conf file
 
      You can run all samples tests with
-        ./gradlew :integtest:integTest --tests "org.gradle.integtests.samples.UserGuideSamplesIntegrationTest"
+        ./gradlew :samples:integTest --tests "org.gradle.integtests.samples.UserGuideSamplesIntegrationTest"
 
      To run a subset of samples, use a more fine-grained test filter like
-        ./gradlew :integtest:integTest --tests "org.gradle.integtests.samples.UserGuideSamplesIntegrationTest.*native*"
+        ./gradlew :samples:integTest --tests "org.gradle.integtests.samples.UserGuideSamplesIntegrationTest.*native*"
     */
 
     // NOTE: This weirdness is here because GradleSamplesRunner does not support JUnit @Rule, @After or @Before.


### PR DESCRIPTION
### Context

This PR adds support for failing resolution in case:

- dynamic versions are encountered in the graph _or_
- changing versions are encountered in the graph

This can be used in case locking is not an option.
As the PR is implemented today, it's not compatible with locking: if those flags are activated _and_ that locking is used at the same time, the build would still fail on dynamic versions.

Fixes #8901