### PR TITLE
Report invalid JaCoCo configuration

### DIFF
--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -65,14 +65,18 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "dependencies report shows default jacoco dependencies"() {
-        when: succeeds("dependencies", "--configuration", "jacocoAgent")
-        then: output.contains "org.jacoco:org.jacoco.agent:"
+        when:
+        succeeds("dependencies", "--configuration", "jacocoAgent")
+        then:
+        output.contains "org.jacoco:org.jacoco.agent:"
 
-        when: succeeds("dependencies", "--configuration", "jacocoAnt")
-        then: output.contains "org.jacoco:org.jacoco.ant:"
+        when:
+        succeeds("dependencies", "--configuration", "jacocoAnt")
+        then:
+        output.contains "org.jacoco:org.jacoco.ant:"
     }
 
-    void "allows configuring tool dependencies explicitly"() {
+    def "allows configuring tool dependencies explicitly"() {
         when:
         buildFile << """
             dependencies {
@@ -83,13 +87,16 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         """
 
         succeeds("dependencies", "--configuration", "jacocoAgent")
-        then: output.contains "org.jacoco:org.jacoco.agent:0.6.0.201210061924"
+        then:
+        output.contains "org.jacoco:org.jacoco.agent:0.6.0.201210061924"
 
-        when: succeeds("dependencies", "--configuration", "jacocoAnt")
-        then: output.contains "org.jacoco:org.jacoco.ant:0.6.0.201210061924"
+        when:
+        succeeds("dependencies", "--configuration", "jacocoAnt")
+        then:
+        output.contains "org.jacoco:org.jacoco.ant:0.6.0.201210061924"
     }
 
-    void jacocoReportIsIncremental() {
+    def "jacoco report is incremental"() {
         def reportResourceDir = file("${REPORTING_BASE}/jacoco/test/html/jacoco-resources")
 
         when:
@@ -120,6 +127,23 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
 
     private JacocoReportFixture htmlReport(String basedir = "${REPORTING_BASE}/jacoco/test/html") {
         return new JacocoReportFixture(file(basedir))
+    }
+
+    def "reports miss configuration of destination file"() {
+        given:
+        buildFile << """
+            test {
+                jacoco {
+                    destinationFile = provider { null }
+                }
+            }
+        """
+
+        when:
+        runAndFail("test")
+
+        then:
+        errorOutput.contains("JaCoCo destination file must not be null if output type is configured to FILE")
     }
 }
 

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -143,7 +143,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         runAndFail("test")
 
         then:
-        errorOutput.contains("JaCoCo destination file must not be null if output type is configured to FILE")
+        errorOutput.contains("JaCoCo destination file must not be null if output type is FILE")
     }
 }
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -17,6 +17,7 @@ package org.gradle.testing.jacoco.plugins;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.Named;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -134,6 +135,9 @@ public class JacocoPluginExtension {
                     // This makes the task cacheable even if multiple JVMs write to same destination file, e.g. when executing tests in parallel.
                     // The JaCoCo agent supports writing in parallel to the same file, see https://github.com/jacoco/jacoco/pull/52.
                     File coverageFile = extension.getDestinationFile();
+                    if (coverageFile == null) {
+                        throw new GradleException("JaCoCo destination file must not be null if output type is configured to FILE");
+                    }
                     fileOperations.delete(coverageFile);
                 }
             }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -136,7 +136,7 @@ public class JacocoPluginExtension {
                     // The JaCoCo agent supports writing in parallel to the same file, see https://github.com/jacoco/jacoco/pull/52.
                     File coverageFile = extension.getDestinationFile();
                     if (coverageFile == null) {
-                        throw new GradleException("JaCoCo destination file must not be null if output type is configured to FILE");
+                        throw new GradleException("JaCoCo destination file must not be null if output type is FILE");
                     }
                     fileOperations.delete(coverageFile);
                 }


### PR DESCRIPTION
The destination file has to be set if output is set to FILE. This is no
validated and reported with a clear error message instead of crashing
somewhere deep down the call stack.

Fixes #11130