### PR TITLE
Changes in Gradle Module Metadata loading

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -54,7 +54,7 @@ public enum CacheLayout {
         .changedTo(68, "5.0-milestone-1")
         .changedTo(69, "5.0-rc-1")
         .changedTo(71, "5.3-rc-1")
-        .changedTo(77, "6.0-rc-1")
+        .changedTo(78, "6.0-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
@@ -60,7 +60,7 @@ public class DefaultGradleModuleMetadataSource extends AbstractMetadataSource<Mu
         DefaultIvyArtifactName moduleMetadataArtifact = new DefaultIvyArtifactName(moduleComponentIdentifier.getModule(), "module", "module");
         LocallyAvailableExternalResource gradleMetadataArtifact = artifactResolver.resolveArtifact(new DefaultModuleComponentArtifactMetadata(moduleComponentIdentifier, moduleMetadataArtifact), result);
         if (gradleMetadataArtifact != null) {
-            MutableModuleComponentResolveMetadata metaDataFromResource = mutableModuleMetadataFactory.create(moduleComponentIdentifier);
+            MutableModuleComponentResolveMetadata metaDataFromResource = mutableModuleMetadataFactory.createForGradleModuleMetadata(moduleComponentIdentifier);
             metadataParser.parse(gradleMetadataArtifact, metaDataFromResource);
             validateGradleMetadata(metaDataFromResource);
             metadataCompatibilityConverter.process(metaDataFromResource);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/IvyMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/IvyMutableModuleMetadataFactory.java
@@ -49,18 +49,13 @@ public class IvyMutableModuleMetadataFactory implements MutableModuleMetadataFac
         this.schema = schema;
     }
 
-    @Override
-    public MutableIvyModuleResolveMetadata create(ModuleComponentIdentifier from) {
-        return create(from, ImmutableList.<IvyDependencyDescriptor>of());
-    }
-
     public MutableIvyModuleResolveMetadata create(ModuleComponentIdentifier from, List<IvyDependencyDescriptor> dependencies) {
         return create(
             from,
             dependencies,
             DEFAULT_CONFIGURATION_LIST,
             createDefaultArtifact(from),
-            ImmutableList.<Exclude>of());
+            ImmutableList.of());
     }
 
     public MutableIvyModuleResolveMetadata create(ModuleComponentIdentifier from,
@@ -80,6 +75,11 @@ public class IvyMutableModuleMetadataFactory implements MutableModuleMetadataFac
             schema);
     }
 
+    @Override
+    public MutableIvyModuleResolveMetadata createForGradleModuleMetadata(ModuleComponentIdentifier from) {
+        return create(from, ImmutableList.of(), ImmutableList.of(), createDefaultArtifact(from), ImmutableList.of());
+    }
+
     private ImmutableList<? extends Artifact> createDefaultArtifact(ModuleComponentIdentifier from) {
         return ImmutableList.of(new Artifact(new DefaultIvyArtifactName(from.getModule(), "jar", "jar"), SINGLE_DEFAULT_CONFIGURATION_NAME));
     }
@@ -90,7 +90,7 @@ public class IvyMutableModuleMetadataFactory implements MutableModuleMetadataFac
 
     @Override
     public MutableIvyModuleResolveMetadata missing(ModuleComponentIdentifier from) {
-        MutableIvyModuleResolveMetadata metadata = create(from);
+        MutableIvyModuleResolveMetadata metadata = create(from, ImmutableList.of());
         metadata.setMissing(true);
         return metadata;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.repositories.metadata;
 
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -46,9 +47,9 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
     }
 
     @Override
-    public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from) {
+    public MutableMavenModuleResolveMetadata createForGradleModuleMetadata(ModuleComponentIdentifier from) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.emptyList(), attributesFactory, objectInstantiator, schema);
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.emptyList(), attributesFactory, objectInstantiator, schema, ImmutableMap.of());
     }
 
     private ModuleVersionIdentifier asVersionIdentifier(ModuleComponentIdentifier from) {
@@ -57,7 +58,7 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
 
     @Override
     public MutableMavenModuleResolveMetadata missing(ModuleComponentIdentifier from) {
-        MutableMavenModuleResolveMetadata metadata = create(from);
+        MutableMavenModuleResolveMetadata metadata = create(from, Collections.emptyList());
         metadata.setMissing(true);
         return MavenResolver.processMetaData(metadata);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MutableModuleMetadataFactory.java
@@ -22,7 +22,8 @@ import org.gradle.internal.component.external.model.MutableModuleComponentResolv
  * A factory for creating instances of `MutableComponentResolveMetadata` for different repository formats.
  */
 public interface MutableModuleMetadataFactory<S extends MutableModuleComponentResolveMetadata> {
-    S create(ModuleComponentIdentifier from);
+
+    S createForGradleModuleMetadata(ModuleComponentIdentifier from);
 
     S missing(ModuleComponentIdentifier from);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
@@ -41,12 +41,23 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
     private boolean relocated;
     private String snapshotTimestamp;
     private ImmutableList<MavenDependencyDescriptor> dependencies;
+    private ImmutableMap<String, Configuration> configurationDefinitions;
 
     public DefaultMutableMavenModuleResolveMetadata(ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier, Collection<MavenDependencyDescriptor> dependencies,
                                                     ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator, AttributesSchemaInternal schema) {
         super(attributesFactory, id, componentIdentifier, schema);
         this.dependencies = ImmutableList.copyOf(dependencies);
         this.objectInstantiator = objectInstantiator;
+        this.configurationDefinitions = GradlePomModuleDescriptorBuilder.MAVEN2_CONFIGURATIONS;
+    }
+
+    public DefaultMutableMavenModuleResolveMetadata(ModuleVersionIdentifier id, ModuleComponentIdentifier componentIdentifier, Collection<MavenDependencyDescriptor> dependencies,
+                                                    ImmutableAttributesFactory attributesFactory, NamedObjectInstantiator objectInstantiator, AttributesSchemaInternal schema,
+                                                    ImmutableMap<String, Configuration> configurationDefinitions) {
+        super(attributesFactory, id, componentIdentifier, schema);
+        this.dependencies = ImmutableList.copyOf(dependencies);
+        this.objectInstantiator = objectInstantiator;
+        this.configurationDefinitions = configurationDefinitions;
     }
 
     DefaultMutableMavenModuleResolveMetadata(MavenModuleResolveMetadata metadata,
@@ -57,6 +68,7 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
         this.snapshotTimestamp = metadata.getSnapshotTimestamp();
         this.dependencies = metadata.getDependencies();
         this.objectInstantiator = objectInstantiator;
+        this.configurationDefinitions = GradlePomModuleDescriptorBuilder.MAVEN2_CONFIGURATIONS;
     }
 
     @Override
@@ -66,7 +78,7 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
 
     @Override
     protected ImmutableMap<String, Configuration> getConfigurationDefinitions() {
-        return GradlePomModuleDescriptorBuilder.MAVEN2_CONFIGURATIONS;
+        return configurationDefinitions;
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -526,7 +526,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
 
     private DefaultMutableIvyModuleResolveMetadata ivyMetadata() {
         def module = DefaultModuleIdentifier.newId("group", "module")
-        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
+        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"), [])
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata
@@ -534,7 +534,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
 
     private DefaultMutableMavenModuleResolveMetadata mavenMetadata() {
         def module = DefaultModuleIdentifier.newId("group", "module")
-        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
+        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"), [])
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -186,7 +186,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
 
     private DefaultMutableIvyModuleResolveMetadata ivyMetadata() {
         def module = DefaultModuleIdentifier.newId("group", "module")
-        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
+        def metadata = ivyMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"), [])
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata
@@ -194,7 +194,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
 
     private DefaultMutableMavenModuleResolveMetadata mavenMetadata() {
         def module = DefaultModuleIdentifier.newId("group", "module")
-        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"))
+        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(module, "version"), [])
         metadata.status = "integration"
         metadata.statusScheme = ["integration", "release"]
         return metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 77
+        expectedVersion = 78
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -140,7 +140,7 @@ class ModuleMetadataSerializerTest extends Specification {
     }
 
     MutableModuleComponentResolveMetadata parseGradle(File gradleFile) {
-        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('test', 'test-module'), '1.0'))
+        def metadata = mavenMetadataFactory.create(DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('test', 'test-module'), '1.0'), [])
         gradleMetadataParser.parse(resource(gradleFile), metadata)
         metadata
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
@@ -59,7 +59,7 @@ class ModuleMetadataStoreTest extends Specification {
     def "putModuleDescriptor uses PathKeyFileStore to write file"() {
         setup:
         File descriptorFile = temporaryFolder.createFile("fileStoreEntry")
-        def descriptor = mavenMetadataFactory.create(moduleComponentIdentifier).asImmutable()
+        def descriptor = mavenMetadataFactory.create(moduleComponentIdentifier, []).asImmutable()
 
         when:
         store.putModuleDescriptor(new ModuleComponentAtRepositoryKey(repository, moduleComponentIdentifier), descriptor)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -64,7 +64,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         ivyMetadataFactory.create(componentIdentifier, [], [new Configuration("configurationDefinedInIvyMetadata", true, true, [])], [], [])
     }
     private gradleComponentMetadata() {
-        def metadata = mavenMetadataFactory.create(componentIdentifier)
+        def metadata = mavenMetadataFactory.create(componentIdentifier, [])
         metadata.addVariant("variantDefinedInGradleMetadata1", attributes) //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
         metadata.addVariant("variantDefinedInGradleMetadata2", AttributeTestUtil.attributesFactory().of(testAttribute, "other")) //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
         gradleMetadata = metadata
@@ -72,7 +72,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     }
 
     private MutableMavenModuleResolveMetadata mavenComponentMetadata() {
-        mavenMetadataFactory.create(componentIdentifier)
+        mavenMetadataFactory.create(componentIdentifier, [])
     }
 
     def setup() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -101,7 +101,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         mavenMetadataFactory.create(componentIdentifier, dependencies)
     }
     private gradleComponentMetadata(String[] deps) {
-        def metadata = mavenMetadataFactory.create(componentIdentifier)
+        def metadata = mavenMetadataFactory.create(componentIdentifier, [])
         //gradle metadata is distinguished from maven POM metadata by explicitly defining variants
         defaultVariant = metadata.addVariant("default", attributes)
         deps.each { name ->

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -107,7 +107,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
     def "copy with different source"() {
         given:
         def source = Stub(ModuleSource)
-        def mutable = mavenMetadataFactory.create(id)
+        def mutable = mavenMetadataFactory.create(id, [])
         mutable.packaging = "other"
         mutable.relocated = true
         mutable.snapshotTimestamp = "123"
@@ -125,7 +125,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
 
     def "recognises pom packaging"() {
         when:
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
         metadata.packaging = packaging
 
         then:
@@ -146,7 +146,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         given:
         def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
         def componentTypeAttribute = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class)
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
         metadata.packaging = packaging
         metadata.variantMetadataRules.variantDerivationStrategy = new JavaEcosystemVariantDerivationStrategy()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
@@ -40,7 +40,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
 
     @Override
     AbstractMutableModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id) {
-        ivyMetadataFactory.create(id) as AbstractMutableModuleComponentResolveMetadata
+        ivyMetadataFactory.create(id, []) as AbstractMutableModuleComponentResolveMetadata
     }
 
     def "initialises values from descriptor state and defaults"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -41,12 +41,12 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
 
     @Override
     AbstractMutableModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id) {
-        mavenMetadataFactory.create(id) as AbstractMutableModuleComponentResolveMetadata
+        mavenMetadataFactory.create(id, []) as AbstractMutableModuleComponentResolveMetadata
     }
 
     def "defines configurations for maven scopes and several usage buckets"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
 
         expect:
         def immutable = metadata.asImmutable()
@@ -62,7 +62,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
 
     def "default metadata"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
 
         expect:
         metadata.packaging == 'jar'
@@ -81,7 +81,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
 
         def vid = Mock(ModuleVersionIdentifier)
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
 
         expect:
         metadata.id == id
@@ -132,7 +132,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         def source = Stub(ModuleSource)
         def contentHash = new HashValue("123")
 
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
 
         when:
         metadata.id = newId
@@ -188,7 +188,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
 
         when:
         def immutable = metadata.asImmutable()
@@ -237,7 +237,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
         def source = Stub(ModuleSource)
-        def metadata = mavenMetadataFactory.create(id)
+        def metadata = mavenMetadataFactory.create(id, [])
 
         when:
         def immutable = metadata.asImmutable()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -82,7 +82,7 @@ class VariantFilesMetadataRulesTest extends Specification {
     }
 
     private gradleComponentMetadata(String[] deps) {
-        def metadata = mavenMetadataFactory.create(componentIdentifier)
+        def metadata = mavenMetadataFactory.create(componentIdentifier, [])
         defaultVariant = metadata.addVariant("runtime", attributes)
         deps.each { name ->
             defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY, [], false, null)


### PR DESCRIPTION
We no longer define any configurations, like default or the maven ones.
In the past, we still had these defined which allowed partial legacy
selection. But it made no sense since all these configurations would not
 have any dependencies for example.