### PR TITLE
Refactor performance baseline version selection

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -411,7 +411,7 @@ enum class PerformanceTestType(val taskId: String, val displayName: String, val 
     slow("SlowPerformanceTest", "Slow Performance Regression Test", 420, "defaults", uuid = "PerformanceExperimentCoordinator"),
     experiment("PerformanceExperiment", "Performance Experiment", 420, "defaults", uuid = "PerformanceExperimentOnlyCoordinator"),
     flakinessDetection("FlakinessDetection", "Performance Test Flakiness Detection", 600, "flakiness-detection-commit"),
-    historical("HistoricalPerformanceTest", "Historical Performance Test", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
+    historical("HistoricalPerformanceTest", "Historical Performance Test", 2280, "3.5.1,4.10.2,5.6.2,last", "--checks none");
 
     fun asId(model: CIBuildModel): String =
         "${model.projectPrefix}Performance${name.capitalize()}Coordinator"

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractCrossVersionPerformanceTestRunner.groovy
@@ -138,92 +138,90 @@ class AbstractCrossVersionPerformanceTestRunner extends PerformanceTestSpec {
         version.replace('+', '')
     }
 
+    static Object resolveVersion(String version, ReleasedVersionDistributions releases) {
+        switch (version) {
+            case GradleVersion.current().getBaseVersion().version:
+                // current version is run by default, skip adding it to baseline
+                return []
+            case 'last':
+                return releases.mostRecentRelease.version.version
+            case 'nightly':
+                return LatestNightlyBuildDeterminer.latestNightlyVersion
+            case 'defaults':
+                throw new IllegalArgumentException("'defaults' shouldn't be used in target versions.")
+            default:
+                def releasedVersion = findRelease(releases, version)
+                if (releasedVersion) {
+                    return releasedVersion.version.version
+                } else if (isRcVersionOrSnapshot(version)) {
+                    // for snapshots, we don't have a cheap way to check if it really exists, so we'll just
+                    // blindly add it to the list and trust the test author
+                    // Only active rc versions are listed in all-released-versions.properties that ReleasedVersionDistributions uses
+                    return version
+                } else {
+                    throw new RuntimeException("Cannot find Gradle release that matches version '$version'")
+                }
+        }
+    }
+
     static Iterable<String> toBaselineVersions(ReleasedVersionDistributions releases, List<String> targetVersions, String minimumBaseVersion) {
-        Iterable<String> versions
-        boolean addMostRecentRelease = true
+        List<String> versions
         def overrideBaselinesProperty = System.getProperty('org.gradle.performance.baselines')
         if (overrideBaselinesProperty) {
             versions = resolveOverriddenVersions(overrideBaselinesProperty, targetVersions)
-            addMostRecentRelease = false
         } else {
             versions = targetVersions
         }
 
-        def resultBaselineVersions = new LinkedHashSet<String>()
-
-        def mostRecentRelease = releases.mostRecentRelease.version.version
-        def currentBaseVersion = GradleVersion.current().getBaseVersion().version
-
-        for (String version : versions) {
-            if (version == currentBaseVersion) {
-                // current version is run by default, skip adding it to baseline
-                continue
-            }
-            if (version == 'last') {
-                addMostRecentRelease = false
-                resultBaselineVersions.add(mostRecentRelease)
-                continue
-            }
-            if (version == 'nightly') {
-                addMostRecentRelease = false
-                resultBaselineVersions.add(LatestNightlyBuildDeterminer.latestNightlyVersion)
-                continue
-            }
-            if (version == 'none') {
-                return Collections.emptyList()
-            }
-            if (version == 'defaults') {
-                throw new IllegalArgumentException("'defaults' shouldn't be used in target versions.")
-            }
-            def releasedVersion = findRelease(releases, version)
-            def versionObject = GradleVersion.version(version)
-            if (minimumBaseVersion != null && baseVersionLowerThanMinimunRequirement(versionObject, minimumBaseVersion)) {
-                //this version is not supported by this scenario, as it uses features not yet available in this version of Gradle
-                continue
-            }
-            if (releasedVersion) {
-                resultBaselineVersions.add(releasedVersion.version.version)
-            } else if (versionObject.snapshot || isRcVersion(versionObject)) {
-                // for snapshots, we don't have a cheap way to check if it really exists, so we'll just
-                // blindly add it to the list and trust the test author
-                // Only active rc versions are listed in all-released-versions.properties that ReleasedVersionDistributions uses
-                addMostRecentRelease = false
-                resultBaselineVersions.add(version)
-            } else {
-                throw new RuntimeException("Cannot find Gradle release that matches version '$version'")
-            }
+        if (versions.contains("none")) {
+            return []
         }
 
-        if (allBaselineVersionsAreFiltered(resultBaselineVersions, versions, minimumBaseVersion)) {
-            throw new RuntimeException("All versions are filtered out by minimumBaseVersion!")
-        }
+        LinkedHashSet<String> resolvedVersions = versions.collect { resolveVersion(it, releases) }.flatten() as LinkedHashSet<String>
 
-        if (resultBaselineVersions.empty || addMostRecentRelease) {
+        if (resolvedVersions.isEmpty() || addMostRecentRelease(overrideBaselinesProperty, versions)) {
             // Always include the most recent final release if we're not testing against a nightly or a snapshot
-            resultBaselineVersions.add(mostRecentRelease)
+            resolvedVersions.add(releases.mostRecentRelease.version.version)
         }
 
-        resultBaselineVersions
+        resolvedVersions.removeAll { !versionMeetsLowerBaseVersionRequirement(it, minimumBaseVersion) }
+
+        if (resolvedVersions.isEmpty()) {
+            Assume.assumeFalse(isHistoricalPerformanceTest(versions))
+        }
+
+        assert !resolvedVersions.isEmpty(): "No versions selected: ${versions}"
+
+        resolvedVersions
     }
 
-    static boolean allBaselineVersionsAreFiltered(LinkedHashSet<String> resultBaselineVersions, Iterable<String> versionsToBeAdded, String minimumBaseVersion) {
-        return resultBaselineVersions.empty && minimumBaseVersion != null && versionsToBeAdded.any { baseVersionLowerThanMinimunRequirement(GradleVersion.version(it), minimumBaseVersion) }
+    static boolean addMostRecentRelease(String overrideBaselinesProperty, List<String> versions) {
+        if (overrideBaselinesProperty) {
+            return false
+        }
+        return !versions.any { it == 'last' || it == 'nightly' || isRcVersionOrSnapshot(it) }
     }
 
-    private static boolean baseVersionLowerThanMinimunRequirement(GradleVersion version, String minimumBaseVersion) {
-        return version.getBaseVersion() < GradleVersion.version(minimumBaseVersion)
+    static boolean versionMeetsLowerBaseVersionRequirement(String targetVersion, String minimumBaseVersion) {
+        return minimumBaseVersion == null || GradleVersion.version(targetVersion).baseVersion >= GradleVersion.version(minimumBaseVersion)
     }
 
-    private static boolean isRcVersion(GradleVersion versionObject) {
+    static boolean isHistoricalPerformanceTest(List<String> versions) {
+        // Currently only historical performance test has more than 3 baseline versions
+        return versions.size() > 3
+    }
+
+    private static boolean isRcVersionOrSnapshot(String version) {
+        GradleVersion versionObject = GradleVersion.version(version)
         // there is no public API for checking for RC version, this is an internal way
-        versionObject.stage.stage == 3
+        return versionObject.snapshot || versionObject.stage?.stage == 3
     }
 
-    private static Iterable<String> resolveOverriddenVersions(String overrideBaselinesProperty, List<String> targetVersions) {
+    private static List<String> resolveOverriddenVersions(String overrideBaselinesProperty, List<String> targetVersions) {
         def versions = Splitter.on(COMMA_OR_SEMICOLON)
             .omitEmptyStrings()
             .splitToList(overrideBaselinesProperty)
-        versions.collectMany([] as Set) { version -> version == 'defaults' ? targetVersions : [version] }
+        versions.collectMany([] as Set) { version -> version == 'defaults' ? targetVersions : [version] } as List
     }
 
     protected static GradleDistribution findRelease(ReleasedVersionDistributions releases, String requested) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
@@ -56,7 +56,7 @@ public class ResultsStoreHelper {
     }
 
     public static boolean isHistoricalChannel() {
-        return "historical".equals(determineChannel());
+        return determineChannel().startsWith("historical-");
     }
 
     public static String determineTeamCityBuildId() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
@@ -55,6 +55,10 @@ public class ResultsStoreHelper {
         return System.getProperty(SYSPROP_PERFORMANCE_TEST_CHANNEL, "commits");
     }
 
+    public static boolean isHistoricalChannel() {
+        return "historical".equals(determineChannel());
+    }
+
     public static String determineTeamCityBuildId() {
         return System.getenv("BUILD_ID");
     }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunnerTest.groovy
@@ -59,7 +59,6 @@ class CrossVersionPerformanceTestRunnerTest extends Specification {
         thrown(AssumptionViolatedException)
     }
 
-
     def 'lastest release is added if no versions specified'() {
         expect:
         toBaselineVersions(distributions, [], null) == ['6.1'] as LinkedHashSet


### PR DESCRIPTION
### Context

Previously, performance test version selection is a little mess
and versions higher than minimumBaseVersion might be executed.
This commit refactors version selection code and ignore the historical
performance test if all versions don't meet minimumBaseVersion requirement.

The release instructions are also updated: https://github.com/gradle/gradle-promote/commit/672c5162b87fae45176d53cc5b31bb5117784d45