### PR TITLE
More changes around Gradle Module Metadata and unique -SNAPSHOT handling

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -54,7 +54,7 @@ public enum CacheLayout {
         .changedTo(68, "5.0-milestone-1")
         .changedTo(69, "5.0-rc-1")
         .changedTo(71, "5.3-rc-1")
-        .changedTo(78, "6.0-rc-1")
+        .changedTo(79, "6.0-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/GradleModuleMetadataCompatibilityConverter.java
@@ -16,15 +16,20 @@
 
 package org.gradle.api.internal.artifacts.repositories.metadata;
 
+import com.google.common.collect.Lists;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.component.external.model.ComponentVariant;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
+
+import java.util.List;
 
 public class GradleModuleMetadataCompatibilityConverter {
 
@@ -40,6 +45,37 @@ public class GradleModuleMetadataCompatibilityConverter {
     }
 
     public void process(MutableModuleComponentResolveMetadata metaDataFromResource) {
+        handleAttributeCompatibility(metaDataFromResource);
+        handleMavenSnapshotCompatibility(metaDataFromResource);
+    }
+
+    private void handleMavenSnapshotCompatibility(MutableModuleComponentResolveMetadata metaDataFromResource) {
+        if (metaDataFromResource.getId() instanceof MavenUniqueSnapshotComponentIdentifier) {
+            // Action needed only for Maven unique snapshots
+            // Verify that the URL of the artifacts properly references the unique version and not -SNAPSHOT
+            MavenUniqueSnapshotComponentIdentifier uniqueIdentifier = (MavenUniqueSnapshotComponentIdentifier) metaDataFromResource.getId();
+            for (MutableComponentVariant mutableVariant : metaDataFromResource.getMutableVariants()) {
+                List<ComponentVariant.File> invalidFiles = null;
+                for (ComponentVariant.File file : mutableVariant.getFiles()) {
+                    if (file.getUri().contains("SNAPSHOT")) {
+                        if (invalidFiles == null) {
+                            invalidFiles = Lists.newArrayListWithExpectedSize(2);
+                        }
+                        invalidFiles.add(file);
+                    }
+                }
+                if (invalidFiles != null) {
+                    for (ComponentVariant.File invalidFile : invalidFiles) {
+                        mutableVariant.removeFile(invalidFile);
+                        mutableVariant.addFile(invalidFile.getName(), invalidFile.getUri().replace("SNAPSHOT", uniqueIdentifier.getTimestamp()));
+                    }
+                }
+            }
+        }
+    }
+
+
+    private void handleAttributeCompatibility(MutableModuleComponentResolveMetadata metaDataFromResource) {
         // This code path will always be a no-op following the changes in DefaultImmutableAttributesFactory
         // However this code will have to remain forever while the other one should be removed at some point (Gradle 7.0?)
         for (MutableComponentVariant variant : metaDataFromResource.getMutableVariants()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotExternalResourceArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotExternalResourceArtifactResolver.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.UrlBackedArtifactMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
@@ -37,12 +38,20 @@ class MavenUniqueSnapshotExternalResourceArtifactResolver implements ExternalRes
 
     @Override
     public boolean artifactExists(ModuleComponentArtifactMetadata artifact, ResourceAwareResolveResult result) {
-        return delegate.artifactExists(timestamp(artifact), result);
+        if (artifact instanceof UrlBackedArtifactMetadata) {
+            return delegate.artifactExists(artifact, result);
+        } else {
+            return delegate.artifactExists(timestamp(artifact), result);
+        }
     }
 
     @Override
     public LocallyAvailableExternalResource resolveArtifact(ModuleComponentArtifactMetadata artifact, ResourceAwareResolveResult result) {
-        return delegate.resolveArtifact(timestamp(artifact), result);
+        if (artifact instanceof UrlBackedArtifactMetadata) {
+            return delegate.resolveArtifact(artifact, result);
+        } else {
+            return delegate.resolveArtifact(timestamp(artifact), result);
+        }
     }
 
     protected ModuleComponentArtifactMetadata timestamp(ModuleComponentArtifactMetadata artifact) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -294,6 +294,16 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
+        public List<? extends ComponentVariant.File> getFiles() {
+            return files;
+        }
+
+        @Override
+        public boolean removeFile(ComponentVariant.File file) {
+            return files.remove(file);
+        }
+
+        @Override
         public void addFile(String name, String uri) {
             files.add(new FileImpl(name, uri));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -26,7 +26,12 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 public interface MutableComponentVariant {
+
+    List<? extends ComponentVariant.File> getFiles();
+
     void addFile(String name, String uri);
+
+    boolean removeFile(ComponentVariant.File file);
 
     void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities, boolean endorsing, @Nullable IvyArtifactName artifact);
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 78
+        expectedVersion = 79
     }
 
     def "use transforms layout"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSnapshotIntegTest.groovy
@@ -98,7 +98,16 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
         }
 
         and:
-        resolveArtifacts(module) { expectFiles "snapshotPublish-${secondVersion}.jar" }
+        resolveArtifacts(module) {
+            withModuleMetadata {
+                expectFiles "snapshotPublish-1.0-SNAPSHOT.jar"
+            }
+            withoutModuleMetadata {
+                // This is not ideal but also does not reflect reality, will need some work to fix
+                // This is only possible because Gradle manages to return a path to the supposedly remote file
+                expectFiles "snapshotPublish-${secondVersion}.jar"
+            }
+        }
     }
 
     def "can publish a snapshot version that was previously published with uploadArchives"() {
@@ -163,7 +172,16 @@ class MavenPublishSnapshotIntegTest extends AbstractMavenPublishIntegTest {
         module.snapshotMetaData.snapshotVersions == [secondVersion]
 
         and:
-        resolveArtifacts(module) { expectFiles "snapshotPublish-${secondVersion}.jar" }
+        resolveArtifacts(module) {
+            withModuleMetadata {
+                expectFiles "snapshotPublish-1.0-SNAPSHOT.jar"
+            }
+            withoutModuleMetadata {
+                // This is not ideal but also does not reflect reality, will need some work to fix
+                // This is only possible because Gradle manages to return a path to the supposedly remote file
+                expectFiles "snapshotPublish-${secondVersion}.jar"
+            }
+        }
     }
 
     def "can install snapshot versions"() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -228,7 +228,7 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
                 try (PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(timestamped), StandardCharsets.UTF_8)))) {
                     try (Stream<String> lines = Files.lines(content.toPath(), StandardCharsets.UTF_8)) {
                         lines.forEach(line -> {
-                            if (line.contains("\"url\"") || line.contains("\"name\"")) {
+                            if (line.contains("\"url\"")) {
                                 // We cannot replace versions that appear as path elements, and so there should only be one version to replace at most
                                 writer.println(line.replaceFirst(moduleVersion + "([^/])", artifactVersion + "$1"));
                             } else {


### PR DESCRIPTION
* Produced unique snapshot metadata now will generate variant files as follows:
```
"files": [
  {
    "name": "publish-snapshot-1.0-SNAPSHOT.jar",
    "url": "publish-snapshot-1.0-20191016.062132-1.jar",
    "size": 939,
    "sha1": "845d9cb512298843e9e3c6eaf5b2ff9434574011",
    "md5": "7148a1e5d677ecaf79d0d56811c584e0"
  }
]
```
* When an artifact is referenced by an `UrlBackedArtifactMetadata`, it now longer enters a special path for Maven specifics handling.
* 6.0 will be able to resolve artifacts for Gradle Module Metadata with `-SNAPSHOT` published by Gradle 5.3 and above
