### PR TITLE
Specify test tasks in TestLauncher API

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -22,6 +22,12 @@ TBD - `ObjectFactory` has a method to create `ExtensiblePolymorphicDomainObjectC
 TBD - `ObjectFactory` has a method to create `NamedDomainObjectSet` instances.
 TBD - `ObjectFactory` has a method to create `NamedDomainObjectList` instances.
 
+## Features for Gradle tooling providers
+
+### `TestLauncher` can select specific methods
+
+The `TestLauncher` interface in the Tooling API is capable of launching tests by specifying the name of the test classes or methods. If there are multiple test tasks contain those test classes/methods, then all tasks are executed. This is not ideal for IDEs: developers usually want to execute only one test variant at the time. To overcome this, Gradle 6.1 introduces the `withTaskAndTestClasses()` and `withTaskAndTestMethods()` methods.
+
 ## Upgrade Instructions
 
 Switch your build to use Gradle @version@ by updating your wrapper:

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
@@ -39,14 +39,16 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
     private final Set<String> classNames;
     private final Set<InternalJvmTestRequest> internalJvmTestRequests;
     private final InternalDebugOptions debugOptions;
+    private final List<String> testTasks;
 
-    private TestExecutionRequestAction(BuildClientSubscriptions clientSubscriptions, StartParameterInternal startParameter, Set<InternalTestDescriptor> testDescriptors, Set<String> providerClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions) {
+    private TestExecutionRequestAction(BuildClientSubscriptions clientSubscriptions, StartParameterInternal startParameter, Set<InternalTestDescriptor> testDescriptors, Set<String> providerClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions, List<String> testTasks) {
         super(clientSubscriptions);
         this.startParameter = startParameter;
         this.testDescriptors = testDescriptors;
         this.classNames = providerClassNames;
         this.internalJvmTestRequests = internalJvmTestRequests;
         this.debugOptions = debugOptions;
+        this.testTasks = testTasks;
     }
 
     // Unpacks the request to serialize across to the daemon and creates instance of
@@ -59,7 +61,8 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
                                                 ImmutableSet.copyOf(testExecutionRequest.getTestExecutionDescriptors()),
                                                 ImmutableSet.copyOf(testClassNames),
                                                 providerInternalJvmTestRequests,
-                                                getDebugOptions(testExecutionRequest));
+                                                getDebugOptions(testExecutionRequest),
+                                                getTestTasks(testExecutionRequest));
     }
 
     private static InternalDebugOptions getDebugOptions(ProviderInternalTestExecutionRequest testExecutionRequest) {
@@ -68,6 +71,15 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
         } catch (UnsupportedMethodException e) {
             // default value for older Gradle clients
             return new DefaultDebugOptions();
+        }
+    }
+
+    private static List<String> getTestTasks(ProviderInternalTestExecutionRequest testExecutionRequest) {
+        try {
+            return testExecutionRequest.getTestTasks();
+        } catch (UnsupportedMethodException e) {
+            // default value for older Gradle clients
+            return Collections.emptyList();
         }
     }
 
@@ -109,5 +121,9 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
 
     public InternalDebugOptions getDebugOptions() {
         return debugOptions;
+    }
+
+    public List<String> getTestTasks() {
+        return testTasks;
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
@@ -31,6 +31,7 @@ import org.gradle.util.CollectionUtils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class TestExecutionRequestAction extends SubscribableBuildAction {
@@ -39,16 +40,16 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
     private final Set<String> classNames;
     private final Set<InternalJvmTestRequest> internalJvmTestRequests;
     private final InternalDebugOptions debugOptions;
-    private final List<String> testTasks;
+    private final Map<String, List<InternalJvmTestRequest>> taskAndTests;
 
-    private TestExecutionRequestAction(BuildClientSubscriptions clientSubscriptions, StartParameterInternal startParameter, Set<InternalTestDescriptor> testDescriptors, Set<String> providerClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions, List<String> testTasks) {
+    private TestExecutionRequestAction(BuildClientSubscriptions clientSubscriptions, StartParameterInternal startParameter, Set<InternalTestDescriptor> testDescriptors, Set<String> providerClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions, Map<String, List<InternalJvmTestRequest>> taskAndTests) {
         super(clientSubscriptions);
         this.startParameter = startParameter;
         this.testDescriptors = testDescriptors;
         this.classNames = providerClassNames;
         this.internalJvmTestRequests = internalJvmTestRequests;
         this.debugOptions = debugOptions;
-        this.testTasks = testTasks;
+        this.taskAndTests = taskAndTests;
     }
 
     // Unpacks the request to serialize across to the daemon and creates instance of
@@ -62,7 +63,7 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
                                                 ImmutableSet.copyOf(testClassNames),
                                                 providerInternalJvmTestRequests,
                                                 getDebugOptions(testExecutionRequest),
-                                                getTestTasks(testExecutionRequest));
+                                                getTaskAndTests(testExecutionRequest));
     }
 
     private static InternalDebugOptions getDebugOptions(ProviderInternalTestExecutionRequest testExecutionRequest) {
@@ -74,12 +75,12 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
         }
     }
 
-    private static List<String> getTestTasks(ProviderInternalTestExecutionRequest testExecutionRequest) {
+    private static Map<String, List<InternalJvmTestRequest>> getTaskAndTests(ProviderInternalTestExecutionRequest testExecutionRequest) {
         try {
-            return testExecutionRequest.getTestTasks();
+            return testExecutionRequest.getTaskAndTests();
         } catch (UnsupportedMethodException e) {
             // default value for older Gradle clients
-            return Collections.emptyList();
+            return Collections.emptyMap();
         }
     }
 
@@ -123,7 +124,7 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
         return debugOptions;
     }
 
-    public List<String> getTestTasks() {
-        return testTasks;
+    public Map<String, List<InternalJvmTestRequest>> getTaskAndTests() {
+        return taskAndTests;
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/test/ProviderInternalTestExecutionRequest.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/test/ProviderInternalTestExecutionRequest.java
@@ -21,6 +21,7 @@ import org.gradle.tooling.internal.protocol.test.InternalDebugOptions;
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @since 2.7-rc-1
@@ -30,4 +31,5 @@ public interface ProviderInternalTestExecutionRequest {
     Collection<String> getTestClassNames();
     Collection<InternalJvmTestRequest> getInternalJvmTestRequests(Collection<InternalJvmTestRequest> defaults);
     InternalDebugOptions getDebugOptions();
+    List<String> getTestTasks();
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/test/ProviderInternalTestExecutionRequest.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/test/ProviderInternalTestExecutionRequest.java
@@ -22,6 +22,7 @@ import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @since 2.7-rc-1
@@ -31,5 +32,5 @@ public interface ProviderInternalTestExecutionRequest {
     Collection<String> getTestClassNames();
     Collection<InternalJvmTestRequest> getInternalJvmTestRequests(Collection<InternalJvmTestRequest> defaults);
     InternalDebugOptions getDebugOptions();
-    List<String> getTestTasks();
+    Map<String, List<InternalJvmTestRequest>> getTaskAndTests();
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -59,7 +59,7 @@ class BuildActionSerializerTest extends SerializerSpec {
         where:
         action << [
             new ClientProvidedBuildAction(new StartParameterInternal(), new SerializedPayload(null, []), true, new BuildClientSubscriptions(EnumSet.allOf(OperationType))),
-            new TestExecutionRequestAction(new BuildClientSubscriptions(EnumSet.allOf(OperationType)), new StartParameterInternal(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), new DefaultDebugOptions()),
+            new TestExecutionRequestAction(new BuildClientSubscriptions(EnumSet.allOf(OperationType)), new StartParameterInternal(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), new DefaultDebugOptions(), Collections.emptyMap()),
             new BuildModelAction(new StartParameterInternal(), "model", false, new BuildClientSubscriptions(EnumSet.allOf(OperationType)))
         ]
     }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationActionTest.groovy
@@ -78,6 +78,7 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
     def "empty test execution request configures no tasks"() {
         1 * testExecutionRequest.getTestExecutionDescriptors() >> []
         1 * testExecutionRequest.getInternalJvmTestRequests() >> []
+        1 * testExecutionRequest.getTaskAndTests() >> [:]
 
         setup:
         def buildConfigurationAction = new TestExecutionBuildConfigurationAction(testExecutionRequest, gradleInternal);
@@ -95,6 +96,7 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
 
         1 * testExecutionRequest.getTestExecutionDescriptors() >> descriptors
         1 * testExecutionRequest.getInternalJvmTestRequests() >> internalJvmRequests
+        1 * testExecutionRequest.getTaskAndTests() >> tasksAndTests
 
         def buildConfigurationAction = new TestExecutionBuildConfigurationAction(testExecutionRequest, gradleInternal);
         when:
@@ -106,10 +108,11 @@ class TestExecutionBuildConfigurationActionTest extends Specification {
         1 * testFilter.setFailOnNoMatchingTests(false)
         1 * outputsInternal.upToDateWhen(Specs.SATISFIES_NONE)
         where:
-        requestType        | descriptors        | internalJvmRequests                                 | expectedClassFilter | expectedMethodFilter
-        "test descriptors" | [testDescriptor()] | []                                                  | TEST_CLASS_NAME     | TEST_METHOD_NAME
-        "test classes"     | []                 | [jvmTestRequest(TEST_CLASS_NAME, null)]             | TEST_CLASS_NAME     | null
-        "test methods"     | []                 | [jvmTestRequest(TEST_CLASS_NAME, TEST_METHOD_NAME)] | TEST_CLASS_NAME     | TEST_METHOD_NAME
+        requestType        | descriptors        | internalJvmRequests                                 | expectedClassFilter | expectedMethodFilter | tasksAndTests
+        "test descriptors" | [testDescriptor()] | []                                                  | TEST_CLASS_NAME     | TEST_METHOD_NAME     | [:]
+        "test classes"     | []                 | [jvmTestRequest(TEST_CLASS_NAME, null)]             | TEST_CLASS_NAME     | null     | [:]
+        "test methods"     | []                 | [jvmTestRequest(TEST_CLASS_NAME, TEST_METHOD_NAME)] | TEST_CLASS_NAME     | TEST_METHOD_NAME     | [:]
+        "test type"        | []                 | []                                                  | TEST_CLASS_NAME     | TEST_METHOD_NAME     | [':test' : [jvmTestRequest(TEST_CLASS_NAME, TEST_METHOD_NAME)]]
     }
 
     InternalJvmTestRequest jvmTestRequest(String className, String methodName) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/TestLauncherCrossVersionSpec.groovy
@@ -30,7 +30,7 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
     def "build succeeds if test class is only available in one test task"() {
         when:
         launchTests { TestLauncher launcher ->
-            launcher.withJvmTestClasses("example.MyTest").withTests(":secondTest")
+            launcher.withTaskAndTestClasses(':secondTest',"example.MyTest")
         }
         then:
         assertTaskNotExecuted(":test")

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/TestLauncherCrossVersionSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r61
+
+import org.gradle.integtests.tooling.TestLauncherSpec
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.TestLauncher
+import spock.lang.Timeout
+
+@Timeout(120)
+@ToolingApiVersion('>=6.1')
+@TargetGradleVersion(">=6.1")
+class TestLauncherCrossVersionSpec extends TestLauncherSpec {
+
+    def "build succeeds if test class is only available in one test task"() {
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withJvmTestClasses("example.MyTest").withTests(":secondTest")
+        }
+        then:
+        assertTaskNotExecuted(":test")
+        assertTaskExecuted(":secondTest")
+        assertTestExecuted(className: "example.MyTest", methodName: "foo", task: ":secondTest")
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r61/TestLauncherCrossVersionSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.tooling.r61
 import org.gradle.integtests.tooling.TestLauncherSpec
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.internal.io.NullOutputStream
 import org.gradle.tooling.TestLauncher
 import spock.lang.Timeout
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -54,7 +54,6 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      */
     TestLauncher withJvmTestClasses(String... testClasses);
 
-    TestLauncher withTaskAndTestClasses(String task, String... testClasses);
 
     /**
      * Adds tests to be executed declared by class name.
@@ -64,8 +63,6 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      * @since 2.6
      */
     TestLauncher withJvmTestClasses(Iterable<String> testClasses);
-
-    TestLauncher withTaskAndTestClasses(String task, Iterable<String> testClasses);
 
     /**
      * Adds tests to be executed declared by class and method name.
@@ -77,8 +74,6 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      */
     TestLauncher withJvmTestMethods(String testClass, String... methods);
 
-    TestLauncher withTaskAndTestMethods(String task, String testClass, String... methods);
-
     /**
      * Adds tests to be executed declared by class and methods name.
      *
@@ -89,6 +84,51 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      */
     TestLauncher withJvmTestMethods(String testClass, Iterable<String> methods);
 
+    /**
+     * Adds tests to be executed declared by the container task and the class name.
+     *
+     * @param task The path of the target task.
+     * @param testClasses The class names of the tests to be executed.
+     * @return this
+     * @since 6.1
+     */
+    @Incubating
+    TestLauncher withTaskAndTestClasses(String task, String... testClasses);
+
+
+    /**
+     * Adds tests to be executed declared by the container task and the class name.
+     *
+     * @param task The path of the target task.
+     * @param testClasses The class names of the tests to be executed.
+     * @return this
+     * @since 6.1
+     */
+    @Incubating
+    TestLauncher withTaskAndTestClasses(String task, Iterable<String> testClasses);
+
+    /**
+     * Adds tests to be executed declared by the container task, class and method name.
+     *
+     * @param task The path of the target task.
+     * @param testClass The name of the class containing the methods to execute.
+     * @param methods The names of the test methods to be executed.
+     * @return this
+     * @since 6.1
+     */
+    @Incubating
+    TestLauncher withTaskAndTestMethods(String task, String testClass, String... methods);
+
+    /**
+     * Adds tests to be executed declared by the container task, class and method name.
+     *
+     * @param task The path of the target task.
+     * @param testClass The name of the class containing the methods to execute.
+     * @param methods The names of the test methods to be executed.
+     * @return this
+     * @since 6.1
+     */
+    @Incubating
     TestLauncher withTaskAndTestMethods(String task, String testClass, Iterable<String> methods);
 
     /**

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -28,6 +28,19 @@ import org.gradle.tooling.events.test.TestOperationDescriptor;
 public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
 
     /**
+     * Specifies the test tasks to be executed.
+     * - When specified by default all tests are executed in the tasks
+     * - TODO how TestOperations overwrites this
+     * - TODO how withJVMTesttasks and methods overrides this
+     *
+     * @param testTasks
+     * @return this
+     * @since 6.1
+     */
+    @Incubating
+    TestLauncher withTests(String... testTasks);
+
+    /**
      * Adds tests to be executed by passing test descriptors received from a previous Gradle Run.
      *
      * @param descriptors The OperationDescriptor defining one or more tests.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -87,6 +87,8 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
     /**
      * Adds tests to be executed declared by the container task and the class name.
      *
+     * <p>Note: the values are ignored for target Gradle version 6.1 or earlier.</p>
+     *
      * @param task The path of the target task.
      * @param testClasses The class names of the tests to be executed.
      * @return this
@@ -98,6 +100,7 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
     /**
      * Adds tests to be executed declared by the container task, class and method name.
      *
+     * <p>Note: the values are ignored for target Gradle version 6.1 or earlier.</p>
      * @param task The path of the target task.
      * @param testClass The name of the class containing the methods to execute.
      * @param methods The names of the test methods to be executed.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -93,31 +93,7 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      * @since 6.1
      */
     @Incubating
-    TestLauncher withTaskAndTestClasses(String task, String... testClasses);
-
-
-    /**
-     * Adds tests to be executed declared by the container task and the class name.
-     *
-     * @param task The path of the target task.
-     * @param testClasses The class names of the tests to be executed.
-     * @return this
-     * @since 6.1
-     */
-    @Incubating
     TestLauncher withTaskAndTestClasses(String task, Iterable<String> testClasses);
-
-    /**
-     * Adds tests to be executed declared by the container task, class and method name.
-     *
-     * @param task The path of the target task.
-     * @param testClass The name of the class containing the methods to execute.
-     * @param methods The names of the test methods to be executed.
-     * @return this
-     * @since 6.1
-     */
-    @Incubating
-    TestLauncher withTaskAndTestMethods(String task, String testClass, String... methods);
 
     /**
      * Adds tests to be executed declared by the container task, class and method name.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/TestLauncher.java
@@ -28,19 +28,6 @@ import org.gradle.tooling.events.test.TestOperationDescriptor;
 public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
 
     /**
-     * Specifies the test tasks to be executed.
-     * - When specified by default all tests are executed in the tasks
-     * - TODO how TestOperations overwrites this
-     * - TODO how withJVMTesttasks and methods overrides this
-     *
-     * @param testTasks
-     * @return this
-     * @since 6.1
-     */
-    @Incubating
-    TestLauncher withTests(String... testTasks);
-
-    /**
      * Adds tests to be executed by passing test descriptors received from a previous Gradle Run.
      *
      * @param descriptors The OperationDescriptor defining one or more tests.
@@ -67,6 +54,8 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      */
     TestLauncher withJvmTestClasses(String... testClasses);
 
+    TestLauncher withTaskAndTestClasses(String task, String... testClasses);
+
     /**
      * Adds tests to be executed declared by class name.
      *
@@ -75,6 +64,8 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      * @since 2.6
      */
     TestLauncher withJvmTestClasses(Iterable<String> testClasses);
+
+    TestLauncher withTaskAndTestClasses(String task, Iterable<String> testClasses);
 
     /**
      * Adds tests to be executed declared by class and method name.
@@ -86,6 +77,8 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      */
     TestLauncher withJvmTestMethods(String testClass, String... methods);
 
+    TestLauncher withTaskAndTestMethods(String task, String testClass, String... methods);
+
     /**
      * Adds tests to be executed declared by class and methods name.
      *
@@ -95,6 +88,8 @@ public interface TestLauncher extends ConfigurableLauncher<TestLauncher> {
      * @since 2.7
      */
     TestLauncher withJvmTestMethods(String testClass, Iterable<String> methods);
+
+    TestLauncher withTaskAndTestMethods(String task, String testClass, Iterable<String> methods);
 
     /**
      * Configures test JVM to run in debug mode.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultInternalJvmTestRequest.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultInternalJvmTestRequest.java
@@ -19,8 +19,9 @@ package org.gradle.tooling.internal.consumer;
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 
 import javax.annotation.Nullable;
+import java.io.Serializable;
 
-public class DefaultInternalJvmTestRequest implements InternalJvmTestRequest {
+public class DefaultInternalJvmTestRequest implements InternalJvmTestRequest, Serializable {
     private final String className;
     private final String methodName;
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -39,6 +39,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     private final Set<String> testClassNames = new LinkedHashSet<String>();
     private final Set<InternalJvmTestRequest> internalJvmTestRequests = new LinkedHashSet<InternalJvmTestRequest>();
     private final DefaultDebugOptions debugOptions = new DefaultDebugOptions();
+    private final List<String> testTasks = new ArrayList<String>();
 
     public DefaultTestLauncher(AsyncConsumerActionExecutor connection, ConnectionParameters parameters) {
         super(parameters);
@@ -49,6 +50,12 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
 
     @Override
     protected DefaultTestLauncher getThis() {
+        return this;
+    }
+
+    @Override
+    public TestLauncher withTests(String... testTasks) {
+        this.testTasks.addAll(Arrays.asList(testTasks));
         return this;
     }
 
@@ -121,7 +128,7 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
             throw new TestExecutionException("No test declared for execution.");
         }
         final ConsumerOperationParameters operationParameters = getConsumerOperationParameters();
-        final TestExecutionRequest testExecutionRequest = new TestExecutionRequest(operationDescriptors, ImmutableList.copyOf(testClassNames), ImmutableSet.copyOf(internalJvmTestRequests), debugOptions);
+        final TestExecutionRequest testExecutionRequest = new TestExecutionRequest(operationDescriptors, ImmutableList.copyOf(testClassNames), ImmutableSet.copyOf(internalJvmTestRequests), debugOptions, ImmutableList.copyOf(testTasks));
         connection.run(new ConsumerAction<Void>() {
             @Override
             public ConsumerOperationParameters getParameters() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -31,7 +31,6 @@ import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 import org.gradle.util.CollectionUtils;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTestLauncher> implements TestLauncher {
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -16,7 +16,9 @@
 
 package org.gradle.tooling.internal.consumer;
 
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Transformer;
 import org.gradle.tooling.ResultHandler;
 import org.gradle.tooling.TestExecutionException;
@@ -30,7 +32,13 @@ import org.gradle.tooling.internal.consumer.parameters.ConsumerOperationParamete
 import org.gradle.tooling.internal.protocol.test.InternalJvmTestRequest;
 import org.gradle.util.CollectionUtils;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTestLauncher> implements TestLauncher {
 
@@ -155,6 +163,11 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     public void run(final ResultHandler<? super Void> handler) {
         if (operationDescriptors.isEmpty() && internalJvmTestRequests.isEmpty() && tasksAndTests.isEmpty()) {
             throw new TestExecutionException("No test declared for execution.");
+        }
+        for (Map.Entry<String, List<InternalJvmTestRequest>> entry : tasksAndTests.entrySet()) {
+            if (entry.getValue().isEmpty()) {
+                throw new TestExecutionException("No test for task " + entry.getKey() + " declared for execution.");
+            }
         }
         final ConsumerOperationParameters operationParameters = getConsumerOperationParameters();
         final TestExecutionRequest testExecutionRequest = new TestExecutionRequest(operationDescriptors, ImmutableList.copyOf(testClassNames), ImmutableSet.copyOf(internalJvmTestRequests), debugOptions, ImmutableMap.copyOf(tasksAndTests));

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultTestLauncher.java
@@ -104,19 +104,6 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
     }
 
     @Override
-    public TestLauncher withTaskAndTestClasses(String task, String... testClasses) {
-        List<InternalJvmTestRequest> tests = CollectionUtils.collect(testClasses, new Transformer<InternalJvmTestRequest, String>() {
-            @Override
-            public InternalJvmTestRequest transform(String testClass) {
-                return new DefaultInternalJvmTestRequest(testClass, null);
-            }
-        });
-
-        addTests(task, tests);
-        return this;
-    }
-
-    @Override
     public TestLauncher withTaskAndTestClasses(String task, Iterable<String> testClasses) {
         List<InternalJvmTestRequest> tests = CollectionUtils.collect(testClasses, new Transformer<InternalJvmTestRequest, String>() {
             @Override
@@ -125,18 +112,6 @@ public class DefaultTestLauncher extends AbstractLongRunningOperation<DefaultTes
             }
         });
 
-        addTests(task, tests);
-        return this;
-    }
-
-    @Override
-    public TestLauncher withTaskAndTestMethods(String task, String testClass, String... methods) {
-        List<InternalJvmTestRequest> tests = CollectionUtils.collect(methods, new Transformer<InternalJvmTestRequest, String>() {
-            @Override
-            public InternalJvmTestRequest transform(String methodName) {
-                return new DefaultInternalJvmTestRequest(testClass, methodName);
-            }
-        });
         addTests(task, tests);
         return this;
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/TestExecutionRequest.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/TestExecutionRequest.java
@@ -27,6 +27,7 @@ import org.gradle.tooling.internal.protocol.test.InternalTestExecutionRequest;
 import org.gradle.util.CollectionUtils;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public class TestExecutionRequest implements InternalTestExecutionRequest {
@@ -34,16 +35,22 @@ public class TestExecutionRequest implements InternalTestExecutionRequest {
     private final Collection<String> testClassNames;
     private final Collection<InternalJvmTestRequest> internalJvmTestRequests;
     private final InternalDebugOptions debugOptions;
+    private final List<String> testTasks;
 
-    public TestExecutionRequest(Iterable<TestOperationDescriptor> operationDescriptors, Collection<String> testClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions) {
+    public TestExecutionRequest(Iterable<TestOperationDescriptor> operationDescriptors, Collection<String> testClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions, List<String> testTasks) {
         this.testDescriptors = adaptDescriptors(operationDescriptors);
         this.testClassNames = testClassNames;
         this.internalJvmTestRequests = internalJvmTestRequests;
         this.debugOptions = debugOptions;
+        this.testTasks = testTasks;
     }
 
     public InternalDebugOptions getDebugOptions() {
         return debugOptions;
+    }
+
+    public List<String> getTestTasks() {
+        return testTasks;
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/TestExecutionRequest.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/TestExecutionRequest.java
@@ -28,6 +28,7 @@ import org.gradle.util.CollectionUtils;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class TestExecutionRequest implements InternalTestExecutionRequest {
@@ -35,22 +36,22 @@ public class TestExecutionRequest implements InternalTestExecutionRequest {
     private final Collection<String> testClassNames;
     private final Collection<InternalJvmTestRequest> internalJvmTestRequests;
     private final InternalDebugOptions debugOptions;
-    private final List<String> testTasks;
+    private final Map<String, List<InternalJvmTestRequest>> taskAndTests;
 
-    public TestExecutionRequest(Iterable<TestOperationDescriptor> operationDescriptors, Collection<String> testClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions, List<String> testTasks) {
+    public TestExecutionRequest(Iterable<TestOperationDescriptor> operationDescriptors, Collection<String> testClassNames, Set<InternalJvmTestRequest> internalJvmTestRequests, InternalDebugOptions debugOptions, Map<String, List<InternalJvmTestRequest>> testTasks) {
         this.testDescriptors = adaptDescriptors(operationDescriptors);
         this.testClassNames = testClassNames;
         this.internalJvmTestRequests = internalJvmTestRequests;
         this.debugOptions = debugOptions;
-        this.testTasks = testTasks;
+        this.taskAndTests = testTasks;
     }
 
     public InternalDebugOptions getDebugOptions() {
         return debugOptions;
     }
 
-    public List<String> getTestTasks() {
-        return testTasks;
+    public Map<String, List<InternalJvmTestRequest>>  getTaskAndTests() {
+        return taskAndTests;
     }
 
     @Override


### PR DESCRIPTION
### Goal

Add a new `withTest()` method to the TestLauncher interface.

### Context

For complex cases, clients (like IntelliJ IDEA) want to specify exactly which task should be executed by the `TestLauncher`. For complex projects define multiple test tasks that execute the same tests in multiple environments. For example, the Gradle build defines daemon and no-daemon integration tests. When working on the project, developers want to specify which tests they want to execute.

A more detailed description is available [here](https://github.com/gradle/gradle/issues/7520#issuecomment-440599095).

### Task addressing

Tooling API clients don't have a direct reference to test types, only via information returned via tooling models. Proposal for the sake of simplicity: use the same addressing as on the command line (i.e. project tasks and task selectors):

 - `withTests(':test', ':sub:integTest')`: will execute the `test` and `integTest` tasks in the root and `sub1` project respectively.
 - `withTest('test')` will execute all the `test` task in all projects.

### Filtering

The new `withTest()` method should have an effect on the other `TestLauncher` methods. When the test launcher specifies test descriptors then those descriptors should only be executed when they belong to the tasks specified by `withTests()`. In other words, `withTests()` should act as a filter on the test descriptors. Similarly, only those test classes and methods should be executed that belong to the tasks from `withTests()`.

### Corner-cases

1. No tests specified in `withTests()`: no-op
2. Task specified in `withTests()` is not a `Test` task: no-op.
3. Task specified in `withTests()` does not exist: no-op.
4. If `withTests()` is called without any test descriptors or test classes then all tests should be executed from the selected test tasks.
### Open questions

- Shall we emit a warning when no tests are found?
- Shall we use strong types instead of task paths strings in the `withTests()` argument list? Maybe reuse the classes from the `BuildInvocations` tooling model?
