### PR TITLE
Run smoke tests on both minimum and maximum supported Java versions

### DIFF
--- a/.teamcity/Gradle_Check/configurations/BuildJavaVersions.kt
+++ b/.teamcity/Gradle_Check/configurations/BuildJavaVersions.kt
@@ -6,5 +6,4 @@ private val linuxJava11Openjdk = "%linux.java11.openjdk.64bit%"
 val buildJavaHome = linuxJava11Openjdk
 val coordinatorPerformanceTestJavaHome = linuxJava8Oracle
 val individualPerformanceTestJavaHome = linuxJava8Oracle
-val smokeTestJavaHome = linuxJava8Oracle
 val distributionTestJavaHome = linuxJava11Openjdk

--- a/.teamcity/Gradle_Check/configurations/SmokeTests.kt
+++ b/.teamcity/Gradle_Check/configurations/SmokeTests.kt
@@ -1,13 +1,14 @@
 package configurations
 
+import common.JvmCategory
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
 import model.CIBuildModel
 import model.Stage
 
-class SmokeTests(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
-    uuid = "${model.projectPrefix}SmokeTests"
+class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory) : BaseGradleBuildType(model, stage = stage, init = {
+    uuid = "${model.projectPrefix}SmokeTests${testJava.version.name.capitalize()}"
     id = AbsoluteId(uuid)
-    name = "Smoke Tests with 3rd Party Plugins - Java8 Linux"
+    name = "Smoke Tests with 3rd Party Plugins - ${testJava.version.name.capitalize()} Linux"
     description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"
 
     params {
@@ -20,10 +21,10 @@ class SmokeTests(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model,
     }
 
     applyTestDefaults(
-            model,
-            this,
-            "smokeTest:smokeTest",
-            notQuick = true,
-            extraParameters = buildScanTag("SmokeTests") + " -PtestJavaHome=$smokeTestJavaHome"
+        model,
+        this,
+        "smokeTest:smokeTest",
+        notQuick = true,
+        extraParameters = buildScanTag("SmokeTests") + " -PtestJavaHome=%linux.${testJava.version.name}.${testJava.vendor.name}.64bit%"
     )
 })

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -52,7 +52,9 @@ data class CIBuildModel(
             specificBuilds = listOf(
                 SpecificBuild.BuildDistributions,
                 SpecificBuild.Gradleception,
-                SpecificBuild.SmokeTests),
+                SpecificBuild.SmokeTestsMinJavaVersion,
+                SpecificBuild.SmokeTestsMaxJavaVersion
+            ),
             functionalTests = listOf(
                 TestCoverage(3, TestType.platform, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(4, TestType.platform, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)),
@@ -445,9 +447,14 @@ enum class SpecificBuild {
             return Gradleception(model, stage)
         }
     },
-    SmokeTests {
+    SmokeTestsMinJavaVersion {
         override fun create(model: CIBuildModel, stage: Stage): BuildType {
-            return SmokeTests(model, stage)
+            return SmokeTests(model, stage, JvmCategory.MIN_VERSION)
+        }
+    },
+    SmokeTestsMaxJavaVersion {
+        override fun create(model: CIBuildModel, stage: Stage): BuildType {
+            return SmokeTests(model, stage, JvmCategory.MAX_VERSION)
         }
     },
     DependenciesCheck {

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -40,7 +40,7 @@ class PerformanceTestBuildTypeTest {
                 specificBuilds = listOf(
                         SpecificBuild.BuildDistributions,
                         SpecificBuild.Gradleception,
-                        SpecificBuild.SmokeTests),
+                        SpecificBuild.SmokeTestsMinJavaVersion),
                 functionalTests = listOf(
                         TestCoverage(1, TestType.platform, Os.linux, JvmVersion.java8),
                         TestCoverage(2, TestType.platform, Os.windows, JvmVersion.java11, vendor = JvmVendor.openjdk)),


### PR DESCRIPTION
This PR changes the CI model to run smoke tests on both the minimum supported Java version and the maximum supported Java version.

Motivation is that we should not only get signal when we break tested scenario with the minimum supported Java version only.

What triggered the change is the will to introduce a smoke test that would require Java >= 9, and running smoke tests on Java 8 only prevented that.