### PR TITLE
Allow to use registerFeature when there is no main SourceSet

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -10,6 +10,7 @@ Include only their name, impactful features should be called out separately belo
 
 [Mark Nordhoff](https://github.com/MarkNordhoff),
 [Kazuki Matsuda](https://github.com/kazuki-ma),
+[Emmanuel Guérin](https://github.com/emmanuelguerin),
 and [Nicholas Gates](https://github.com/gatesn).
 
 ## Features for Gradle tooling providers

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryFeatureCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryFeatureCompilationIntegrationTest.groovy
@@ -489,6 +489,48 @@ class JavaLibraryFeatureCompilationIntegrationTest extends AbstractIntegrationSp
         executedAndNotSkipped ':compileTestJava', ':test'
     }
 
+    @Issue("gradle/gradle#10999")
+    def "registerFeature can be used when there is no main SourceSet"() {
+        given:
+        buildFile << """
+            apply plugin: 'java-base'
+
+            sourceSets {
+               main211 {}
+               main212 {}
+            }
+            java {
+               registerFeature('scala211') {
+                  usingSourceSet(sourceSets.main211)
+               }
+               registerFeature('scala212') {
+                  usingSourceSet(sourceSets.main212)
+               }
+            }
+        """
+        file("src/main211/java/com/foo/Foo.java") << """
+            package com.foo;
+            public class Foo {
+                public void foo() {
+                }
+            }
+        """
+        file("src/main212/java/com/bar/Bar.java") << """
+            package com.bar;
+
+            public class Bar {
+                public void bar() {
+                }
+            }
+        """
+
+        when:
+        succeeds ':compileMain211Java', ':compileMain212Java'
+
+        then:
+        executedAndNotSkipped ':compileMain211Java', ':compileMain212Java'
+    }
+
     private void packagingTasks(boolean expectExecuted, String subproject, String feature = '') {
         def tasks = [":$subproject:process${feature.capitalize()}Resources", ":$subproject:${feature.isEmpty()? 'classes' : feature + 'Classes'}", ":$subproject:${feature.isEmpty()? 'jar' : feature + 'Jar'}"]
         if (expectExecuted) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -255,8 +255,7 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
     }
 
     private boolean isMainSourceSet(SourceSet sourceSet) {
-        SourceSet mainSourceSet = javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-        return mainSourceSet.equals(sourceSet);
+        return sourceSet.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME);
     }
 
 }


### PR DESCRIPTION


### Context
I'm developing a plugin for building and publishing scala libraries against multiple versions of scala.
I'm interested in producing one variant per scala version. I used to create the variants manually and decided to switch to using the releaseFeature helper.
But since I decided to not use the default "main" sourceSet, this use case doesn't work:
```
plugins {
   id "java-base"
}

sourceSets {
   main211 {}
   main212 {}
}

components.add(softwareFactory.adhoc("java"))

java {
   registerFeature('scala211') {
      usingSourceSet(sourceSets.main211)
   }
   registerFeature('scala212') {
      usingSourceSet(sourceSets.main212)
   }
}
```
With this PR, the registerFeature help no longer requires a main sourceset to be present.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
