### PR TITLE
Set 'org.gradle.workers.max' to 'maxParallelForks' on CI

### DIFF
--- a/.teamcity/common/extensions.kt
+++ b/.teamcity/common/extensions.kt
@@ -102,6 +102,10 @@ fun BuildSteps.checkCleanM2(os: Os = Os.linux) {
 
 fun buildToolGradleParameters(daemon: Boolean = true, isContinue: Boolean = true, os: Os = Os.linux): List<String> =
     listOf(
+        // We pass the 'maxParallelForks' setting as 'workers.max' to limit the maximum number of executers even
+        // if multiple test tasks run in parallel. We also pass it to the Gradle build as a maximum (maxParallelForks)
+        // for each test task, such that we are independent of whatever default value is defined in the build itself.
+        "-Dorg.gradle.workers.max=%maxParallelForks%",
         "-PmaxParallelForks=%maxParallelForks%",
         "-s",
         if (daemon) "--daemon" else "--no-daemon",

--- a/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
@@ -123,5 +123,5 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "") =
-        "-PmaxParallelForks=%maxParallelForks% -s $daemon --continue -I \"%teamcity.build.checkoutDir%/gradle/init-scripts/build-scan.init.gradle.kts\" -Dorg.gradle.internal.tasks.createops -Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url% $extraParameters -PteamCityToken=%teamcity.user.bot-gradle.token% -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\""
+        "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -s $daemon --continue -I \"%teamcity.build.checkoutDir%/gradle/init-scripts/build-scan.init.gradle.kts\" -Dorg.gradle.internal.tasks.createops -Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url% $extraParameters -PteamCityToken=%teamcity.user.bot-gradle.token% -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\""
 }

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -65,6 +65,7 @@ class PerformanceTestBuildTypeTest {
                 "-Porg.gradle.performance.db.password=%performance.db.password.tcagent%",
                 "-PteamCityToken=%teamcity.user.bot-gradle.token%",
                 "-PtestJavaHome=%linux.java8.oracle.64bit%",
+                "-Dorg.gradle.workers.max=%maxParallelForks%",
                 "-PmaxParallelForks=%maxParallelForks%",
                 "-s",
                 "--daemon",


### PR DESCRIPTION
We now also have situations were two or more integration test tasks
run in parallel. We want to limit the total amount of test workers
that run in parallel to reduce flakiness caused by too many Gradle
daemon processes running in parallel.
