### PR TITLE
Fix spelling: it's coordinates -> its coordinates

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/dependency_management_terminology.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/dependency_management_terminology.adoc
@@ -31,7 +31,7 @@ Directories are common in the case of inter-project dependencies to avoid the co
 
 A capability identifies a feature offered by one or multiple components.
 A capability is identified by coordinates similar to the coordinates used for a <<sub:terminology_module_version,module versions>>.
-By default, each module version offers a capability that matches it's coordinates, for example `com.google:guava:18.0`.
+By default, each module version offers a capability that matches its coordinates, for example `com.google:guava:18.0`.
 Capabilities can be used to express that a component provides multiple <<sub:terminology_feature_variant,feature variants>> or that two different components implement the same feature (and thus cannot be used together).
 For more details, see the section on <<component_capabilities.adoc#,capabilities>>.
 


### PR DESCRIPTION
I skipped most of the "Contributor Checklist" because it's irrelevant for a simple typo/spelling fix on a Apache 2 licensed project. Please, consider making a short path for that.

### Gradle Core Team Checklist
- [ ] Verify documentation
