### PR TITLE
Fix publication warning report

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -80,7 +80,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         given:
         file("settings.gradle") << '''
-            rootProject.name = 'publishTest' 
+            rootProject.name = 'publishTest'
             include "b"
         '''
         buildFile << """
@@ -100,7 +100,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                     }
                 }
             }
-            
+
             dependencies {
                 $gradleConfiguration project(':b')
             }
@@ -108,10 +108,10 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         file('b/build.gradle') << """
             apply plugin: 'java'
-            
+
             group = 'org.gradle.test'
             version = '1.2'
-            
+
         """
 
         when:
@@ -531,7 +531,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 constraints {
                     api "commons-logging:commons-logging:1.1"
                     implementation "commons-logging:commons-logging:1.2"
-                    
+
                     implementation("org.tukaani:xz") {
                         version { strictly "1.6" }
                     }
@@ -869,7 +869,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                     }
                 }
                 implementation("commons-collections:commons-collections:[3.2, 4)") {
-                    version { 
+                    version {
                         reject '3.2.1', '[3.2.2,)'
                     }
                 }
@@ -993,6 +993,35 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         javaLibrary.assertPublished()
     }
 
+    def "can ignore all publication warnings by variant name"() {
+        given:
+        def silenceMethod = "suppressIvyMetadataWarningsFor"
+        createBuildScripts("""
+
+            configurations.api.outgoing.capability 'org:foo:1.0'
+            configurations.implementation.outgoing.capability 'org:bar:1.0'
+
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        $silenceMethod('apiElements')
+                        $silenceMethod('runtimeElements')
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        outputDoesNotContain(DefaultIvyPublication.PUBLICATION_WARNING_FOOTER)
+        outputDoesNotContain("Ivy publication 'ivy' warnings:")
+        outputDoesNotContain('Declares capability org:foo:1.0')
+        javaLibrary.assertPublished()
+    }
+
     def "can ignore all publication warnings"() {
         given:
         createBuildScripts("""
@@ -1045,13 +1074,13 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                         attribute(attr1, 'hello')
                     }
                 }
-                
+
                 api(project(':utils')) {
                     attributes {
                         attribute(attr1, 'bazinga')
                     }
                 }
-                
+
                 constraints {
                     implementation("org.test:bar:1.1") {
                         attributes {
@@ -1061,7 +1090,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                     }
                 }
             }
-            
+
             publishing {
                 publications {
                     ivy(IvyPublication) {
@@ -1135,7 +1164,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                     }
                 }
             }
-            
+
             generateMetadataFileForIvyPublication.enabled = $enabled
         """)
         settingsFile.text = "rootProject.name = 'publishTest' "

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
@@ -344,7 +344,7 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
                     }
                 }
                 implementation("commons-collections:commons-collections:[3.2, 4)") {
-                    version { 
+                    version {
                         reject '3.2.1', '[3.2.2,)'
                     }
                 }
@@ -554,7 +554,7 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
                     }
                 }
             }
-            
+
             dependencies {
                 $gradleConfiguration project(':b')
             }
@@ -565,10 +565,10 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
 
         file('b/build.gradle') << """
             apply plugin: 'java'
-            
+
             group = 'org.gradle.test'
             version = '1.2'
-            
+
         """
 
         when:
@@ -860,13 +860,13 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
                         attribute(attr1, 'hello')
                     }
                 }
-                
+
                 api(project(':utils')) {
                     attributes {
                         attribute(attr1, 'bazinga')
                     }
                 }
-                
+
                 constraints {
                     implementation("org.test:bar:1.1") {
                         attributes {
@@ -876,7 +876,7 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
                     }
                 }
             }
-            
+
             publishing {
                 publications {
                     maven(MavenPublication) {
@@ -1008,7 +1008,7 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
                 api platform("org.test:platform:1.0")
                 components.withModule('org.test:bar', VirtualPlatform)
             }
-            
+
             class VirtualPlatform implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext ctx) {
                     ctx.details.with {
@@ -1060,7 +1060,7 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
                 api platform("org.test:platform:1.0")
                 components.withModule('org.test:bar', VirtualPlatform)
             }
-            
+
             class VirtualPlatform implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext ctx) {
                     ctx.details.with {
@@ -1183,7 +1183,7 @@ include(':platform')
                     }
                 }
             }
-            
+
             generateMetadataFileForMavenPublication.enabled = $enabled
         """)
         settingsFile.text = "rootProject.name = 'publishTest' "
@@ -1221,12 +1221,12 @@ include(':platform')
             publishing {
                 publications {
                     maven(MavenPublication) {
-                        from components.java                        
+                        from components.java
                     }
                 }
-            }            
-                
-            
+            }
+
+
             ${features().collect { """
                 components.java.withVariantsFromConfiguration(configurations.${MavenJavaModule.variantName(it, 'apiElements')}) { skip() }
                 components.java.withVariantsFromConfiguration(configurations.${MavenJavaModule.variantName(it, 'runtimeElements')}) { skip() }
@@ -1268,7 +1268,7 @@ include(':platform')
             }
             group = 'org.gradle.test'
             version = '1.9'
-            
+
             $append
         """
     }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -110,4 +110,32 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishJavaIntegTest {
             assert variants[0].dependencies*.coords == ["org:foo:1.0"]
         }
     }
+
+    def "can ignore all publication warnings by variant name"() {
+        given:
+        def silenceMethod = "suppressPomMetadataWarningsFor"
+        createBuildScripts("""
+
+            configurations.api.outgoing.capability 'org:foo:1.0'
+            configurations.implementation.outgoing.capability 'org:bar:1.0'
+
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                        $silenceMethod('runtimeElements')
+                        $silenceMethod('apiElements')
+                    }
+                }
+            }
+        """)
+
+        when:
+        run "publish"
+
+        then:
+        outputDoesNotContain(DefaultMavenPublication.PUBLICATION_WARNING_FOOTER)
+        javaLibrary.assertPublished()
+    }
+
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
@@ -56,13 +56,13 @@ public class PublicationWarningsCollector {
     public void complete(String header, Set<String> silencedVariants) {
         saveVariantWarnings();
 
+        variantToWarnings.keySet().removeAll(silencedVariants);
         if (!variantToWarnings.isEmpty()) {
             TreeFormatter treeFormatter = new TreeFormatter();
             treeFormatter.node(header + " warnings (silence with '" + disableMethod + "(variant)')");
             treeFormatter.startChildren();
-            variantToWarnings.entrySet().stream().filter(entry -> !silencedVariants.contains(entry.getKey())).forEach(entry -> {
-                CollectedWarnings warnings = entry.getValue();
-                treeFormatter.node("Variant " + entry.getKey() + ":");
+            variantToWarnings.forEach((key, warnings) -> {
+                treeFormatter.node("Variant " + key + ":");
                 treeFormatter.startChildren();
                 if (warnings.getVariantUnsupported() != null) {
                     warnings.getVariantUnsupported().forEach(treeFormatter::node);


### PR DESCRIPTION
An output is no longer presented if all warnings are silenced by variant
name.