### PR TITLE
Archive Kotlin compiler logs

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/CiReportingPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/CiReportingPlugin.kt
@@ -71,6 +71,7 @@ open class CiReportingPlugin : Plugin<Project> {
         is FindBrokenInternalLinks -> listOf(reportFile.get().asFile to project.name)
         is DistributionTest -> listOf(
             gradleInstallationForTest.gradleUserHomeDir.dir("worker-1/test-kit-daemon").get().asFile to "all-logs",
+            gradleInstallationForTest.gradleUserHomeDir.dir("worker-1/kotlin-compiler-daemon").get().asFile to "all-logs",
             gradleInstallationForTest.daemonRegistry.get().asFile to "all-logs"
         )
         else -> emptyList()

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -214,7 +214,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
         """
         def otherDir = file("buildSrc/other")
         otherDir.file("build.gradle") << """
-            plugins { 
+            plugins {
                 id("java-library")
             }
             dependencies {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
@@ -22,11 +22,15 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import javax.inject.Inject
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 
 @LeaksFileHandles
 @Requires(TestPrecondition.KOTLIN_SCRIPT)
@@ -55,7 +59,7 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInter
                 val set = objectFactory.setProperty(Int::class.java)
                 @Internal
                 val map = objectFactory.mapProperty(Int::class.java, Boolean::class.java)
-                
+
                 @TaskAction
                 fun run() {
                     println("flag = " + flag.get())
@@ -76,7 +80,7 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInter
 
             class SomePlugin: Plugin<Project> {
                 override fun apply(project: Project) {
-                    project.tasks.register("someTask", SomeTask::class.java) { 
+                    project.tasks.register("someTask", SomeTask::class.java) {
                         flag.set(true)
                         message.set("some value")
                         list.set(listOf(1, 2))
@@ -96,7 +100,7 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInter
 
             class SomePlugin: Plugin<Project> {
                 override fun apply(project: Project) {
-                    project.tasks.register("someTask", SomeTask::class.java) { 
+                    project.tasks.register("someTask", SomeTask::class.java) {
                         flag.set(project.provider { true })
                         message.set(project.provider { "some value" })
                         list.set(project.provider { listOf(1, 2) })
@@ -116,7 +120,7 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInter
 
             class SomePlugin: Plugin<Project> {
                 override fun apply(project: Project) {
-                    project.tasks.register("someTask", SomeTask::class.java) { 
+                    project.tasks.register("someTask", SomeTask::class.java) {
                         val provider = project.provider { "some value" }
                         flag.set(provider.map { s -> !s.isEmpty() })
                         message.set(provider.map { s -> s })
@@ -137,9 +141,22 @@ class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInter
 
             class SomePlugin: Plugin<Project> {
                 override fun apply(project: Project) {
-                    project.tasks.register("someTask", SomeTask::class.java) 
+                    project.tasks.register("someTask", SomeTask::class.java)
                 }
             }
         """
+    }
+
+    def cleanup() {
+        // Let's copy the Kotlin compiler logs in case of failure
+        if (result instanceof ExecutionFailure) {
+            def pattern = "kotlin-daemon.${new Date().format("yyyy-MM-dd")}.*.log"
+            def kotlinCompilerLogFiles = new FileNameFinder().getFileNames(System.getenv("TMPDIR"), pattern)
+            def target = buildContext.gradleUserHomeDir.createDir("kotlin-compiler-daemon").toPath()
+            kotlinCompilerLogFiles.each {
+                def source = Paths.get(it)
+                Files.copy(source, target.resolve(source.fileName), StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
     }
 }


### PR DESCRIPTION
We see test failures on CI that are linked to the Kotlin compiler daemon
We now attempt at archiving these logs whenever a impacted test fails.