### PR TITLE
Refine performance baseline selection logic

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -133,7 +133,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
         String displayName
         String testClassName
         List<String> targetVersions = []
-        String minimumVersion
+        String minimumBaseVersion
         List<File> extraTestClassPath = []
         Closure<?> action
         Integer invocationCount
@@ -204,7 +204,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
             )
             def resolver = new ToolingApiDistributionResolver().withDefaultRepository()
             try {
-                List<String> baselines = AbstractCrossVersionPerformanceTestRunner.toBaselineVersions(RELEASES, experiment.targetVersions, experiment.minimumVersion).toList()
+                List<String> baselines = AbstractCrossVersionPerformanceTestRunner.toBaselineVersions(RELEASES, experiment.targetVersions, experiment.minimumBaseVersion).toList()
                 [*baselines, 'current'].each { String version ->
                     def experimentSpec = new ToolingApiBuildExperimentSpec(version, temporaryFolder.testDirectory, experiment)
                     def workingDirProvider = copyTemplateTo(projectDir, experimentSpec.workingDirectory, version)

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.fixture
+
+import org.gradle.integtests.fixtures.executer.DefaultGradleDistribution
+import org.gradle.integtests.fixtures.executer.GradleDistribution
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
+import org.gradle.util.GradleVersion
+import spock.lang.Specification
+
+import static org.gradle.performance.fixture.AbstractCrossVersionPerformanceTestRunner.toBaselineVersions
+
+class CrossVersionPerformanceTestRunnerTest extends Specification {
+    private GradleDistribution gradle60 =
+        new DefaultGradleDistribution(GradleVersion.version('6.0'), null, null)
+    private GradleDistribution gradle61 =
+        new DefaultGradleDistribution(GradleVersion.version('6.1'), null, null)
+    private ReleasedVersionDistributions distributions = Mock()
+
+    def setup() {
+        _ * distributions.mostRecentRelease >> gradle61
+        _ * distributions.all >> [gradle60, gradle61]
+    }
+
+    def 'nightly can be used if minimumBaseVersion matched'() {
+        expect:
+        toBaselineVersions(distributions, ['6.0-20190823180744+0000'], '6.0') == ['6.0-20190823180744+0000'] as LinkedHashSet
+    }
+
+    def 'throw exception if all versions are filtered out by minimumBaseVersion'() {
+        when:
+        toBaselineVersions(distributions, ['6.0-20190823180744+0000'], '6.1')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message == 'All versions are filtered out by minimumBaseVersion!'
+    }
+
+    def 'lastest release is added if no versions specified'() {
+        expect:
+        toBaselineVersions(distributions, [], null) == ['6.1'] as LinkedHashSet
+    }
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -43,7 +43,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         runner.args = parallel ? ['-Dorg.gradle.parallel=true'] : []
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
-        runner.minimumVersion = "5.6.1" // AGP 3.6 requires 5.6.1+
+        runner.minimumBaseVersion = "5.6.1" // AGP 3.6 requires 5.6.1+
         runner.targetVersions = ["6.0-20190823180744+0000"]
 
         when:
@@ -73,7 +73,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         runner.warmUpRuns = warmUpRuns
         runner.cleanTasks = ["clean"]
         runner.runs = runs
-        runner.minimumVersion = "5.4"
+        runner.minimumBaseVersion = "5.4"
         runner.targetVersions = ["5.7-20190807220120+0000"]
         runner.addBuildMutator { invocationSettings ->
             new ClearArtifactTransformCacheMutator(invocationSettings.getGradleUserHome(), AbstractCleanupMutator.CleanupSchedule.BUILD)
@@ -97,7 +97,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         given:
         testProject.configureForAbiChange(runner)
         runner.args = ['-Dorg.gradle.parallel=true']
-        runner.minimumVersion = "5.4"
+        runner.minimumBaseVersion = "5.4"
         runner.targetVersions = ["6.0-20190823180744+0000"]
 
         when:
@@ -115,7 +115,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         given:
         testProject.configureForNonAbiChange(runner)
         runner.args = ['-Dorg.gradle.parallel=true']
-        runner.minimumVersion = "5.4"
+        runner.minimumBaseVersion = "5.4"
         runner.targetVersions = ["6.0-20190823180744+0000"]
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -26,7 +26,7 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractAndroidStudioMo
         given:
 
         experiment(testProject) {
-            minimumVersion = "4.3.1"
+            minimumBaseVersion = "4.3.1"
             targetVersions = ["6.0-20190823180744+0000"]
             action('org.gradle.performance.android.SyncAction') {
                 jvmArguments = ["-Xms5g", "-Xmx5g"]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -41,7 +41,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
     def setup() {
         runner.warmUpRuns = 11
         runner.runs = 21
-        runner.minimumVersion = "3.5"
+        runner.minimumBaseVersion = "3.5"
         runner.targetVersions = ["6.0-20190823180744+0000"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Unroll
 class TaskOutputCachingNativePerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
 
     def setup() {
-        runner.minimumVersion = "4.3"
+        runner.minimumBaseVersion = "4.3"
         runner.targetVersions = ["6.0-20190922220036+0000"]
         runner.args += ["-Dorg.gradle.caching.native=true", "--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Unroll
 class TaskOutputCachingSwiftPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
 
     def setup() {
-        runner.minimumVersion = "4.5"
+        runner.minimumBaseVersion = "4.5"
         runner.targetVersions = ["6.0-20190823180744+0000"]
         runner.args += ["--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/DeprecationCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/DeprecationCreationPerformanceTest.groovy
@@ -25,7 +25,7 @@ class DeprecationCreationPerformanceTest extends AbstractCrossVersionGradleProfi
         runner.testProject = "generateLotsOfDeprecationWarnings"
         runner.tasksToRun = ['help']
         runner.gradleOpts = ["-Xms1g", "-Xmx1g"]
-        runner.minimumVersion = '4.9'
+        runner.minimumBaseVersion = '4.9'
         runner.targetVersions = ["6.0-20190923220443+0000"]
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -24,7 +24,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionGradleProfil
     private final static TEST_PROJECT_NAME = 'excludeRuleMergingBuild'
 
     def setup() {
-        runner.minimumVersion = '4.9'
+        runner.minimumBaseVersion = '4.9'
         runner.targetVersions = ["6.0-20190823180744+0000"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -28,7 +28,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionGradleProf
     public static final String MAX_MEMORY = "-Xmx800m"
 
     def setup() {
-        runner.minimumVersion = '4.8'
+        runner.minimumBaseVersion = '4.8'
         runner.targetVersions = ["6.0-20190823180744+0000"]
     }
 
@@ -80,7 +80,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionGradleProf
 
     @Ignore
     def "resolve large dependency graph with strict versions"() {
-        runner.minimumVersion = '5.7-20190807220120+0000'
+        runner.minimumBaseVersion = '6.0'
         runner.testProject = TEST_PROJECT_NAME
         startServer()
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -48,7 +48,7 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionGradleInterna
     def setup() {
         runner.targetVersions = ["6.0-20190823180744+0000"]
         // Example project requires TaskContainer.register
-        runner.minimumVersion = "4.9"
+        runner.minimumBaseVersion = "4.9"
         runner.warmUpRuns = 5
         runner.runs = 15
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/WorkerApiPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/WorkerApiPerformanceTest.groovy
@@ -21,7 +21,7 @@ import spock.lang.Unroll
 
 class WorkerApiPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
-        runner.minimumVersion = '5.0'
+        runner.minimumBaseVersion = '5.0'
         runner.targetVersions = ["5.7-20190805220111+0000"]
         runner.testProject = "workerApiProject"
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -55,7 +55,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionGradleInternalP
     def setup() {
         def targetVersion = "6.0-20190918220850+0000"
         runner.targetVersions = [targetVersion]
-        runner.minimumVersion = targetVersion
+        runner.minimumBaseVersion = targetVersion
     }
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -55,7 +55,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionGradleInternalP
     def setup() {
         def targetVersion = "6.0-20190918220850+0000"
         runner.targetVersions = [targetVersion]
-        runner.minimumBaseVersion = targetVersion
+        runner.minimumBaseVersion = '6.0'
     }
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaABIChangePerformanceTest.groovy
@@ -37,7 +37,7 @@ class JavaABIChangePerformanceTest extends AbstractCrossVersionGradleInternalPer
         runner.addBuildExperimentListener(new ApplyAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
         runner.targetVersions = ["5.7-20190811220031+0000"]
         if (testProject.name().contains("GROOVY")) {
-            runner.minimumVersion = '5.0'
+            runner.minimumBaseVersion = '5.0'
         }
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
@@ -35,7 +35,7 @@ class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionGradleInterna
         runner.runs = runs
         runner.tasksToRun = ["clean", "assemble"]
         runner.targetVersions = ["6.0-20190823180744+0000"]
-        runner.minimumVersion = minimumVersion
+        runner.minimumBaseVersion = minimumBaseVersion
 
         when:
         def result = runner.run()
@@ -44,7 +44,7 @@ class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionGradleInterna
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject                            | warmUpRuns | runs  | minimumVersion
+        testProject                            | warmUpRuns | runs  | minimumBaseVersion
         LARGE_MONOLITHIC_JAVA_PROJECT          | 2          | 6     | null
         LARGE_JAVA_MULTI_PROJECT               | 2          | 6     | null
         MEDIUM_JAVA_COMPOSITE_BUILD            | 2          | 6     | "4.0"

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -33,7 +33,7 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
     def "get IDE model on #testProject for Eclipse"() {
         given:
         experiment(testProject.projectName) {
-            minimumVersion = "2.11"
+            minimumBaseVersion = "2.11"
             targetVersions = [BASELINE_VERSION]
             invocationCount = iterations
             warmUpCount = iterations
@@ -93,7 +93,7 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
     def "get IDE model on #testProject for IDEA"() {
         given:
         experiment(testProject.projectName) {
-            minimumVersion = "2.11"
+            minimumBaseVersion = "2.11"
             targetVersions = [BASELINE_VERSION]
             invocationCount = iterations
             warmUpCount = iterations

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -46,7 +46,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
 
         given:
         runner.targetVersions = ["6.0-20190925220032+0000"]
-        runner.minimumVersion = "5.6-20190625073933+0000"
+        runner.minimumBaseVersion = "5.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
         runner.args = ["-Dorg.gradle.unsafe.instant-execution"]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaNonABIChangePerformanceTest.groovy
@@ -36,7 +36,7 @@ class JavaNonABIChangePerformanceTest extends AbstractCrossVersionGradleInternal
         runner.addBuildExperimentListener(new ApplyNonAbiChangeToJavaSourceFileMutator(testProject.config.fileToChangeByScenario['assemble']))
         runner.targetVersions = ["6.0-20190823180744+0000"]
         if (testProject.name().contains("GROOVY")) {
-            runner.minimumVersion = '5.0'
+            runner.minimumBaseVersion = '5.0'
         }
 
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaUpToDatePerformanceTest.groovy
@@ -56,7 +56,7 @@ class JavaUpToDatePerformanceTest extends AbstractCrossVersionGradleProfilerPerf
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['assemble']
         runner.targetVersions = ["6.0-20190823180744+0000"]
-        runner.minimumVersion = "3.5"
+        runner.minimumBaseVersion = "3.5"
         runner.args += ["-Dorg.gradle.parallel=$parallel", "-D${StartParameterBuildOptions.BuildCacheOption.GRADLE_PROPERTY}=true"]
         def cacheDir = temporaryFolder.file("local-cache")
         runner.addBuildMutator { invocationSettings ->

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
@@ -23,7 +23,7 @@ class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionGradlePro
 
     def setup() {
         runner.targetVersions = ["6.0-20190823180744+0000"]
-        runner.minimumVersion = "4.0"
+        runner.minimumBaseVersion = "4.0"
     }
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Unroll
 
 class NativeBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
-        runner.minimumVersion = '4.1' // minimum version that contains new C++ plugins
+        runner.minimumBaseVersion = '4.1' // minimum version that contains new C++ plugins
         runner.targetVersions = ["6.0-20190925220032+0000"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 @Category(SlowPerformanceRegressionTest)
 class NativeCleanBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
     def setup() {
-        runner.minimumVersion = '4.1' // minimum version that contains new C++ plugins
+        runner.minimumBaseVersion = '4.1' // minimum version that contains new C++ plugins
         runner.targetVersions = ["6.0-20190919220024+0000"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
@@ -28,7 +28,7 @@ class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionGradleInt
 
     def setup() {
         runner.targetVersions = ["6.0-20190823180744+0000"]
-        runner.minimumVersion = "4.0"
+        runner.minimumBaseVersion = "4.0"
     }
 
     @Unroll

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 class SwiftBuildPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
     def setup() {
-        runner.minimumVersion = '4.6'
+        runner.minimumBaseVersion = '4.6'
         runner.targetVersions = ["6.0-20190823180744+0000"]
         runner.args += ["--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Unroll
 class SwiftCleanBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
 
     def setup() {
-        runner.minimumVersion = '4.6'
+        runner.minimumBaseVersion = '4.6'
         runner.targetVersions = ["6.0-20190823180744+0000"]
         runner.args += ["--parallel", "--${ParallelismBuildOptions.MaxWorkersOption.LONG_OPTION}=6"]
     }


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-private/issues/2571

This PR refines performance baseline selection logic:

- Rename `minimumVersion` to `minimumBaseVersion`. If `minimumBaseVersion` is `6.0`, a 6.0-nightly can be used.
- Throw an error if all versions are filtered out by `minimumBaseVersion`.
- Several unit tests are added to cover these logic.