### PR TITLE
Instant execution serializes beans with abstract properties and injected services

### DIFF
--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     testImplementation(testFixtures(project(":core")))
     testImplementation(testLibrary("mockito_kotlin2"))
 
+    testRuntimeOnly(project(":runtimeApiInfo"))
+    testRuntimeOnly(kotlin("reflect"))
+
     integTestImplementation(project(":toolingApi"))
 
     integTestImplementation(library("guava"))
@@ -54,8 +57,6 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
     integTestRuntimeOnly(project(":kotlinDsl"))
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
-
-    testRuntimeOnly(kotlin("reflect"))
 }
 
 gradlebuildJava {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -694,8 +694,14 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
     def "restores task abstract properties"() {
         buildFile << """
+            interface Bean {
+                @Internal
+                Property<String> getValue() 
+            }
 
             abstract class SomeTask extends DefaultTask {
+                @Nested
+                abstract Bean getBean()
 
                 @Internal
                 abstract Property<String> getValue()
@@ -703,11 +709,14 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
                 @TaskAction
                 void run() {
                     println "this.value = " + value.getOrNull()
+                    def b = bean
+                    println "this.bean.value = " + b.value.getOrNull()
                 }
             }
 
             task ok(type: SomeTask) {
                 value = "42"
+                bean.value = "42"
             }
         """
 
@@ -717,6 +726,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         outputContains("this.value = 42")
+        outputContains("this.bean.value = 42")
     }
 
     def "task can reference itself"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -697,20 +697,31 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
             interface Bean {
                 @Internal
                 Property<String> getValue() 
+
+                @Internal
+                Property<String> getUnused() 
             }
 
             abstract class SomeTask extends DefaultTask {
                 @Nested
                 abstract Bean getBean()
 
+                @Nested
+                abstract Bean getUnusedBean()
+
                 @Internal
                 abstract Property<String> getValue()
+
+                @Internal
+                abstract Property<String> getUnused()
 
                 @TaskAction
                 void run() {
                     println "this.value = " + value.getOrNull()
-                    def b = bean
-                    println "this.bean.value = " + b.value.getOrNull()
+                    println "this.unused = " + unused.getOrNull()
+                    println "this.bean.value = " + bean.value.getOrNull()
+                    println "this.bean.unused = " + bean.unused.getOrNull()
+                    println "this.unusedBean.value = " + unusedBean.value.getOrNull()
                 }
             }
 
@@ -726,7 +737,10 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         then:
         outputContains("this.value = 42")
+        outputContains("this.unused = null")
         outputContains("this.bean.value = 42")
+        outputContains("this.bean.unused = null")
+        outputContains("this.unusedBean.value = null")
     }
 
     def "task can reference itself"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -205,6 +205,7 @@ class DefaultInstantExecution internal constructor(
     fun readContextFor(decoder: KryoBackedDecoder) = DefaultReadContext(
         codecs.userTypesCodec,
         decoder,
+        service(),
         beanConstructors,
         logger
     )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -26,6 +26,7 @@ import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.instantexecution.serialization.beans.BeanPropertyWriter
 import org.gradle.instantexecution.serialization.beans.BeanStateReader
 import org.gradle.instantexecution.serialization.beans.BeanStateWriter
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 
@@ -145,6 +146,9 @@ class DefaultReadContext(
     val decoder: Decoder,
 
     private
+    val instantiatorFactory: InstantiatorFactory,
+
+    private
     val constructors: BeanConstructors,
 
     override val logger: Logger
@@ -186,7 +190,7 @@ class DefaultReadContext(
         get() = getIsolate()
 
     override fun beanStateReaderFor(beanType: Class<*>): BeanStateReader =
-        beanStateReaders.computeIfAbsent(beanType) { type -> BeanPropertyReader(type, constructors) }
+        beanStateReaders.computeIfAbsent(beanType) { type -> BeanPropertyReader(type, constructors, instantiatorFactory) }
 
     override fun readClass(): Class<*> {
         val id = readSmallInt()

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -24,6 +24,8 @@ import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.logPropertyInfo
 import org.gradle.instantexecution.serialization.logPropertyWarning
 import org.gradle.instantexecution.serialization.withPropertyTrace
+import org.gradle.internal.instantiation.InstantiationScheme
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.reflect.JavaReflectionUtil
 import java.io.IOException
 import java.lang.reflect.Field
@@ -33,8 +35,12 @@ import java.util.function.Supplier
 
 class BeanPropertyReader(
     private val beanType: Class<*>,
-    private val constructors: BeanConstructors
+    private val constructors: BeanConstructors,
+    instantiatorFactory: InstantiatorFactory
 ) : BeanStateReader {
+    // TODO should use the same scheme as the original bean
+    private
+    val instantiationScheme: InstantiationScheme = instantiatorFactory.decorateScheme()
 
     private
     val fieldSetters = relevantStateOf(beanType).map { Pair(it.name, setterFor(it)) }
@@ -44,8 +50,11 @@ class BeanPropertyReader(
         constructors.constructorForSerialization(beanType)
     }
 
-    override suspend fun ReadContext.newBean() =
+    override suspend fun ReadContext.newBean(generated: Boolean) = if (generated) {
+        instantiationScheme.deserializationInstantiator().newInstance(beanType, Any::class.java)
+    } else {
         constructorForSerialization.newInstance()
+    }
 
     override suspend fun ReadContext.readStateOf(bean: Any) {
         for (field in fieldSetters) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanPropertyReader.kt
@@ -23,10 +23,12 @@ import org.gradle.instantexecution.serialization.PropertyTrace
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.logPropertyInfo
 import org.gradle.instantexecution.serialization.logPropertyWarning
+import org.gradle.instantexecution.serialization.service
 import org.gradle.instantexecution.serialization.withPropertyTrace
 import org.gradle.internal.instantiation.InstantiationScheme
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.reflect.JavaReflectionUtil
+import org.gradle.internal.service.ServiceRegistry
 import java.io.IOException
 import java.lang.reflect.Field
 import java.util.concurrent.Callable
@@ -51,7 +53,8 @@ class BeanPropertyReader(
     }
 
     override suspend fun ReadContext.newBean(generated: Boolean) = if (generated) {
-        instantiationScheme.deserializationInstantiator().newInstance(beanType, Any::class.java)
+        val services = isolate.owner.service<ServiceRegistry>()
+        instantiationScheme.withServices(services).deserializationInstantiator().newInstance(beanType, Any::class.java)
     } else {
         constructorForSerialization.newInstance()
     }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanStateReader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/beans/BeanStateReader.kt
@@ -21,12 +21,12 @@ import org.gradle.instantexecution.serialization.ReadContext
 
 interface BeanStateReader {
 
-    suspend fun ReadContext.newBeanWithId(id: Int) =
-        newBean().also {
+    suspend fun ReadContext.newBeanWithId(generated: Boolean, id: Int) =
+        newBean(generated).also {
             isolate.identities.putInstance(id, it)
         }
 
-    suspend fun ReadContext.newBean(): Any
+    suspend fun ReadContext.newBean(generated: Boolean): Any
 
     suspend fun ReadContext.readStateOf(bean: Any)
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
@@ -52,7 +52,7 @@ class SerializableWriteObjectCodec : EncodingProducer, Decoding {
                 val beanType = readClass()
                 withBeanTrace(beanType) {
                     val beanStateReader = beanStateReaderFor(beanType)
-                    beanStateReader.run { newBeanWithId(id) }.also { bean ->
+                    beanStateReader.run { newBeanWithId(false, id) }.also { bean ->
                         readObjectMethodOf(beanType).invoke(
                             bean,
                             ObjectInputStreamAdapter(

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -36,6 +36,7 @@ import org.gradle.internal.io.NullOutputStream
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
+import org.gradle.util.TestUtil
 
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
@@ -268,6 +269,7 @@ class UserTypesCodecTest {
         DefaultReadContext(
             codec = codecs().userTypesCodec,
             decoder = KryoBackedDecoder(inputStream),
+            instantiatorFactory = TestUtil.instantiatorFactory(),
             constructors = BeanConstructors(TestCrossBuildInMemoryCacheFactory()),
             logger = mock()
         )

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -580,6 +580,9 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             } else if (mainGetter.getReturnType().equals(Boolean.TYPE) && !metadata.getReturnType().equals(Boolean.TYPE)) {
                 // Prefer non-boolean over boolean
                 mainGetter = metadata;
+            } else if (mainGetter.getReturnType().isAssignableFrom(metadata.getReturnType())) {
+                // Prefer the most specialized type
+                mainGetter = metadata;
             }
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -106,6 +106,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         Property.class,
         NamedDomainObjectContainer.class
     );
+    private static final Object[] NO_PARAMS = new Object[0];
 
     private final CrossBuildInMemoryCache<Class<?>, GeneratedClassImpl> generatedClasses;
     private final ImmutableSet<Class<? extends Annotation>> disabledAnnotations;
@@ -139,7 +140,9 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     private <T> TypeToken<Provider<T>> providerOf(Class<T> providerType) {
-        return new TypeToken<Provider<T>>() {}.where(new TypeParameter<T>() {}, providerType);
+        return new TypeToken<Provider<T>>() {
+        }.where(new TypeParameter<T>() {
+        }, providerType);
     }
 
     @Override
@@ -185,7 +188,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         }
         validators.add(new InjectionAnnotationValidator(enabledAnnotations, allowedTypesForAnnotation));
 
-        final Class<?> generatedClass;
+        Class<?> generatedClass;
         try {
             ClassInspectionVisitor inspectionVisitor = start(type);
 
@@ -240,7 +243,9 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
     protected abstract ClassInspectionVisitor start(Class<?> type);
 
-    protected abstract <T> T newInstance(Constructor<T> constructor, ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws InvocationTargetException, IllegalAccessException, InstantiationException;
+    protected abstract InstantiationStrategy createUsingConstructor(Constructor<?> constructor);
+
+    protected abstract InstantiationStrategy createForSerialization(Class<?> generatedType, Class<?> baseClass);
 
     private void inspectType(Class<?> type, List<ClassValidator> validators, List<ClassGenerationHandler> generationHandlers, UnclaimedPropertyHandler unclaimedHandler) {
         ClassDetails classDetails = ClassInspector.inspect(type);
@@ -368,6 +373,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             ImmutableList.Builder<GeneratedConstructor<Object>> builder = ImmutableList.builderWithExpectedSize(generatedClass.getDeclaredConstructors().length);
             for (final Constructor<?> constructor : generatedClass.getDeclaredConstructors()) {
                 if (!constructor.isSynthetic()) {
+                    constructor.setAccessible(true);
                     builder.add(new GeneratedConstructorImpl(constructor));
                 }
             }
@@ -390,16 +396,36 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             return constructors;
         }
 
+        @Override
+        public SerializationConstructor<Object> getSerializationConstructor(Class<? super Object> baseClass) {
+            return new SerializationConstructorImpl(baseClass);
+        }
+
+        private class SerializationConstructorImpl implements SerializationConstructor<Object> {
+            private final InstantiationStrategy strategy;
+
+            public SerializationConstructorImpl(Class<?> baseClass) {
+                this.strategy = createForSerialization(generatedClass, baseClass);
+            }
+
+            @Override
+            public Object newInstance(ServiceLookup services, InstanceGenerator nested) throws InvocationTargetException, IllegalAccessException, InstantiationException {
+                return strategy.newInstance(services, nested, null, NO_PARAMS);
+            }
+        }
+
         private class GeneratedConstructorImpl implements GeneratedConstructor<Object> {
             private final Constructor<?> constructor;
+            private final InstantiationStrategy strategy;
 
             public GeneratedConstructorImpl(Constructor<?> constructor) {
                 this.constructor = constructor;
+                this.strategy = createUsingConstructor(constructor);
             }
 
             @Override
             public Object newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws InvocationTargetException, IllegalAccessException, InstantiationException {
-                return AbstractClassGenerator.this.newInstance(constructor, services, nested, displayName, params);
+                return strategy.newInstance(services, nested, displayName, params);
             }
 
             @Override
@@ -420,11 +446,6 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             @Override
             public boolean serviceInjectionTriggeredByAnnotation(Class<? extends Annotation> serviceAnnotation) {
                 return annotationsTriggeringServiceInjection.contains(serviceAnnotation);
-            }
-
-            @Override
-            public Class<?> getGeneratedClass() {
-                return constructor.getDeclaringClass();
             }
 
             @Override
@@ -1228,6 +1249,10 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         void attachDuringConstruction(PropertyMetadata property);
 
         ClassGenerationVisitor builder();
+    }
+
+    protected interface InstantiationStrategy {
+        Object newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws InvocationTargetException, IllegalAccessException, InstantiationException;
     }
 
     protected interface ClassGenerationVisitor {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ClassGenerator.java
@@ -29,6 +29,8 @@ import java.util.List;
 interface ClassGenerator {
     /**
      * Generates a proxy class for the given class. May return the given class unmodified or may generate a subclass.
+     *
+     * <p>Implementation should ensure that it is efficient to call this method multiple types for the same class.</p>
      */
     <T> GeneratedClass<? extends T> generate(Class<T> type) throws ClassGenerationException;
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ClassGenerator.java
@@ -42,6 +42,18 @@ interface ClassGenerator {
         Class<?> getOuterType();
 
         List<GeneratedConstructor<T>> getConstructors();
+
+        /**
+         * Creates a serialization constructor. Note: this can be expensive and does not perform any caching.
+         */
+        SerializationConstructor<T> getSerializationConstructor(Class<? super T> baseClass);
+    }
+
+    interface SerializationConstructor<T> {
+        /**
+         * Creates a new instance, using the given services and parameters. Uses the given instantiator to create nested objects, if required.
+         */
+        T newInstance(ServiceLookup services, InstanceGenerator nested) throws InvocationTargetException, IllegalAccessException, InstantiationException;
     }
 
     interface GeneratedConstructor<T> {
@@ -59,9 +71,6 @@ interface ClassGenerator {
          * Does this constructor use a service injected via the given annotation?
          */
         boolean serviceInjectionTriggeredByAnnotation(Class<? extends Annotation> serviceAnnotation);
-
-        //TODO:instant-execution: remove this
-        Class<?> getGeneratedClass();
 
         Class<?>[] getParameterTypes();
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -19,16 +19,13 @@ package org.gradle.internal.instantiation.generator;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.instantiation.DeserializationInstantiator;
 import org.gradle.internal.instantiation.InstanceFactory;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.service.ServiceLookup;
-import sun.reflect.ReflectionFactory;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
 
@@ -36,17 +33,21 @@ class DefaultInstantiationScheme implements InstantiationScheme {
     private final DependencyInjectingInstantiator instantiator;
     private final ConstructorSelector constructorSelector;
     private final Set<Class<? extends Annotation>> injectionAnnotations;
+    private final CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> deserializationConstructorCache;
     private final DeserializationInstantiator deserializationInstantiator;
+    private final ClassGenerator classGenerator;
 
-    public DefaultInstantiationScheme(ConstructorSelector constructorSelector, ServiceLookup defaultServices, Set<Class<? extends Annotation>> injectionAnnotations, CrossBuildInMemoryCacheFactory cacheFactory) {
-        this(constructorSelector, injectionAnnotations, new DependencyInjectingInstantiator(constructorSelector, defaultServices), new DefaultDeserializationInstantiator(constructorSelector, cacheFactory));
+    public DefaultInstantiationScheme(ConstructorSelector constructorSelector, ClassGenerator classGenerator, ServiceLookup defaultServices, Set<Class<? extends Annotation>> injectionAnnotations, CrossBuildInMemoryCacheFactory cacheFactory) {
+        this(constructorSelector, classGenerator, defaultServices, injectionAnnotations, cacheFactory.newClassCache());
     }
 
-    private DefaultInstantiationScheme(ConstructorSelector constructorSelector, Set<Class<? extends Annotation>> injectionAnnotations, DependencyInjectingInstantiator instantiator, DeserializationInstantiator deserializationInstantiator) {
-        this.instantiator = instantiator;
+    private DefaultInstantiationScheme(ConstructorSelector constructorSelector, ClassGenerator classGenerator, ServiceLookup defaultServices, Set<Class<? extends Annotation>> injectionAnnotations, CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> deserializationConstructorCache) {
+        this.classGenerator = classGenerator;
+        this.instantiator = new DependencyInjectingInstantiator(constructorSelector, defaultServices);
         this.constructorSelector = constructorSelector;
         this.injectionAnnotations = injectionAnnotations;
-        this.deserializationInstantiator = deserializationInstantiator;
+        this.deserializationConstructorCache = deserializationConstructorCache;
+        this.deserializationInstantiator = new DefaultDeserializationInstantiator(classGenerator, defaultServices, instantiator, deserializationConstructorCache);
     }
 
     @Override
@@ -61,7 +62,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
 
     @Override
     public InstantiationScheme withServices(ServiceLookup services) {
-        return new DefaultInstantiationScheme(constructorSelector, injectionAnnotations, new DependencyInjectingInstantiator(constructorSelector, services), deserializationInstantiator);
+        return new DefaultInstantiationScheme(constructorSelector, classGenerator, services, injectionAnnotations, deserializationConstructorCache);
     }
 
     @Override
@@ -75,26 +76,23 @@ class DefaultInstantiationScheme implements InstantiationScheme {
     }
 
     private static class DefaultDeserializationInstantiator implements DeserializationInstantiator {
-        private final ConstructorSelector constructorSelector;
-        private final CrossBuildInMemoryCache<Class<?>, Constructor<?>> constructorCache;
+        private final ClassGenerator classGenerator;
+        private final ServiceLookup services;
+        private final InstanceGenerator nestedGenerator;
+        private final CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> constructorCache;
 
-        public DefaultDeserializationInstantiator(ConstructorSelector constructorSelector, CrossBuildInMemoryCacheFactory cacheFactory) {
-            this.constructorSelector = constructorSelector;
-            this.constructorCache = cacheFactory.newClassCache();
+        public DefaultDeserializationInstantiator(ClassGenerator classGenerator, ServiceLookup services, InstanceGenerator nestedGenerator, CrossBuildInMemoryCache<Class<?>, ClassGenerator.SerializationConstructor<?>> constructorCache) {
+            this.classGenerator = classGenerator;
+            this.services = services;
+            this.nestedGenerator = nestedGenerator;
+            this.constructorCache = constructorCache;
         }
 
         @Override
         public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
-            //TODO:instant-execution - use the class generator instead
             try {
-                Constructor<?> constructor = constructorCache.get(implType, type -> {
-                    try {
-                        return ReflectionFactory.getReflectionFactory().newConstructorForSerialization(constructorSelector.forType(type).getGeneratedClass(), baseClass.getDeclaredConstructor());
-                    } catch (NoSuchMethodException e) {
-                        throw UncheckedException.throwAsUncheckedException(e);
-                    }
-                });
-                return implType.cast(constructor.newInstance());
+                ClassGenerator.SerializationConstructor<?> constructor = constructorCache.get(implType, type -> classGenerator.generate(implType).getSerializationConstructor(baseClass));
+                return implType.cast(constructor.newInstance(services, nestedGenerator));
             } catch (InvocationTargetException e) {
                 throw new ObjectInstantiationException(implType, e.getCause());
             } catch (Exception e) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiationScheme.java
@@ -90,6 +90,7 @@ class DefaultInstantiationScheme implements InstantiationScheme {
 
         @Override
         public <T> T newInstance(Class<T> implType, Class<? super T> baseClass) {
+            // TODO - The baseClass can be inferred from the implType, so attach the serialization constructor onto the GeneratedClass rather than parameterizing and caching here
             try {
                 ClassGenerator.SerializationConstructor<?> constructor = constructorCache.get(implType, type -> classGenerator.generate(implType).getSerializationConstructor(baseClass));
                 return implType.cast(constructor.newInstance(services, nestedGenerator));

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiatorFactory.java
@@ -53,17 +53,17 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
         DefaultServiceRegistry services = new DefaultServiceRegistry();
         services.add(InstantiatorFactory.class, this);
         this.defaultServices = services;
-        ClassGenerator injectOnly = AsmBackedClassGenerator.injectOnly(annotationHandlers, ImmutableSet.of(), cacheFactory, MANAGED_FACTORY_ID);
-        ClassGenerator decorated = AsmBackedClassGenerator.decorateAndInject(annotationHandlers, ImmutableSet.of(), cacheFactory, MANAGED_FACTORY_ID);
-        this.managedFactory = new ClassGeneratorBackedManagedFactory(injectOnly);
-        ConstructorSelector injectOnlyJsr330Selector = new Jsr330ConstructorSelector(injectOnly, cacheFactory.newClassCache());
-        ConstructorSelector decoratedJsr330Selector = new Jsr330ConstructorSelector(decorated, cacheFactory.newClassCache());
-        ConstructorSelector injectOnlyLenientSelector = new ParamsMatchingConstructorSelector(injectOnly, cacheFactory.newClassCache());
-        ConstructorSelector decoratedLenientSelector = new ParamsMatchingConstructorSelector(decorated, cacheFactory.newClassCache());
-        injectOnlyScheme = new DefaultInstantiationScheme(injectOnlyJsr330Selector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
-        injectOnlyLenientScheme = new DefaultInstantiationScheme(injectOnlyLenientSelector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
-        decoratingScheme = new DefaultInstantiationScheme(decoratedJsr330Selector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
-        decoratingLenientScheme = new DefaultInstantiationScheme(decoratedLenientSelector, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
+        ClassGenerator injectOnlyGenerator = AsmBackedClassGenerator.injectOnly(annotationHandlers, ImmutableSet.of(), cacheFactory, MANAGED_FACTORY_ID);
+        ClassGenerator decoratedGenerator = AsmBackedClassGenerator.decorateAndInject(annotationHandlers, ImmutableSet.of(), cacheFactory, MANAGED_FACTORY_ID);
+        this.managedFactory = new ClassGeneratorBackedManagedFactory(injectOnlyGenerator);
+        ConstructorSelector injectOnlyJsr330Selector = new Jsr330ConstructorSelector(injectOnlyGenerator, cacheFactory.newClassCache());
+        ConstructorSelector decoratedJsr330Selector = new Jsr330ConstructorSelector(decoratedGenerator, cacheFactory.newClassCache());
+        ConstructorSelector injectOnlyLenientSelector = new ParamsMatchingConstructorSelector(injectOnlyGenerator, cacheFactory.newClassCache());
+        ConstructorSelector decoratedLenientSelector = new ParamsMatchingConstructorSelector(decoratedGenerator, cacheFactory.newClassCache());
+        injectOnlyScheme = new DefaultInstantiationScheme(injectOnlyJsr330Selector, injectOnlyGenerator, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
+        injectOnlyLenientScheme = new DefaultInstantiationScheme(injectOnlyLenientSelector, injectOnlyGenerator, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
+        decoratingScheme = new DefaultInstantiationScheme(decoratedJsr330Selector, decoratedGenerator, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
+        decoratingLenientScheme = new DefaultInstantiationScheme(decoratedLenientSelector, decoratedGenerator, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
         ImmutableSet.Builder<Class<? extends Annotation>> builder = ImmutableSet.builderWithExpectedSize(injectAnnotations.size() + 1);
         builder.addAll(injectAnnotations);
         builder.add(Inject.class);
-        return new DefaultInstantiationScheme(constructorSelector, defaultServices, builder.build(), cacheFactory);
+        return new DefaultInstantiationScheme(constructorSelector, classGenerator, defaultServices, builder.build(), cacheFactory);
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DefaultInstantiatorFactory.java
@@ -58,8 +58,8 @@ public class DefaultInstantiatorFactory implements InstantiatorFactory {
         this.managedFactory = new ClassGeneratorBackedManagedFactory(injectOnlyGenerator);
         ConstructorSelector injectOnlyJsr330Selector = new Jsr330ConstructorSelector(injectOnlyGenerator, cacheFactory.newClassCache());
         ConstructorSelector decoratedJsr330Selector = new Jsr330ConstructorSelector(decoratedGenerator, cacheFactory.newClassCache());
-        ConstructorSelector injectOnlyLenientSelector = new ParamsMatchingConstructorSelector(injectOnlyGenerator, cacheFactory.newClassCache());
-        ConstructorSelector decoratedLenientSelector = new ParamsMatchingConstructorSelector(decoratedGenerator, cacheFactory.newClassCache());
+        ConstructorSelector injectOnlyLenientSelector = new ParamsMatchingConstructorSelector(injectOnlyGenerator);
+        ConstructorSelector decoratedLenientSelector = new ParamsMatchingConstructorSelector(decoratedGenerator);
         injectOnlyScheme = new DefaultInstantiationScheme(injectOnlyJsr330Selector, injectOnlyGenerator, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
         injectOnlyLenientScheme = new DefaultInstantiationScheme(injectOnlyLenientSelector, injectOnlyGenerator, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);
         decoratingScheme = new DefaultInstantiationScheme(decoratedJsr330Selector, decoratedGenerator, defaultServices, ImmutableSet.of(Inject.class), cacheFactory);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.instantiation.generator;
 
-import org.gradle.api.Transformer;
-import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.internal.Cast;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.reflect.JavaReflectionUtil;
@@ -25,11 +23,9 @@ import org.gradle.internal.reflect.JavaReflectionUtil;
 import java.util.List;
 
 class ParamsMatchingConstructorSelector implements ConstructorSelector {
-    private final CrossBuildInMemoryCache<Class<?>, ClassGenerator.GeneratedClass<?>> constructorCache;
     private final ClassGenerator classGenerator;
 
-    public ParamsMatchingConstructorSelector(ClassGenerator classGenerator, CrossBuildInMemoryCache<Class<?>, ClassGenerator.GeneratedClass<?>> constructorCache) {
-        this.constructorCache = constructorCache;
+    public ParamsMatchingConstructorSelector(ClassGenerator classGenerator) {
         this.classGenerator = classGenerator;
     }
 
@@ -45,12 +41,7 @@ class ParamsMatchingConstructorSelector implements ConstructorSelector {
 
     @Override
     public <T> ClassGenerator.GeneratedConstructor<? extends T> forParams(final Class<T> type, Object[] params) {
-        ClassGenerator.GeneratedClass<?> generatedClass = constructorCache.get(type, new Transformer<ClassGenerator.GeneratedClass<?>, Class<?>>() {
-            @Override
-            public ClassGenerator.GeneratedClass<?> transform(Class<?> aClass) {
-                return classGenerator.generate(type);
-            }
-        });
+        ClassGenerator.GeneratedClass<?> generatedClass = classGenerator.generate(type);
 
         if (generatedClass.getOuterType() != null && (params.length == 0 || !generatedClass.getOuterType().isInstance(params[0]))) {
             TreeFormatter formatter = new TreeFormatter();

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AbstractClassGeneratorSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AbstractClassGeneratorSpec.groovy
@@ -34,6 +34,12 @@ abstract class AbstractClassGeneratorSpec extends Specification {
 
     abstract ClassGenerator getGenerator()
 
+    protected <T> T createForSerialization(Class<T> clazz) {
+        def nested = Stub(InstanceGenerator)
+        _ * nested.newInstanceWithDisplayName(_, _, _) >> { type, displayName, params -> create(type) }
+        return generator.generate(clazz).getSerializationConstructor(Object).newInstance(defaultServices(), nested)
+    }
+
     protected <T> T create(Class<T> clazz, Object... args) {
         return doCreate(generator, clazz, defaultServices(), null, args)
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -31,6 +31,7 @@ import static org.gradle.internal.instantiation.generator.AsmBackedClassGenerato
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantReadOnlyPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.Bean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BeanWithAbstractProperty
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BrokenConstructor
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceContainerPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceDirectoryPropertyBean
@@ -266,7 +267,15 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         InterfaceMapPropertyBean       | _
     }
 
-    def canConstructInstanceOfInterfaceWithReadOnlyMethodsWithCovariantReturnTypeWhereSomeTypesAreNotSupported() {
+    def "can construct instance of class without running its constructor to use for deserialization"() {
+        def bean = createForSerialization(BrokenConstructor)
+
+        expect:
+        !bean.value.present
+        bean.bean != null
+    }
+
+    def canConstructInstanceOfInterfaceWithReadOnlyMethodsWithCovariantReturnTypeWhereOverriddenTypesAreNotSupported() {
         def bean = create(AbstractCovariantReadOnlyPropertyBean)
 
         expect:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -25,13 +25,14 @@ import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
 import spock.lang.Unroll
 
-import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.*
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractClassWithTypeParamProperty
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractCovariantReadOnlyPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.Bean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.BeanWithAbstractProperty
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceBean
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceContainerPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceDirectoryPropertyBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceFileCollectionBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.InterfaceFilePropertyBean
@@ -263,6 +264,13 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         InterfaceListPropertyBean      | _
         InterfaceSetPropertyBean       | _
         InterfaceMapPropertyBean       | _
+    }
+
+    def canConstructInstanceOfInterfaceWithReadOnlyMethodsWithCovariantReturnTypeWhereSomeTypesAreNotSupported() {
+        def bean = create(AbstractCovariantReadOnlyPropertyBean)
+
+        expect:
+        bean.prop.toString() == "property 'prop'"
     }
 
     def canConstructInstanceOfInterfaceWithDefaultMethodsOnly() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -56,7 +56,6 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.reflect.JavaReflectionUtil;
-import org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStoreTest;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -56,6 +56,7 @@ import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.reflect.JavaReflectionUtil;
+import org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStoreTest;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
@@ -1927,5 +1928,16 @@ public class AsmBackedClassGeneratorTest {
     }
 
     public static abstract class AbstractClassWithTypeParamProperty implements InterfacePropertyWithTypeParamBean<Param<String>> {
+    }
+
+    public static abstract class BrokenConstructor {
+        public BrokenConstructor() {
+            throw new RuntimeException("broken");
+        }
+
+        abstract Property<Number> getValue();
+
+        @Nested
+        abstract InterfaceFilePropertyBean getBean();
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -42,6 +42,7 @@ import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
@@ -1845,6 +1846,23 @@ public class AsmBackedClassGeneratorTest {
 
     public interface InterfaceMapPropertyBean {
         MapProperty<String, Number> getProp();
+    }
+
+    public interface InterfaceProviderBean {
+        Provider<? extends Number> getProp();
+    }
+
+    public abstract static class AbstractProviderBean implements InterfaceProviderBean {
+        // Covariant return type
+        @Override
+        public abstract Provider<Long> getProp();
+    }
+
+    public interface InterfaceCovariantReadOnlyPropertyBean extends InterfaceProviderBean {
+        Property<Long> getProp();
+    }
+
+    public abstract static class AbstractCovariantReadOnlyPropertyBean extends AbstractProviderBean implements InterfaceCovariantReadOnlyPropertyBean {
     }
 
     public static abstract class NamedBean {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
@@ -17,14 +17,13 @@
 package org.gradle.internal.instantiation.generator
 
 import org.gradle.api.reflect.ObjectInstantiationException
-import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.service.ServiceLookup
 import spock.lang.Specification
 
 class DependencyInjectionUsingLenientConstructorSelectorTest extends Specification {
     def services = Mock(ServiceLookup)
     def classGenerator = new IdentityClassGenerator()
-    def instantiator = new DependencyInjectingInstantiator(new ParamsMatchingConstructorSelector(classGenerator, new TestCrossBuildInMemoryCacheFactory.TestCache()), services)
+    def instantiator = new DependencyInjectingInstantiator(new ParamsMatchingConstructorSelector(classGenerator), services)
 
     def "creates instance that has default constructor"() {
         when:

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/IdentityClassGenerator.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/IdentityClassGenerator.java
@@ -50,6 +50,11 @@ class IdentityClassGenerator implements ClassGenerator {
             }
 
             @Override
+            public SerializationConstructor<T> getSerializationConstructor(Class<? super T> baseClass) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
             public List<GeneratedConstructor<T>> getConstructors() {
                 List<GeneratedConstructor<T>> constructors = new ArrayList<GeneratedConstructor<T>>();
                 for (final Constructor<?> constructor : type.getDeclaredConstructors()) {
@@ -68,11 +73,6 @@ class IdentityClassGenerator implements ClassGenerator {
                         @Override
                         public boolean serviceInjectionTriggeredByAnnotation(Class<? extends Annotation> serviceAnnotation) {
                             return false;
-                        }
-
-                        @Override
-                        public Class<?> getGeneratedClass() {
-                            return constructor.getDeclaringClass();
                         }
 
                         @Override

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReport.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReport.java
@@ -17,52 +17,30 @@
 package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Task;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.provider.DefaultProvider;
-import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.DirectoryReport;
 
 import javax.inject.Inject;
 import java.io.File;
 
-public class TaskGeneratedSingleDirectoryReport extends TaskGeneratedReport implements DirectoryReport {
-
+public abstract class TaskGeneratedSingleDirectoryReport extends TaskGeneratedReport implements DirectoryReport {
     private final String relativeEntryPath;
-    // TODO - make these managed properties, once instant execution can deserialize abstract beans
-    private final DirectoryProperty outputLocation;
-    private final Property<Boolean> activated;
 
     @Inject
     public TaskGeneratedSingleDirectoryReport(String name, Task task, String relativeEntryPath) {
         super(name, OutputType.DIRECTORY, task);
         this.relativeEntryPath = relativeEntryPath;
-        this.outputLocation = getObjectFactory().directoryProperty().convention(getProjectLayout().dir(new DefaultProvider<>(() -> {
+        getOutputLocation().convention(getProjectLayout().dir(new DefaultProvider<>(() -> {
             return (File) ((IConventionAware) TaskGeneratedSingleDirectoryReport.this).getConventionMapping().getConventionValue(null, "destination", false);
         })));
-        this.activated = getObjectFactory().property(Boolean.class).convention(false);
+        getActivated().convention(false);
     }
 
     @Inject
     protected ProjectLayout getProjectLayout() {
         throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected ObjectFactory getObjectFactory() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Property<Boolean> getActivated() {
-        return activated;
-    }
-
-    @Override
-    public DirectoryProperty getOutputLocation() {
-        return outputLocation;
     }
 
     @Override

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/TaskGeneratedSingleFileReport.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/TaskGeneratedSingleFileReport.java
@@ -18,49 +18,27 @@ package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Task;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.provider.DefaultProvider;
-import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.SingleFileReport;
 
 import javax.inject.Inject;
 import java.io.File;
 
-public class TaskGeneratedSingleFileReport extends TaskGeneratedReport implements SingleFileReport {
-    // TODO - make these managed properties, once instant execution can deserialize abstract beans
-    private final RegularFileProperty outputLocation;
-    private final Property<Boolean> activated;
-
+public abstract class TaskGeneratedSingleFileReport extends TaskGeneratedReport implements SingleFileReport {
     @Inject
     public TaskGeneratedSingleFileReport(String name, Task task) {
         super(name, OutputType.FILE, task);
         // This is for backwards compatibility for plugins that attach a convention mapping to the replaced property
         // TODO - this wiring should happen automatically (and be deprecated too)
-        this.outputLocation = getObjectFactory().fileProperty().convention(getProjectLayout().file(new DefaultProvider<>(() -> {
+        getOutputLocation().convention(getProjectLayout().file(new DefaultProvider<>(() -> {
             return (File) ((IConventionAware) TaskGeneratedSingleFileReport.this).getConventionMapping().getConventionValue(null, "destination", false);
         })));
-        this.activated = getObjectFactory().property(Boolean.class).convention(false);
+        getActivated().convention(false);
     }
 
     @Inject
     protected ProjectLayout getProjectLayout() {
         throw new UnsupportedOperationException();
-    }
-
-    @Inject
-    protected ObjectFactory getObjectFactory() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Property<Boolean> getActivated() {
-        return activated;
-    }
-
-    @Override
-    public RegularFileProperty getOutputLocation() {
-        return outputLocation;
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
@@ -20,7 +20,7 @@ import org.gradle.api.Task;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleDirectoryReport;
 import org.gradle.api.tasks.testing.JUnitXmlReport;
 
-public class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectoryReport implements JUnitXmlReport {
+public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectoryReport implements JUnitXmlReport {
 
     private boolean outputPerTestCase;
 


### PR DESCRIPTION

### Context

Change bean deserialization to reuse the approach used to deserialized tasks with abstract properties, and improve the instantiation infrastructure to support managed properties and service injection for deserialized objects that do not provide their own service registry.

Change the `Report` implementations to remove a bunch of manual wiring.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
