### PR TITLE
Do not add enforced-platform variant to published components

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.DependencyConstraint;
 
 /**
@@ -87,7 +88,11 @@ public interface DependencyConstraintHandler {
      * @param notation the coordinates of the platform
      *
      * @since 5.0
+     *
+     * @deprecated Please use {@link DependencyHandler#enforcedPlatform(Object)}
      */
+    @Incubating
+    @Deprecated
     DependencyConstraint enforcedPlatform(Object notation);
 
     /**
@@ -100,6 +105,10 @@ public interface DependencyConstraintHandler {
      * @param configureAction the dependency configuration block
      *
      * @since 5.0
+     *
+     * @deprecated Please use {@link DependencyHandler#enforcedPlatform(Object, Action)} )}
      */
+    @Incubating
+    @Deprecated
     DependencyConstraint enforcedPlatform(Object notation, Action<? super DependencyConstraint> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -520,6 +520,7 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 5.0
      */
+    @Incubating
     Dependency enforcedPlatform(Object notation);
 
     /**
@@ -533,6 +534,7 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 5.0
      */
+    @Incubating
     Dependency enforcedPlatform(Object notation, Action<? super Dependency> configureAction);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
@@ -50,7 +50,10 @@ public interface Category extends Named {
 
     /**
      * The enforced platform, usually a synthetic variant derived from the {@code platform}
+     *
+     * Deprecated: enforced platforms are no longer represented as derive variants, but define them through strict versions and component metadata rules
      */
+    @Deprecated
     String ENFORCED_PLATFORM = "enforced-platform";
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -44,6 +44,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     private final ProjectInternal dependencyProject;
     private final boolean buildProjectDependencies;
     private final ProjectAccessListener projectAccessListener;
+    private DependencyConstraint associatedConstraint;
 
     public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
         this(dependencyProject, null, projectAccessListener, buildProjectDependencies);

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
@@ -161,7 +161,7 @@ class ForcingUsingStrictlyPlatformAlignmentTest extends AbstractAlignmentSpec {
         then:
         failure.assertHasCause """Cannot find a version of 'org:databind' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:databind:{strictly 2.7.9}'
-   Constraint path ':test:unspecified' --> 'org:platform:2.9.4' --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
+   Constraint path ':test:unspecified' --> 'org:core:2.9.4' --> 'org:platform:2.9.4' --> 'org:databind:2.9.4' because of the following reason: belongs to platform org:platform:2.9.4"""
     }
 
     def "fails if forcing a virtual platform version by forcing multiple leaves with different versions, including transitively"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -412,6 +412,90 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         }
     }
 
+    @Issue("gradle/gradle#11091")
+    def "resolves to runtime platform variant of a platform with gradle metadata if no attributes are requested"() {
+        def platform = mavenHttpRepo.module("org", "platform", "1.0").withModuleMetadata().withoutDefaultVariants()
+            .withVariant('api') {
+                useDefaultArtifacts = false
+                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
+                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+            }
+            .withVariant('runtime') {
+                useDefaultArtifacts = false
+                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
+                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+            }.publish()
+
+        when:
+        buildFile << """
+            configurations { conf }
+            dependencies {
+                conf "org:platform:1.0"
+            }
+        """
+        checkConfiguration("conf")
+
+        platform.pom.expectGet()
+        platform.moduleMetadata.expectGet()
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", "org.test:test:1.9") {
+                module("org:platform:1.0") {
+                    variant("runtime", [
+                        'org.gradle.category': 'platform',
+                        'org.gradle.status': 'release',
+                        'org.gradle.usage': 'java-runtime'])
+                    noArtifacts()
+                }
+            }
+        }
+    }
+
+    @Issue("gradle/gradle#11091")
+    def "can enforce a platform that is already on the dependency graph"() {
+        // TODO add test with published platform dependency
+        def platform = mavenHttpRepo.module("org", "platform", "1.0").withModuleMetadata().withoutDefaultVariants()
+            .withVariant('api') {
+                useDefaultArtifacts = false
+                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
+                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+            }
+            .withVariant('runtime') {
+                useDefaultArtifacts = false
+                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
+                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+            }.publish()
+
+        when:
+        buildFile << """
+            dependencies {
+                api platform("org:platform:1.0")
+                api enforcedPlatform("org:platform:1.0")
+            }
+        """
+        checkConfiguration("compileClasspath")
+
+        platform.pom.expectGet()
+        platform.moduleMetadata.expectGet()
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", "org.test:test:1.9") {
+                module("org:platform:1.0") {
+                    variant("api", [
+                        'org.gradle.category': 'platform',
+                        'org.gradle.status': 'release',
+                        'org.gradle.usage': 'java-api'])
+                    noArtifacts()
+                }
+                edge("org:platform:{strictly 1.0}", "org:platform:1.0")
+            }
+        }
+    }
+
     private void checkConfiguration(String configuration) {
         resolve = new ResolveTestFixture(buildFile, configuration)
         resolve.expectDefaultConfiguration("compile")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -91,6 +91,8 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     public DependencyConstraint enforcedPlatform(Object notation) {
         DependencyConstraintInternal platformDependency = (DependencyConstraintInternal) create(notation);
         platformDependency.setForce(true);
+        // This might no longer have an effect as published components usually won't carry the attribute anymore
+        // This is therefore deprecated and only dependencies (and not constraints) should be declared as 'enforcedPlatform'
         platformSupport.addPlatformAttribute(platformDependency, enforcedPlatform);
         return platformDependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/EnforcedPlatformComponentMetadataRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/EnforcedPlatformComponentMetadataRule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import org.gradle.api.artifacts.CacheableRule;
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+import org.gradle.api.artifacts.DependencyConstraintMetadata;
+import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.artifacts.DirectDependencyMetadata;
+
+import java.util.List;
+
+@CacheableRule
+public class EnforcedPlatformComponentMetadataRule implements ComponentMetadataRule {
+
+    @Override
+    public void execute(ComponentMetadataContext context) {
+        context.getDetails().allVariants(variantMetadata -> {
+            variantMetadata.withDependencyConstraints(constraints -> {
+                for (DependencyConstraintMetadata constraint : constraints) {
+                    makeStrict(constraint);
+                }
+            });
+            variantMetadata.withDependencies(dependencies -> {
+                for (DirectDependencyMetadata dependency : dependencies) {
+                    makeStrict(dependency);
+                }
+            });
+        });
+    }
+
+    private void makeStrict(DependencyMetadata<?> dependency) {
+        List<String> rejectedVersions = dependency.getVersionConstraint().getRejectedVersions();
+        dependency.version(v -> {
+            v.strictly(v.getRequiredVersion());
+            if (!rejectedVersions.isEmpty()) {
+                v.reject(rejectedVersions.toArray(new String[0]));
+            }
+        });
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -55,6 +55,7 @@ public enum CacheLayout {
         .changedTo(69, "5.0-rc-1")
         .changedTo(71, "5.3-rc-1")
         .changedTo(79, "6.0-rc-1")
+        .changedTo(787_889_432, "6.0-rc-2")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -24,15 +24,12 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.Category;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
-import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAttributesFactory;
-import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
@@ -60,7 +57,6 @@ import static com.google.gson.stream.JsonToken.END_ARRAY;
 import static com.google.gson.stream.JsonToken.END_OBJECT;
 import static com.google.gson.stream.JsonToken.NUMBER;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang.StringUtils.capitalize;
 
 public class GradleModuleMetadataParser {
     private final static Logger LOGGER = Logging.getLogger(GradleModuleMetadataParser.class);
@@ -207,13 +203,6 @@ public class GradleModuleMetadataParser {
 
         MutableComponentVariant variant = metadata.addVariant(variantName, attributes);
         populateVariant(files, dependencies, dependencyConstraints, capabilities, variant);
-        AttributeValue<String> entry = attributes.findEntry(MavenImmutableAttributesFactory.CATEGORY_ATTRIBUTE);
-        if (entry.isPresent() && Category.REGULAR_PLATFORM.equals(entry.get())) {
-            // This generates a synthetic enforced platform variant with the same dependencies, similar to what the Maven variant derivation strategy does
-            ImmutableAttributes enforcedAttributes = attributesFactory.concat(attributes, MavenImmutableAttributesFactory.CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.ENFORCED_PLATFORM, instantiator));
-            MutableComponentVariant syntheticEnforcedVariant = metadata.addVariant("enforced" + capitalize(variantName), enforcedAttributes);
-            populateVariant(files, dependencies, dependencyConstraints, capabilities, syntheticEnforcedVariant);
-        }
     }
 
     private void populateVariant(List<ModuleFile> files, List<ModuleDependency> dependencies, List<ModuleDependencyConstraint> dependencyConstraints, List<VariantCapability> capabilities, MutableComponentVariant variant) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -50,10 +50,8 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
                     // component we cannot mix precise usages with more generic ones)
                 libraryWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API),
                 libraryWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME),
-                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, false, shadowedPlatformCapability),
-                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, false, shadowedPlatformCapability),
-                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, true, shadowedPlatformCapability),
-                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, true, shadowedPlatformCapability));
+                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, shadowedPlatformCapability),
+                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, shadowedPlatformCapability));
         }
         return null;
     }
@@ -77,17 +75,14 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
                 .build();
     }
 
-    private static ConfigurationMetadata platformWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage, boolean enforcedPlatform, ImmutableCapabilities shadowedPlatformCapability) {
-        ImmutableAttributes attributes = attributesFactory.platformWithUsage(originAttributes, usage, enforcedPlatform);
-        String prefix = enforcedPlatform ? "enforced-platform-" : "platform-";
+    private static ConfigurationMetadata platformWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage, ImmutableCapabilities shadowedPlatformCapability) {
+        ImmutableAttributes attributes = attributesFactory.platformWithUsage(originAttributes, usage, false);
+        String prefix = "platform-";
         DefaultConfigurationMetadata.Builder builder = conf.mutate()
                 .withName(prefix + conf.getName())
                 .withAttributes(attributes)
                 .withConstraintsOnly()
                 .withCapabilities(shadowedPlatformCapability);
-        if (enforcedPlatform) {
-            builder = builder.withForcedDependencies();
-        }
         return builder.build();
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 79
+        expectedVersion = 787_889_432
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -160,7 +160,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         assertHasOnlyStatusAttribute(compileConf.attributes)
         assertHasOnlyStatusAttribute(runtimeConf.attributes)
 
-        variantsForGraphTraversal.size() == 6
+        variantsForGraphTraversal.size() == 4
         variantsForGraphTraversal[0].name == "compile"
         variantsForGraphTraversal[0].attributes.getAttribute(stringUsageAttribute) == "java-api"
         variantsForGraphTraversal[1].name == "runtime"
@@ -171,12 +171,6 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         variantsForGraphTraversal[3].name == "platform-runtime"
         variantsForGraphTraversal[3].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
         variantsForGraphTraversal[3].attributes.getAttribute(componentTypeAttribute) == "platform"
-        variantsForGraphTraversal[4].name == "enforced-platform-compile"
-        variantsForGraphTraversal[4].attributes.getAttribute(stringUsageAttribute) == "java-api"
-        variantsForGraphTraversal[4].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
-        variantsForGraphTraversal[5].name == "enforced-platform-runtime"
-        variantsForGraphTraversal[5].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
-        variantsForGraphTraversal[5].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
 
         where:
         packaging << ["pom", "jar", "maven-plugin", "war", "aar"]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -165,7 +165,7 @@ class VariantFilesMetadataRulesTest extends Specification {
 
         where:
         metadataType | metadata                       | initialVariantCount
-        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "maven"      | mavenComponentMetadata('dep')  | 4 // default derivation strategy for maven
         "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
         "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
     }
@@ -187,7 +187,7 @@ class VariantFilesMetadataRulesTest extends Specification {
 
         where:
         metadataType | metadata                       | initialVariantCount
-        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "maven"      | mavenComponentMetadata('dep')  | 4 // default derivation strategy for maven
         "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
         "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
     }

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
@@ -349,8 +349,6 @@ All dependencies of those scopes are considered _runtime dependencies_.
 * 4 "platform" variants derived from the `<dependencyManagement>` block (attribute `org.gradle.category` = `platform`):
 ** the `platform-compile` variant maps the  `<scope>compile</scope>` dependency management dependencies as _dependency constraints_.
 ** the `platform-runtime` variant maps both the `<scope>compile</scope>` and `<scope>runtime</scope>` dependency management dependencies as _dependency constraints_.
-** the `enforced-platform-compile` is similar to `platform-compile` but all the constraints are _forced_
-** the `enforced-platform-runtime` is similar to `platform-runtime` but all the constraints are _forced_
 
 You can understand more about the use of platform and enforced platforms variants by looking at the <<platforms.adoc#sub:bom_import, importing BOMs>> section of the manual.
 By default, whenever you declare a dependency on a Maven module, Gradle is going to look for the `library` variants.

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/metadataRule/failRuntimeClasspathResolve.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/metadataRule/failRuntimeClasspathResolve.out
@@ -4,21 +4,10 @@ Execution failed for task ':failRuntimeClasspathResolve'.
      Required by:
          project :
       > Cannot choose between the following variants of org.lwjgl:lwjgl:3.2.3:
-          - enforced-platform-runtime
           - natives-windows-runtime
           - natives-windows-x86-runtime
           - platform-runtime
         All of them match the consumer attributes:
-          - Variant 'enforced-platform-runtime' capability org.lwjgl:lwjgl-derived-platform:3.2.3:
-              - Unmatched attributes:
-                  - Found org.gradle.category 'enforced-platform' but wasn't required.
-                  - Required org.gradle.dependency.bundling 'external' but no value provided.
-                  - Required org.gradle.jvm.version '11' but no value provided.
-                  - Required org.gradle.libraryelements 'jar' but no value provided.
-                  - Required org.gradle.native.operatingSystem 'windows' but no value provided.
-                  - Found org.gradle.status 'release' but wasn't required.
-              - Compatible attribute:
-                  - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.
           - Variant 'natives-windows-runtime' capability org.lwjgl:lwjgl:3.2.3:
               - Unmatched attributes:
                   - Found org.gradle.category 'library' but wasn't required.

--- a/subprojects/docs/src/samples/userguide/java/fixtures/dependencyInsight.out
+++ b/subprojects/docs/src/samples/userguide/java/fixtures/dependencyInsight.out
@@ -8,8 +8,6 @@ com.google.code.gson:gson:2.8.5 FAILED
                - Variant runtime provides com.google.code.gson:gson:2.8.5
                - Variant platform-compile provides com.google.code.gson:gson-derived-platform:2.8.5
                - Variant platform-runtime provides com.google.code.gson:gson-derived-platform:2.8.5
-               - Variant enforced-platform-compile provides com.google.code.gson:gson-derived-platform:2.8.5
-               - Variant enforced-platform-runtime provides com.google.code.gson:gson-derived-platform:2.8.5
 
 com.google.code.gson:gson:2.8.5 FAILED
 \--- functionalTestClasspath


### PR DESCRIPTION
Instead, implement `enforcedPlatform()` with strict versions for external modules:
- For external dependencies, we use `stricty` and no additional variant. This avoids "leaking" an enforced-platform variant everywhere causing potential disambiguety issues and in general make matching issues/errors harder to understand.
In particular, there is no more variant derivation for Gradle Module Metadata directly in the parser (!).
It also means cleaner semantics and error messages as we do not use "force" anymore.
- For platform projects, we still use the _enforced platform_ variant. But that's only an internal usage of the attribute/variant can be improved in the future. Also, the java-platform plugin comes with additional disambiguation rules to deal with the variant.
- declaring `enforcedPlatform` for dependency constraints is deprecated. It won't work this way and I fail to see the use case for it. There is also not test coverage. (This could maybe be removed directly - it was still incubating.)
