### PR TITLE
Append .gitignore file on `gradle init` if it exists

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BasicTypeInitIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
+import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 
 class BasicTypeInitIntegrationTest extends AbstractInitIntegrationSpec {
@@ -46,6 +47,29 @@ class BasicTypeInitIntegrationTest extends AbstractInitIntegrationSpec {
 
         then:
         noExceptionThrown()
+
+        where:
+        scriptDsl << ScriptDslFixture.SCRIPT_DSLS
+    }
+
+    @Unroll
+    def "merges .gitignore if it already exists"() {
+        when:
+        def gitignoreFile = targetDir.file(".gitignore")
+        gitignoreFile << "*.class\nexistingIgnores"
+        run('init', '--project-name', 'someApp', '--dsl', scriptDsl.id)
+
+        then:
+
+        assert gitignoreFile.file
+        assert gitignoreFile.text == toPlatformLineSeparators("""*.class
+existingIgnores
+# Ignore Gradle project-specific cache directory
+.gradle
+
+# Ignore Gradle build output directory
+build
+""")
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -48,9 +48,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         runInitWith scriptDsl
 
         then:
-        dslFixture.assertGradleFilesGenerated()
-        targetDir.file(".gitignore").assertIsFile()
-        targetDir.file(".gitattributes").assertIsFile()
+        commonFilesGenerated(scriptDsl)
 
         and:
         dslFixture.buildFile.assertContents(

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitIgnoreGenerator.java
@@ -34,19 +34,22 @@ public class GitIgnoreGenerator implements BuildContentGenerator {
     @Override
     public void generate(InitSettings settings) {
         File file = fileResolver.resolve(".gitignore");
-        try {
-            PrintWriter writer = new PrintWriter(new FileWriter(file));
-            try {
-                writer.println("# Ignore Gradle project-specific cache directory");
-                writer.println(".gradle");
+        try (PrintWriter writer = new PrintWriter(new FileWriter(file, true))) {
+            if(file.exists()) {
                 writer.println();
-                writer.println("# Ignore Gradle build output directory");
-                writer.println("build");
-            } finally {
-                writer.close();
             }
+            appendGradleSpecificIgnores(writer);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
+
+    private void appendGradleSpecificIgnores(PrintWriter writer) {
+        writer.println("# Ignore Gradle project-specific cache directory");
+        writer.println(".gradle");
+        writer.println();
+        writer.println("# Ignore Gradle build output directory");
+        writer.println("build");
+    }
+
 }

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.buildinit.plugins.internal
+
+import org.gradle.api.internal.file.TestFiles/**/
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+import static org.gradle.util.TextUtil.toPlatformLineSeparators
+
+class GitIgnoreGeneratorTest extends Specification {
+
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+
+    def fileResolver = TestFiles.resolver(tmpDir.testDirectory)
+
+    def "generates .gitignore file"() {
+        setup:
+        def generator = new GitIgnoreGenerator(fileResolver)
+
+        when:
+        generator.generate(null)
+
+        then:
+        def gitignoreFile = tmpDir.file(".gitignore")
+        assert gitignoreFile.file
+        assert gitignoreFile.text == toPlatformLineSeparators("""
+# Ignore Gradle project-specific cache directory
+.gradle
+
+# Ignore Gradle build output directory
+build
+""")
+    }
+
+    def "appends .gitignore file if it already exists"() {
+        setup:
+        def generator = new GitIgnoreGenerator(fileResolver)
+        def gitignoreFile = tmpDir.file(".gitignore")
+        gitignoreFile << 'ignoredFolder/'
+
+        when:
+        generator.generate(null)
+
+        then:
+        assert gitignoreFile.file
+        assert gitignoreFile.text == toPlatformLineSeparators("""ignoredFolder/
+# Ignore Gradle project-specific cache directory
+.gradle
+
+# Ignore Gradle build output directory
+build
+""")
+    }
+}


### PR DESCRIPTION
Especially when using other scaffolding mechanisms (e.g. new
GitHub repository or gitignore.io), a `.gitignore` may already
exist before invoking `gradle init`. Just append gradle specific
ignore patterns in those cases.

Signed-off-by: Benjamin Muskalla <benjamin.muskalla@tasktop.com>

<!--- The issue this PR addresses -->
Fixes #11159

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
