### PR TITLE
Fix discovery of components without metadata in repositories

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -36,7 +36,7 @@ import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +49,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     private ImmutableAttributesFactory attributesFactory;
     private NotationParser<Object, Capability> capabilityNotationParser;
     private DefaultExcludeRuleContainer excludeRuleContainer = new DefaultExcludeRuleContainer();
-    private Set<DependencyArtifact> artifacts = new HashSet<DependencyArtifact>();
+    private Set<DependencyArtifact> artifacts = new LinkedHashSet<>();
     private ImmutableActionSet<ModuleDependency> onMutate = ImmutableActionSet.empty();
     private AttributeContainerInternal attributes;
     private ModuleDependencyCapabilitiesInternal moduleDependencyCapabilities;
@@ -142,7 +142,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
 
     protected void copyTo(AbstractModuleDependency target) {
         super.copyTo(target);
-        target.setArtifacts(new HashSet<DependencyArtifact>(getArtifacts()));
+        target.setArtifacts(new LinkedHashSet<>(getArtifacts()));
         target.setExcludeRuleContainer(new DefaultExcludeRuleContainer(getExcludeRules()));
         target.setTransitive(isTransitive());
         if (attributes != null) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/ClientModuleDependencySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/ClientModuleDependencySpec.groovy
@@ -27,14 +27,14 @@ class ClientModuleDependencySpec extends AbstractModuleDependencySpec {
         new DefaultClientModule(group, name, version, configuration)
     }
 
-    def "equals but content not equal with different module dependencies"() {
+    def "not equal with different module dependencies"() {
         when:
         def dep1 = createDependency("group1", "name1", "version1", null)
         def dep2 = createDependency("group1", "name1", "version1", null)
         dep2.addDependency(Mock(ModuleDependency))
 
         then:
-        dep1 == dep2
+        dep1 != dep2
         !dep1.contentEquals(dep2)
         !dep2.contentEquals(dep1)
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifacts/DependencyArtifactsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/artifacts/DependencyArtifactsResolveIntegrationTest.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.artifacts
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+import spock.lang.Unroll
+
+/**
+ * There is more test coverage for 'dependency artifacts' in ArtifactDependenciesIntegrationTest (old test setup).
+ */
+@RequiredFeatures(
+    // This test bypasses all metadata using 'artifact()' metadata sources. It is sufficient to test with one metadata setup.
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+)
+class DependencyArtifactsResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        resolve.expectDefaultConfiguration(useMaven() ? 'runtime' : 'default')
+        buildFile << """
+            repositories.all {
+                metadataSources {
+                    artifact() //sss
+                }
+            }
+        """
+    }
+
+    def "can combine artifact notation and constraints"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                withModule {
+                    undeclaredArtifact(type: 'distribution-tgz')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo@distribution-tgz')
+              
+                constraints {
+                   conf('org:foo:1.0')
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectHeadArtifact(type: 'distribution-tgz') // test for the artifact when we would usually download metadata
+                expectHeadArtifact(type: 'distribution-tgz') // test for the artifact before actually retrieving it
+                expectGetArtifact(type: 'distribution-tgz')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:foo', 'org:foo:1.0') {
+                    artifact(type: 'distribution-tgz')
+                }
+                constraint('org:foo:1.0')
+            }
+        }
+    }
+
+    @Unroll
+    def "The first artifact is used as replacement for metadata if multiple artifacts are declared using #declaration"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                withModule {
+                    undeclaredArtifact(name: artifactName, type: 'distribution-tgz')
+                    undeclaredArtifact(name: artifactName, type: 'zip')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                $declaration
+                constraints {
+                   conf('org:foo:1.0')
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                (0..declarationCount).each {
+                    // These happen in parallel when Gradle downloads metadata.
+                    // In this cases "downloading metadata" means testing for the artifact.
+                    // Each declaration is treated separately with it's own "consumer provided" metadata
+                    expectHeadArtifact(name: artifactName, type: 'distribution-tgz')
+                }
+                expectGetArtifact(name: artifactName, type: 'distribution-tgz')
+                expectGetArtifact(name: artifactName, type: 'zip')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:foo', 'org:foo:1.0') {
+                    artifact(name: artifactName, type: 'distribution-tgz')
+                    artifact(name: artifactName, type: 'zip')
+                }
+                constraint('org:foo:1.0')
+            }
+        }
+
+        where:
+        notation                                               | artifactName | declarationCount | declaration
+        'multiple dependency declarations (AT notation)'       | 'foo'        | 2                | "conf('org:foo@distribution-tgz'); conf('org:foo@zip')"
+        'multiple dependency declarations (artifact notation)' | 'bar'        | 2                | "conf('org:foo') { artifact { name = 'bar'; type = 'distribution-tgz' } }; conf('org:foo') { artifact { name = 'bar'; type = 'zip' } }"
+        'multiple artifact declaration'                        | 'bar'        | 1                | "conf('org:foo') { artifact { name = 'bar'; type = 'distribution-tgz' }; artifact { name = 'bar'; type = 'zip' } }"
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
@@ -59,9 +59,8 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         when:
         repositoryInteractions {
             'org:foo:1.0' {
-                expectHeadArtifact(type: 'distribution-tgz') // test for the artifact when we would usually download metadata
-                expectHeadArtifact(type: 'distribution-tgz') // test for the artifact before actually retrieving it
-                expectGetArtifact(type: 'distribution-tgz')
+                // expectHeadArtifact(type: 'distribution-tgz') <- head request can happen once or twice depending on timing
+                maybeHeadOrGetArtifact(type: 'distribution-tgz')
             }
         }
         succeeds 'checkDeps'

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -49,7 +49,7 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     }
 
     protected boolean isContentEqualsFor(ExternalModuleDependency dependencyRhs) {
-        if (!isKeyEquals(dependencyRhs) || !isCommonContentEquals(dependencyRhs)) {
+        if (!isCommonContentEquals(dependencyRhs)) {
             return false;
         }
         return force == dependencyRhs.isForce() && changing == dependencyRhs.isChanging();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
@@ -73,6 +73,11 @@ public class DefaultClientModule extends AbstractExternalModuleDependency implem
     }
 
     @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
     public boolean contentEquals(Dependency dependency) {
         if (this == dependency) {
             return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultClientModule.java
@@ -65,6 +65,14 @@ public class DefaultClientModule extends AbstractExternalModuleDependency implem
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Dependency)) {
+            return false;
+        }
+        return contentEquals((Dependency) o);
+    }
+
+    @Override
     public boolean contentEquals(Dependency dependency) {
         if (this == dependency) {
             return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -41,6 +41,7 @@ import org.gradle.internal.component.external.model.ModuleComponentResolveMetada
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.RejectedByAttributesVersion;
@@ -477,7 +478,8 @@ public class DynamicVersionResolver {
 
         private void process(ModuleComponentRepositoryAccess access, DefaultBuildableModuleComponentMetaDataResolveResult result) {
             DependencyMetadata dependency = dependencyMetadata.withRequestedVersion(new DefaultImmutableVersionConstraint(version.getSource()));
-            access.resolveComponentMetaData(identifier, DefaultComponentOverrideMetadata.forDependency(dependency), result);
+            IvyArtifactName firstArtifact = dependency.getArtifacts().isEmpty() ? null : dependency.getArtifacts().get(0);
+            access.resolveComponentMetaData(identifier, DefaultComponentOverrideMetadata.forDependency(dependency, firstArtifact), result);
             attemptCollector.execute(result);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -479,7 +479,7 @@ public class DynamicVersionResolver {
         private void process(ModuleComponentRepositoryAccess access, DefaultBuildableModuleComponentMetaDataResolveResult result) {
             DependencyMetadata dependency = dependencyMetadata.withRequestedVersion(new DefaultImmutableVersionConstraint(version.getSource()));
             IvyArtifactName firstArtifact = dependency.getArtifacts().isEmpty() ? null : dependency.getArtifacts().get(0);
-            access.resolveComponentMetaData(identifier, DefaultComponentOverrideMetadata.forDependency(dependency, firstArtifact), result);
+            access.resolveComponentMetaData(identifier, DefaultComponentOverrideMetadata.forDependency(dependency.isChanging(), firstArtifact, DefaultComponentOverrideMetadata.extractClientModule(dependency)), result);
             attemptCollector.execute(result);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -19,7 +19,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StringVersioned;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.VirtualPlatformState;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 
@@ -30,8 +29,6 @@ public interface ComponentResolutionState extends StringVersioned {
     ComponentIdentifier getComponentId();
 
     ModuleVersionIdentifier getId();
-
-    void selectedBy(ResolvableSelectorState selectorState);
 
     /**
      * Returns the meta-data for the component. Resolves if not already resolved.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -184,7 +184,10 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
         ComponentOverrideMetadata componentOverrideMetadata;
         if (selectors != null && selectors.size() > 0) {
-            componentOverrideMetadata = DefaultComponentOverrideMetadata.forDependency(selectors.first().getDependencyMetadata(), selectors.getFirstDependencyArtifact());
+            // Taking the first selector here to determine the 'changing' status and 'client module' is our best bet to get the selector that will most likely be chosen in the end.
+            // As selectors are sorted accordingly (see ModuleSelectors.SELECTOR_COMPARATOR).
+            SelectorState firstSelector = selectors.first();
+            componentOverrideMetadata = DefaultComponentOverrideMetadata.forDependency(firstSelector.isChanging(), selectors.getFirstDependencyArtifact(), firstSelector.getClientModule());
         } else {
             componentOverrideMetadata = DefaultComponentOverrideMetadata.EMPTY;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -370,6 +370,7 @@ class ModuleResolveState implements CandidateModule {
             return false;
         }
         ComponentState newSelected = selectorStateResolver.selectBest(getId(), selectors);
+        newSelected.setSelectors(selectors);
         if (selected == null) {
             select(newSelected);
             return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.internal.Cast;
+import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -171,5 +172,14 @@ public class ModuleSelectors<T extends ResolvableSelectorState> implements Itera
             return selectors.get(0);
         }
         return selectors.get(0);
+    }
+
+    public IvyArtifactName getFirstDependencyArtifact() {
+        for (T selector: selectors) {
+            if (selector.getFirstDependencyArtifact() != null) {
+                return selector.getFirstDependencyArtifact();
+            }
+        }
+        return null;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
@@ -54,8 +54,6 @@ class PotentialEdge {
         edge.computeSelector();
         ModuleVersionIdentifier toModuleVersionId = DefaultModuleVersionIdentifier.newId(toSelector.getModuleIdentifier(), toSelector.getVersion());
         ComponentState version = resolveState.getModule(toSelector.getModuleIdentifier()).getVersion(toModuleVersionId, toComponent);
-        SelectorState selector = edge.getSelector();
-        version.selectedBy(selector);
         // We need to check if the target version exists. For this, we have to try to get metadata for the aligned version.
         // If it's there, it means we can align, otherwise, we must NOT add the edge, or resolution would fail
         ComponentResolveMetadata metadata = version.getMetadata();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleIdentifier;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -78,7 +78,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private boolean softForced;
     private boolean fromLock;
 
-    // The following state needs to be tracked to consistently construct `` independent of the order dependencies are vistited
+    // The following state needs to be tracked to consistently construct `ComponentOverrideMetadata` independent of the order dependencies are visited
     private IvyArtifactName firstDependencyArtifact;
     private ClientModule clientModule;
     private boolean changing;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -372,7 +372,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
             }
         }
         ClientModule nextClientModule = DefaultComponentOverrideMetadata.extractClientModule(dependencyState.getDependency());
-        if (nextClientModule != null) {
+        if (nextClientModule != null && !nextClientModule.equals(clientModule)) {
             if (clientModule == null) {
                 clientModule = nextClientModule;
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -59,7 +59,6 @@ import java.util.List;
 class SelectorState implements DependencyGraphSelector, ResolvableSelectorState {
     private final Long id;
     private final DependencyState dependencyState;
-    private final DependencyMetadata firstSeenDependency;
     private final DependencyToComponentIdResolver resolver;
     private final ResolvedVersionConstraint versionConstraint;
     private final List<ComponentSelectionDescriptorInternal> dependencyReasons = Lists.newArrayListWithExpectedSize(4);
@@ -92,10 +91,9 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         }
         update(dependencyState);
         this.dependencyState = dependencyState;
-        this.firstSeenDependency = dependencyState.getDependency();
         this.versionConstraint = versionByAncestor ?
             resolveState.resolveVersionConstraint(DefaultImmutableVersionConstraint.of()) :
-            resolveState.resolveVersionConstraint(firstSeenDependency.getSelector());
+            resolveState.resolveVersionConstraint(dependencyState.getDependency().getSelector());
         this.isProjectSelector = getSelector() instanceof ProjectComponentSelector;
         this.attributeDesugaring = resolveState.getAttributeDesugaring();
     }
@@ -133,7 +131,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
     @Override
     public String toString() {
-        return firstSeenDependency.toString();
+        return dependencyState.getDependency().toString();
     }
 
     @Override
@@ -181,7 +179,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
             if (dependencyState.failure != null) {
                 idResolveResult.failed(dependencyState.failure);
             } else {
-                resolver.resolve(firstSeenDependency, selector, rejector, idResolveResult);
+                resolver.resolve(dependencyState.getDependency(), selector, rejector, idResolveResult);
             }
 
             if (idResolveResult.getFailure() != null) {
@@ -291,7 +289,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     public DependencyMetadata getDependencyMetadata() {
-        return firstSeenDependency;
+        return dependencyState.getDependency();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleIdentifier;
@@ -33,6 +34,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.RejectedByAttributesVersion;
@@ -73,6 +75,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private boolean forced;
     private boolean softForced;
     private boolean fromLock;
+    private IvyArtifactName firstDependencyArtifact;
 
     // An internal counter used to track the number of outgoing edges
     // that use this selector. Since a module resolve state tracks all selectors
@@ -293,6 +296,11 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     @Override
+    public IvyArtifactName getFirstDependencyArtifact() {
+        return firstDependencyArtifact;
+    }
+
+    @Override
     public ResolvedVersionConstraint getVersionConstraint() {
         return versionConstraint;
     }
@@ -336,6 +344,12 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
                 resolved = false; // when a selector changes from non lock to lock, we must reselect
             }
             dependencyState.addSelectionReasons(dependencyReasons);
+            if (firstDependencyArtifact == null) {
+                List<IvyArtifactName> artifacts = dependencyState.getDependency().getArtifacts();
+                if (!artifacts.isEmpty()) {
+                    firstDependencyArtifact = artifacts.get(0);
+                }
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.gradle.api.Describable;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
@@ -32,6 +34,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
+import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.logging.text.TreeFormatter;
@@ -74,7 +77,11 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private boolean forced;
     private boolean softForced;
     private boolean fromLock;
+
+    // The following state needs to be tracked to consistently construct `` independent of the order dependencies are vistited
     private IvyArtifactName firstDependencyArtifact;
+    private ClientModule clientModule;
+    private boolean changing;
 
     // An internal counter used to track the number of outgoing edges
     // that use this selector. Since a module resolve state tracks all selectors
@@ -300,6 +307,16 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     @Override
+    public ClientModule getClientModule() {
+        return clientModule;
+    }
+
+    @Override
+    public boolean isChanging() {
+        return changing;
+    }
+
+    @Override
     public ResolvedVersionConstraint getVersionConstraint() {
         return versionConstraint;
     }
@@ -343,13 +360,26 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
                 resolved = false; // when a selector changes from non lock to lock, we must reselect
             }
             dependencyState.addSelectionReasons(dependencyReasons);
-            if (firstDependencyArtifact == null) {
-                List<IvyArtifactName> artifacts = dependencyState.getDependency().getArtifacts();
-                if (!artifacts.isEmpty()) {
-                    firstDependencyArtifact = artifacts.get(0);
-                }
+            trackDetailsForOverrideMetadata(dependencyState);
+        }
+    }
+
+    private void trackDetailsForOverrideMetadata(DependencyState dependencyState) {
+        if (firstDependencyArtifact == null) {
+            List<IvyArtifactName> artifacts = dependencyState.getDependency().getArtifacts();
+            if (!artifacts.isEmpty()) {
+                firstDependencyArtifact = artifacts.get(0);
             }
         }
+        ClientModule nextClientModule = DefaultComponentOverrideMetadata.extractClientModule(dependencyState.getDependency());
+        if (nextClientModule != null) {
+            if (clientModule == null) {
+                clientModule = nextClientModule;
+            } else {
+                throw new InvalidUserDataException(dependencyState.getDependency().getSelector().getDisplayName() + " has more than one client module definitions.");
+            }
+        }
+        changing = changing || dependencyState.getDependency().isChanging();
     }
 
     private class UnmatchedVersionsReason implements Describable {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
 
+import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
@@ -68,6 +69,10 @@ public interface ResolvableSelectorState {
     boolean hasStrongOpinion();
 
     IvyArtifactName getFirstDependencyArtifact();
+
+    ClientModule getClientModule();
+
+    boolean isChanging();
 
     default boolean isProject() {
         return getSelector() instanceof ProjectComponentSelector;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
+import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 
@@ -65,6 +66,8 @@ public interface ResolvableSelectorState {
     boolean isFromLock();
 
     boolean hasStrongOpinion();
+
+    IvyArtifactName getFirstDependencyArtifact();
 
     default boolean isProject() {
         return getSelector() instanceof ProjectComponentSelector;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -107,7 +107,6 @@ class SelectorStateResolverResults {
 
     public static <T extends ComponentResolutionState> T componentForIdResolveResult(ComponentStateFactory<T> componentFactory, ComponentIdResolveResult idResolveResult, ResolvableSelectorState selector) {
         T component = componentFactory.getRevision(idResolveResult.getId(), idResolveResult.getModuleVersionId(), idResolveResult.getMetadata());
-        component.selectedBy(selector);
         if (idResolveResult.isRejected()) {
             component.reject();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -169,7 +169,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
 
     private ComponentArtifactsResult buildComponentResult(ComponentIdentifier componentId, ComponentMetaDataResolver componentMetaDataResolver, ArtifactResolver artifactResolver) {
         BuildableComponentResolveResult moduleResolveResult = new DefaultBuildableComponentResolveResult();
-        componentMetaDataResolver.resolve(componentId, new DefaultComponentOverrideMetadata(), moduleResolveResult);
+        componentMetaDataResolver.resolve(componentId, DefaultComponentOverrideMetadata.EMPTY, moduleResolveResult);
         ComponentResolveMetadata component = moduleResolveResult.getMetadata();
         DefaultComponentArtifactsResult componentResult = new DefaultComponentArtifactsResult(component.getId());
         for (Class<? extends Artifact> artifactType : artifactTypes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
@@ -68,7 +68,7 @@ public class ExternalResourceResolverDescriptorParseContext implements Descripto
     private File resolveMetaDataArtifactFile(ModuleComponentIdentifier moduleComponentIdentifier, ComponentMetaDataResolver componentResolver,
                                              ArtifactResolver artifactResolver, ArtifactType artifactType) {
         BuildableComponentResolveResult moduleVersionResolveResult = new DefaultBuildableComponentResolveResult();
-        componentResolver.resolve(moduleComponentIdentifier, new DefaultComponentOverrideMetadata(), moduleVersionResolveResult);
+        componentResolver.resolve(moduleComponentIdentifier, DefaultComponentOverrideMetadata.EMPTY, moduleVersionResolveResult);
 
         BuildableArtifactSetResolveResult moduleArtifactsResolveResult = new DefaultBuildableArtifactSetResolveResult();
         artifactResolver.resolveArtifactsWithType(moduleVersionResolveResult.getMetadata(), artifactType, moduleArtifactsResolveResult);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
@@ -25,23 +25,23 @@ import java.util.Collections;
 import java.util.List;
 
 public class DefaultComponentOverrideMetadata implements ComponentOverrideMetadata {
-    public static final ComponentOverrideMetadata EMPTY = new DefaultComponentOverrideMetadata();
+    public static final ComponentOverrideMetadata EMPTY = new DefaultComponentOverrideMetadata(false, (IvyArtifactName) null, null);
 
     private final boolean changing;
     private final List<IvyArtifactName> artifacts;
     private final ClientModule clientModule;
 
-    public static ComponentOverrideMetadata forDependency(DependencyMetadata dependencyMetadata) {
-        return new DefaultComponentOverrideMetadata(dependencyMetadata.isChanging(), dependencyMetadata.getArtifacts(), extractClientModule(dependencyMetadata));
+    public static ComponentOverrideMetadata forDependency(DependencyMetadata dependencyMetadata, IvyArtifactName mainArtifact) {
+        return new DefaultComponentOverrideMetadata(dependencyMetadata.isChanging(), mainArtifact, extractClientModule(dependencyMetadata));
     }
 
-    private DefaultComponentOverrideMetadata() {
-        this(false, Collections.emptyList(), null);
+    private DefaultComponentOverrideMetadata(boolean changing, IvyArtifactName artifact, ClientModule clientModule) {
+        this(changing, artifact == null ? Collections.emptyList() : ImmutableList.of(artifact), clientModule);
     }
 
     private DefaultComponentOverrideMetadata(boolean changing, List<IvyArtifactName> artifacts, ClientModule clientModule) {
         this.changing = changing;
-        this.artifacts = ImmutableList.copyOf(artifacts);
+        this.artifacts = artifacts;
         this.clientModule = clientModule;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class DefaultComponentOverrideMetadata implements ComponentOverrideMetadata {
+    public static final ComponentOverrideMetadata EMPTY = new DefaultComponentOverrideMetadata();
+
     private final boolean changing;
     private final List<IvyArtifactName> artifacts;
     private final ClientModule clientModule;
@@ -33,8 +35,8 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
         return new DefaultComponentOverrideMetadata(dependencyMetadata.isChanging(), dependencyMetadata.getArtifacts(), extractClientModule(dependencyMetadata));
     }
 
-    public DefaultComponentOverrideMetadata() {
-        this(false, Collections.<IvyArtifactName>emptyList(), null);
+    private DefaultComponentOverrideMetadata() {
+        this(false, Collections.emptyList(), null);
     }
 
     private DefaultComponentOverrideMetadata(boolean changing, List<IvyArtifactName> artifacts, ClientModule clientModule) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
@@ -31,8 +31,11 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
     private final List<IvyArtifactName> artifacts;
     private final ClientModule clientModule;
 
-    public static ComponentOverrideMetadata forDependency(DependencyMetadata dependencyMetadata, IvyArtifactName mainArtifact) {
-        return new DefaultComponentOverrideMetadata(dependencyMetadata.isChanging(), mainArtifact, extractClientModule(dependencyMetadata));
+    public static ComponentOverrideMetadata forDependency(boolean changing, IvyArtifactName mainArtifact, ClientModule clientModule) {
+        if (!changing && mainArtifact == null && clientModule == null) {
+            return EMPTY;
+        }
+        return new DefaultComponentOverrideMetadata(changing, mainArtifact, clientModule);
     }
 
     private DefaultComponentOverrideMetadata(boolean changing, IvyArtifactName artifact, ClientModule clientModule) {
@@ -45,7 +48,7 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
         this.clientModule = clientModule;
     }
 
-    private static ClientModule extractClientModule(DependencyMetadata dependencyMetadata) {
+    public static ClientModule extractClientModule(DependencyMetadata dependencyMetadata) {
         if (dependencyMetadata instanceof DslOriginDependencyMetadata) {
             Dependency source = ((DslOriginDependencyMetadata) dependencyMetadata).getSource();
             if (source instanceof ClientModule) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -96,7 +96,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private static List<IvyArtifactName> asImmutable(List<IvyArtifactName> artifactNames) {
-        return artifactNames.isEmpty() ? Collections.emptyList() : ImmutableList.copyOf(artifactNames);
+        return artifactNames.isEmpty() ? Collections.emptyList() : artifactNames instanceof ImmutableList ? artifactNames : ImmutableList.copyOf(artifactNames);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
@@ -71,7 +71,7 @@ class ProjectDependencyResolverTest extends Specification {
         def projectComponentId = newProjectId(":projectPath")
 
         when:
-        resolver.resolve(projectComponentId, new DefaultComponentOverrideMetadata(), result)
+        resolver.resolve(projectComponentId, DefaultComponentOverrideMetadata.EMPTY, result)
 
         then:
         1 * registry.getComponent(projectComponentId) >> componentMetaData

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.VirtualPlatformState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictResolverDetails
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.model.ComponentResolveMetadata
@@ -122,11 +121,6 @@ abstract class AbstractConflictResolverTest extends Specification {
         }
 
         String toString() { id }
-
-        @Override
-        void selectedBy(ResolvableSelectorState selectorState) {
-
-        }
 
         @Override
         Set<VirtualPlatformState> getPlatformOwners() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
@@ -57,11 +57,6 @@ public class TestComponentResolutionState implements ComponentResolutionState {
         return id;
     }
 
-    @Override
-    public void selectedBy(ResolvableSelectorState selectorState) {
-
-    }
-
     @Nullable
     @Override
     public ComponentResolveMetadata getMetadata() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -31,9 +31,6 @@ import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult;
 
-import java.util.Collections;
-import java.util.List;
-
 public class TestModuleSelectorState implements ResolvableSelectorState {
 
     private static final VersionParser VERSION_PARSER = new VersionParser();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors;
 
+import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
@@ -122,5 +123,15 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
     @Override
     public IvyArtifactName getFirstDependencyArtifact() {
         return null;
+    }
+
+    @Override
+    public ClientModule getClientModule() {
+        return null;
+    }
+
+    @Override
+    public boolean isChanging() {
+        return false;
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -24,11 +24,15 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult;
+
+import java.util.Collections;
+import java.util.List;
 
 public class TestModuleSelectorState implements ResolvableSelectorState {
 
@@ -116,5 +120,10 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
     @Override
     public boolean hasStrongOpinion() {
         return false;
+    }
+
+    @Override
+    public IvyArtifactName getFirstDependencyArtifact() {
+        return null;
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
+import org.gradle.internal.component.model.IvyArtifactName
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.result.ComponentIdResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult
@@ -59,16 +60,16 @@ class TestProjectSelectorState implements ResolvableSelectorState {
 
     @Override
     void failed(ModuleVersionResolveException failure) {
-        throw new UnsupportedOperationException("To be implemented");
+        throw new UnsupportedOperationException("To be implemented")
     }
 
     @Override
-    public void markResolved() {
+    void markResolved() {
     }
 
     @Override
-    public boolean isForce() {
-        return false;
+    boolean isForce() {
+        return false
     }
 
     @Override
@@ -84,6 +85,11 @@ class TestProjectSelectorState implements ResolvableSelectorState {
     @Override
     boolean hasStrongOpinion() {
         return false
+    }
+
+    @Override
+    IvyArtifactName getFirstDependencyArtifact() {
+        return null
     }
 }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors
 
+import org.gradle.api.artifacts.ClientModule
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
@@ -90,6 +91,16 @@ class TestProjectSelectorState implements ResolvableSelectorState {
     @Override
     IvyArtifactName getFirstDependencyArtifact() {
         return null
+    }
+
+    @Override
+    ClientModule getClientModule() {
+        return null
+    }
+
+    @Override
+    boolean isChanging() {
+        return false
     }
 }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -75,7 +75,7 @@ class IvyResolverTest extends Specification {
     @Unroll
     def "remote access fails directly for module id #moduleId with layout #layoutPattern"() {
         given:
-        def overrideMetadata = new DefaultComponentOverrideMetadata()
+        def overrideMetadata = DefaultComponentOverrideMetadata.EMPTY
         def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
 
         when:
@@ -105,7 +105,7 @@ class IvyResolverTest extends Specification {
     @Unroll
     def "remote access attempts to access metadata for id #moduleId with layout #layoutPattern"() {
         given:
-        def overrideMetadata = new DefaultComponentOverrideMetadata()
+        def overrideMetadata = DefaultComponentOverrideMetadata.EMPTY
         def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
 
         when:

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -105,6 +105,10 @@ class ModuleVersionSpec {
         expectGetArtifact << new ArtifactExpectation(InteractionExpectation.HEAD_MISSING, artifact)
     }
 
+    void maybeHeadOrGetArtifact(Map<String, String> artifact) {
+        expectGetArtifact << new ArtifactExpectation(InteractionExpectation.MAYBE, artifact)
+    }
+
     void maybeGetMetadata() {
         expectGetMetadata << InteractionExpectation.MAYBE
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -421,12 +421,13 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     ModuleArtifact getArtifact(Map<String, ?> options) {
         def artifact = toArtifact(options)
         def suffix = (artifact.classifier ? "-${artifact.classifier}" : "") + (artifact.type ? ".${artifact.type}" : "")
+        def artifactName = artifact.name ? artifact.name : artifactId
         return new ModuleArtifact() {
             String getFileName() {
                 if (version.endsWith("-SNAPSHOT") && !metaDataFile.exists() && uniqueSnapshots) {
-                    return "${artifactId}-${version}${suffix}"
+                    return "${artifactName}-${version}${suffix}"
                 } else {
-                    return "$artifactId-${publishArtifactVersion}${suffix}"
+                    return "$artifactName-${publishArtifactVersion}${suffix}"
                 }
             }
 
@@ -450,7 +451,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
     protected Map<String, Object> toArtifact(Map<String, ?> options) {
         options = new HashMap<String, Object>(options)
-        def artifact = [type: options.containsKey('type') ? options.remove('type') : type, classifier: options.remove('classifier') ?: null]
+        def artifact = [type: options.containsKey('type') ? options.remove('type') : type, classifier: options.remove('classifier') ?: null, name: options.containsKey('name') ? options.remove('name') : null]
         assert options.isEmpty(): "Unknown options : ${options.keySet()}"
         return artifact
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/ExpectOne.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/ExpectOne.groovy
@@ -16,8 +16,14 @@
 
 package org.gradle.test.fixtures.server
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 abstract class ExpectOne implements ServerExpectation {
-    boolean run
+    AtomicBoolean atomicRun = new AtomicBoolean()
+
+    boolean isRun() {
+        return atomicRun.get()
+    }
 
     void assertMet() {
         if (!run) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -624,10 +624,9 @@ class HttpServer extends ServerWithExpectations implements HttpServerFixture {
         expectations << expectation
         add(path, matchPrefix, methods, new AbstractHandler() {
             void handle(String target, HttpServletRequest request, HttpServletResponse response, int dispatch) {
-                if (expectation.run) {
+                if (expectation.atomicRun.getAndSet(true)) {
                     return
                 }
-                expectation.run = true
                 action.handle(request, response)
                 request.handled = true
             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/sftp/SFTPServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/sftp/SFTPServer.groovy
@@ -382,7 +382,7 @@ class SFTPServer extends ServerWithExpectations implements RepositoryServer {
         boolean matches(Buffer buffer, int type, int id) {
             if (!run && type == expectedType) {
                 int originalBufferPosition = buffer.rpos()
-                run = bufferMatches(buffer, id)
+                atomicRun.set(bufferMatches(buffer, id))
                 buffer.rpos(originalBufferPosition)
                 return run
             } else {

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/fixtures/GcsServer.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/fixtures/GcsServer.groovy
@@ -456,7 +456,7 @@ class GcsServer extends HttpServer implements RepositoryServer {
                         return
                     }
                     if (!((Request) request).isHandled()) {
-                        expectation.run = true
+                        expectation.atomicRun.set(true)
                         action.handle(request, response)
                         ((Request) request).setHandled(true)
                     }

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/S3Server.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/S3Server.groovy
@@ -480,7 +480,7 @@ class S3Server extends HttpServer implements RepositoryServer {
                         return
                     }
                     if (!((Request) request).isHandled()) {
-                        expectation.run = true
+                        expectation.atomicRun.set(true)
                         action.handle(request, response)
                         ((Request) request).setHandled(true)
                     }


### PR DESCRIPTION
For components without metadata (_metadataSource = artifact_), we need to HEAD an artifact to check if a component exists in a repository. This is done in the metadata download phase in resolution (instead of actually downloading a metadata file).

For this to work consistently, information about _dependency artifacts_ needs to be preserved when we construct the so called `ComponentOverrideMetadata`. However, there can be multiple dependencies (or dependency constraints) declarations with different _dependency artifact_ information. We basically always took the first definition we found. However, this does not work, if the first definition does **not**  define an artifact at all (which is always true for dependency constraints). So it never worked for all cases. Recent changes in _selector sorting_ (8eb2d60dd9381720e4b95025e88a5eeffa81ef30 of #9307 and probably others) have lead to changes in the ordering and now some cases that worked before do not work anymore (#10948).

This PR fixes the issue in general by tracking the first found artifact across all sectors for a module instead of just tracking the first selector.

**Note:** these changes are only necessary to fix the discovery of components in repositories. The actual retrieving of artifact is done later after resolution. This works (and worked before): All artifacts are retrieved or, if one is missing, an error is thrown.  

_In addition to the changes required for artifact handling, this PR also improves the handling of 'client modules' and 'changing' status (the other details of ComponentOverrideMetadata)._