### PR TITLE
Extract Jacoco agent with TransformAction

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/JacocoAgentJar.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/JacocoAgentJar.java
@@ -18,12 +18,9 @@ package org.gradle.internal.jacoco;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.specs.Spec;
 import org.gradle.util.VersionNumber;
 
 import java.io.File;
-import javax.inject.Inject;
 
 /**
  * Helper to resolve the {@code jacocoagent.jar} from inside of the {@code org.jacoco.agent.jar}.
@@ -33,17 +30,7 @@ public class JacocoAgentJar {
     private static final VersionNumber V_0_6_2_0 = VersionNumber.parse("0.6.2.0");
     private static final VersionNumber V_0_7_6_0 = VersionNumber.parse("0.7.6.0");
 
-    private final FileOperations fileOperations;
     private FileCollection agentConf;
-    private File agentJar;
-
-    /**
-     * Constructs a new agent JAR wrapper.
-     */
-    @Inject
-    public JacocoAgentJar(FileOperations fileOperations) {
-        this.fileOperations = fileOperations;
-    }
 
     /**
      * @return the configuration that the agent JAR is located in
@@ -62,15 +49,7 @@ public class JacocoAgentJar {
      * @return a file pointing to the {@code jacocoagent.jar}
      */
     public File getJar() {
-        if (agentJar == null) {
-            agentJar = fileOperations.zipTree(getAgentConf().getSingleFile()).filter(new Spec<File>() {
-                @Override
-                public boolean isSatisfiedBy(File file) {
-                    return file.getName().equals("jacocoagent.jar");
-                }
-            }).getSingleFile();
-        }
-        return agentJar;
+        return getAgentConf().getSingleFile();
     }
 
     public boolean supportsJmx() {

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/transform/AgentJarExtraction.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/transform/AgentJarExtraction.java
@@ -47,8 +47,7 @@ public abstract class AgentJarExtraction implements TransformAction<TransformPar
     }
 
     private void extractAgentJar(File input, File output) {
-        try {
-            ZipFile zipFile = new ZipFile(input);
+        try (ZipFile zipFile = new ZipFile(input)) {
             Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
             while (zipEntries.hasMoreElements()) {
                 ZipEntry zipEntry = zipEntries.nextElement();

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/transform/AgentJarExtraction.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/transform/AgentJarExtraction.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.jacoco.transform;
+
+import org.gradle.api.UncheckedIOException;
+import org.gradle.api.artifacts.transform.InputArtifact;
+import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformOutputs;
+import org.gradle.api.artifacts.transform.TransformParameters;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public abstract class AgentJarExtraction implements TransformAction<TransformParameters.None> {
+
+    @InputArtifact
+    public abstract Provider<FileSystemLocation> getInputArtifact();
+
+    @Override
+    public void transform(TransformOutputs outputs) {
+        File input = getInputArtifact().get().getAsFile();
+        File output = outputs.file(input.getName());
+
+        extractAgentJar(input, output);
+    }
+
+    private void extractAgentJar(File input, File output) {
+        try {
+            ZipFile zipFile = new ZipFile(input);
+            Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+            while (zipEntries.hasMoreElements()) {
+                ZipEntry zipEntry = zipEntries.nextElement();
+                if (zipEntry.getName().endsWith("jacocoagent.jar")) {
+                    try (InputStream in = zipFile.getInputStream(zipEntry)) {
+                        Files.copy(in, output.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    }
+                    return;
+                }
+            }
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Failed to extract jacocoagent.jar");
+        }
+    }
+
+}

--- a/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.jacoco
 
-import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
@@ -24,7 +23,7 @@ import spock.lang.Unroll
 
 class JacocoAgentJarTest extends Specification {
     def project = ProjectBuilder.builder().build()
-    def jacocoAgentJar = new JacocoAgentJar(project.services.get(FileOperations))
+    def jacocoAgentJar = new JacocoAgentJar()
 
     @Unroll
     def "versions >= 0.6.2 support jmx #version -> #jmxSupport"() {


### PR DESCRIPTION
Moves the extraction of the Jacoco Agent jar, which is included inside
the org.jacoco.agent library fromt he JacocoAgentJar class to a
dedicated TransformAction called AgentJarExtraction.

### Context

After discussion with @jjohannes  and @wolfs we came to the conclusion that the extraction of the Jacoco agent jar is a good use case for `TransfromAction`.
