### PR TITLE
Fix correct caching of default excludes

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
@@ -94,8 +94,8 @@ public class PatternSpecFactory {
     private Spec<FileTreeElement> updateDefaultExcludeCache(List<String> defaultExcludes, boolean caseSensitive) {
         previousDefaultExcludes.clear();
         previousDefaultExcludes.addAll(defaultExcludes);
-        defaultExcludeSpecs.put(caseSensitive, createSpec(defaultExcludes, false, true));
-        defaultExcludeSpecs.put(caseSensitive, createSpec(defaultExcludes, false, false));
+        defaultExcludeSpecs.put(true, createSpec(defaultExcludes, false, true));
+        defaultExcludeSpecs.put(false, createSpec(defaultExcludes, false, false));
         return defaultExcludeSpecs.get(caseSensitive);
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/PatternSpecFactory.java
@@ -42,14 +42,14 @@ import java.util.Map;
 public class PatternSpecFactory {
     public static final PatternSpecFactory INSTANCE = new PatternSpecFactory();
     private final List<String> previousDefaultExcludes = Lists.newArrayList();
-    private final Map<Boolean, Spec<FileTreeElement>> defaultExcludeSpecs = new HashMap<Boolean, Spec<FileTreeElement>>(2);
+    private final Map<Boolean, Spec<FileTreeElement>> defaultExcludeSpecs = new HashMap<>(2);
 
     public Spec<FileTreeElement> createSpec(PatternSet patternSet) {
         return Specs.intersect(createIncludeSpec(patternSet), Specs.negate(createExcludeSpec(patternSet)));
     }
 
     public Spec<FileTreeElement> createIncludeSpec(PatternSet patternSet) {
-        List<Spec<FileTreeElement>> allIncludeSpecs = new ArrayList<Spec<FileTreeElement>>(1 + patternSet.getIncludeSpecs().size());
+        List<Spec<FileTreeElement>> allIncludeSpecs = new ArrayList<>(1 + patternSet.getIncludeSpecs().size());
 
         if (!patternSet.getIncludes().isEmpty()) {
             allIncludeSpecs.add(createSpec(patternSet.getIncludes(), true, patternSet.isCaseSensitive()));
@@ -61,7 +61,7 @@ public class PatternSpecFactory {
     }
 
     public Spec<FileTreeElement> createExcludeSpec(PatternSet patternSet) {
-        List<Spec<FileTreeElement>> allExcludeSpecs = new ArrayList<Spec<FileTreeElement>>(2 + patternSet.getExcludeSpecs().size());
+        List<Spec<FileTreeElement>> allExcludeSpecs = new ArrayList<>(2 + patternSet.getExcludeSpecs().size());
 
         if (!patternSet.getExcludes().isEmpty()) {
             allExcludeSpecs.add(createSpec(patternSet.getExcludes(), false, patternSet.isCaseSensitive()));

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -940,4 +940,33 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         then:
         !file("build/headers/java/main/Foo.h").exists()
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/11017")
+    def "does not use case insensitive default excludes"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+        """
+        file("src/main/java/com/example/Main.java") << """
+            package com.example;
+            
+            import com.example.cvs.Test;
+            
+            public class Main {
+            
+              public static void main(String[] args) {
+                System.out.println(new Test());
+              }
+            }
+        """
+        file("src/main/java/com/example/cvs/Test.java") << """
+            package com.example.cvs;
+            
+            public class Test {
+            }
+        """
+
+        expect:
+        succeeds("compileJava")
+    }
 }


### PR DESCRIPTION
We have been using case insensitive default excludes since Gradle 5.4.

See https://github.com/gradle/gradle/commit/954d5e8d5e35d49f0f575c093a7fdf24b79a4c1b

Fixes https://github.com/gradle/gradle/issues/11017