### PR TITLE
Disallow (via deprecation) querying a mapped task output property before the task has completed

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -49,10 +49,10 @@ import java.util.concurrent.Callable;
  * <p>There are a number of ways to create a {@link Provider} instance. Some common methods:</p>
  *
  * <ul>
+ *     <li>A number of Gradle types, such as {@link Property}, extend {@link Provider} and can be used directly as a provider.</li>
  *     <li>Calling {@link #map(Transformer)} to create a new provider from an existing provider.</li>
  *     <li>Using the return value of {@link org.gradle.api.tasks.TaskContainer#register(String)}, which is a provider that represents the task instance.</li>
  *     <li>Using the methods on {@link org.gradle.api.file.Directory} and {@link org.gradle.api.file.DirectoryProperty} to produce file providers.</li>
- *     <li>Many Gradle types extend {@link Provider} and can be used directly as a provider.</li>
  *     <li>By calling {@link ProviderFactory#provider(Callable)} or {@link org.gradle.api.Project#provider(Callable)} to create a new provider from a {@link Callable}.</li>
  * </ul>
  *

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -54,7 +54,27 @@ No potential breaking changes were introduced.
 
 === Deprecations
 
-Nothing was deprecated.
+==== Query a mapped task output property before the task has completed
+
+It is now deprecated to query the value of a mapped task output property before the task has completed. Here is an example of this case, where a task's output file is parsed to produce an `Integer` and
+the result used as input to another task:
+
+```
+class TaskA: DefaultTask {
+    @Input
+    final Property<Integer> threadPoolSize = ...
+}
+
+class TaskB: DefaultTask {
+    @OutputFile
+    final RegularFileProperty outputFile = ...
+}
+
+taskA.threadPoolSize = taskB.outputFile.map { it.text.toInteger() }
+```
+
+In this case, calling `get()`, or any other query method, on `taskA.threadPoolSize` will produce a deprecation warning if done prior to `taskB` completing, as the file has not yet been generated.
+This will become an error in Gradle 7.0
 
 === Potential breaking changes
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyWriter.kt
@@ -27,6 +27,8 @@ import org.gradle.instantexecution.serialization.PropertyKind
 import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.logPropertyError
 import org.gradle.instantexecution.serialization.logPropertyInfo
+import org.gradle.internal.Factory
+import org.gradle.util.DeprecationLogger
 import java.io.IOException
 import java.util.concurrent.Callable
 import java.util.function.Supplier
@@ -58,7 +60,8 @@ class BeanPropertyWriter(
     private
     fun valueOrConvention(fieldValue: Any?, bean: Any, fieldName: String): Any? = when (fieldValue) {
         is Property<*> -> {
-            if (!fieldValue.isPresent) {
+            val present = DeprecationLogger.whileDisabled(Factory { fieldValue.isPresent })!!
+            if (!present) {
                 // TODO - disallow using convention mapping + property types
                 val convention = conventionalValueOf(bean, fieldName)
                 if (convention != null) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.base.Preconditions;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.internal.provider.Collectors.ElementFromProvider;
 import org.gradle.api.internal.provider.Collectors.ElementsFromArray;
 import org.gradle.api.internal.provider.Collectors.ElementsFromCollection;
@@ -329,8 +331,9 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return left.isContentProducedByTask() || right.isContentProducedByTask();
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            left.visitProducerTasks(visitor);
+            right.visitProducerTasks(visitor);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMappingProvider.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import javax.annotation.Nullable;
@@ -39,29 +41,34 @@ public abstract class AbstractMappingProvider<OUT, IN> extends AbstractMinimalPr
         return provider;
     }
 
-    @Override
-    public boolean isValueProducedByTask() {
-        // Need the content in order to transform the value
-        return provider.isContentProducedByTask();
+    protected void beforeRead() {
     }
 
     @Override
-    public boolean isContentProducedByTask() {
-        return provider.isContentProducedByTask();
+    public boolean isValueProducedByTask() {
+        return provider.isValueProducedByTask();
+    }
+
+    @Override
+    public void visitProducerTasks(Action<? super Task> visitor) {
+        provider.visitProducerTasks(visitor);
     }
 
     @Override
     public boolean isPresent() {
+        beforeRead();
         return provider.isPresent();
     }
 
     @Override
     public OUT get() {
+        beforeRead();
         return mapValue(provider.get());
     }
 
     @Override
     public OUT getOrNull() {
+        beforeRead();
         IN value = provider.getOrNull();
         if (value != null) {
             return mapValue(value);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
@@ -81,8 +83,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     }
 
     @Override
-    public boolean isContentProducedByTask() {
-        return false;
+    public void visitProducerTasks(Action<? super Task> visitor) {
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.Describables;
@@ -69,7 +70,7 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
      */
     protected abstract String describeContents();
 
-    // Final - implement describeContents() instead
+    // This method is final - implement describeContents() instead
     @Override
     public final String toString() {
         if (displayName != null) {
@@ -80,8 +81,12 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     }
 
     @Override
-    public boolean isContentProducedByTask() {
-        return producer != null || getSupplier().isContentProducedByTask();
+    public void visitProducerTasks(Action<? super Task> visitor) {
+        if (producer != null) {
+            visitor.execute(producer);
+        } else {
+            getSupplier().visitProducerTasks(visitor);
+        }
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.provider;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.DisplayName;
@@ -57,8 +59,7 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -106,8 +107,7 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -182,8 +182,8 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return providerOfElement.isContentProducedByTask();
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            providerOfElement.visitProducerTasks(visitor);
         }
 
         @Override
@@ -248,8 +248,7 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -319,8 +318,8 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return provider.isContentProducedByTask();
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            provider.visitProducerTasks(visitor);
         }
 
         @Override
@@ -353,7 +352,7 @@ public class Collectors {
         @Override
         public int size() {
             if (provider instanceof CollectionProviderInternal) {
-                return ((CollectionProviderInternal)provider).size();
+                return ((CollectionProviderInternal) provider).size();
             } else {
                 throw new UnsupportedOperationException();
             }
@@ -386,8 +385,7 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -437,8 +435,7 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -489,7 +486,7 @@ public class Collectors {
 
         @Override
         public boolean isProvidedBy(Provider<?> provider) {
-            return delegate instanceof ProvidedCollector && ((ProvidedCollector<T>)delegate).isProvidedBy(provider);
+            return delegate instanceof ProvidedCollector && ((ProvidedCollector<T>) delegate).isProvidedBy(provider);
         }
 
         @Override
@@ -503,8 +500,8 @@ public class Collectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return delegate.isContentProducedByTask();
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            delegate.visitProducerTasks(visitor);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.provider;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
@@ -332,24 +334,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
         }
     }
 
-    @Override
-    public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        if (super.maybeVisitBuildDependencies(context)) {
-            return true;
-        }
-        return value.maybeVisitBuildDependencies(context);
-    }
-
-    @Override
-    public boolean isContentProducedByTask() {
-        return super.isContentProducedByTask() || value.isContentProducedByTask();
-    }
-
-    @Override
-    public boolean isValueProducedByTask() {
-        return value.isValueProducedByTask();
-    }
-
     private class KeySetProvider extends AbstractReadOnlyProvider<Set<K>> {
 
         @Nullable
@@ -436,13 +420,14 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return left.isContentProducedByTask() || right.isContentProducedByTask();
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            left.visitProducerTasks(visitor);
+            right.visitProducerTasks(visitor);
         }
 
         @Override
         public boolean isValueProducedByTask() {
-            return left.isValueProducedByTask() || right.isContentProducedByTask();
+            return left.isValueProducedByTask() || right.isValueProducedByTask();
         }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.DisplayName;
 
@@ -62,8 +64,7 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -120,8 +121,7 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -208,8 +208,8 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return providerOfValue.isContentProducedByTask();
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            providerOfValue.visitProducerTasks(visitor);
         }
 
         @Override
@@ -264,8 +264,7 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override
@@ -330,8 +329,8 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return providerOfEntries.isContentProducedByTask();
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            providerOfEntries.visitProducerTasks(visitor);
         }
 
         @Override
@@ -377,8 +376,7 @@ public class MapCollectors {
         }
 
         @Override
-        public boolean isContentProducedByTask() {
-            return false;
+        public void visitProducerTasks(Action<? super Task> visitor) {
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -34,17 +36,21 @@ public interface ProviderInternal<T> extends Provider<T>, TaskDependencyContaine
     Class<T> getType();
 
     /**
-     * Returns true when the <em>value</em> of this provider is produced by a task.
+     * Returns true when the <em>value</em> of this provider is produced by a task. The <em>value</em> is the object returned by {@link #get()} and other query methods.
+     * This is distinct from the <em>content</em>, which is the state of the value or the thing that the value points to. For example, for a file property, the file path
+     * represents the value of the property, and the contents of the file on the file system represents the content of the property.
      *
-     * <p>Note that a task producing the value of this provider is not the same as a task producing the <em>content</em> of
+     * <p>Note that a task producing the value of this provider is not necessarily the same as a task producing the <em>content</em> of
      * the value of this provider.
      */
     boolean isValueProducedByTask();
 
     /**
-     * Returns true when the <em>content</em> of the value of this provider is produced by a task.
+     * Visits the tasks that produce the <em>content</em> of the value of this provider, if any.
+     *
+     * At some point, this method can {@link #maybeVisitBuildDependencies(TaskDependencyResolveContext)} could be merged.
      */
-    boolean isContentProducedByTask();
+    void visitProducerTasks(Action<? super Task> visitor);
 
     /**
      * Visits the build dependencies of this provider, if possible.

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 public interface ValueSupplier {
@@ -25,9 +27,9 @@ public interface ValueSupplier {
     boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context);
 
     /**
-     * See {@link ProviderInternal#isContentProducedByTask()}.
+     * See {@link ProviderInternal#visitProducerTasks(Action)}.
      */
-    boolean isContentProducedByTask();
+    void visitProducerTasks(Action<? super Task> visitor);
 
     /**
      * See {@link ProviderInternal#isValueProducedByTask()}.

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/TransformBackedProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/TransformBackedProviderTest.groovy
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.api.Task
+import org.gradle.api.logging.configuration.WarningMode
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.TaskState
+import org.gradle.internal.Describables
+import org.gradle.internal.featurelifecycle.DeprecatedFeatureUsage
+import org.gradle.internal.featurelifecycle.DeprecatedUsageBuildOperationProgressBroadaster
+import org.gradle.internal.featurelifecycle.UsageLocationReporter
+import org.gradle.util.DeprecationLogger
+import org.gradle.util.RedirectStdOutAndErr
+import org.junit.Rule
+import spock.lang.Specification
+
+class TransformBackedProviderTest extends Specification {
+    @Rule
+    RedirectStdOutAndErr outputs = new RedirectStdOutAndErr()
+    def broadcaster = Mock(DeprecatedUsageBuildOperationProgressBroadaster)
+
+    def setup() {
+        DeprecationLogger.reset()
+        DeprecationLogger.init(Stub(UsageLocationReporter), WarningMode.All, broadcaster)
+    }
+
+    def teardown() {
+        DeprecationLogger.reset()
+    }
+
+    def "warns when calling isPresent() before producer task has completed"() {
+        given:
+        def property = propertyWithProducer()
+        def provider = property.map { Integer.parseInt(it) }
+
+        when:
+        provider.isPresent()
+
+        then:
+        1 * broadcaster.progress(_) >> { DeprecatedFeatureUsage usage ->
+            assert usage.formattedMessage() == "Querying the mapped value of <prop> before <task> has completed has been deprecated. This will fail with an error in Gradle 7.0."
+        }
+        0 * broadcaster._
+    }
+
+    def "warns when calling get() before producer task has completed"() {
+        given:
+        def property = propertyWithProducer()
+        def provider = property.map { Integer.parseInt(it) }
+
+        when:
+        provider.get()
+
+        then:
+        1 * broadcaster.progress(_) >> { DeprecatedFeatureUsage usage ->
+            assert usage.formattedMessage() == "Querying the mapped value of <prop> before <task> has completed has been deprecated. This will fail with an error in Gradle 7.0."
+        }
+        0 * broadcaster._
+    }
+
+    def "does not warn when calling get() after producer task has completed"() {
+        given:
+        def property = propertyWithCompletedProducer()
+        def provider = property.map { Integer.parseInt(it) }
+
+        when:
+        provider.get()
+
+        then:
+        0 * broadcaster._
+    }
+
+    def "warns when calling getOrNull() before producer task has completed"() {
+        given:
+        def property = propertyWithProducer()
+        def provider = property.map { Integer.parseInt(it) }
+
+        when:
+        provider.getOrNull()
+
+        then:
+        1 * broadcaster.progress(_) >> { DeprecatedFeatureUsage usage ->
+            assert usage.formattedMessage() == "Querying the mapped value of <prop> before <task> has completed has been deprecated. This will fail with an error in Gradle 7.0."
+        }
+        0 * broadcaster._
+    }
+
+    def "warns when calling getOrElse() before producer task has completed"() {
+        given:
+        def property = propertyWithProducer()
+        def provider = property.map { Integer.parseInt(it) }
+
+        when:
+        provider.getOrElse(12)
+
+        then:
+        1 * broadcaster.progress(_) >> { DeprecatedFeatureUsage usage ->
+            assert usage.formattedMessage() == "Querying the mapped value of <prop> before <task> has completed has been deprecated. This will fail with an error in Gradle 7.0."
+        }
+        0 * broadcaster._
+    }
+
+    def "warns when querying chained mapping before producer task has completed"() {
+        given:
+        def property = propertyWithProducer()
+        def provider = property.map { Integer.parseInt(it) }.map { it + 2 }
+
+        when:
+        provider.get()
+
+        then:
+        1 * broadcaster.progress(_) >> { DeprecatedFeatureUsage usage ->
+            assert usage.formattedMessage() == "Querying the mapped value of map(<prop>) before <task> has completed has been deprecated. This will fail with an error in Gradle 7.0."
+        }
+        1 * broadcaster.progress(_) >> { DeprecatedFeatureUsage usage ->
+            assert usage.formattedMessage() == "Querying the mapped value of <prop> before <task> has completed has been deprecated. This will fail with an error in Gradle 7.0."
+        }
+        0 * broadcaster._
+    }
+
+    def "warns when querying orElse() mapping before producer task has completed"() {
+        given:
+        def property = propertyWithProducer()
+        def provider = property.map { Integer.parseInt(it) }.orElse(12)
+
+        when:
+        provider.get()
+
+        then:
+        1 * broadcaster.progress(_) >> { DeprecatedFeatureUsage usage ->
+            assert usage.formattedMessage() == "Querying the mapped value of <prop> before <task> has completed has been deprecated. This will fail with an error in Gradle 7.0."
+        }
+        0 * broadcaster._
+    }
+
+    Property<String> propertyWithProducer() {
+        def task = Mock(Task)
+        def state = Mock(TaskState)
+        _ * task.toString() >> "<task>"
+        _ * task.state >> state
+        def property = new DefaultProperty(String)
+        property.attachDisplayName(Describables.of("<prop>"))
+        property.attachProducer(task)
+        property.set("12")
+        return property
+    }
+
+    Property<String> propertyWithCompletedProducer() {
+        def task = Mock(Task)
+        def state = Mock(TaskState)
+        _ * task.toString() >> "<task>"
+        _ * task.state >> state
+        _ * state.executed >> true
+        def property = new DefaultProperty(String)
+        property.attachDisplayName(Describables.of("<prop>"))
+        property.attachProducer(task)
+        property.set("12")
+        return property
+    }
+}

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -71,7 +71,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         this.source = getProject().files();
         this.linkedFile = objectFactory.fileProperty();
         this.destinationDirectory = objectFactory.directoryProperty();
-        destinationDirectory.set(linkedFile.map(regularFile -> {
+        destinationDirectory.set(linkedFile.getLocationOnly().map(regularFile -> {
             // TODO: Get rid of destinationDirectory entirely and replace it with a
             // collection of link outputs
             DirectoryProperty dirProp = objectFactory.directoryProperty();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -213,7 +213,7 @@ public class InstallExecutable extends DefaultTask {
     }
 
     private Provider<Directory> getLibDirectory() {
-        return getInstallDirectory().dir("lib");
+        return getInstallDirectory().getLocationOnly().map(dir -> dir.dir("lib"));
     }
 
     private void installWindows(File executable, File runScript) {


### PR DESCRIPTION

### Context

Some initial changes to disallow using a task output until the task has completed execution. This PR deprecates querying a `Provider` that represents a mapped task output file, until that task has completed execution.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
