### PR TITLE
Include version constraint comparison in equals() check of dependency

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dependencies;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
@@ -52,7 +53,8 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
         if (!isKeyEquals(dependencyRhs) || !isCommonContentEquals(dependencyRhs)) {
             return false;
         }
-        return force == dependencyRhs.isForce() && changing == dependencyRhs.isChanging();
+        return force == dependencyRhs.isForce() && changing == dependencyRhs.isChanging() &&
+            Objects.equal(getVersionConstraint(), dependencyRhs.getVersionConstraint());
     }
 
     @Override


### PR DESCRIPTION
The version constraint was ignored when comparing two dependency
declarations. This can lead to dropping dependency declarations for
the same module with the same required version, even if other version
constraint details differ.

This fixes the issue described here: https://github.com/gradle/gradle/issues/10533#issuecomment-531169253
