### PR TITLE
Support variant selection in capability conflict resolution

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/CapabilityResolutionDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/CapabilityResolutionDetails.java
@@ -16,7 +16,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -41,7 +40,7 @@ public interface CapabilityResolutionDetails {
     /**
      * Returns the list of components which are in conflict on this capability
      */
-    List<ComponentIdentifier> getCandidates();
+    List<ComponentVariantIdentifier> getCandidates();
 
     /**
      * Selects a particular candidate to solve the conflict. It is recommended to
@@ -49,8 +48,10 @@ public interface CapabilityResolutionDetails {
      *
      * @param candidate the selected candidate
      * @return this details instance
+     *
+     * @since 6.0
      */
-    CapabilityResolutionDetails select(ComponentIdentifier candidate);
+    CapabilityResolutionDetails select(ComponentVariantIdentifier candidate);
 
     /**
      * Selects a particular candidate to solve the conflict. It is recommended to

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentVariantIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentVariantIdentifier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+
+/**
+ * Identifies a variant of a component by module identifier and variant name.
+ *
+ * @since 6.0
+ */
+@Incubating
+public interface ComponentVariantIdentifier {
+
+    /**
+     * Returns the component identifier.
+     */
+    ComponentIdentifier getId();
+
+    /**
+     * Returns the variant name.
+     */
+    String getVariantName();
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -81,7 +80,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
         where:
         rule                               | error
         "throw new NullPointerException()" | "Capability resolution rule failed with an error" // error in user code
-        "select('org:testD:1.0')"          | "org:testD:1.0 is not a valid candidate for conflict resolution on capability capability group='org.test', name='cap', version='null': candidates are [org:testA:1.0, org:testB:1.0]"// invalid candidate
+        "select('org:testD:1.0')"          | "org:testD:1.0 is not a valid candidate for conflict resolution on capability capability group='org.test', name='cap', version='null': candidates are [org:testA:1.0(runtime), org:testB:1.0(runtime)]"// invalid candidate
 
     }
 
@@ -146,15 +145,130 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
         where:
         rule << [
-            "select(candidates.find { it.module == 'testB'})",
+            "select(candidates.find { it.id.module == 'testB'})",
             "select('org:testB:1.0')",
             "select('org:testB:1.1')", // we are lenient wrt to the version number
         ]
     }
 
-    @Ignore
-    def "Spock workaround"() {
-        expect:
-        true
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "can express preference for a certain variant with capabilities declared in published modules"() {
+        given:
+        repository {
+            'org:testB:1.0' {
+                variant('runtime') {
+                    capability('org', 'testB', '1.0')
+                }
+                variant('runtimeAlt') {
+                    capability('org', 'testB', '1.0')
+                    capability('special')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf 'org:testB:1.0'
+                conf('org:testB:1.0') {
+                    capabilities {
+                        requireCapability("org.test:special")
+                    }
+                }
+            }
+            
+            // fix the conflict between variants of module providing the same capability using resolution rules
+            configurations.all {
+                resolutionStrategy {
+                   capabilitiesResolution.withCapability('org:testB') {
+                      select(candidates.find { it.variantName == 'runtimeAlt'})
+                      because "we want runtimeAlt with 'special'"
+                   }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:testB:1.0' {
+                expectResolve()
+            }
+        }
+        run ":checkDeps"
+
+        then:
+
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:testB:1.0:runtimeAlt').byConflictResolution("On capability org:testB we want runtimeAlt with 'special'")
+                module('org:testB:1.0:runtimeAlt')
+            }
+        }
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "expressing a preference for a variant with capabilities declared in a published modules does not evict unrelated variants"() {
+        given:
+        repository {
+            'org:testB:1.0' {
+                variant('runtime') {
+                    capability('org', 'testB', '1.0')
+                }
+                variant('runtimeAlt') {
+                    capability('org', 'testB', '1.0')
+                    capability('special')
+                }
+                variant('runtimeOptional') {
+                    capability('optional')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf 'org:testB:1.0'
+                conf('org:testB:1.0') {
+                    capabilities {
+                        requireCapability("org.test:special")
+                    }
+                }
+                conf('org:testB:1.0') {
+                    capabilities {
+                        requireCapability("org.test:optional")
+                    }
+                }
+            }
+            
+            // fix the conflict between variants of module providing the same capability using resolution rules
+            configurations.all {
+                resolutionStrategy {
+                   capabilitiesResolution.withCapability('org:testB') {
+                      select(candidates.find { it.variantName == 'runtimeAlt'})
+                      because "we want runtimeAlt with 'special'"
+                   }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:testB:1.0' {
+                expectResolve()
+            }
+        }
+        run ":checkDeps"
+
+        then:
+
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:testB:1.0:runtimeAlt').byConflictResolution("On capability org:testB we want runtimeAlt with 'special'")
+                module('org:testB:1.0:runtimeAlt')
+                module('org:testB:1.0:runtimeOptional')
+            }
+        }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -134,11 +134,11 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
         }
 
         where:
-        rule                                                                               | reason
-        'all { selectHighestVersion() }'                                                   | 'latest version of capability cglib:cglib'
-        'withCapability("cglib:cglib") { selectHighestVersion() }'                         | 'latest version of capability cglib:cglib'
-        'withCapability("cglib", "cglib") { selectHighestVersion() }'                      | 'latest version of capability cglib:cglib'
-        'all { select(candidates.find { it.module == "cglib" }) because "custom reason" }' | 'On capability cglib:cglib custom reason'
+        rule                                                                                  | reason
+        'all { selectHighestVersion() }'                                                      | 'latest version of capability cglib:cglib'
+        'withCapability("cglib:cglib") { selectHighestVersion() }'                            | 'latest version of capability cglib:cglib'
+        'withCapability("cglib", "cglib") { selectHighestVersion() }'                         | 'latest version of capability cglib:cglib'
+        'all { select(candidates.find { it.id.module == "cglib" }) because "custom reason" }' | 'On capability cglib:cglib custom reason'
     }
 
     def "can detect conflict between local project and capability from external dependency"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -107,11 +107,11 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         }
 
         where:
-        rule                                                                               | reason
+        rule                                                                                  | reason
         'all { selectHighestVersion() }'                                                      | 'latest version of capability cglib:cglib'
         'withCapability("cglib:cglib") { selectHighestVersion() }'                            | 'latest version of capability cglib:cglib'
         'withCapability("cglib", "cglib") { selectHighestVersion() }'                         | 'latest version of capability cglib:cglib'
-        'all { select(candidates.find { it.module == "cglib" }) because "custom reason" }' | 'On capability cglib:cglib custom reason'
+        'all { select(candidates.find { it.id.module == "cglib" }) because "custom reason" }' | 'On capability cglib:cglib custom reason'
 
     }
 
@@ -319,7 +319,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
             }
             
             configurations.conf.resolutionStrategy.capabilitiesResolution.withCapability('org:cap') {
-                select candidates.find { it.module == "$expected" }
+                select candidates.find { it.id.module == "$expected" }
                 because "prefers module ${expected}"
             }
         """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCapabilitiesResolution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultCapabilitiesResolution.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.CapabilityResolutionDetails;
+import org.gradle.api.artifacts.ComponentVariantIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.capabilities.Capability;
@@ -28,6 +29,7 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.CapabilityInternal;
+import org.gradle.internal.component.external.model.DefaultComponentVariantIdentifier;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.typeconversion.NotationParser;
 
@@ -75,9 +77,9 @@ public class DefaultCapabilitiesResolution implements CapabilitiesResolutionInte
             .forEach(e -> {
                 Capability key = e.getKey();
                 List<? extends Capability> versions = e.getValue();
-                List<ComponentIdentifier> candidateIds = versions.stream()
+                List<ComponentVariantIdentifier> candidateIds = versions.stream()
                     .flatMap(c -> details.getCandidates(c).stream())
-                    .map(CapabilitiesConflictHandler.CandidateDetails::getId)
+                    .map(detail -> new DefaultComponentVariantIdentifier(detail.getId(), detail.getVariantName()))
                     .collect(Collectors.toList());
                 DefaultCapabilityResolutionDetails resolutionDetails = new DefaultCapabilityResolutionDetails(componentNotationParser, key, candidateIds);
                 handleCapabilityAction(details, key, versions, resolutionDetails);
@@ -109,11 +111,15 @@ public class DefaultCapabilitiesResolution implements CapabilitiesResolutionInte
     }
 
     private void selectExplicitCandidate(DefaultCapabilityResolutionDetails resolutionDetails, CapabilityInternal version, CapabilitiesConflictHandler.CandidateDetails cand) {
-        if (cand.getId().equals(resolutionDetails.selected)) {
-            cand.select();
-            String reason = resolutionDetails.reason;
-            if (reason != null) {
-                cand.byReason(Describables.of("On capability", version.getCapabilityId(), reason));
+        if (cand.getId().equals(resolutionDetails.selected.getId())) {
+            if (cand.getVariantName().equals(resolutionDetails.selected.getVariantName())) {
+                cand.select();
+                String reason = resolutionDetails.reason;
+                if (reason != null) {
+                    cand.byReason(Describables.of("On capability", version.getCapabilityId(), reason));
+                }
+            } else {
+                cand.evict();
             }
         }
     }
@@ -121,14 +127,14 @@ public class DefaultCapabilitiesResolution implements CapabilitiesResolutionInte
     private static class DefaultCapabilityResolutionDetails implements CapabilityResolutionDetails {
         private final NotationParser<Object, ComponentIdentifier> notationParser;
         private final Capability capability;
-        private final List<ComponentIdentifier> candidates;
+        private final List<ComponentVariantIdentifier> candidates;
 
         boolean didSomething;
         boolean useHighest;
         private String reason;
-        private ComponentIdentifier selected;
+        private ComponentVariantIdentifier selected;
 
-        private DefaultCapabilityResolutionDetails(NotationParser<Object, ComponentIdentifier> notationParser, Capability capability, List<ComponentIdentifier> candidates) {
+        private DefaultCapabilityResolutionDetails(NotationParser<Object, ComponentIdentifier> notationParser, Capability capability, List<ComponentVariantIdentifier> candidates) {
             this.notationParser = notationParser;
             this.capability = capability;
             this.candidates = candidates;
@@ -140,12 +146,12 @@ public class DefaultCapabilitiesResolution implements CapabilitiesResolutionInte
         }
 
         @Override
-        public List<ComponentIdentifier> getCandidates() {
+        public List<ComponentVariantIdentifier> getCandidates() {
             return candidates;
         }
 
         @Override
-        public CapabilityResolutionDetails select(ComponentIdentifier candidate) {
+        public CapabilityResolutionDetails select(ComponentVariantIdentifier candidate) {
             didSomething = true;
             selected = candidate;
             return this;
@@ -154,16 +160,16 @@ public class DefaultCapabilitiesResolution implements CapabilitiesResolutionInte
         @Override
         public CapabilityResolutionDetails select(Object notation) {
             ComponentIdentifier componentIdentifier = notationParser.parseNotation(notation);
-            for (ComponentIdentifier candidate : candidates) {
-                if (componentIdentifier.equals(candidate)) {
+            for (ComponentVariantIdentifier candidate : candidates) {
+                if (componentIdentifier.equals(candidate.getId())) {
                     select(candidate);
                     return this;
                 }
-                if (candidate instanceof ModuleComponentIdentifier && componentIdentifier instanceof ModuleComponentIdentifier) {
+                if (candidate.getId() instanceof ModuleComponentIdentifier && componentIdentifier instanceof ModuleComponentIdentifier) {
                     // because it's a capability conflict resolution, there is only one candidate per module identifier
                     // so we can be lenient wrt the version number used in the descriptor, which helps whenever the user
                     // used the convenience "notation" method
-                    ModuleComponentIdentifier candMCI = (ModuleComponentIdentifier) candidate;
+                    ModuleComponentIdentifier candMCI = (ModuleComponentIdentifier) candidate.getId();
                     ModuleComponentIdentifier compMCI = (ModuleComponentIdentifier) componentIdentifier;
                     if (candMCI.getModuleIdentifier().equals(compMCI.getModuleIdentifier())) {
                         select(candidate);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
@@ -37,6 +37,7 @@ public interface CapabilitiesConflictHandler extends ConflictHandler<Capabilitie
 
     interface CandidateDetails {
         ComponentIdentifier getId();
+        String getVariantName();
         void evict();
         void select();
         void reject();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -203,6 +203,11 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                             }
 
                             @Override
+                            public String getVariantName() {
+                                return node.getResolvedConfigurationId().getConfiguration();
+                            }
+
+                            @Override
                             public void evict() {
                                 node.evict();
                                 evicted.add(node);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultComponentVariantIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultComponentVariantIdentifier.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.artifacts.ComponentVariantIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+
+public class DefaultComponentVariantIdentifier implements ComponentVariantIdentifier {
+
+    private final ComponentIdentifier id;
+    private final String variantName;
+
+    public DefaultComponentVariantIdentifier(ComponentIdentifier id, String variantName) {
+        this.id = id;
+        this.variantName = variantName;
+    }
+
+    @Override
+    public ComponentIdentifier getId() {
+        return id;
+    }
+
+    @Override
+    public String getVariantName() {
+        return variantName;
+    }
+
+    @Override
+    public String toString() {
+        return id + "(" + variantName + ")";
+    }
+}

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
@@ -389,6 +389,7 @@ The following breaking changes will appear as deprecation warnings with Gradle 5
 * The `isLegacyLayout()` method is removed from `SourceSetOutput`.
 * The map returned by `TaskInputs.getProperties()` is now unmodifiable.
   Trying to modify it will result in an `UnsupportedOperationException` being thrown.
+* There are slight changes in the incubating <<dependency_capability_conflict.adoc#sub:selecting-between-candidates,capabilities resolution>> API, which has been introduced in 5.6, to also allow variant selection based on variant name
 
 [[changes_5.6]]
 == Upgrading from 5.5 and earlier

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/declaring-capabilities.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/declaring-capabilities.sample.conf
@@ -12,5 +12,20 @@ commands: [{
     flags: --quiet
     expected-output-file: dependencyReport.out
     expect-failure: false
+},
+{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: "dependencyInsight --configuration compileClasspath --dependency log4j -Preplace"
+    flags: "--quiet"
+    expected-output-file: dependencyReportReplaced.out
+    expect-failure: false
+}, {
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: "dependencyInsight --configuration compileClasspath --dependency log4j -Preplace"
+    flags: --quiet
+    expected-output-file: dependencyReportReplaced.out
+    expect-failure: false
 }]
 

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReportReplaced.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReportReplaced.out
@@ -1,0 +1,38 @@
+org.slf4j:log4j-over-slf4j:1.7.10
+   variant "compile" [
+      org.gradle.status              = release (not requested)
+      org.gradle.usage               = java-api
+      org.gradle.libraryelements     = jar (compatible with: classes)
+      org.gradle.category            = library (not requested)
+
+      Requested attributes not found in the selected variant:
+         org.gradle.dependency.bundling = external
+         org.gradle.jvm.version = 11
+   ]
+   Selection reasons:
+      - By conflict resolution : On capability log4j:log4j use slf4j in place of log4j
+
+log4j:log4j:1.2.16 -> org.slf4j:log4j-over-slf4j:1.7.10
+\--- org.apache.zookeeper:zookeeper:3.4.9
+     \--- compileClasspath
+
+org.slf4j:log4j-over-slf4j:1.7.10
+\--- compileClasspath
+
+org.slf4j:slf4j-log4j12:1.6.1
+   variant "compile" [
+      org.gradle.status              = release (not requested)
+      org.gradle.usage               = java-api
+      org.gradle.libraryelements     = jar (compatible with: classes)
+      org.gradle.category            = library (not requested)
+
+      Requested attributes not found in the selected variant:
+         org.gradle.dependency.bundling = external
+         org.gradle.jvm.version = 11
+   ]
+
+org.slf4j:slf4j-log4j12:1.6.1
+\--- org.apache.zookeeper:zookeeper:3.4.9
+     \--- compileClasspath
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/groovy/build.gradle
@@ -89,7 +89,7 @@ if (project.hasProperty("replace")) {
     // tag::use_slf4j[]
     configurations.all {
         resolutionStrategy.capabilitiesResolution.withCapability("log4j:log4j") {
-            select(candidates.find { it.module == 'log4j-over-slf4j' } )
+            select(candidates.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'log4j-over-slf4j' } )
             because 'use slf4j in place of log4j'
         }
     }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/kotlin/build.gradle.kts
@@ -84,10 +84,7 @@ if (project.hasProperty("replace")) {
     // tag::use_slf4j[]
     configurations.all {
         resolutionStrategy.capabilitiesResolution.withCapability("log4j:log4j") {
-            select(candidates.find {
-                it as ModuleComponentIdentifier
-                it.module == "log4j-over-slf4j"
-            } )
+            select(candidates.first { it.id.let { id -> id is ModuleComponentIdentifier && id.module == "log4j-over-slf4j" } } )
             because("use slf4j in place of log4j")
         }
     }


### PR DESCRIPTION
A conflict can also occur between two variants of the same component.
This gives access to the variant name in the selection rule and
evicts nodes that represent the not-selected variant.
