### PR TITLE
Refine how we skip buildSrc checks

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -119,8 +119,12 @@ val isSkipBuildSrcVerification: Boolean =
 
 if (isSkipBuildSrcVerification) {
     allprojects {
-        tasks.matching { it.group == LifecycleBasePlugin.VERIFICATION_GROUP }.configureEach {
-            enabled = false
+        afterEvaluate {
+            plugins.withId("lifecycle-base") {
+                tasks.named("check") {
+                    setDependsOn(listOf("assemble"))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Moving from disabling verification tasks to clearing `check` dependencies.

This makes local builds feedback loop faster when changing buildSrc because it now skips ktlint checks validatePlugins and all test sources compilation.
