### PR TITLE
Relocatable metadata cache

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/CacheResolveIntegrationTest.groovy
@@ -15,12 +15,16 @@
  */
 package org.gradle.integtests.resolve
 
+import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
+import org.gradle.cache.internal.DefaultCacheScopeMapping
 import org.gradle.integtests.fixtures.cache.CachingIntegrationFixture
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 
-public class CacheResolveIntegrationTest extends AbstractHttpDependencyResolutionTest implements CachingIntegrationFixture {
+import java.nio.file.Files
 
-    public void "cache handles manual deletion of cached artifacts"() {
+class CacheResolveIntegrationTest extends AbstractHttpDependencyResolutionTest implements CachingIntegrationFixture {
+
+    void "cache handles manual deletion of cached artifacts"() {
         given:
         def module = ivyHttpRepo.module('group', 'projectA', '1.2').publish()
 
@@ -59,7 +63,7 @@ task deleteCacheFiles(type: Delete) {
         succeeds('listJars')
     }
 
-    public void "cache entries are segregated between different repositories"() {
+    void "cache entries are segregated between different repositories"() {
         given:
         def repo1 = ivyHttpRepo('ivy-repo-a')
         def module1 = repo1.module('org.gradle', 'testproject', '1.0').publish()
@@ -111,5 +115,45 @@ project('b') {
         and:
         file('a/build/testproject-1.0.jar').assertIsCopyOf(module1.jarFile)
         file('b/build/testproject-1.0.jar').assertIsCopyOf(module2.jarFile)
+    }
+
+    def 'dependency cache can be relocated'() {
+        given:
+        def module = ivyHttpRepo.module('group', 'projectA', '1.2').publish()
+
+        and:
+        buildFile << """
+repositories {
+    ivy { url "${ivyHttpRepo.uri}" }
+}
+configurations { compile }
+dependencies { compile 'group:projectA:1.2' }
+task listJars {
+    doLast {
+        assert configurations.compile.collect { it.name } == ['projectA-1.2.jar']
+    }
+}
+"""
+
+        and:
+        module.allowAll()
+
+        and:
+        succeeds('listJars')
+
+        when:
+        server.resetExpectations()
+        relocateCachesAndChangeGradleHome()
+
+        then:
+        succeeds('listJars')
+    }
+
+    def relocateCachesAndChangeGradleHome() {
+        def otherHome = executer.gradleUserHomeDir.parentFile.createDir('other-home')
+        def otherCacheDir = otherHome.toPath().resolve(DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME)
+        Files.createDirectory(otherCacheDir)
+        Files.move(getMetadataCacheDir().toPath(), otherCacheDir.resolve(CacheLayout.ROOT.key))
+        executer.withGradleUserHomeDir(otherHome)
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -217,7 +217,8 @@ class DependencyManagementBuildScopeServices {
                 "module-artifact",
                 timeProvider,
                 artifactCacheLockingManager,
-                artifactIdentifierFileStore.getFileAccessTracker()
+                artifactIdentifierFileStore.getFileAccessTracker(),
+                artifactCacheMetadata.getCacheDir().toPath()
             ))
         );
         ModuleRepositoryCaches inMemoryCaches = new ModuleRepositoryCaches(
@@ -229,12 +230,13 @@ class DependencyManagementBuildScopeServices {
         return new ModuleRepositoryCacheProvider(caches, inMemoryCaches);
     }
 
-    ByUrlCachedExternalResourceIndex createArtifactUrlCachedResolutionIndex(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ExternalResourceFileStore externalResourceFileStore) {
+    ByUrlCachedExternalResourceIndex createArtifactUrlCachedResolutionIndex(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ExternalResourceFileStore externalResourceFileStore, ArtifactCacheMetadata artifactCacheMetadata) {
         return new ByUrlCachedExternalResourceIndex(
             "resource-at-url",
             timeProvider,
             artifactCacheLockingManager,
-            externalResourceFileStore.getFileAccessTracker()
+            externalResourceFileStore.getFileAccessTracker(),
+            artifactCacheMetadata.getCacheDir().toPath()
         );
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -56,6 +56,7 @@ public enum CacheLayout {
         .changedTo(71, "5.3-rc-1")
         .changedTo(79, "6.0-rc-1")
         .changedTo(82, "6.0-rc-2")
+        .changedTo(90, "6.1-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManager.java
@@ -98,7 +98,7 @@ public class DefaultArtifactCacheLockingManager implements ArtifactCacheLockingM
     public <K, V> PersistentIndexedCache<K, V> createCache(String cacheName, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         String cacheFileInMetaDataStore = CacheLayout.META_DATA.getKey() + "/" + cacheName;
         final PersistentIndexedCache<K, V> persistentCache = cache.createCache(PersistentIndexedCacheParameters.of(cacheFileInMetaDataStore, keySerializer, valueSerializer));
-        return new CacheLockingPersistentCache<K, V>(persistentCache);
+        return new CacheLockingPersistentCache<>(persistentCache);
     }
 
     private class CacheLockingPersistentCache<K, V> implements PersistentIndexedCache<K, V> {
@@ -111,42 +111,22 @@ public class DefaultArtifactCacheLockingManager implements ArtifactCacheLockingM
         @Nullable
         @Override
         public V get(final K key) {
-            return cache.useCache(new Factory<V>() {
-                @Override
-                public V create() {
-                    return persistentCache.get(key);
-                }
-            });
+            return cache.useCache(() -> persistentCache.get(key));
         }
 
         @Override
         public V get(final K key, final Transformer<? extends V, ? super K> producer) {
-            return cache.useCache(new Factory<V>() {
-                @Override
-                public V create() {
-                    return persistentCache.get(key, producer);
-                }
-            });
+            return cache.useCache(() -> persistentCache.get(key, producer));
         }
 
         @Override
         public void put(final K key, final V value) {
-            cache.useCache(new Runnable() {
-                @Override
-                public void run() {
-                    persistentCache.put(key, value);
-                }
-            });
+            cache.useCache(() -> persistentCache.put(key, value));
         }
 
         @Override
         public void remove(final K key) {
-            cache.useCache(new Runnable() {
-                @Override
-                public void run() {
-                    persistentCache.remove(key);
-                }
-            });
+            cache.useCache(() -> persistentCache.remove(key));
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCache.java
@@ -128,7 +128,7 @@ public class DefaultModuleArtifactCache extends AbstractCachedIndex<ArtifactAtRe
                 return new DefaultCachedArtifact(file, createTimestamp, hash);
             } else {
                 int size = decoder.readSmallInt();
-                List<String> attempted = new ArrayList<String>(size);
+                List<String> attempted = new ArrayList<>(size);
                 for (int i = 0; i < size; i++) {
                     attempted.add(decoder.readString());
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ByUrlCachedExternalResourceIndex.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ByUrlCachedExternalResourceIndex.java
@@ -21,8 +21,10 @@ import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.util.BuildCommencedTimeProvider;
 
+import java.nio.file.Path;
+
 public class ByUrlCachedExternalResourceIndex extends DefaultCachedExternalResourceIndex<String> {
-    public ByUrlCachedExternalResourceIndex(String persistentCacheFile, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, FileAccessTracker fileAccessTracker) {
-        super(persistentCacheFile, BaseSerializerFactory.STRING_SERIALIZER, timeProvider, artifactCacheLockingManager, fileAccessTracker);
+    public ByUrlCachedExternalResourceIndex(String persistentCacheFile, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, FileAccessTracker fileAccessTracker, Path commonRootPath) {
+        super(persistentCacheFile, BaseSerializerFactory.STRING_SERIALIZER, timeProvider, artifactCacheLockingManager, fileAccessTracker, commonRootPath);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 82
+        expectedVersion = 90
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
@@ -42,7 +42,7 @@ class DefaultArtifactResolutionCacheTest extends Specification {
     DefaultCachedExternalResourceIndex<String> index
 
     def setup() {
-        index = new DefaultCachedExternalResourceIndex("index", BaseSerializerFactory.STRING_SERIALIZER, timeProvider, cacheLockingManager, fileAccessTracker)
+        index = new DefaultCachedExternalResourceIndex("index", BaseSerializerFactory.STRING_SERIALIZER, timeProvider, cacheLockingManager, fileAccessTracker, tmp.testDirectory.toPath())
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndexTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndexTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.cached
+
+import org.gradle.internal.serialize.Decoder
+import org.gradle.internal.serialize.Encoder
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+class DefaultCachedExternalResourceIndexTest extends Specification {
+
+    @Rule TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider()
+
+    def commonPath = folder.createDir("common").toPath()
+
+    def "value serializer can relativize path"() {
+        given:
+        def serializer = new DefaultCachedExternalResourceIndex.CachedExternalResourceSerializer(commonPath)
+        def encoder = Mock(Encoder)
+        def value = Mock(CachedExternalResource)
+        def fileName = "file.txt"
+
+        when:
+        serializer.write(encoder, value)
+
+        then:
+        _ * value.getCachedFile() >> commonPath.resolve(fileName).toFile()
+
+        1 * encoder.writeString(fileName)
+    }
+
+    def "value serializer can expand relative path"() {
+        given:
+        def serializer = new DefaultCachedExternalResourceIndex.CachedExternalResourceSerializer(commonPath)
+        def decoder = Mock(Decoder)
+        def fileName = "file.txt"
+
+        when:
+        def result = serializer.read(decoder)
+
+        then:
+        1 * decoder.readBoolean() >> true
+        1 * decoder.readString() >> fileName
+        1 * decoder.readLong() >> 42L
+        1 * decoder.readBoolean() >> false
+
+        result.getCachedFile() == commonPath.resolve(fileName).toFile()
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -40,6 +40,16 @@ See the User Manual section on the “[Feature Lifecycle](userguide/feature_life
 
 The following are the features that have been promoted in this Gradle release.
 
+### Gradle Dependency Cache can be relocated
+
+With this release, the Gradle Dependency cache, that is the content under `$GRADLE_HOME/caches/modules-2`, can be relocated, for data cached by Gradle version 6.1 and later.
+This enables its copy from host to host, allowing to fully leverage all the cached information: artifacts downloaded and metadata parsed.
+
+Note that priming the cache and consuming it needs to use the same Gradle version for maximum effect.
+See [the documentation](userguide/dependency_resolution.html#sub:cache_copy) for details on this.
+
+This is one step in helping out ephemeral CI setups where host images can be seeded with dependency cache content, reducing the amout of downloads during the build.
+
 <!--
 ### Example promoted
 -->

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -227,6 +227,26 @@ Gradle keeps track of which artifacts in the dependency cache are accessed.
 Using this information, the cache is periodically (at most every 24 hours) scanned for artifacts that have not been used for more than 30 days.
 Obsolete artifacts are then deleted to ensure the cache does not grow indefinitely.
 
+[[sub:cache_copy]]
+==== Copy and reuse the cache
+
+As of Gradle 6.1, the dependency cache, both the file and metadata parts, are fully encoded using relative path.
+This means that it is perfectly possible to copy a cache around and see Gradle benefit from it.
+
+The path that can be copied is `$GRADLE_HOME/caches/modules-<version>`.
+The only constraint is placing it using the same structure at the destination, where the value of `GRADLE_HOME` can be different.
+
+Note that creating the cache and consuming it must be done using compatible Gradle version, as shown in the table below.
+If multiple incompatible Gradle versions are in play, all should be used when seeding the cache.
+
+.Dependency cache versions
+[%header%autowidth,compact]
+|===
+| Module cache version  | File cache version    | Metadata cache version    | Gradle version(s)
+
+| `modules-2`           | `files-2.1`           | `metadata-2.90`           | Gradle 6.1
+|===
+
 [[sec:programmatic_api]]
 == Accessing the resolution result programmatically
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/cache/CachingIntegrationFixture.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures.cache
 
 import groovy.transform.SelfType
+import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
 
@@ -26,5 +27,9 @@ import static org.gradle.cache.internal.DefaultCacheScopeMapping.GLOBAL_CACHE_DI
 trait CachingIntegrationFixture {
     TestFile getUserHomeCacheDir() {
         return executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME)
+    }
+
+    TestFile getMetadataCacheDir() {
+        return executer.gradleUserHomeDir.file(GLOBAL_CACHE_DIR_NAME).file(CacheLayout.ROOT.key)
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -114,7 +114,7 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         private final CacheBuilder.LockTarget lockTarget;
         private final LockOptions lockOptions;
         private final ReferencablePersistentCache cache;
-        private final Set<ReferenceTrackingCache> references = new HashSet<ReferenceTrackingCache>();
+        private final Set<ReferenceTrackingCache> references = new HashSet<>();
 
         DirCacheReference(ReferencablePersistentCache cache, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions) {
             this.cache = cache;


### PR DESCRIPTION
Reference to file are now relative to the root of the module cache
instead of being absolute.
This allows moving the full module cache around to be reused with
a different root path.
The path are also normalized, so that they are portable across systems
where the name separator changes.