### PR TITLE
Handle serialization for shadowed capabilities in the GMM case

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -55,7 +55,7 @@ public enum CacheLayout {
         .changedTo(69, "5.0-rc-1")
         .changedTo(71, "5.3-rc-1")
         .changedTo(79, "6.0-rc-1")
-        .changedTo(81, "6.0-rc-2")
+        .changedTo(82, "6.0-rc-2")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -313,6 +313,11 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
+        public void addCapability(Capability capability) {
+            capabilities.add(capability);
+        }
+
+        @Override
         public List<? extends ComponentVariant.File> getFiles() {
             return files;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -47,6 +47,8 @@ public interface MutableComponentVariant {
 
     void addCapability(String group, String name, String version);
 
+    void addCapability(Capability capability);
+
     ImmutableAttributes getAttributes();
 
     void setAttributes(ImmutableAttributes updatedAttributes);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 81
+        expectedVersion = 82
     }
 
     def "use transforms layout"() {


### PR DESCRIPTION
This is now done in the same way as it is done in the `AbstractRealisedModuleResolveMetadataSerializationHelper` for cases without GMM.

Follow up to: #11118