### PR TITLE
Strip userinfo from Gradle dist cache key

### DIFF
--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
@@ -114,8 +114,12 @@ public class Download implements IDownload {
      * @param uri Original URI
      * @return a new URI with no user info
      */
-    static URI safeUri(URI uri) throws URISyntaxException {
-        return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+    static URI safeUri(URI uri) {
+        try {
+            return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Failed to parse URI", e);
+        }
     }
 
     private void addBasicAuthentication(URI address, URLConnection connection) throws IOException {

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/PathAssembler.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/PathAssembler.java
@@ -46,7 +46,7 @@ public class PathAssembler {
     }
 
     private String rootDirName(String distName, WrapperConfiguration configuration) {
-        String urlHash = getHash(configuration.getDistribution().toString());
+        String urlHash = getHash(Download.safeUri(configuration.getDistribution()).toString());
         return distName + "/" + urlHash;
     }
 

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/PathAssemblerTest.java
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/PathAssemblerTest.java
@@ -36,11 +36,11 @@ public class PathAssemblerTest {
         configuration.setZipBase(PathAssembler.GRADLE_USER_HOME_STRING);
         configuration.setZipPath("somePath");
     }
-    
+
     @Test
     public void distributionDirWithGradleUserHomeBase() throws Exception {
         configuration.setDistribution(new URI("http://server/dist/gradle-0.9-bin.zip"));
-        
+
         File distributionDir = pathAssembler.getDistribution(configuration).getDistributionDir();
         assertThat(distributionDir.getName(), equalTo("emn8ua2x0re2y4jlewhnxhasz"));
         assertThat(distributionDir.getParentFile(), equalTo(file(TEST_GRADLE_USER_HOME + "/somePath/gradle-0.9-bin")));
@@ -70,6 +70,19 @@ public class PathAssemblerTest {
     }
 
     @Test
+    public void distributionDirWithUserInfo() throws Exception {
+        configuration.setDistributionBase(PathAssembler.PROJECT_STRING);
+
+        configuration.setDistribution(new URI("http://username1:password1@server/dist/gradle-0.9-bin.zip"));
+        File distributionDir1 = pathAssembler.getDistribution(configuration).getDistributionDir();
+
+        configuration.setDistribution(new URI("http://username2:password2@server/dist/gradle-0.9-bin.zip"));
+        File distributionDir2 = pathAssembler.getDistribution(configuration).getDistributionDir();
+
+        assertThat(distributionDir1.getName(), equalTo(distributionDir2.getName()));
+    }
+
+    @Test
     public void distZipWithGradleUserHomeBase() throws Exception {
         configuration.setDistribution(new URI("http://server/dist/gradle-1.0.zip"));
 
@@ -93,7 +106,7 @@ public class PathAssemblerTest {
     private File file(String path) {
         return new File(path);
     }
-    
+
     private String currentDirPath() {
         return System.getProperty("user.dir");
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #11120 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Prevents unnecessary downloads of distributions.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
