### PR TITLE
Remove the generated samples from the -all distribution

### DIFF
--- a/subprojects/distributions/distributions.gradle
+++ b/subprojects/distributions/distributions.gradle
@@ -128,11 +128,6 @@ ext {
         into('docs') {
             from configurations.gradleFullDocs
         }
-        into('samples') {
-            from configurations.gradleSamples
-            exclude '**/*.out'
-            exclude '**/*.sample.conf*'
-        }
     }
 }
 

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle
 
-import groovy.io.FileType
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Shared
 
@@ -44,15 +43,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
         contentsDir.file('src/wrapper/org/gradle/wrapper/WrapperExecutor.java').assertIsFile()
 
         // Samples
-        contentsDir.file('samples/java/quickstart/groovy/build.gradle').assertIsFile()
-
-        def buildAndGradleDirs = []
-        contentsDir.file('samples').eachFileRecurse(FileType.DIRECTORIES) {
-            if (it.name == "build" || it.name == ".gradle") {
-                buildAndGradleDirs << it
-            }
-        }
-        buildAndGradleDirs == []
+        contentsDir.file('samples').assertDoesNotExist()
 
         // Javadoc
         contentsDir.file('docs/javadoc/index.html').assertIsFile()

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -140,7 +140,7 @@ configurations {
     }
     gradleFullDocsElements {
         outgoing.artifact(docsDir) {
-            builtBy 'javadocAll', 'userguide', 'dslHtml', 'releaseNotes', 'publishSamplesToDocsZip'
+            builtBy 'javadocAll', 'userguide', 'dslHtml', 'releaseNotes'
         }
     }
     gradleGettingStartedElements {

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
@@ -58,7 +58,7 @@ class UserGuideSamplesIntegrationTest {
     Important info: This test uses Exemplar (https://github.com/gradle/exemplar/) to discover and check samples.
 
     In order to add a new sample:
-        * Create your new sample project in a subdirectory under subprojects/docs/samples/
+        * Create your new sample project in a subdirectory under subprojects/docs/src/samples/
         * Write a *.sample.conf HOCON file in the root of your sample project dir
         * Exemplar will automatically discover your sample. See instructions below for running it
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/10938

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
I can confirm the documentation included in the -all distribution is from the `full-docs` configuration. However, I can't confirm that the nightly documentation zip is built with `:docs:docsZip`. At this point, it's guesswork. We can merge and see or digg deeper. Unless someone has an idea.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fremove-generated-samples-from-all-distribution)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
