### PR TITLE
Compatibility fix for Gradle Module Metadata

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultArtifactIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dsl.ArtifactFile;
+import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
@@ -31,13 +32,29 @@ import org.gradle.internal.component.model.IvyArtifactName;
  */
 public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadata {
     private final ModuleComponentIdentifier componentIdentifier;
+    private final String fileName;
     private final String relativeUrl;
-    private final ModuleComponentFileArtifactIdentifier id;
+    private final ModuleComponentArtifactIdentifier id;
+
+    private IvyArtifactName ivyArtifactName;
 
     public UrlBackedArtifactMetadata(ModuleComponentIdentifier componentIdentifier, String fileName, String relativeUrl) {
         this.componentIdentifier = componentIdentifier;
+        this.fileName = fileName;
         this.relativeUrl = relativeUrl;
-        id = new ModuleComponentFileArtifactIdentifier(componentIdentifier, fileName);
+        id = createArtifactId(componentIdentifier, fileName);
+    }
+
+    private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier, String fileName) {
+        if (componentIdentifier instanceof MavenUniqueSnapshotComponentIdentifier) {
+            // This special case is for Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
+            // corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility
+            return new DefaultModuleComponentArtifactIdentifier(
+                componentIdentifier,
+                getName()
+            );
+        }
+        return new ModuleComponentFileArtifactIdentifier(componentIdentifier, fileName);
     }
 
     @Override
@@ -48,6 +65,10 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
     @Override
     public ModuleComponentArtifactIdentifier getId() {
         return id;
+    }
+
+    public String getFileName() {
+        return fileName;
     }
 
     public String getRelativeUrl() {
@@ -62,12 +83,26 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
 
     @Override
     public IvyArtifactName getName() {
-        ArtifactFile names = new ArtifactFile(relativeUrl, componentIdentifier.getVersion());
-        return new DefaultIvyArtifactName(names.getName(), names.getExtension(), names.getExtension(), names.getClassifier());
+        if (ivyArtifactName == null) {
+            ArtifactFile names = new ArtifactFile(relativeUrl, uniqueVersion());
+            if (names.getName().endsWith(componentIdentifier.getVersion())) {
+                // Corner case of Maven -SNAPSHOT compat
+                names = new ArtifactFile(relativeUrl, componentIdentifier.getVersion());
+            }
+            ivyArtifactName = new DefaultIvyArtifactName(names.getName(), names.getExtension(), names.getExtension(), names.getClassifier());
+        }
+        return ivyArtifactName;
     }
 
     @Override
     public TaskDependency getBuildDependencies() {
         return TaskDependencyInternal.EMPTY;
+    }
+
+    private String uniqueVersion() {
+        if (componentIdentifier instanceof MavenUniqueSnapshotComponentIdentifier) {
+            return ((MavenUniqueSnapshotComponentIdentifier) componentIdentifier).getTimestampedVersion();
+        }
+        return componentIdentifier.getVersion();
     }
 }


### PR DESCRIPTION
This fix will enable Gradle 5.6.3 to consume Gradle Module Metadata for
-SNAPSHOT produced by Gradle 6+