### PR TITLE
GradlePomModuleDescriptorParser: Fix GAV when inheritance from Parent POM

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -131,6 +131,12 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
                     new DefaultImmutableVersionConstraint(parentVersion));
                 PomReader parentPomReader = parsePomForSelector(parserSettings, parentId, pomReader.getAllPomProperties());
                 pomReader.setPomParent(parentPomReader);
+
+                // Current POM can derive version/artifactId from parent. Resolve GAV and substitute values
+                pomReader.resolveGAV();
+                groupId = pomReader.getGroupId();
+                artifactId = pomReader.getArtifactId();
+                version = pomReader.getVersion();
             }
         }
         mdBuilder.setModuleRevId(groupId, artifactId, version);


### PR DESCRIPTION
Closes #11021 

Given a parent POM:

```

<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>test</groupId>
    <artifactId>parent</artifactId>
    <version>1.0.0</version>
    <packaging>pom</packaging>
    <properties>
        <scala.version>2.12.1</scala.version>
        <scala.binary.version>2.12</scala.binary.version>
    </properties>
</project>
```` 

and child:

```
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <parent>
        <groupId>test</groupId>
        <artifactId>parent</artifactId>
        <version>1.0.0</version>
        <relativePath>..</relativePath>
    </parent>

    <artifactId>child_${scala.binary.version}</artifactId>
    <version>1.0.0</version>
    <packaging>pom</packaging>
</project>
``` 

when running `./gradlew build`, get the following error:

```
❯ ./gradlew build
> Task :compileScala FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileScala'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve test:child_2.12:1.0.0.
     Required by:
         project :
      > Could not resolve test:child_2.12:1.0.0.
         > inconsistent module metadata found. Descriptor: test:child_${scala.binary.version}:1.0.0 Errors: bad module name: expected='child_2.12' found='child_${scala.binary.version}'

``` 

Looking at https://github.com/gradle/gradle/commit/fe6a13809696f4da35dd03973a4534950ca3c334#diff-9b61aeb5a80076794aa5af9e987a7964, the parent configuration happens after `GAV` is resolved so it doesn't reflect any value coming from the parent that might affect the version/name in the child POM

This PR addresses that and also adds a test around this use-case.


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
