### PR TITLE
Normalize CPP system include paths

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.FileUtils;
 import org.gradle.internal.io.StreamByteBuffer;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.nativeplatform.platform.internal.ArchitectureInternal;
@@ -143,7 +144,7 @@ public class GccMetadataProvider extends AbstractMetadataProvider<GccMetadata> {
                     if (isCygwin) {
                         include = mapCygwinPath(cygpathExe, include);
                     }
-                    builder.add(new File(include));
+                    builder.add(FileUtils.normalize(new File(include)));
                 }
             }
             return builder.build();

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProviderTest.groovy
@@ -305,6 +305,7 @@ End of search list.
         1 * visitor.node("g++ appears to be GCC rather than Clang. Treating it as GCC.")
     }
 
+    @Requires(TestPrecondition.NOT_WINDOWS)
     def "parses gcc system includes"() {
         def includes = correctPathSeparators(['/usr/local', '/usr/some/dir'])
         expect:
@@ -312,6 +313,7 @@ End of search list.
         result.component.systemIncludes*.path == includes
     }
 
+    @Requires(TestPrecondition.NOT_WINDOWS)
     def "parses clang system includes"() {
         def includes = correctPathSeparators([
             '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0/include',
@@ -337,6 +339,7 @@ End of search list.
         result.component.systemIncludes*.path == includes
     }
 
+    @Requires(TestPrecondition.WINDOWS)
     def "parses gcc cygwin system includes and maps to windows paths"() {
         def includes = [
             '/usr/include',


### PR DESCRIPTION
In order to only use normalized absolute paths throughout Gradle, include paths should be normalized as well. For this, the paths of the search path together with the (relative) include paths need to be normalized.

The regular search path comes from a file collection, so all those paths are already normalized. What is missing is to normalize the system includes and the full includes.