### PR TITLE
Introduce system property to fail instant execution store on problems

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -181,7 +181,8 @@ class DefaultInstantExecution internal constructor(
     fun instantExecutionReport() = InstantExecutionReport(
         reportOutputDir,
         logger,
-        maxProblems()
+        maxProblems(),
+        failOnProblems()
     )
 
     private
@@ -331,6 +332,12 @@ class DefaultInstantExecution internal constructor(
         systemProperty(SystemProperties.maxProblems)
             ?.let(Integer::valueOf)
             ?: 512
+
+    private
+    fun failOnProblems(): Boolean =
+        systemProperty(SystemProperties.failOnProblems)
+            ?.toBoolean()
+            ?: false
 
     private
     fun systemProperty(propertyName: String) =

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
@@ -33,3 +33,8 @@ class InstantExecutionErrorsException : InstantExecutionException(
 class TooManyInstantExecutionProblemsException : InstantExecutionException(
     "Maximum number of instant execution problems has been exceeded. This behavior can be adjusted via -D${SystemProperties.maxProblems}=<integer>."
 )
+
+
+class InstantExecutionProblemsException : InstantExecutionException(
+    "Problems found while caching instant execution state. Failing because -D${SystemProperties.failOnProblems} is 'true'."
+)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
@@ -44,7 +44,10 @@ class InstantExecutionReport(
     val logger: Logger,
 
     private
-    val maxProblems: Int
+    val maxProblems: Int,
+
+    private
+    val failOnProblems: Boolean
 ) {
 
     private
@@ -71,6 +74,7 @@ class InstantExecutionReport(
 
         return fatalError?.withSuppressed(errors())
             ?: instantExecutionExceptionForErrors()
+            ?: instantExecutionExceptionForProblems()
     }
 
     private
@@ -100,6 +104,11 @@ class InstantExecutionReport(
         errors()
             .takeIf { it.isNotEmpty() }
             ?.let { errors -> InstantExecutionErrorsException().withSuppressed(errors) }
+
+    private
+    fun instantExecutionExceptionForProblems(): Throwable? =
+        if (failOnProblems) InstantExecutionProblemsException()
+        else null
 
     private
     fun Throwable.withSuppressed(errors: List<PropertyProblem.Error>) = apply {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemProperties.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemProperties.kt
@@ -23,4 +23,6 @@ object SystemProperties {
     const val isEnabled = "org.gradle.unsafe.instant-execution"
 
     const val maxProblems = "org.gradle.unsafe.instant-execution.max-problems"
+
+    const val failOnProblems = "org.gradle.unsafe.instant-execution.fail-on-problems"
 }


### PR DESCRIPTION
Main intent is usage in coverage where we want tests to fail on problems/warnings, not only on errors.
