### PR TITLE
Use volatile in DefaultClassLoaderScope

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -34,7 +34,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
 
     private final ClassLoaderScope parent;
 
-    private boolean locked;
+    private volatile boolean locked;
 
     protected ClassPath export = ClassPath.EMPTY;
     private List<ClassLoader> exportLoaders; // if not null, is not empty


### PR DESCRIPTION
### Context 

This is an attempt to fix https://github.com/gradle/gradle-private/issues/1903

A field should be volatile when used in multithread environment, otherwise there might
be visibility issues - which might be the cause of gradle-private#1903

This commit fixes this issue by using volatile correctly.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-private/issues/1903