### PR TITLE
Don't pass main class name if --module is present

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/JvmOptionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/JvmOptionsIntegrationTest.groovy
@@ -76,6 +76,7 @@ class JvmOptionsIntegrationTest extends AbstractPluginIntegrationTest {
             public class HelloWorld {
                 private final static String hello = "Hello %s World!%n";
                 static public void main(String... args){
+                    assert args.length == 1 : "Should have one parameter!";
                     assert hasOnlyAppArgs(args) : "When executing a JPMS module's Main-Class, JVM options located after the application's entry point are illegal";
 
                     for(String world : args ){
@@ -96,16 +97,13 @@ class JvmOptionsIntegrationTest extends AbstractPluginIntegrationTest {
                 id 'application'
             }
 
-            mainClassName = "my.module/io.greeting.HelloWorld"
-
             run {
                 doFirst {
                     args = ['Gradle']
-                    main = ''
                     jvmArgs = [
                         '-ea',
                         '--module-path', classpath.asPath,
-                        '--module', mainClassName
+                        '--module', 'my.module/io.greeting.HelloWorld'
                     ]
                     classpath = files()
                     println ":run Task's command line: $commandLine"

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -80,7 +80,9 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
             if (realClasspath != null && realClasspath.getFiles().size() == 1) {
                 allArgs.add("-jar");
                 allArgs.add(realClasspath.getSingleFile().getAbsolutePath());
-            } else {
+            } else if (!allArgs.contains("--module")) {
+                // `java --module <module>/<main-class>` is enough, no main class needed
+                // https://github.com/gradle/gradle/issues/11124
                 throw new IllegalStateException("No main class specified and classpath is not an executable jar.");
             }
         } else {

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -67,7 +67,7 @@ class JavaExecHandleBuilderTest extends Specification {
 
         then:
         String executable = Jvm.current().getJavaExecutable().getAbsolutePath()
-        commandLine == [executable,  '-Dprop=value', '-Xms64m', '-Xmx1g', fileEncodingProperty(expectedEncoding), *localeProperties(), 'jvm1', 'jvm2', '-cp', "$jar1$File.pathSeparator$jar2", 'mainClass', 'arg1', 'arg2']
+        commandLine == [executable, '-Dprop=value', '-Xms64m', '-Xmx1g', fileEncodingProperty(expectedEncoding), *localeProperties(), 'jvm1', 'jvm2', '-cp', "$jar1$File.pathSeparator$jar2", 'mainClass', 'arg1', 'arg2']
 
         where:
         inputEncoding | expectedEncoding
@@ -122,9 +122,22 @@ class JavaExecHandleBuilderTest extends Specification {
 
     }
 
+    @Issue('https://github.com/gradle/gradle/issues/11124')
+    def 'allow null main class if --module is present'() {
+        when:
+        builder.main = null
+        builder.jvmArgs('--module', 'someModule/MainClass')
+        builder.jvmArgs('myParameter')
+
+        then:
+        builder.commandLine[-3..-1] == ['--module', 'someModule/MainClass', 'myParameter']
+    }
+
     def "detects null entries early"() {
-        when: builder.args(1, null)
-        then: thrown(IllegalArgumentException)
+        when:
+        builder.args(1, null)
+        then:
+        thrown(IllegalArgumentException)
     }
 
     private String fileEncodingProperty(String encoding = Charset.defaultCharset().name()) {


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle/issues/11124

Java 9+ allows `java --module <module>/<main-class> your java program parameters`.
In this case, no main class name is needed. We should allow null main class name
and not use it when constructing command line arguments.