### PR TITLE
Fix jacoco flaky test

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -24,10 +24,12 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
 
         given:
         new JavaProjectUnderTest(testDirectory).writeBuildScript().writeSourceFiles()
+        buildFile << '\njacocoTestReport.dependsOn test'
         def htmlReportDir = file("build/reports/jacoco/test/html")
 
+
         expect:
-        instantRun 'test', 'jacocoTestReport'
+        instantRun 'jacocoTestReport'
         htmlReportDir.assertIsDir()
 
         when:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -26,9 +26,9 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
         new JavaProjectUnderTest(testDirectory).writeBuildScript().writeSourceFiles()
         // jacoco plugin makes jacocoTestReport mustRunAfter test, not dependsOn
         // mustRunAfter is not captured by instant execution currently
+        // https://github.com/gradle/instant-execution/issues/86
         buildFile << '\njacocoTestReport.dependsOn test'
         def htmlReportDir = file("build/reports/jacoco/test/html")
-
 
         expect:
         instantRun 'test', 'jacocoTestReport'

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJacocoIntegrationTest.groovy
@@ -24,12 +24,14 @@ class InstantExecutionJacocoIntegrationTest extends AbstractInstantExecutionInte
 
         given:
         new JavaProjectUnderTest(testDirectory).writeBuildScript().writeSourceFiles()
+        // jacoco plugin makes jacocoTestReport mustRunAfter test, not dependsOn
+        // mustRunAfter is not captured by instant execution currently
         buildFile << '\njacocoTestReport.dependsOn test'
         def htmlReportDir = file("build/reports/jacoco/test/html")
 
 
         expect:
-        instantRun 'jacocoTestReport'
+        instantRun 'test', 'jacocoTestReport'
         htmlReportDir.assertIsDir()
 
         when:


### PR DESCRIPTION
This fixes https://github.com/gradle/build-tool-flaky-tests/issues/2

Previously jacocoTestReport task seems to be executed before test task,
which results in sporadical errors. This PR fixes it by explicitly
making jacocoTestReport depend on test task.