### PR TITLE
Gradle module metadata snapshot fixes

### DIFF
--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
@@ -75,6 +75,10 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
             snapshotVersions == ["1.0-${snapshotTimestamp}-${snapshotBuildNumber}"]
         }
 
+        with (module.parsedModuleMetadata) {
+            variants[0].files[0].url == "snapshotPublish-${initialVersion}.jar"
+        }
+
         when: // Publish a second time
         succeeds 'publish'
 
@@ -88,6 +92,10 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
         module.snapshotMetaData.snapshotBuildNumber == '2'
 
         module.snapshotMetaData.snapshotVersions == [secondVersion]
+
+        with (module.parsedModuleMetadata) {
+            variants[0].files[0].url == "snapshotPublish-${secondVersion}.jar"
+        }
 
         and:
         resolveArtifacts(module) { expectFiles "snapshotPublish-${secondVersion}.jar" }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -229,7 +229,8 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
                     try (Stream<String> lines = Files.lines(content.toPath(), StandardCharsets.UTF_8)) {
                         lines.forEach(line -> {
                             if (line.contains("\"url\"") || line.contains("\"name\"")) {
-                                writer.println(line.replace(moduleVersion, artifactVersion));
+                                // We cannot replace versions that appear as path elements, and so there should only be one version to replace at most
+                                writer.println(line.replaceFirst(moduleVersion + "([^/])", artifactVersion + "$1"));
                             } else {
                                 writer.println(line);
                             }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -134,7 +134,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
             publishing {
                 publications {
                     custom(MavenPublication) {
-                        artifact customJar 
+                        artifact customJar
                     }
                 }
             }
@@ -253,6 +253,35 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
 
         then:
         failure.assertHasCause("Signing Gradle Module Metadata is not supported for snapshot dependencies.")
+    }
+
+    def "with signing not required, does not fail on Gradle metadata if version is a snapshot"() {
+        given:
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            version = '1.0-SNAPSHOT'
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+            signing {
+                required { false }
+                sign publishing.publications.maven
+            }
+
+        """
+
+        when:
+        succeeds "signMavenPublication"
+
+        then:
+        notExecuted "signMavenPublication"
+
     }
 
     def "publishes signature files for Maven publication"() {
@@ -386,7 +415,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 sign publishing.publications.mavenJava
             }
 
-            publishing.publications.mavenJava.artifacts = [] 
+            publishing.publications.mavenJava.artifacts = []
             publishing.publications.mavenJava.artifact(sourceJar)
             generateMetadataFileForMavenJavaPublication.enabled = false
         """
@@ -432,7 +461,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
             signMavenJavaPublication.signatures.all { signature ->
                 if (signature.toSign.name.endsWith('.jar')) {
                     signMavenJavaPublication.signatures.remove signature
-                }    
+                }
             }
         """
 

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/InvalidSignature.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/InvalidSignature.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.signing;
+
+import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.publish.PublicationArtifact;
+
+import java.io.File;
+import java.util.concurrent.Callable;
+
+class InvalidSignature extends Signature {
+    public InvalidSignature(PublicationArtifact publicationArtifact, Callable<File> fileCallable, SignatureSpec signatureSpec) {
+        super(publicationArtifact, fileCallable, null, null, signatureSpec, signatureSpec);
+    }
+
+    @Override
+    public void generate() {
+        throw new InvalidUserCodeException("Signing Gradle Module Metadata is not supported for snapshot dependencies.");
+    }
+}


### PR DESCRIPTION
* Prior to this change, configuring signing in the build would always fail.
It now fails only if signing effectively happens.
* Previously the value was always replaced. But only the SNAPSHOT part of
a file name must be replaced, not the part in a path element.