### PR TITLE
Fail when applying the java plugin on top of platform

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaIncompatiblePluginsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaIncompatiblePluginsIntegrationTest.groovy
@@ -22,17 +22,19 @@ import spock.lang.Unroll
 class JavaIncompatiblePluginsIntegrationTest  extends AbstractIntegrationSpec {
 
     @Unroll
-    def "nag users when applying both java-platform and #plugin"() {
-        when:
+    def "cannot apply both the java-platform and #plugin"() {
+        given:
         buildFile << """
 plugins {
     id 'java-platform'
     id '${plugin}'
 }
 """
+        when:
+        fails 'help'
+
         then:
-        executer.expectDeprecationWarning()
-        succeeds 'help'
+        failureHasCause("The \"java\" or \"java-library\" plugin cannot be applied together with the \"java-platform\" plugin")
 
         where:
         plugin << ['java', 'java-library']
@@ -40,15 +42,17 @@ plugins {
 
     @Unroll
     def "cannot apply both #plugin and java-platform"() {
-        when:
+        given:
         buildFile << """
 plugins {
     id '${plugin}'
     id 'java-platform'
 }
 """
-        then:
+        when:
         fails 'help'
+
+        then:
         failureHasCause("The \"java-platform\" plugin cannot be applied together with the \"java\" (or \"java-library\") plugin")
 
         where:

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -55,7 +55,6 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.language.jvm.tasks.ProcessResources;
-import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -288,6 +287,11 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
 
     @Override
     public void apply(ProjectInternal project) {
+        if (project.getPluginManager().hasPlugin("java-platform")) {
+            throw new IllegalStateException("The \"java\" or \"java-library\" plugin cannot be applied together with the \"java-platform\" plugin. " +
+                "A project is either a platform or a library but cannot be both at the same time.");
+        }
+
         project.getPluginManager().apply(JavaBasePlugin.class);
 
         JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
@@ -301,11 +305,6 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         configureJavadocTask(project, javaConvention);
         configureArchivesAndComponent(project, javaConvention);
         configureBuild(project);
-
-        if (project.getPluginManager().hasPlugin("java-platform")) {
-            DeprecationLogger.nagUserOfDeprecatedBehaviour("The \"java\" (or \"java-library\") plugin cannot be used together with the \"java-platform\" plugin on a given project. " +
-                "A project is either a platform or a library but cannot be both at the same time.");
-        }
     }
 
     private void configureSourceSets(JavaPluginConvention pluginConvention, final BuildOutputCleanupRegistry buildOutputCleanupRegistry) {


### PR DESCRIPTION
Previously, this would only log a deprecation warning. With 6.0 this is
finally an error, in the same way that applying the `java-platform`
plugin on top of the `java` one is already.