### PR TITLE
Repository MetadataSources: add public API to retrieve current state

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts.repositories;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ComponentMetadataSupplier;
 
 import java.net.URI;
@@ -269,6 +270,14 @@ public interface IvyArtifactRepository extends ArtifactRepository, UrlArtifactRe
     void metadataSources(Action<? super MetadataSources> configureAction);
 
     /**
+     * Returns the current metadataSources configuration for the repository
+     *
+     * @since 6.0
+     */
+    @Incubating
+    MetadataSources getMetadataSources();
+
+    /**
      * Allows configuring the sources of metadata for a specific repository.
      *
      * @since 4.5
@@ -301,6 +310,42 @@ public interface IvyArtifactRepository extends ArtifactRepository, UrlArtifactRe
          *
          */
         void ignoreGradleMetadataRedirection();
+
+        /**
+         * Indicates if this repository contains Gradle metadata
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isGradleMetadataEnabled();
+
+        /**
+         * Indicates if this repository contains Ivy descriptors
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isIvyDescriptorEnabled();
+
+        /**
+         * Indicates if this repository contains Artifact
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isArtifactEnabled();
+
+        /**
+         * Indicates if this repository ignores Gradle Metadata Redirection
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isIgnoreGradleMetadataRedirectionEnabled();
     }
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 
 import java.net.URI;
 import java.util.Set;
@@ -104,6 +105,14 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
     void metadataSources(Action<? super MetadataSources> configureAction);
 
     /**
+     * Returns the current metadataSources configuration for the repository
+     *
+     * @since 6.0
+     */
+    @Incubating
+    MetadataSources getMetadataSources();
+
+    /**
      * Allows configuring the sources of metadata for a specific repository.
      *
      * @since 4.5
@@ -136,6 +145,42 @@ public interface MavenArtifactRepository extends ArtifactRepository, UrlArtifact
          *
          */
         void ignoreGradleMetadataRedirection();
+
+        /**
+         * Indicates if this repository contains Gradle metadata
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isGradleMetadataEnabled();
+
+        /**
+         * Indicates if this repository contains POM files
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isMavenPomEnabled();
+
+        /**
+         * Indicates if this repository contains Artifact
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isArtifactEnabled();
+
+        /**
+         * Indicates if this repository ignores Gradle Metadata Redirection
+         *
+         * @since 6.0
+         *
+         */
+        @Incubating
+        boolean isIgnoreGradleMetadataRedirectionEnabled();
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -237,6 +237,11 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         configureAction.execute(metadataSources);
     }
 
+    @Override
+    public MetadataSources getMetadataSources() {
+        return metadataSources;
+    }
+
     private ImmutableMetadataSources createMetadataSources() {
         ImmutableList.Builder<MetadataSource<?>> sources = ImmutableList.builder();
         DefaultGradleModuleMetadataSource gradleModuleMetadataSource = new DefaultGradleModuleMetadataSource(moduleMetadataParser, metadataFactory, true);
@@ -494,6 +499,26 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         @Override
         public void ignoreGradleMetadataRedirection() {
             ignoreGradleMetadataRedirection = true;
+        }
+
+        @Override
+        public boolean isGradleMetadataEnabled() {
+            return gradleMetadata;
+        }
+
+        @Override
+        public boolean isIvyDescriptorEnabled() {
+            return ivyDescriptor;
+        }
+
+        @Override
+        public boolean isArtifactEnabled() {
+            return artifact;
+        }
+
+        @Override
+        public boolean isIgnoreGradleMetadataRedirectionEnabled() {
+            return ignoreGradleMetadataRedirection;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -277,6 +277,11 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     }
 
     @Override
+    public MetadataSources getMetadataSources() {
+        return metadataSources;
+    }
+
+    @Override
     public void mavenContent(Action<? super MavenRepositoryContentDescriptor> configureAction) {
         content(Cast.uncheckedCast(configureAction));
     }
@@ -413,6 +418,26 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         @Override
         public void ignoreGradleMetadataRedirection() {
             ignoreGradleMetadataRedirection = true;
+        }
+
+        @Override
+        public boolean isGradleMetadataEnabled() {
+            return gradleMetadata;
+        }
+
+        @Override
+        public boolean isMavenPomEnabled() {
+            return mavenPom;
+        }
+
+        @Override
+        public boolean isArtifactEnabled() {
+            return artifact;
+        }
+
+        @Override
+        public boolean isIgnoreGradleMetadataRedirectionEnabled() {
+            return ignoreGradleMetadataRedirection;
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -15,12 +15,14 @@
  */
 package org.gradle.api.internal.artifacts.repositories
 
+import org.gradle.api.Action
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ComponentMetadataListerDetails
 import org.gradle.api.artifacts.ComponentMetadataSupplier
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
 import org.gradle.api.artifacts.ComponentMetadataVersionLister
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
@@ -358,6 +360,33 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         then:
         lister.rules.configurableRules[0].ruleClass == CustomVersionListerWithParams
         lister.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1,2,3]] as Object[]
+    }
+
+    def "can retrieve metadataSources"() {
+        repository.name = 'name'
+        repository.url = 'http://host'
+        fileResolver.resolveUri('http://host') >> new URI('http://host/')
+        standardMockHttpTransport()
+
+        given:
+        repository.metadataSources(new Action<IvyArtifactRepository.MetadataSources>() {
+            @Override
+            void execute(IvyArtifactRepository.MetadataSources metadataSources) {
+                metadataSources.ivyDescriptor()
+                metadataSources.artifact()
+                metadataSources.gradleMetadata()
+                metadataSources.ignoreGradleMetadataRedirection()
+            }
+        })
+
+        when:
+        IvyArtifactRepository.MetadataSources metadataSources = repository.getMetadataSources()
+
+        then:
+        metadataSources.isIvyDescriptorEnabled()
+        metadataSources.isArtifactEnabled()
+        metadataSources.isGradleMetadataEnabled()
+        metadataSources.isIgnoreGradleMetadataRedirectionEnabled()
     }
 
     private void standardMockFileTransport() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -15,12 +15,14 @@
  */
 package org.gradle.api.internal.artifacts.repositories
 
+import org.gradle.api.Action
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ComponentMetadataListerDetails
 import org.gradle.api.artifacts.ComponentMetadataSupplier
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
 import org.gradle.api.artifacts.ComponentMetadataVersionLister
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
@@ -238,6 +240,33 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         then:
         lister.rules.configurableRules[0].ruleClass == CustomVersionListerWithParams
         lister.rules.configurableRules[0].ruleParams.isolate() == ["a", 12, [1, 2, 3]] as Object[]
+    }
+
+    def "can retrieve metadataSources"() {
+        repository.name = 'name'
+        repository.url = 'http://host'
+        resolver.resolveUri('http://host') >> new URI('http://host/')
+        transportFactory.createTransport('http', 'name', _, _) >> transport()
+
+        given:
+        repository.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {
+            @Override
+            void execute(MavenArtifactRepository.MetadataSources metadataSources) {
+                metadataSources.mavenPom()
+                metadataSources.artifact()
+                metadataSources.gradleMetadata()
+                metadataSources.ignoreGradleMetadataRedirection()
+            }
+        })
+
+        when:
+        MavenArtifactRepository.MetadataSources metadataSources = repository.getMetadataSources()
+
+        then:
+        metadataSources.isMavenPomEnabled()
+        metadataSources.isArtifactEnabled()
+        metadataSources.isGradleMetadataEnabled()
+        metadataSources.isIgnoreGradleMetadataRedirectionEnabled()
     }
 
     static class CustomVersionLister implements ComponentMetadataVersionLister {


### PR DESCRIPTION
Signed-off-by: Roberto Perez Alcolea <rperezalcolea@netflix.com>

### Context
We encountered a use-case where we replace build repositories coming from customers to add some credentials but we do it so by removing the declared repo and add a new one with some internal opinions.

 This has been working great until now that we need to carry over things like `metadataSources `config. 

This change is to provide access to the `MetadataSources` state on a repo so it could be used to configure others.

Same way, this could be used to verify that repositories configurations are ok based provided information

This is for https://github.com/gradle/gradle/issues/10982

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
