### PR TITLE
Fix regexp for checking error message

### DIFF
--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -60,7 +60,7 @@ public class SecurityManagerTest {
         // cause connection errors to show up in stderr.
         executer.withStackTraceChecksDisabled()
         fails('test')
-        failure.assertThatCause(matchesRegexp(".*Process 'Gradle Test Executor \\d' finished with non-zero exit value 1.*"))
+        failure.assertThatCause(matchesRegexp(".*Process 'Gradle Test Executor \\d+' finished with non-zero exit value 1.*"))
         failure.assertThatCause(containsText("This problem might be caused by incorrect test process configuration."))
         failure.assertThatCause(containsText("Please refer to the test execution section in the User Manual at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_testing.html#sec:test_execution"))
     }


### PR DESCRIPTION
Test executor number can now go into two digits as well.

Fixes gradle/build-tool-flaky-tests#8
