### PR TITLE
Set a green branch tag when Ready for nightly finishes

### DIFF
--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -16,6 +16,7 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2018_2.triggers.vcs
 import model.CIBuildModel
 import model.Stage
+import model.StageNames
 import model.Trigger
 import projects.StageProject
 
@@ -82,7 +83,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
     steps {
         gradleWrapper {
             name = "GRADLE_RUNNER"
-            tasks = "createBuildReceipt"
+            tasks = "createBuildReceipt" + if (stage.stageName == StageNames.READY_FOR_NIGHTLY) " updateBranchStatus" else ""
             gradleParams = defaultGradleParameters
         }
         script {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ import org.gradle.gradlebuild.ProjectGroups.javaProjects
 import org.gradle.gradlebuild.ProjectGroups.kotlinJsProjects
 import org.gradle.gradlebuild.ProjectGroups.pluginProjects
 import org.gradle.gradlebuild.ProjectGroups.publicJavaProjects
+import org.gradle.gradlebuild.UpdateBranchStatus
 import org.gradle.gradlebuild.buildquality.incubation.IncubatingApiAggregateReportTask
 import org.gradle.gradlebuild.buildquality.incubation.IncubatingApiReportTask
 
@@ -373,6 +374,8 @@ tasks.register<Install>("installAll") {
     with(distributionImage("allDistImage"))
     installDirPropertyName = ::gradle_installPath.name
 }
+
+tasks.register<UpdateBranchStatus>("updateBranchStatus")
 
 fun distributionImage(named: String) =
         project(":distributions").property(named) as CopySpec

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream-candidates.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream-candidates.kt
@@ -36,6 +36,25 @@ fun Project.execAndGetStdout(workingDir: File, vararg args: String): String {
 }
 
 
+fun Project.execAndGetOutput(ignoreExitCode: Boolean = true, vararg args: String): String {
+    val out = ByteArrayOutputStream()
+    exec {
+        isIgnoreExitValue = ignoreExitCode
+        commandLine(*args)
+        standardOutput = out
+        errorOutput = out
+        this.workingDir = File(".")
+    }
+    return out.toString().trim()
+}
+
+
+fun Project.execAndGetOutput(vararg args: String) = execAndGetOutput(true, *args)
+
+
+fun Project.execAndGetOutputExpectingZeroCode(vararg args: String) = execAndGetOutput(false, *args)
+
+
 fun Project.execAndGetStdout(vararg args: String) = execAndGetStdout(File("."), *args)
 
 

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream-candidates.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream-candidates.kt
@@ -36,25 +36,6 @@ fun Project.execAndGetStdout(workingDir: File, vararg args: String): String {
 }
 
 
-fun Project.execAndGetOutput(ignoreExitCode: Boolean = true, vararg args: String): String {
-    val out = ByteArrayOutputStream()
-    exec {
-        isIgnoreExitValue = ignoreExitCode
-        commandLine(*args)
-        standardOutput = out
-        errorOutput = out
-        this.workingDir = File(".")
-    }
-    return out.toString().trim()
-}
-
-
-fun Project.execAndGetOutput(vararg args: String) = execAndGetOutput(true, *args)
-
-
-fun Project.execAndGetOutputExpectingZeroCode(vararg args: String) = execAndGetOutput(false, *args)
-
-
 fun Project.execAndGetStdout(vararg args: String) = execAndGetStdout(File("."), *args)
 
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/UpdateBranchStatus.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/UpdateBranchStatus.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.*
+import org.gradle.plugins.performance.determineCurrentBranch
+
+
+/**
+ * When a Ready for Nightly trigger build completes successfully on master/release, we publish a git tag
+ * green-master/green-release to remote repository so that developers can checkout new branches from these tags.
+ */
+open class UpdateBranchStatus : DefaultTask() {
+    @TaskAction
+    fun publishBranchStatus() {
+        when (project.determineCurrentBranch()) {
+            "master" -> publishBranchStatus("master")
+            "release" -> publishBranchStatus("release")
+        }
+    }
+
+    private
+    fun publishBranchStatus(branch: String) {
+        project.execAndGetOutput("git", "tag", "-d", "green-$branch")
+        project.execAndGetOutputExpectingZeroCode("git", "tag", "green-$branch")
+        project.execAndGetOutputExpectingZeroCode("git", "push", "origin", "green-$branch")
+    }
+}

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/UpdateBranchStatus.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/UpdateBranchStatus.kt
@@ -37,8 +37,8 @@ open class UpdateBranchStatus : DefaultTask() {
 
     private
     fun publishBranchStatus(branch: String) {
-        project.execAndGetOutput("git", "tag", "-d", "green-$branch")
-        project.execAndGetOutputExpectingZeroCode("git", "tag", "green-$branch")
-        project.execAndGetOutputExpectingZeroCode("git", "push", "origin", "green-$branch")
+        project.execAndGetStdout("git", "tag", "-d", "green-$branch")
+        project.execAndGetStdout("git", "tag", "green-$branch")
+        project.execAndGetStdout("git", "push", "origin", "green-$branch")
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/1398

This PR sets up a "green status" for master/release branch,
which can be used by user to checkout new branches.