### PR TITLE
Scala plugin: Zinc compiler validation and documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -148,7 +148,10 @@ Unless a task's `scalaClasspath` is configured explicitly, the Scala (base) plug
 [[sec:configure_zinc_compiler]]
 == Configuring the Zinc compiler
 
-The Scala plugin uses a configuration named `zinc` to resolve the https://github.com/typesafehub/zinc[Zinc compiler] and its dependencies. Gradle will provide a default version of Zinc, but if you need to use a particular Zinc version, you can change the version. Gradle supports version 1.2.0 of Zinc and above.
+The Scala plugin uses a configuration named `zinc` to resolve the https://github.com/typesafehub/zinc[Zinc compiler] and its dependencies.
+Gradle will provide a default version of Zinc, but if you need to use a particular Zinc version, you can change it.
+Gradle supports version 1.2.0 of Zinc and above.
+footnote:[However Zinc 1.2.0 for Scala 2.11 is not supported.]
 
 .Declaring a version of the Zinc compiler to use
 ====
@@ -156,9 +159,19 @@ include::sample[dir="userguide/scala/zincDependency/groovy",files="build.gradle[
 include::sample[dir="userguide/scala/zincDependency/kotlin",files="build.gradle.kts[tags=zinc-dependency]"]
 ====
 
-The Zinc compiler itself needs a compatible version of `scala-library` that may be different from the version required by your application. Gradle takes care of specifying a compatible version of `scala-library` for you.
+The Zinc compiler itself needs a compatible version of `scala-library` that may be different from the version required by your application.
+Gradle takes care of specifying a compatible version of `scala-library` for you.
 
 You can diagnose problems with the version of the Zinc compiler selected by running <<viewing_debugging_dependencies.adoc#,dependencyInsight>> for the `zinc` configuration.
+
+.Zinc compatibility table
+[%header%autowidth,compact]
+|===
+| Gradle version    | Supported Zinc version                                                    | Supported scala version
+
+| < 6.0             | `com.typesage.zinc:zinc:0.3.0`, with the exception of `[0.3.2, 0.3.5.2]`  | `2.10.x`
+| 6+                | `org.scala-sbt:zinc_2.12:1.2+`                                            | `2.12.x`
+|===
 
 [[sec:scala_convention_properties]]
 == Convention properties

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -151,7 +151,6 @@ Unless a task's `scalaClasspath` is configured explicitly, the Scala (base) plug
 The Scala plugin uses a configuration named `zinc` to resolve the https://github.com/typesafehub/zinc[Zinc compiler] and its dependencies.
 Gradle will provide a default version of Zinc, but if you need to use a particular Zinc version, you can change it.
 Gradle supports version 1.2.0 of Zinc and above.
-footnote:[However Zinc 1.2.0 for Scala 2.11 is not supported.]
 
 .Declaring a version of the Zinc compiler to use
 ====
@@ -161,16 +160,18 @@ include::sample[dir="userguide/scala/zincDependency/kotlin",files="build.gradle.
 
 The Zinc compiler itself needs a compatible version of `scala-library` that may be different from the version required by your application.
 Gradle takes care of specifying a compatible version of `scala-library` for you.
+footnote:[Gradle does not support running the Zinc compiler v1.2.0 with Scala 2.11.]
 
 You can diagnose problems with the version of the Zinc compiler selected by running <<viewing_debugging_dependencies.adoc#,dependencyInsight>> for the `zinc` configuration.
 
 .Zinc compatibility table
 [%header%autowidth,compact]
 |===
-| Gradle version    | Supported Zinc version                                                    | Supported scala version
+| Gradle version    | Supported Zinc versions | Zinc coordinates | Required Scala version | Supported Scala compilation version
 
-| < 6.0             | `com.typesage.zinc:zinc:0.3.0`, with the exception of `[0.3.2, 0.3.5.2]`  | `2.10.x`
-| 6+                | `org.scala-sbt:zinc_2.12:1.2+`                                            | `2.12.x`
+| 6.0 and newer     | link:https://github.com/sbt/zinc[SBT Zinc]. Versions 1.2.0 and above. | `org.scala-sbt:zinc_2.12` | Scala `2.12.x` is required for _running_ Zinc. | Scala `2.10.x` through `2.12.x` can be compiled.
+| 1.x trough 5.x    | link:https://github.com/typesafehub/zinc[**Deprecated** Typesafe Zinc compiler.] Versions 0.3.0 and above, except for 0.3.2 through 0.3.5.2. | `com.typesafe.zinc:zinc` | Scala `2.10.x` is required for _running_ Zinc. | Scala `2.9.x` through `2.12.x` can be compiled.
+
 |===
 
 [[sec:scala_convention_properties]]

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.scala
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.language.scala.internal.toolchain.DefaultScalaToolProvider
 import spock.lang.Issue
 
 import static org.hamcrest.CoreMatchers.containsString
@@ -216,7 +217,7 @@ task someTask
         succeeds("install")
     }
 
-    def "forcing an incompatible version of Scala does not interfere with Zinc compiler"() {
+    def "forcing an incompatible version of Scala fails with a clear error message"() {
         settingsFile << """
             rootProject.name = "scala"
         """
@@ -236,8 +237,12 @@ task someTask
         file("src/main/scala/Foo.scala") << """
             class Foo
         """
-        expect:
-        succeeds("assemble")
+        when:
+        fails("assemble")
+
+        then:
+        failureHasCause("The version of 'scala-library' was changed while using the default Zinc version." +
+            " Version 2.10.7 is not compatible with org.scala-sbt:zinc_2.12:" + DefaultScalaToolProvider.DEFAULT_ZINC_VERSION)
     }
 
     def "trying to use an old version of Zinc switches to Gradle-supported version"() {

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -54,6 +54,7 @@ import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.api.tasks.scala.ScalaDoc;
 import org.gradle.jvm.tasks.Jar;
+import org.gradle.language.scala.internal.toolchain.DefaultScalaToolProvider;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -63,14 +64,13 @@ import java.util.concurrent.Callable;
  * <p>A {@link Plugin} which compiles and tests Scala sources.</p>
  */
 public class ScalaBasePlugin implements Plugin<Project> {
-
-    public static final String DEFAULT_ZINC_VERSION = "1.3.0";
+    private static final String DEFAULT_ZINC_VERSION = DefaultScalaToolProvider.DEFAULT_ZINC_VERSION;
+    private static final String DEFAULT_SCALA_ZINC_VERSION = "2.12";
 
     @VisibleForTesting
     public static final String ZINC_CONFIGURATION_NAME = "zinc";
     public static final String SCALA_RUNTIME_EXTENSION_NAME = "scalaRuntime";
 
-    private static final String DEFAULT_SCALA_ZINC_VERSION = "2.12";
 
     private final ObjectFactory objectFactory;
 


### PR DESCRIPTION
* Add a table indicating the compatibility of Gradle / Zinc / Scala
* Clear error message when breaking default zinc setup 