### PR TITLE
Let Gradle 6.0 work with Zinc 1.3.0

### DIFF
--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -23,7 +23,6 @@ import org.gradle.cache.internal.Cache;
 import org.gradle.cache.internal.MapBackedCache;
 import org.gradle.internal.Factory;
 import sbt.internal.inc.ScalaInstance;
-import sbt.internal.inc.ZincUtil;
 import scala.Option;
 import xsbti.ArtifactInfo;
 import xsbti.compile.ClasspathOptionsUtil;
@@ -89,12 +88,38 @@ public class ZincScalaCompilerFactory {
             @Override
             public ZincScalaCompiler create() {
                 ScalaInstance scalaInstance = getScalaInstance(scalaClasspath);
-                File bridgeJar = findFile(ZincUtil.getDefaultBridgeModule(scalaInstance.version()).name(), scalaClasspath);
+                String bridgeModule = getBridgeModule(scalaInstance.version());
+                File bridgeJar = findFile(bridgeModule, scalaClasspath);
                 ScalaCompiler scalaCompiler = ZincCompilerUtil.scalaCompiler(scalaInstance, bridgeJar, ClasspathOptionsUtil.auto());
 
                 return new ZincScalaCompiler(scalaInstance, scalaCompiler, ANALYSIS_STORE_PROVIDER);
             }
         });
+    }
+
+    private static String getBridgeModule(String version) {
+        if (version.startsWith("2.10.")) {
+            return "compiler-bridge_2.10";
+        }
+        if (version.startsWith("2.11.")) {
+            return "compiler-bridge_2.11";
+        }
+        if (version.startsWith("2.12.")) {
+            return "compiler-bridge_2.12";
+        }
+        if (version.equals("2.13.0-M1")) {
+            return "compiler-bridge_2.12";
+        }
+        if (version.startsWith("2.13.0-pre-")) {
+            return "compiler-bridge_2.13.0-M2";
+        }
+        if (version.startsWith("2.13.0-M")) {
+            return "compiler-bridge_2.13.0-M2";
+        }
+        if (version.startsWith("2.13.0-RC")) {
+            return "compiler-bridge_2.13.0-M2";
+        }
+        return "compiler-bridge_2.13";
     }
 
     private static File findFile(String prefix, Iterable<File> files) {


### PR DESCRIPTION
The current implementation of `org.gradle.api.internal.tasks.scala.ZincScalaCompilerFactory#getCompiler` calls `ZincUtil#getDefaultBridgeModule`,
which is an internal class, but more importantly, it's been removed in Zinc 1.3.0.

There is probably a better way to prevent the use of Zinc internal classes, but moving the functionality to determine the bridge module name
feels good enough and not too intrusive given the short time left for Gradle 6.0.

A quick try to pull in zinc 1.3.0 via the `zinc` configuration works with the patch, but fails without it.

Signed-off-by: Robert Stupp <snazy@snazy.de>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
