### PR TITLE
Use JaCoCo 0.8.5 by default

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.8.4</literal></td>
+                <td><literal>0.8.5</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/groovy/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.4"
+    toolVersion = "0.8.5"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/kotlin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.4"
+    toolVersion = "0.8.5"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -53,7 +53,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * The jacoco version used if none is explicitly specified.
      * @since 3.4
      */
-    public static final String DEFAULT_JACOCO_VERSION = "0.8.4";
+    public static final String DEFAULT_JACOCO_VERSION = "0.8.5";
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";

--- a/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -45,6 +45,7 @@ class JacocoAgentJarTest extends Specification {
         '0.7.8'               | true
         '0.8.3'               | true
         '0.8.4'               | true
+        '0.8.5'               | true
     }
 
     @Unroll
@@ -66,5 +67,6 @@ class JacocoAgentJarTest extends Specification {
         '0.7.8'               | true
         '0.8.3'               | true
         '0.8.4'               | true
+        '0.8.5'               | true
     }
 }


### PR DESCRIPTION
### Context
This JaCoCo release provides new features which are of particular interest for
* early adopters of Java 14
* for developers who use Kotlin compiler

And it contains general bug fixes, full changelog - http://www.jacoco.org/jacoco/trunk/doc/changes.html

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
