### PR TITLE
Upgrade to idea-ext 0.7

### DIFF
--- a/buildSrc/subprojects/ide/ide.gradle.kts
+++ b/buildSrc/subprojects/ide/ide.gradle.kts
@@ -3,7 +3,7 @@ dependencies {
     implementation(project(":kotlinDsl"))
     // TODO remove dependency once docs has publications
     implementation(project(":docs"))
-    implementation("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.4.2")
+    implementation("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")
 }
 
 gradlePlugin {

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -155,23 +155,6 @@ open class IdePlugin : Plugin<Project> {
     private
     fun ProjectSettings.configureRunConfigurations(rootProject: Project) {
         runConfigurations {
-            val gradleRunners = mapOf(
-                "Regenerate Int Test Image" to "prepareVersionsInfo intTestImage publishLocalArchives"
-            )
-            gradleRunners.forEach { (name, tasks) ->
-                create<Application>(name) {
-                    mainClass = "org.gradle.testing.internal.util.GradlewRunner"
-                    programParameters = tasks
-                    workingDirectory = rootProject.projectDir.absolutePath
-                    moduleName = "org.gradle.internalTesting.main"
-                    envs = mapOf("TERM" to "xterm")
-                    beforeRun {
-                        create<Make>("make") {
-                            enabled = false
-                        }
-                    }
-                }
-            }
             create<Application>("Run Gradle") {
                 mainClass = "org.gradle.debug.GradleRunConfiguration"
                 programParameters = "help"


### PR DESCRIPTION
The new version doesn't use some of the deprecated APIs. I tried it out and it seems to work apart from creating the `Regenerate Int Test Image` task. Though I think we should remove that gradle runner anyway and run the correct task in the subprojects. WDYT?