### PR TITLE
Correct illegal cmd lines to exec modules' main class

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/JvmOptionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/JvmOptionsIntegrationTest.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal
+
+import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
+import org.gradle.util.Requires
+import org.gradle.util.Resources
+import org.gradle.util.TestPrecondition
+import org.junit.Rule
+import spock.lang.Issue
+
+class JvmOptionsIntegrationTest extends AbstractPluginIntegrationTest {
+
+    @Rule
+    Resources resources = new Resources()
+
+    @Issue("https://github.com/gradle/gradle/issues/10825")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "build a legal command line to execute a module's Main-Class"() {
+        given:
+        buildFile << runModule()
+        file("src/main/java/module-info.java") << 'module my.module { exports io.greeting; }'
+        file("src/main/java/io/greeting/HelloWorld.java") << helloWorld()
+
+        when:
+        run("compileJava", "run")
+
+        then:
+        file("build/classes/java/main/module-info.class").exists()
+        file("build/classes/java/main/io/greeting/HelloWorld.class").exists()
+        noExceptionThrown()
+        outputContains("Hello Gradle World!")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/10825")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "build a legal command line to execute a jar's Main-Class"() {
+        given:
+        settingsFile << """ rootProject.name = 'myApp' """
+        buildFile << runJar()
+        file("src/main/java/io/greeting/HelloWorld.java") << helloWorld()
+
+        when:
+        run("compileJava", "jar", "run")
+
+        then:
+        file("build/classes/java/main/io/greeting/HelloWorld.class").exists()
+        noExceptionThrown()
+        outputContains("Hello Gradle World!")
+    }
+
+    def helloWorld( ){
+        return '''
+            package io.greeting;
+
+            import java.util.*;
+            import static java.lang.System.*;
+            import static java.lang.String.*;
+            import java.util.stream.*;
+            import static java.util.Arrays.asList;
+
+            public class HelloWorld {
+                private final static String hello = "Hello %s World!%n";
+                static public void main(String... args){
+                    assert hasOnlyAppArgs(args) : "When executing a JPMS module's Main-Class, JVM options located after the application's entry point are illegal";
+
+                    for(String world : args ){
+                        out.printf(hello, world);
+                    }
+                }
+
+                static private boolean hasOnlyAppArgs(String... args){
+                    return !asList(args).stream().anyMatch(arg -> arg.charAt(0) == '-');
+                }
+            }
+        '''
+    }
+
+    def runModule( ){
+        return '''
+            plugins {
+                id 'application'
+            }
+
+            mainClassName = "my.module/io.greeting.HelloWorld"
+
+            run {
+                doFirst {
+                    args = ['Gradle']
+                    main = ''
+                    jvmArgs = [
+                        '-ea',
+                        '--module-path', classpath.asPath,
+                        '--module', mainClassName
+                    ]
+                    classpath = files()
+                    println ":run Task's command line: $commandLine"
+                }
+            }
+        '''
+    }
+
+    def runJar( ){
+        return '''
+            plugins {
+                id 'application'
+            }
+
+            jar {
+				manifest.attributes(
+					'Main-Class': 'io.greeting.HelloWorld'
+				)
+            }
+
+            run {
+                doFirst {
+                    args = ['Gradle']
+                    jvmArgs = ['-ea']
+                    classpath = project.files('build/libs/myApp.jar')
+                    println ":run Task's command line: $commandLine"
+                }
+            }
+        '''
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -117,8 +117,8 @@ public class JvmOptions {
      * The result is a subset of options returned by {@link #getAllJvmArgs()}
      */
     public List<String> getAllImmutableJvmArgs() {
-        List<String> args = new ArrayList<String>(getJvmArgs());
-        args.addAll(getManagedJvmArgs());
+        List<String> args = new ArrayList<String>(getManagedJvmArgs());
+        args.addAll(getJvmArgs());
         return args;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -80,22 +80,22 @@ class DefaultJavaForkOptionsTest extends Specification {
         when:
         options.jvmArgumentProviders << jvmArgumentProvider
         then:
-        options.allJvmArgs == ['argFromProvider', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), 'argFromProvider']
 
         when:
         options.allJvmArgs = ['arg1']
         then:
-        options.allJvmArgs == ['arg1', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), 'arg1']
 
         when:
         options.jvmArgumentProviders << jvmArgumentProvider
         then:
-        options.allJvmArgs == ['arg1', 'argFromProvider', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), 'arg1', 'argFromProvider']
 
         when:
         options.setAllJvmArgs(ImmutableSet.of("arg2"))
         then:
-        options.allJvmArgs == ['arg2', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), 'arg2']
     }
 
     def "can add jvmArgs"() {
@@ -130,7 +130,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.jvmArgs('arg1')
 
         then:
-        options.allJvmArgs == ['-Dkey=12', '-Dkey2', '-Dkey3=value', 'arg1', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == ['-Dkey=12', '-Dkey2', '-Dkey3=value', fileEncodingProperty(), *localeProperties(), 'arg1']
     }
 
     def "system properties are updated when added using jvmArgs"() {
@@ -160,7 +160,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.jvmArgs('arg1')
 
         then:
-        options.allJvmArgs == ['arg1', '-Xms64m', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == ['-Xms64m', fileEncodingProperty(), *localeProperties(), 'arg1']
     }
 
     def "allJvmArgs includes maxHeapSize"() {
@@ -169,7 +169,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.jvmArgs('arg1')
 
         then:
-        options.allJvmArgs == ['arg1', '-Xmx1g', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == ['-Xmx1g', fileEncodingProperty(), *localeProperties(), 'arg1']
     }
 
     def "allJvmArgs include jvmArgumentProviders"() {
@@ -189,7 +189,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.jvmArgs('arg1')
 
         then:
-        options.allJvmArgs == ['arg1', 'argFromProvider1', 'argFromProvider2', 'argFromProvider3', fileEncodingProperty(), *localeProperties()]
+        options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), 'arg1', 'argFromProvider1', 'argFromProvider2', 'argFromProvider3']
     }
 
     def "minHeapSize is updated when set using jvmArgs"() {

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -60,14 +60,14 @@ class JavaExecHandleBuilderTest extends Specification {
         List jvmArgs = builder.getAllJvmArgs()
 
         then:
-        jvmArgs == ['-Dprop=value', 'jvm1', 'jvm2', '-Xms64m', '-Xmx1g', fileEncodingProperty(expectedEncoding), *localeProperties(), '-cp', "$jar1$File.pathSeparator$jar2", "mainClass"]
+        jvmArgs == ['-Dprop=value', '-Xms64m', '-Xmx1g', fileEncodingProperty(expectedEncoding), *localeProperties(), 'jvm1', 'jvm2', '-cp', "$jar1$File.pathSeparator$jar2", "mainClass"]
 
         when:
         List commandLine = builder.getCommandLine()
 
         then:
         String executable = Jvm.current().getJavaExecutable().getAbsolutePath()
-        commandLine == [executable,  '-Dprop=value', 'jvm1', 'jvm2', '-Xms64m', '-Xmx1g', fileEncodingProperty(expectedEncoding), *localeProperties(), '-cp', "$jar1$File.pathSeparator$jar2", 'mainClass', 'arg1', 'arg2']
+        commandLine == [executable,  '-Dprop=value', '-Xms64m', '-Xmx1g', fileEncodingProperty(expectedEncoding), *localeProperties(), 'jvm1', 'jvm2', '-cp', "$jar1$File.pathSeparator$jar2", 'mainClass', 'arg1', 'arg2']
 
         where:
         inputEncoding | expectedEncoding


### PR DESCRIPTION
Issue: #10825
Signed-off-by: lingocoder <coder@lingocoder.com>

<!--- The issue this PR addresses -->
Fixes #10825 — ***Refactor JvmOptions.getAllImmutableJvmArgs() to support executing the main class in a JPMS module***. 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Because the Gradle build tool is as popular as it is, reducing the number of JPMS-related defects it has — [*such as this and others reported by several Gradle users*](http://bit.ly/bigguYet) — will have the practical effect of increasing JPMS adoption throughout the wider Java development community.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
