### PR TITLE
Test logging uses display names

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -8,6 +8,8 @@ Include only their name, impactful features should be called out separately belo
  [Some person](https://github.com/some-person)
 -->
 
+[Mark Nordhoff](https://github.com/MarkNordhoff)
+
 <!-- 
 ## 1
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestClassDescriptor.java
@@ -35,12 +35,12 @@ public class DefaultTestClassDescriptor extends DefaultTestSuiteDescriptor {
 
     @Override
     public String getDisplayName() {
-        return classDisplayName;
+        return getClassDisplayName();
     }
 
     @Override
     public String getClassDisplayName() {
-        return getDisplayName();
+        return classDisplayName;
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
@@ -37,13 +37,6 @@ public interface TestDescriptorInternal extends TestDescriptor {
     Object getOwnerBuildOperationId();
 
     /**
-     * The name for display. It may be the same as or different from {@link #getName()}
-     *
-     * @return the name for display.
-     */
-    String getDisplayName();
-
-    /**
      * The class name for display. It may be the same as or different from {@link #getClassName()}
      * @return the class name for display.
      */

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/AbstractTestLogger.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/AbstractTestLogger.java
@@ -72,7 +72,7 @@ public abstract class AbstractTestLogger {
                 // level. This matters when configuring granularity.
                 names.add(current.getClassName() + "." + current.getName());
             } else {
-                names.add(current.getName());
+                names.add(current.getDisplayName());
             }
             current = current.getParent();
         }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestDescriptor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.testing;
 
+import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import javax.annotation.Nullable;
@@ -32,6 +33,15 @@ public interface TestDescriptor {
      * @return The test name
      */
     String getName();
+
+    /**
+     * Returns the display name of the test. It may be the same as or different from {@link #getName()}
+     *
+     * @return the name for display.
+     * @since 6.1
+     */
+    @Incubating
+    String getDisplayName();
 
     /**
      * Returns the test class name for this test, if any.

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
@@ -30,12 +30,12 @@ class AbstractTestLoggerTest extends Specification {
     StyledTextOutputFactory textOutputFactory = new TestStyledTextOutputFactory()
     AbstractTestLogger logger
 
-    def rootDescriptor = new SimpleTestDescriptor(name: "Test Run", composite: true)
-    def workerDescriptor = new SimpleTestDescriptor(name: "Gradle Worker 2", composite: true, parent: rootDescriptor)
-    def outerSuiteDescriptor = new SimpleTestDescriptor(name: "com.OuterSuiteClass", composite: true, parent: workerDescriptor)
-    def innerSuiteDescriptor = new SimpleTestDescriptor(name: "com.InnerSuiteClass", composite: true, parent: outerSuiteDescriptor)
-    def classDescriptor = new SimpleTestDescriptor(name: "foo.bar.TestClass", composite: true, parent: innerSuiteDescriptor)
-    def methodDescriptor = new SimpleTestDescriptor(name: "testMethod", className: "foo.bar.TestClass", parent: classDescriptor)
+    def rootDescriptor = new SimpleTestDescriptor(displayName: "Test Run", composite: true)
+    def workerDescriptor = new SimpleTestDescriptor(displayName: "Gradle Worker 2", composite: true, parent: rootDescriptor)
+    def outerSuiteDescriptor = new SimpleTestDescriptor(name: "com.OuterSuiteClass", displayName: "OuterSuiteClass", composite: true, parent: workerDescriptor)
+    def innerSuiteDescriptor = new SimpleTestDescriptor(name: "com.InnerSuiteClass", displayName: "InnerSuiteClass", composite: true, parent: outerSuiteDescriptor)
+    def classDescriptor = new SimpleTestDescriptor(name: "foo.bar.TestClass", displayName: "TestClass", composite: true, parent: innerSuiteDescriptor)
+    def methodDescriptor = new SimpleTestDescriptor(name: "testMethod", displayName: "a test", className: "foo.bar.TestClass", parent: classDescriptor)
 
     def "log test run event"() {
         createLogger(LogLevel.INFO)
@@ -64,7 +64,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(outerSuiteDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{ERROR}${sep}com.OuterSuiteClass STARTED${sep}"
+        textOutputFactory.toString() == "{TestEventLogger}{ERROR}${sep}OuterSuiteClass STARTED${sep}"
     }
 
     def "log inner suite event"() {
@@ -74,7 +74,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(innerSuiteDescriptor, TestLogEvent.PASSED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{QUIET}${sep}com.OuterSuiteClass > com.InnerSuiteClass {identifier}PASSED{normal}$sep"
+        textOutputFactory.toString() == "{TestEventLogger}{QUIET}${sep}OuterSuiteClass > InnerSuiteClass {identifier}PASSED{normal}$sep"
 
     }
 
@@ -85,7 +85,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(classDescriptor, TestLogEvent.SKIPPED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{WARN}${sep}com.OuterSuiteClass > com.InnerSuiteClass > foo.bar.TestClass {info}SKIPPED{normal}${sep}"
+        textOutputFactory.toString() == "{TestEventLogger}{WARN}${sep}OuterSuiteClass > InnerSuiteClass > TestClass {info}SKIPPED{normal}${sep}"
     }
 
     def "log test method event"() {
@@ -95,7 +95,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{LIFECYCLE}${sep}com.OuterSuiteClass > com.InnerSuiteClass > foo.bar.TestClass > testMethod {failure}FAILED{normal}${sep}"
+        textOutputFactory.toString() == "{TestEventLogger}{LIFECYCLE}${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
     }
 
     def "log standard out event"() {
@@ -105,7 +105,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_OUT, "this is a${sep}standard out${sep}event")
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}com.OuterSuiteClass > com.InnerSuiteClass > foo.bar.TestClass > testMethod STANDARD_OUT${sep}this is a${sep}standard out${sep}event"
+        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_OUT${sep}this is a${sep}standard out${sep}event"
     }
 
     def "log standard error event"() {
@@ -115,7 +115,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_ERROR, "this is a${sep}standard error${sep}event")
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{DEBUG}${sep}com.OuterSuiteClass > com.InnerSuiteClass > foo.bar.TestClass > testMethod STANDARD_ERROR${sep}this is a${sep}standard error${sep}event"
+        textOutputFactory.toString() == "{TestEventLogger}{DEBUG}${sep}OuterSuiteClass > InnerSuiteClass > TestClass > a test STANDARD_ERROR${sep}this is a${sep}standard error${sep}event"
     }
 
     def "log test method event with lowest display granularity"() {
@@ -125,7 +125,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}Test Run > Gradle Worker 2 > com.OuterSuiteClass > com.InnerSuiteClass > foo.bar.TestClass > testMethod {failure}FAILED{normal}${sep}"
+        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}Test Run > Gradle Worker 2 > OuterSuiteClass > InnerSuiteClass > TestClass > a test {failure}FAILED{normal}${sep}"
     }
 
     def "log test method event with highest display granularity"() {
@@ -135,7 +135,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.FAILED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}testMethod {failure}FAILED{normal}${sep}"
+        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}a test {failure}FAILED{normal}${sep}"
     }
 
     def "logging of atomic test whose parent isn't the test class includes test class name"() {
@@ -146,7 +146,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}com.OuterSuiteClass > com.InnerSuiteClass > foo.bar.TestClass.testMethod STARTED${sep}"
+        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > InnerSuiteClass > foo.bar.TestClass.testMethod STARTED${sep}"
     }
 
     def "logs header just once per batch of events with same type and for same test"() {
@@ -157,8 +157,8 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STANDARD_OUT, "event 2")
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}com.OuterSuiteClass > com.InnerSuiteClass\
- > foo.bar.TestClass > testMethod STANDARD_OUT${sep}event 1{TestEventLogger}{INFO}event 2"
+        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > InnerSuiteClass\
+ > TestClass > a test STANDARD_OUT${sep}event 1{TestEventLogger}{INFO}event 2"
     }
 
     void createLogger(LogLevel level, int displayGranularity = 2) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractJvmFailFastIntegrationSpec.groovy
@@ -139,7 +139,7 @@ abstract class AbstractJvmFailFastIntegrationSpec extends AbstractIntegrationSpe
         then:
         testExecution.release(FAILED_RESOURCE)
         gradleHandle.waitForFailure()
-        assert gradleHandle.standardOutput.matches(/(?s).*pkg\.FailedTest.*failTest.*FAILED.*java.lang.RuntimeException at FailedTest.java.*/)
+        assert gradleHandle.standardOutput.matches(/(?s).*FailedTest.*failTest.*FAILED.*java.lang.RuntimeException at FailedTest.java.*/)
         assert !gradleHandle.standardOutput.contains('pkg.OtherTest')
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitConsoleLoggingIntegrationTest.groovy
@@ -41,7 +41,7 @@ class JUnitConsoleLoggingIntegrationTest extends JUnitMultiVersionIntegrationSpe
 
         then:
         outputContains("""
-org.gradle.JUnit4Test > badTest FAILED
+${classNamePrefix}JUnit4Test > badTest FAILED
     java.lang.RuntimeException at JUnit4Test.groovy:44
 """)
     }
@@ -62,7 +62,7 @@ badTest FAILED
 
         outputContains("ignoredTest SKIPPED")
 
-        outputContains("org.gradle.JUnit4Test FAILED")
+        outputContains("${classNamePrefix}JUnit4Test FAILED")
     }
 
     def "standardOutputLogging"() {
@@ -72,7 +72,7 @@ badTest FAILED
 
         then:
         outputContains("""
-org.gradle.JUnit4StandardOutputTest > printTest STANDARD_OUT
+${classNamePrefix}JUnit4StandardOutputTest > printTest STANDARD_OUT
     line 1
     line 2
     line 3
@@ -117,4 +117,7 @@ xml entity: &amp;
                 .assertStderr(equalTo("< html allowed, cdata closing token ]]> encoded!\n"))
     }
 
+    private String getClassNamePrefix() {
+        isJUnitPlatform() ? '' : 'org.gradle.'
+    }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLoggingIntegrationTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.junitplatform
+
+class JUnitPlatformLoggingIntegrationTest extends JUnitPlatformIntegrationSpec  {
+
+    @Override
+    def setup() {
+        buildFile << """
+            test {
+                testLogging {
+                    events "passed", "skipped", "failed"
+                }
+            }
+        """
+    }
+
+    def "should log display names if present"() {
+        given:
+        file("src/test/java/pkg/TopLevelClass.java")  << """
+            package pkg;
+            import org.junit.jupiter.api.DisplayName;
+            import org.junit.jupiter.api.Nested;
+            import org.junit.jupiter.api.Test;
+
+            @DisplayName("Class level display name")
+            public class TopLevelClass {
+
+                @Nested
+                @DisplayName("Nested class display name")
+                public class NestedClass {
+
+                    @Test
+                    @DisplayName("Nested test method display name")
+                    public void nestedTestMethod() {
+                    }
+                }
+
+                @Test
+                @DisplayName("Method display name")
+                public void testMethod() {
+                }
+            }
+         """
+
+        when:
+        run("test")
+
+        then:
+        outputContains("Class level display name > Method display name")
+        outputContains("Class level display name > Nested class display name > Nested test method display name")
+    }
+
+    def "should fall back to plain name if no display names present"() {
+        given:
+        file("src/test/java/pkg/TopLevelClass.java")  << """
+            package pkg;
+
+            import org.junit.jupiter.api.DisplayName;
+            import org.junit.jupiter.api.Nested;
+            import org.junit.jupiter.api.Test;
+
+            public class TopLevelClass {
+
+                @Nested
+                public class NestedClass {
+
+                    @Test
+                    public void nestedTestMethod() {
+                    }
+                }
+
+                @Test
+                public void testMethod() {
+                }
+            }
+         """
+
+        when:
+        run("test")
+
+        then:
+        outputContains("TopLevelClass > testMethod()")
+        outputContains("TopLevelClass > NestedClass > nestedTestMethod()")
+    }
+
+}


### PR DESCRIPTION
Test logging now logs the display name if it is available. Furthermore
getDisplayName() and getClassDisplayName() are moved from
TestDescriptorInternal to TestDescriptor making them available in
beforeTest and afterTest callbacks.

Fixes: #10983 

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
