### PR TITLE
Added default value support in extra properties delegate providers

### DIFF
--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -619,11 +619,16 @@ val myOtherNewProperty by extra { "calculated initial value" }  // <2>
 
 val myProperty: String by extra  // <3>
 val myNullableProperty: String? by extra  // <4>
+
+val myPropertyWithDefault by extra.default("default value") // <5>
+val myOtherPropertyWithDefault by extra.default { "calculated default value" } // <6>
 ----
 <1> Creates a new extra property called `myNewProperty` in the current context (the project in this case) and initializes it with the value `"initial value"`, which also determines the property's _type_
 <2> Create a new extra property whose initial value is calculated by the provided lambda
 <3> Binds an existing extra property from the current context (the project in this case) to a `myProperty` reference
 <4> Does the same as the previous line but allows the property to have a null value
+<5> Creates a new extra property and assigns it default value if it was not initialized before
+<6> Creates extra property with default value eagerly calculated by executing provided lambda
 
 This approach works for all Gradle scripts: project build scripts, script plugins, settings scripts and initialization scripts.
 
@@ -746,7 +751,7 @@ You write these as `*.gradle.kts` files in that same `src/main/kotlin` directory
 
 Precompiled script plugins are Kotlin DSL scripts that are compiled as part of a regular Kotlin source set and then placed on the build classpath or packaged in a binary plugin, depending on what type of project they're in.
 For all intents and purposes, they _are_ binary plugins, particularly as they can be applied by plugin ID, just like a normal plugin.
-In fact, the Kotlin DSL Plugin generates plugin metadata for them thanks to integration with the <<java_gradle_plugin#java_gradle_plugin,Gradle Plugin Development Plugin>>. 
+In fact, the Kotlin DSL Plugin generates plugin metadata for them thanks to integration with the <<java_gradle_plugin#java_gradle_plugin,Gradle Plugin Development Plugin>>.
 
 [NOTE]
 ====

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ExtraPropertiesExtensionsTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockito_kotlin.verify
 
 import org.gradle.api.plugins.ExtraPropertiesExtension
 
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.nullValue
 
 import org.junit.Assert.assertThat
@@ -97,6 +98,114 @@ class ExtraPropertiesExtensionsTest {
             }
             assertThat(property, nullValue())
         }
+    }
+
+    @Test
+    fun `can initialize extra property to default value via delegate provider`() {
+        val extra = mock<ExtraPropertiesExtension> {
+            on { has("property") } doReturn false
+            on { get("property") } doReturn 42
+        }
+
+        val property by extra.default(42)
+
+        inOrder(extra) {
+            // property is checked for present value
+            verify(extra).has("property")
+
+            // property is set to default value
+            verify(extra).set("property", 42)
+
+            assertThat(property, equalTo(42))
+
+            // property is retrieved via delegate provider
+            verify(extra).get("property")
+
+            verifyNoMoreInteractions()
+        }
+
+        // And prove that type is inferred correctly
+        use(property)
+    }
+
+    @Test
+    fun `can initialize extra property to default value using lambda expression`() {
+        val extra = mock<ExtraPropertiesExtension> {
+            on { has("property") } doReturn false
+            on { get("property") } doReturn 42
+        }
+
+        val property by extra.default { 42 }
+
+        inOrder(extra) {
+            // property is checked for present value
+            verify(extra).has("property")
+
+            // property is set to default value
+            verify(extra).set("property", 42)
+
+            assertThat(property, equalTo(42))
+
+            // property is retrieved via delegate provider
+            verify(extra).get("property")
+
+            verifyNoMoreInteractions()
+        }
+
+        // And prove that type is inferred correctly
+        use(property)
+    }
+
+    @Test
+    fun `does not override extra property with default value via delegate provider when it's already set`() {
+        val extra = mock<ExtraPropertiesExtension> {
+            on { has("property") } doReturn true
+            on { get("property") } doReturn 42
+        }
+
+        val property by extra.default(13)
+
+        inOrder(extra) {
+            // property is checked for present value
+            verify(extra).has("property")
+
+            assertThat(property, equalTo(42))
+
+            // property is retrieved via delegate provider
+            verify(extra).get("property")
+
+            // property was not set due to value already present
+            verifyNoMoreInteractions()
+        }
+
+        // And prove that type is inferred correctly
+        use(property)
+    }
+
+    @Test
+    fun `does not override extra property with default value via lambda expression when it's already set`() {
+        val extra = mock<ExtraPropertiesExtension> {
+            on { has("property") } doReturn true
+            on { get("property") } doReturn 42
+        }
+
+        val property by extra.default { 13 }
+
+        inOrder(extra) {
+            // property is checked for present value
+            verify(extra).has("property")
+
+            assertThat(property, equalTo(42))
+
+            // property is retrieved via delegate provider
+            verify(extra).get("property")
+
+            // property was not set due to value already present
+            verifyNoMoreInteractions()
+        }
+
+        // And prove that type is inferred correctly
+        use(property)
     }
 
     private


### PR DESCRIPTION
### Context

Thing like `val property by extra(initialValue)` and `val property by extra { computeInitialValue() }` are useful for sharing such properties via `ExtraPropertiesExtension` but not for setting defaults.

Sometimes one needs to have user-overridable properties with default values set at point of consumption. So if say plugin user doesn't set value it will be set to default one.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
