### PR TITLE
Reinstate Kotlin DSL IDE resolver short circuit behind an IDE flag

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
@@ -69,9 +69,11 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
 
         PseudoFuture(
             KotlinBuildScriptDependencies(
-                imports = implicitImportsForScript(script.text!!, environment),
                 classpath = emptyList(),
-                sources = emptyList()
+                sources = emptyList(),
+                imports = implicitImportsForScript(script.text!!, environment),
+                javaHome = null,
+                classPathBlocksHash = null
             )
         )
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -30,6 +30,7 @@ import org.gradle.tooling.BuildException
 import com.google.common.annotations.VisibleForTesting
 
 import java.io.File
+import java.security.MessageDigest
 
 import kotlin.script.dependencies.KotlinScriptExternalDependencies
 import kotlin.script.dependencies.ScriptContents
@@ -37,6 +38,7 @@ import kotlin.script.dependencies.ScriptContents.Position
 import kotlin.script.dependencies.ScriptDependenciesResolver
 import kotlin.script.dependencies.ScriptDependenciesResolver.ReportSeverity
 
+import kotlin.collections.contentEquals
 
 private
 typealias Report = (ReportSeverity, String, Position?) -> Unit
@@ -105,13 +107,24 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
         val cid = newCorrelationId()
         try {
             log(ResolutionRequest(cid, script.file, environment, previousDependencies))
-            assembleDependenciesFrom(
-                cid,
-                script.file,
-                environment!!,
-                report,
-                previousDependencies
-            )
+            when (val action = ResolverCoordinator.selectNextActionFor(script, environment, previousDependencies)) {
+                is ResolverAction.Return -> {
+                    action.dependencies
+                }
+                is ResolverAction.ReturnPrevious -> {
+                    log(ResolvedToPrevious(cid, script.file, previousDependencies))
+                    previousDependencies
+                }
+                is ResolverAction.RequestNew -> {
+                    assembleDependenciesFrom(
+                        cid,
+                        script.file,
+                        environment!!,
+                        report,
+                        previousDependencies,
+                        action.classPathBlocksHash)
+                }
+            }
         } catch (e: BuildException) {
             log(ResolutionFailure(cid, script.file, e))
             if (previousDependencies == null) report.fatal(EditorMessages.buildConfigurationFailed)
@@ -131,7 +144,8 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
         scriptFile: File?,
         environment: Environment,
         report: Report,
-        previousDependencies: KotlinScriptExternalDependencies?
+        previousDependencies: KotlinScriptExternalDependencies?,
+        classPathBlocksHash: ByteArray?
     ): KotlinScriptExternalDependencies? {
 
         val request = scriptModelRequestFrom(scriptFile, environment, cid)
@@ -150,7 +164,7 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
 
         return when {
             response.exceptions.isEmpty() ->
-                dependenciesFrom(request, response).also {
+                dependenciesFrom(request, response, classPathBlocksHash).also {
                     log(ResolvedDependencies(cid, scriptFile, it))
                 }
             previousDependencies != null && previousDependencies.classpath.count() > response.classPath.size ->
@@ -158,7 +172,7 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
                     log(ResolvedToPreviousWithErrors(cid, scriptFile, previousDependencies, response.exceptions))
                 }
             else ->
-                dependenciesFrom(request, response).also {
+                dependenciesFrom(request, response, classPathBlocksHash).also {
                     log(ResolvedDependenciesWithErrors(cid, scriptFile, it, response.exceptions))
                 }
         }
@@ -194,14 +208,95 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
             ?: GradleInstallation.Wrapper
 
     private
-    fun dependenciesFrom(request: KotlinBuildScriptModelRequest, response: KotlinBuildScriptModel) =
+    fun dependenciesFrom(
+        request: KotlinBuildScriptModelRequest,
+        response: KotlinBuildScriptModel,
+        classPathBlocksHash: ByteArray?
+    ) =
         KotlinBuildScriptDependencies(
             response.classPath,
             response.sourcePath,
             response.implicitImports,
-            request.javaHome?.path
+            request.javaHome?.path,
+            classPathBlocksHash
         )
 }
+
+
+/**
+ * The resolver can either return the previous result
+ * or request new dependency information from Gradle.
+ */
+internal
+sealed class ResolverAction {
+    object ReturnPrevious : ResolverAction()
+    class RequestNew(val classPathBlocksHash: ByteArray?) : ResolverAction()
+    class Return(val dependencies: KotlinScriptExternalDependencies?) : ResolverAction()
+}
+
+
+internal
+object ResolverCoordinator {
+
+    /**
+     * Decides which action the resolver should take based on the given [script] and [environment].
+     */
+    fun selectNextActionFor(
+        script: ScriptContents,
+        environment: Environment?,
+        previousDependencies: KotlinScriptExternalDependencies?
+    ): ResolverAction {
+
+        if (environment == null) {
+            return ResolverAction.ReturnPrevious
+        }
+
+        val classPathBlocksHash = classPathBlocksHashFor(script, environment)
+        if (sameClassPathBlocksHashAs(previousDependencies, classPathBlocksHash)) {
+            return ResolverAction.ReturnPrevious
+        }
+
+        return ResolverAction.RequestNew(classPathBlocksHash)
+    }
+
+    private
+    fun sameClassPathBlocksHashAs(previousDependencies: KotlinScriptExternalDependencies?, hash: ByteArray?) =
+        hash?.let { nonNullHash -> classPathBlocksHashOf(previousDependencies)?.contentEquals(nonNullHash) }
+            ?: false
+
+    private
+    fun classPathBlocksHashOf(previousDependencies: KotlinScriptExternalDependencies?) =
+        (previousDependencies as? KotlinBuildScriptDependencies)?.classPathBlocksHash
+
+    private
+    fun classPathBlocksHashFor(script: ScriptContents, environment: Environment): ByteArray? {
+
+        @Suppress("unchecked_cast")
+        val getScriptSectionTokens = environment["getScriptSectionTokens"] as? ScriptSectionTokensProvider
+        return when (getScriptSectionTokens) {
+            null -> null
+            else ->
+                MessageDigest.getInstance("MD5").run {
+                    val text = script.text ?: script.file?.readText()
+                    text?.let { nonNullText ->
+                        fun updateWith(section: String) =
+                            getScriptSectionTokens(nonNullText, section).forEach {
+                                update(it.toString().toByteArray())
+                            }
+                        updateWith("pluginManagement")
+                        updateWith("initscript")
+                        updateWith("buildscript")
+                        updateWith("plugins")
+                    }
+                    digest()
+                }
+        }
+    }
+}
+
+
+internal
+typealias ScriptSectionTokensProvider = (CharSequence, String) -> Sequence<CharSequence>
 
 
 internal
@@ -209,7 +304,8 @@ class KotlinBuildScriptDependencies(
     override val classpath: Iterable<File>,
     override val sources: Iterable<File>,
     override val imports: Iterable<String>,
-    override val javaHome: String? = null
+    override val javaHome: String? = null,
+    val classPathBlocksHash: ByteArray?
 ) : KotlinScriptExternalDependencies
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -148,9 +148,6 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
     ): KotlinScriptExternalDependencies? =
 
         when (val action = ResolverCoordinator.selectNextActionFor(script, environment, previousDependencies)) {
-            is ResolverAction.Return -> {
-                action.dependencies
-            }
             is ResolverAction.ReturnPrevious -> {
                 log(ResolvedToPrevious(cid, script.file, previousDependencies))
                 previousDependencies
@@ -260,7 +257,6 @@ internal
 sealed class ResolverAction {
     object ReturnPrevious : ResolverAction()
     class RequestNew(val classPathBlocksHash: ByteArray?) : ResolverAction()
-    class Return(val dependencies: KotlinScriptExternalDependencies?) : ResolverAction()
 }
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
@@ -107,7 +107,7 @@ val Environment.gradleEnvironmentVariables: Map<String, String>
  */
 internal
 val Map<String, Any?>?.isShortCircuitEnabled: Boolean
-    get() = (this?.get("gradleKotlinDslScriptDependenciesResolverShortCircuit") as? Boolean) ?: false
+    get() = this?.get("gradleKotlinDslScriptDependenciesResolverShortCircuit") == true
 
 
 private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
@@ -101,6 +101,15 @@ val Environment.gradleEnvironmentVariables: Map<String, String>
     get() = stringMap("gradleEnvironmentVariables")
 
 
+/**
+ * Environment flag to enabled short circuiting TAPI resolution when script
+ * is changed outside classpath blocks. Defaults to false.
+ */
+internal
+val Map<String, Any?>?.isShortCircuitEnabled: Boolean
+    get() = (this?.get("gradleKotlinDslScriptDependenciesResolverShortCircuit") as? Boolean) ?: false
+
+
 private
 fun Environment.path(key: String): File? =
     (get(key) as? String)?.let(::File)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
@@ -88,6 +88,14 @@ data class ResolvedDependenciesWithErrors internal constructor(
 
 
 internal
+data class ResolvedToPrevious(
+    val correlationId: String,
+    val scriptFile: File?,
+    val dependencies: KotlinScriptExternalDependencies?
+) : ResolverEvent()
+
+
+internal
 data class ResolvedToPreviousWithErrors(
     val correlationId: String,
     val scriptFile: File?,

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
@@ -2,10 +2,12 @@ package org.gradle.kotlin.dsl.resolver
 
 import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
 
+import org.junit.Test
+
 
 class ResolverCoordinatorTest {
 
-    @org.junit.Test
+    @Test
     fun `given an environment with a 'getScriptSectionTokens' entry, when no buildscript change, it will not try to retrieve the model`() {
 
         val environment =
@@ -20,7 +22,7 @@ class ResolverCoordinatorTest {
         }
     }
 
-    @org.junit.Test
+    @Test
     fun `given an environment with a 'getScriptSectionTokens' entry, when buildscript changes, it will try to retrieve the model again`() {
 
         val env1 = environmentWithGetScriptSectionTokensReturning("buildscript" to sequenceOf("foo"))
@@ -33,7 +35,7 @@ class ResolverCoordinatorTest {
         }
     }
 
-    @org.junit.Test
+    @Test
     fun `given an environment with a 'getScriptSectionTokens' entry, when plugins block changes, it will try to retrieve the model again`() {
 
         val env1 = environmentWithGetScriptSectionTokensReturning("plugins" to sequenceOf("foo"))
@@ -46,7 +48,7 @@ class ResolverCoordinatorTest {
         }
     }
 
-    @org.junit.Test
+    @Test
     fun `given an environment lacking a 'getScriptSectionTokens' entry, it will always try to retrieve the model`() {
 
         val environment = emptyMap<String, Any?>()

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/resolver/ResolverCoordinatorTest.kt
@@ -1,0 +1,83 @@
+package org.gradle.kotlin.dsl.resolver
+
+import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
+
+
+class ResolverCoordinatorTest {
+
+    @org.junit.Test
+    fun `given an environment with a 'getScriptSectionTokens' entry, when no buildscript change, it will not try to retrieve the model`() {
+
+        val environment =
+            environmentWithGetScriptSectionTokensReturning(
+                "buildscript" to sequenceOf(""),
+                "plugins" to sequenceOf(""))
+
+        val action1 = resolverActionFor(environment, null)
+        org.gradle.kotlin.dsl.fixtures.withInstanceOf<ResolverAction.RequestNew>(action1) {
+            val action2 = resolverActionFor(environment, scriptDependencies())
+            assertInstanceOf<ResolverAction.ReturnPrevious>(action2)
+        }
+    }
+
+    @org.junit.Test
+    fun `given an environment with a 'getScriptSectionTokens' entry, when buildscript changes, it will try to retrieve the model again`() {
+
+        val env1 = environmentWithGetScriptSectionTokensReturning("buildscript" to sequenceOf("foo"))
+        val env2 = environmentWithGetScriptSectionTokensReturning("buildscript" to sequenceOf("bar"))
+
+        val action1 = resolverActionFor(env1, null)
+        org.gradle.kotlin.dsl.fixtures.withInstanceOf<ResolverAction.RequestNew>(action1) {
+            val action2 = resolverActionFor(env2, scriptDependencies())
+            assertInstanceOf<ResolverAction.RequestNew>(action2)
+        }
+    }
+
+    @org.junit.Test
+    fun `given an environment with a 'getScriptSectionTokens' entry, when plugins block changes, it will try to retrieve the model again`() {
+
+        val env1 = environmentWithGetScriptSectionTokensReturning("plugins" to sequenceOf("foo"))
+        val env2 = environmentWithGetScriptSectionTokensReturning("plugins" to sequenceOf("bar"))
+
+        val action1 = resolverActionFor(env1, null)
+        org.gradle.kotlin.dsl.fixtures.withInstanceOf<ResolverAction.RequestNew>(action1) {
+            val action2 = resolverActionFor(env2, scriptDependencies())
+            assertInstanceOf<ResolverAction.RequestNew>(action2)
+        }
+    }
+
+    @org.junit.Test
+    fun `given an environment lacking a 'getScriptSectionTokens' entry, it will always try to retrieve the model`() {
+
+        val environment = emptyMap<String, Any?>()
+        val action1 = resolverActionFor(environment, null)
+        org.gradle.kotlin.dsl.fixtures.withInstanceOf<ResolverAction.RequestNew>(action1) {
+            val action2 = resolverActionFor(environment, scriptDependencies())
+            assertInstanceOf<ResolverAction.RequestNew>(action2)
+        }
+    }
+
+    private
+    fun resolverActionFor(environment: Map<String, Any?>, previousDependencies: kotlin.script.dependencies.KotlinScriptExternalDependencies?) =
+        ResolverCoordinator.selectNextActionFor(EmptyScriptContents, environment, previousDependencies)
+
+    private
+    fun ResolverAction.RequestNew.scriptDependencies() =
+        KotlinBuildScriptDependencies(emptyList(), emptyList(), emptyList(), null, classPathBlocksHash)
+
+    private
+    fun environmentWithGetScriptSectionTokensReturning(vararg sections: Pair<String, Sequence<String>>) =
+        environmentWithGetScriptSectionTokens { _, section -> sections.find { it.first == section }?.second ?: emptySequence() }
+
+    private
+    fun environmentWithGetScriptSectionTokens(function: (CharSequence, String) -> Sequence<String>) =
+        mapOf<String, Any?>("getScriptSectionTokens" to function)
+}
+
+
+private
+object EmptyScriptContents : kotlin.script.dependencies.ScriptContents {
+    override val file: java.io.File? = null
+    override val text: CharSequence? = ""
+    override val annotations: Iterable<Annotation> = emptyList()
+}


### PR DESCRIPTION
This short circuit combined with some upcoming changes in IJ will prevent `.gradle.kts` script editors to constantly do TAPI requests as you type, and only do them when necessary.

Next IJ release will make use of that flag.

It is unset by default, disabling the reintroduced short-circuit, in order not to break users of existing IJ versions.

See https://github.com/gradle/kotlin-dsl-samples/pull/972
