### PR TITLE
Workaround for localhost lookup JDK bug (for 6.0)

### DIFF
--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/origin/OriginMetadataFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/origin/OriginMetadataFactoryTest.groovy
@@ -23,7 +23,14 @@ class OriginMetadataFactoryTest extends Specification {
     def entry = Mock(CacheableEntity)
     def rootDir = Mock(File)
     def buildInvocationId = UUID.randomUUID().toString()
-    def factory = new OriginMetadataFactory(rootDir, "user", "os", buildInvocationId, { it.gradleVersion = "3.0" })
+    def factory = new OriginMetadataFactory(
+        rootDir,
+        "user",
+        "os",
+        buildInvocationId,
+        { it.gradleVersion = "3.0" },
+        { "my-host" }
+    )
 
     def "converts to origin metadata"() {
         entry.identity >> "identity"
@@ -46,7 +53,7 @@ class OriginMetadataFactoryTest extends Specification {
         origin.executionTime == "10"
         origin.rootPath == "root"
         origin.operatingSystem == "os"
-        origin.hostName == InetAddress.localHost.hostName
+        origin.hostName == "my-host"
         origin.userName == "user"
         origin.buildInvocationId == buildInvocationId
     }

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
@@ -37,6 +37,7 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.remote.internal.inet.InetAddressFactory;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.FileSystemMirror;
@@ -65,8 +66,9 @@ public class BuildCacheServices {
     }
 
     OriginMetadataFactory createOriginMetadataFactory(
+        BuildInvocationScopeId buildInvocationScopeId,
         GradleInternal gradleInternal,
-        BuildInvocationScopeId buildInvocationScopeId
+        InetAddressFactory inetAddressFactory
     ) {
         File rootDir = gradleInternal.getRootProject().getRootDir();
         return new OriginMetadataFactory(
@@ -76,7 +78,8 @@ public class BuildCacheServices {
             buildInvocationScopeId.getId().asString(),
             properties -> {
                 properties.setProperty(GRADLE_VERSION_KEY, GradleVersion.current().getVersion());
-            }
+            },
+            inetAddressFactory::getHostname
         );
     }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
@@ -18,6 +18,7 @@ package org.gradle.internal.remote.internal.inet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -141,7 +142,7 @@ public class InetAddressFactory {
         }
     }
 
-
+    @Nullable
     private InetAddress findOpenshiftAddresses() {
         for (String key : System.getenv().keySet()) {
             if (key.startsWith("OPENSHIFT_") && key.endsWith("_IP")) {

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
@@ -15,10 +15,13 @@
  */
 package org.gradle.internal.remote.internal.inet;
 
+import org.gradle.internal.os.OperatingSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -39,16 +42,41 @@ public class InetAddressFactory {
     private String hostName;
 
     public String getHostname() {
-        synchronized (lock) {
-            if (hostName == null) {
-                try {
-                    hostName = InetAddress.getLocalHost().getHostName();
-                } catch (UnknownHostException e) {
-                    hostName = getCommunicationAddresses().get(0).toString();
+        if (hostName == null) {
+            synchronized (lock) {
+                // Work around https://bugs.openjdk.java.net/browse/JDK-8143378 on macOS
+                // See also https://stackoverflow.com/a/39698914
+                if (hostName == null && OperatingSystem.current() == OperatingSystem.MAC_OS) {
+                    ProcessBuilder builder = new ProcessBuilder("hostname");
+                    try {
+                        Process process = builder.start();
+                        int result = process.waitFor();
+                        if (result == 0) {
+                            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                            try {
+                                String line = reader.readLine();
+                                if (line != null) {
+                                    hostName = line;
+                                }
+                            } finally {
+                                reader.close();
+                            }
+                        }
+                    } catch (Exception e) {
+                        logger.debug("Couldn't resolve hostname by running hostname, falling back to using JDK", e);
+                    }
+                }
+
+                if (hostName == null) {
+                    try {
+                        hostName = InetAddress.getLocalHost().getHostName();
+                    } catch (UnknownHostException e) {
+                        hostName = getCommunicationAddresses().get(0).toString();
+                    }
                 }
             }
-            return hostName;
         }
+        return hostName;
     }
 
     /**

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/package-info.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.gradle.internal.remote.internal.inet;
+
+import org.gradle.api.NonNullApi;


### PR DESCRIPTION
Fixes #11121 

Port https://github.com/gradle/gradle/pull/11134 to `release`.