### PR TITLE
Add factory methods for various container types and deprecation nagging to internal constructors

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/Named.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/Named.java
@@ -31,13 +31,13 @@ public interface Named {
 
     // -- Internal note --
     // It would be better to only require getName() to return Object and just call toString() on it, but
-    // if you have a groovy class with a “String name” property the generated getName() method will not 
+    // if you have a groovy class with a “String name” property the generated getName() method will not
     // satisfy the Named interface. This seems to be a bug in the Groovy compiler - LD.
 
     /**
      * An implementation of the namer interface for objects implementing the named interface.
      */
-    public static class Namer implements org.gradle.api.Namer<Named> {
+    class Namer implements org.gradle.api.Namer<Named> {
 
         public static final org.gradle.api.Namer<Named> INSTANCE = new Namer();
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
@@ -27,14 +27,14 @@ import java.util.Collection;
  * <p>The filtered collections returned by the filtering methods, such as {@link #matching(Closure)}, return collections that are <em>live</em>. That is, they reflect
  * changes made to the source collection that they were created from. This is true for filtered collections made from filtered collections etc.</p>
  * <p>
- * You can also add actions which are executed as elements are added to the collection. Actions added to filtered collections will be fired if an addition/removal
+ * You can also add actions that are executed as elements are added to the collection. Actions added to filtered collections will be fired if an addition/removal
  * occurs for the source collection that matches the filter.</p>
  * <p>
  * {@code DomainObjectCollection} instances are not <em>thread-safe</em> and undefined behavior may result from the invocation of any method on a collection that is being mutated by another
  * thread; this includes direct invocations, passing the collection to a method that might perform invocations, and using an existing iterator to examine the collection.
  * </p>
  *
- * @param <T> The type of domain objects in this collection.
+ * @param <T> The type of objects in this collection.
  */
 public interface DomainObjectCollection<T> extends Collection<T> {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectSet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectSet.java
@@ -21,9 +21,9 @@ import org.gradle.api.specs.Spec;
 import java.util.Set;
 
 /**
- * <p>A {@code DomainObjectSet} is a specialisation of {@link DomainObjectCollection} that guarantees {@link Set} semantics.</p>
+ * <p>A {@code DomainObjectSet} is a specialization of {@link DomainObjectCollection} that guarantees {@link Set} semantics.</p>
  *
- * @param <T> The type of domain objects in this set.
+ * @param <T> The type of objects in this set.
  */
 public interface DomainObjectSet<T> extends DomainObjectCollection<T>, Set<T> {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectSet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectSet.java
@@ -23,6 +23,8 @@ import java.util.Set;
 /**
  * <p>A {@code DomainObjectSet} is a specialization of {@link DomainObjectCollection} that guarantees {@link Set} semantics.</p>
  *
+ * <p>You can create an instance of this type using the factory method {@link org.gradle.api.model.ObjectFactory#domainObjectSet(Class)}.</p>
+ *
  * @param <T> The type of objects in this set.
  */
 public interface DomainObjectSet<T> extends DomainObjectCollection<T>, Set<T> {

--- a/subprojects/core-api/src/main/java/org/gradle/api/ExtensiblePolymorphicDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ExtensiblePolymorphicDomainObjectContainer.java
@@ -22,6 +22,8 @@ import org.gradle.api.internal.rules.NamedDomainObjectFactoryRegistry;
  * A {@link org.gradle.api.PolymorphicDomainObjectContainer} that can be extended at runtime to
  * create elements of new types.
  *
+ * <p>You can create an instance of this type using the factory method {@link org.gradle.api.model.ObjectFactory#polymorphicDomainObjectContainer(Class)}.</p>
+ *
  * @param <T> the (base) container element type
  */
 public interface ExtensiblePolymorphicDomainObjectContainer<T> extends PolymorphicDomainObjectContainer<T>, NamedDomainObjectFactoryRegistry<T> {

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
@@ -27,7 +27,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 
 /**
- * <p>A {@code NamedDomainObjectCollection} represents a collection of domain objects that have an inherent, constant, name.</p>
+ * <p>A {@code NamedDomainObjectCollection} represents a collection of objects that have an inherent, constant, name.</p>
  *
  * <p>Objects to be added to a named domain object collection must implement {@code equals()} in such a way that no two objects
  * with different names are considered equal. That is, all equality tests <strong>must</strong> consider the name as an
@@ -71,7 +71,7 @@ import java.util.SortedSet;
  * books.gradle.name == "gradle"
  * </pre>
  *
- * @param <T> The type of domain objects in this collection.
+ * @param <T> The type of objects in this collection.
  */
 public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T> {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
@@ -20,7 +20,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.util.Configurable;
 
 /**
- * <p>A named domain object container is a specialisation of {@link NamedDomainObjectSet} that adds the ability to create
+ * <p>A named domain object container is a specialization of {@link NamedDomainObjectSet} that adds the ability to create
  * instances of the element type.</p>
  *
  * <p>Implementations may use different strategies for creating new object instances.</p>
@@ -28,10 +28,9 @@ import org.gradle.util.Configurable;
  * <p>Note that a container is an implementation of {@link java.util.SortedSet}, which means that the container is guaranteed
  * to only contain elements with unique names within this container. Furthermore, items are ordered by their name.</p>
  *
- * @param <T> The type of domain objects in this container.
- * @see NamedDomainObjectSet
- * @see Project#container(Class) Creating a container.
- * @see Project#container(Class, NamedDomainObjectFactory) Creating a container with a custom factory.
+ * <p>You can create an instance of this type using the factory method {@link org.gradle.api.model.ObjectFactory#domainObjectContainer(Class)}.</p>
+ *
+ * @param <T> The type of objects in this container.
  */
 public interface NamedDomainObjectContainer<T> extends NamedDomainObjectSet<T>, Configurable<NamedDomainObjectContainer<T>> {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectList.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectList.java
@@ -21,13 +21,15 @@ import org.gradle.api.specs.Spec;
 import java.util.List;
 
 /**
- * <p>A specialisation of {@link org.gradle.api.NamedDomainObjectCollection} that also implements {@link java.util.List}.</p>
+ * <p>A specialization of {@link org.gradle.api.NamedDomainObjectCollection} that also implements {@link java.util.List}.</p>
  *
  * <p>All object equality is determined in terms of object names. That is, calling {@code remove()} with an object that is NOT equal to
  * an existing object in terms of {@code equals}, but IS in terms of name equality will result in the existing collection item with
  * the equal name being removed.</p>
  *
- * @param <T> The type of element in the set
+ * <p>You can create an instance of this type using the factory method {@link org.gradle.api.model.ObjectFactory#namedDomainObjectList(Class)}.</p>
+ *
+ * @param <T> The type of objects in the list
  */
 public interface NamedDomainObjectList<T> extends NamedDomainObjectCollection<T>, List<T> {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectSet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectSet.java
@@ -17,16 +17,19 @@ package org.gradle.api;
 
 import groovy.lang.Closure;
 import org.gradle.api.specs.Spec;
+
 import java.util.Set;
 
 /**
- * <p>A specialisation of {@link NamedDomainObjectCollection} that also implements {@link Set} and orders objects by their inherent name.</p>
- * 
+ * <p>A specialization of {@link NamedDomainObjectCollection} that also implements {@link Set} and orders objects by their inherent name.</p>
+ *
  * <p>All object equality is determined in terms of object names. That is, calling {@code remove()} with an object that is NOT equal to
  * an existing object in terms of {@code equals}, but IS in terms of name equality will result in the existing collection item with
  * the equal name being removed.</p>
- * 
- * @param <T> The type of element in the set
+ *
+ * <p>You can create an instance of this type using the factory method {@link org.gradle.api.model.ObjectFactory#namedDomainObjectSet(Class)}.</p>
+ *
+ *  @param <T> The type of objects in the set
  */
 public interface NamedDomainObjectSet<T> extends NamedDomainObjectCollection<T>, Set<T> {
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/PolymorphicDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/PolymorphicDomainObjectContainer.java
@@ -19,9 +19,9 @@ import org.gradle.api.provider.Provider;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
- * A {@link NamedDomainObjectContainer} that allows to create domain objects with different types.
+ * A {@link NamedDomainObjectContainer} that allows you to create objects with different types.
  *
- * @param <T> the (base) type of domain objects in the container
+ * @param <T> the (base) type of objects in the container
  */
 @HasInternalProtocol
 public interface PolymorphicDomainObjectContainer<T> extends NamedDomainObjectContainer<T> {

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -22,6 +22,8 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.NamedDomainObjectList;
+import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
@@ -132,19 +134,6 @@ public interface ObjectFactory {
     <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType);
 
     /**
-     * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type.</p>
-     *
-     * <p>The returned container will not have any factories or bindings registered.</p>
-     *
-     * @param elementType The type of objects for the container to contain.
-     * @param <T> The type of objects for the container to contain.
-     * @return The container.
-     * @since 6.1
-     */
-    @Incubating
-    <T> ExtensiblePolymorphicDomainObjectContainer<T> polymorphicDomainObjectContainer(Class<T> elementType);
-
-    /**
      * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type. The given factory is used to create object instances.</p>
      *
      * <p>All objects <b>MUST</b> expose their name as a bean property named "name". The name must be constant for the life of the object.</p>
@@ -159,6 +148,19 @@ public interface ObjectFactory {
     <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory);
 
     /**
+     * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type.</p>
+     *
+     * <p>The returned container will not have any factories or bindings registered.</p>
+     *
+     * @param elementType The type of objects for the container to contain.
+     * @param <T> The type of objects for the container to contain.
+     * @return The container.
+     * @since 6.1
+     */
+    @Incubating
+    <T> ExtensiblePolymorphicDomainObjectContainer<T> polymorphicDomainObjectContainer(Class<T> elementType);
+
+    /**
      * Creates a new {@link DomainObjectSet} for managing objects of the specified type.
      *
      * @param elementType The type of objects for the domain object set to contain.
@@ -168,6 +170,32 @@ public interface ObjectFactory {
      */
     @Incubating
     <T> DomainObjectSet<T> domainObjectSet(Class<T> elementType);
+
+    /**
+     * Creates a new {@link NamedDomainObjectSet} for managing named objects of the specified type.
+     *
+     * <p>All objects <b>MUST</b> expose their name as a bean property called "name". The name must be constant for the life of the object.</p>
+     *
+     * @param elementType The type of objects for the domain object set to contain.
+     * @param <T> The type of objects for the domain object set to contain.
+     * @return The domain object set.
+     * @since 6.1
+     */
+    @Incubating
+    <T> NamedDomainObjectSet<T> namedDomainObjectSet(Class<T> elementType);
+
+    /**
+     * Creates a new {@link NamedDomainObjectList} for managing named objects of the specified type.
+     *
+     * <p>All objects <b>MUST</b> expose their name as a bean property called "name". The name must be constant for the life of the object.</p>
+     *
+     * @param elementType The type of objects for the domain object set to contain.
+     * @param <T> The type of objects for the domain object set to contain.
+     * @return The domain object list.
+     * @since 6.1
+     */
+    @Incubating
+    <T> NamedDomainObjectList<T> namedDomainObjectList(Class<T> elementType);
 
     /**
      * Creates a {@link Property} implementation to hold values of the given type. The property has no initial value.

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.api.model;
 
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
@@ -106,7 +107,7 @@ public interface ObjectFactory {
     ConfigurableFileCollection fileCollection();
 
     /**
-     * Creates a new {@link ConfigurableFileTree}. The tree has no base dir specified.
+     * Creates a new {@link ConfigurableFileTree}. The tree will have no base dir specified.
      *
      * @since 6.0
      */
@@ -116,7 +117,7 @@ public interface ObjectFactory {
     /**
      * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type.</p>
      *
-     * <p>The specified type must have a public constructor which takes the name as a String parameter. The type must be non-final and a class or abstract class. Interfaces are currently not supported.</p>
+     * <p>The specified element type must have a public constructor which takes the name as a String parameter. The type must be non-final and a class or abstract class. Interfaces are currently not supported.</p>
      *
      * <p>All objects <b>MUST</b> expose their name as a bean property called "name". The name must be constant for the life of the object.</p>
      *
@@ -129,6 +130,19 @@ public interface ObjectFactory {
      */
     @Incubating
     <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType);
+
+    /**
+     * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type.</p>
+     *
+     * <p>The returned container will not have any factories or bindings registered.</p>
+     *
+     * @param elementType The type of objects for the container to contain.
+     * @param <T> The type of objects for the container to contain.
+     * @return The container.
+     * @since 6.1
+     */
+    @Incubating
+    <T> ExtensiblePolymorphicDomainObjectContainer<T> polymorphicDomainObjectContainer(Class<T> elementType);
 
     /**
      * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type. The given factory is used to create object instances.</p>

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
@@ -355,6 +355,28 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         succeeds()
     }
 
+    def "can create instance of interface with read-only DomainObjectSet property"() {
+        buildFile << """
+            class Bean {
+                String name
+            }
+
+            interface Thing {
+                DomainObjectSet<Bean> getValue()
+            }
+            
+            extensions.create("thing", Thing)
+            assert thing.value.toString() == "[]"
+            assert thing.value.empty
+            thing.value.add(new Bean(name: "a"))
+            thing.value.add(new Bean(name: "b"))
+            assert thing.value*.name == ['a', 'b']
+        """
+
+        expect:
+        succeeds()
+    }
+
     def "can create instance of abstract class with mutable property"() {
         buildFile << """
             abstract class Thing {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -519,7 +519,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
         succeeds()
     }
 
-    def "plugin can create NamedDomainObjectContainer which can create decorated elements of type that has public constructor"() {
+    def "plugin can create a NamedDomainObjectContainer instance that creates decorated elements of type using type's public constructor"() {
         given:
         buildFile << """
             abstract class NamedThing implements Named {
@@ -547,7 +547,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
         succeeds()
     }
 
-    def "plugin can create NamedDomainObjectContainer instances with factory"() {
+    def "plugin can create NamedDomainObjectContainer instances that creates elements using user provided factory"() {
         given:
         buildFile << """
             class NamedThing implements Named {
@@ -577,6 +577,28 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
             assert domainObjectSet != null
             assert domainObjectSet.add('foo')
             assert domainObjectSet.size() == 1
+        """
+
+        expect:
+        succeeds()
+    }
+
+    def "plugin can create ExtensiblePolymorphicDomainObjectContainer instances"() {
+        given:
+        buildFile << """
+            class NamedThing implements Named {
+                final String name
+                NamedThing(String name) {
+                    this.name = name
+                }
+            }
+
+            def container = project.objects.polymorphicDomainObjectContainer(Named)
+            container.registerBinding(Named, NamedThing)
+            container.register("a", Named) { }
+            container.register("b", Named) { }
+            assert container.size() == 2
+            assert container.every { it instanceof NamedThing }
         """
 
         expect:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -519,7 +519,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
         succeeds()
     }
 
-    def "plugin can create a NamedDomainObjectContainer instance that creates decorated elements of type using type's public constructor"() {
+    def "plugin can create a NamedDomainObjectContainer instance that creates decorated elements of type and uses name bean property"() {
         given:
         buildFile << """
             abstract class NamedThing implements Named {
@@ -577,6 +577,53 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
             assert domainObjectSet != null
             assert domainObjectSet.add('foo')
             assert domainObjectSet.size() == 1
+        """
+
+        expect:
+        succeeds()
+    }
+
+    def "plugin can create a NamedDomainObjectSet instance that uses name bean property"() {
+        given:
+        buildFile << """
+            class NamedThing implements Named {
+                final String name
+                NamedThing(String name) {
+                    this.name = name
+                }
+            }
+
+            def container = project.objects.namedDomainObjectSet(NamedThing)
+            assert container != null
+            container.add(new NamedThing('foo'))
+            container.add(new NamedThing('bar'))
+            assert container.size() == 2
+            def element = container.getByName('foo')
+            assert element.name == 'foo'
+        """
+
+        expect:
+        succeeds()
+    }
+
+    def "plugin can create a NamedDomainObjectList instance that uses name bean property"() {
+        given:
+        buildFile << """
+            class NamedThing implements Named {
+                final String name
+                NamedThing(String name) {
+                    this.name = name
+                }
+            }
+
+            def container = project.objects.namedDomainObjectList(NamedThing)
+            assert container != null
+            container.add(new NamedThing('foo'))
+            container.add(new NamedThing('bar'))
+            assert container.size() == 2
+            def element = container.getByName('foo')
+            assert element.name == 'foo'
+            assert element == container[0]
         """
 
         expect:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskPropertiesIntegrationTest.groovy
@@ -223,6 +223,37 @@ class TaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         outputContains("beans = [1, 2]")
     }
 
+    def "can define task with abstract read-only DomainObjectSet<T> property"() {
+        given:
+        buildFile << """
+            class Bean {
+                @Input
+                String prop
+            }
+            
+            abstract class MyTask extends DefaultTask {
+                @Nested
+                abstract DomainObjectSet<Bean> getBeans()
+                
+                @TaskAction
+                void go() {
+                    println("beans = \${beans.collect { it.prop } }")
+                }
+            }
+            
+            tasks.create("thing", MyTask) {
+                beans.add(new Bean(prop: '1'))
+                beans.add(new Bean(prop: '2'))
+            }
+        """
+
+        when:
+        succeeds("thing")
+
+        then:
+        outputContains("beans = [1, 2]")
+    }
+
     def "can define task with abstract read-only @Nested property"() {
         given:
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.collections.IterationOrderRetainingSetElementSour
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.ImmutableActionSet;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -39,6 +40,7 @@ public class DefaultDomainObjectSet<T> extends DefaultDomainObjectCollection<T> 
     @Deprecated
     public DefaultDomainObjectSet(Class<? extends T> type) {
         super(type, new IterationOrderRetainingSetElementSource<T>(), CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor DefaultDomainObjectSet(Class<T>)", "Please use ObjectFactory.domainObjectSet(Class<T>) instead.");
     }
 
     public DefaultDomainObjectSet(Class<? extends T> type, CollectionCallbackActionDecorator decorator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectList.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.collections.ListElementSource;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,8 +42,10 @@ public class DefaultNamedDomainObjectList<T> extends DefaultNamedDomainObjectCol
     /**
      * only left here to not break `nebula.dependency-recommender` plugin.
      */
+    @Deprecated
     public DefaultNamedDomainObjectList(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
         super(type, new ListElementSource<T>(), instantiator, namer, CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor DefaultNamedDomainObjectList(Class<T>, Instantiator, Namer<T>)", "Please use ObjectFactory.namedDomainObjectList(Class<T>) instead.");
     }
 
     public DefaultNamedDomainObjectList(Class<T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator decorator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectSet.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.collections.SortedSetElementSource;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -37,8 +38,10 @@ public class DefaultNamedDomainObjectSet<T> extends DefaultNamedDomainObjectColl
         this.parentMutationGuard = MutationGuards.identity();
     }
 
+    @Deprecated
     public DefaultNamedDomainObjectSet(Class<? extends T> type, Instantiator instantiator) {
         this(type, instantiator, CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor DefaultNamedDomainObjectSet(Class<T>, Instantiator, Namer<T>)", "Please use ObjectFactory.namedDomainObjectSet(Class<T>) instead.");
     }
 
     public DefaultNamedDomainObjectSet(Class<? extends T> type, Instantiator instantiator, CollectionCallbackActionDecorator decorator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
@@ -43,7 +43,7 @@ public class DefaultPolymorphicDomainObjectContainer<T> extends AbstractPolymorp
     @Deprecated
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator) {
         this(type, instantiator, Named.Namer.forType(type), CollectionCallbackActionDecorator.NOOP);
-        DeprecationLogger.nagUserOfDeprecated("Internal API constructor DefaultPolymorphicDomainObjectContainer(Class<T>, Instantiator)");
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor DefaultPolymorphicDomainObjectContainer(Class<T>, Instantiator)", "Please use ObjectFactory.polymorphicDomainObjectContainer(Class<T>) instead.");
     }
 
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackDecorator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
@@ -22,6 +22,7 @@ import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.Namer;
 import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.util.DeprecationLogger;
 
 public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObjectContainer<T> {
 
@@ -52,6 +53,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
     @Deprecated
     public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, NamedDomainObjectFactory<T> factory) {
         this(type, instantiator, Named.Namer.forType(type), factory, MutationGuards.identity(), CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor FactoryNamedDomainObjectContainer(Class<T>, Instantiator, NamedDomainObjectFactory<T>)", "Please use ObjectFactory.domainObjectContainer(Class<T>, NamedDomainObjectFactory<T>) instead.");
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
@@ -19,11 +19,13 @@ package org.gradle.api.internal.collections;
 import groovy.lang.Closure;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.internal.DynamicPropertyNamer;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.MutationGuard;
@@ -74,6 +76,12 @@ public class DefaultDomainObjectCollectionFactory implements DomainObjectCollect
     public <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> type, Closure factoryClosure) {
         Instantiator instantiator = instantiatorFactory.decorateLenient();
         return Cast.uncheckedCast(instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factoryClosure, mutationGuard, collectionCallbackActionDecorator));
+    }
+
+    @Override
+    public <T> ExtensiblePolymorphicDomainObjectContainer<T> newPolymorphicDomainObjectContainer(Class<T> elementType) {
+        Instantiator instantiator = instantiatorFactory.decorateLenient();
+        return Cast.uncheckedCast(instantiator.newInstance(DefaultPolymorphicDomainObjectContainer.class, elementType, instantiator, collectionCallbackActionDecorator));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
@@ -22,9 +22,13 @@ import org.gradle.api.DomainObjectSet;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.NamedDomainObjectList;
+import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.DefaultNamedDomainObjectList;
+import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.internal.DynamicPropertyNamer;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
@@ -88,6 +92,18 @@ public class DefaultDomainObjectCollectionFactory implements DomainObjectCollect
     public <T> DomainObjectSet<T> newDomainObjectSet(Class<T> elementType) {
         Instantiator instantiator = instantiatorFactory.decorateLenient();
         return Cast.uncheckedCast(instantiator.newInstance(DefaultDomainObjectSet.class, elementType, collectionCallbackActionDecorator));
+    }
+
+    @Override
+    public <T> NamedDomainObjectSet<T> newNamedDomainObjectSet(Class<T> elementType) {
+        Instantiator instantiator = instantiatorFactory.decorateLenient();
+        return Cast.uncheckedCast(instantiator.newInstance(DefaultNamedDomainObjectSet.class, elementType, instantiator, new DynamicPropertyNamer(), collectionCallbackActionDecorator));
+    }
+
+    @Override
+    public <T> NamedDomainObjectList<T> newNamedDomainObjectList(Class<T> elementType) {
+        Instantiator instantiator = instantiatorFactory.decorateLenient();
+        return Cast.uncheckedCast(instantiator.newInstance(DefaultNamedDomainObjectList.class, elementType, instantiator, new DynamicPropertyNamer(), collectionCallbackActionDecorator));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
@@ -22,6 +22,8 @@ import org.gradle.api.DomainObjectSet;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.NamedDomainObjectList;
+import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 
 public interface DomainObjectCollectionFactory {
@@ -51,6 +53,10 @@ public interface DomainObjectCollectionFactory {
      * Creates a {@link DomainObjectSet} for managing objects of the specified type.
      */
     <T> DomainObjectSet<T> newDomainObjectSet(Class<T> elementType);
+
+    <T> NamedDomainObjectSet<T> newNamedDomainObjectSet(Class<T> elementType);
+
+    <T> NamedDomainObjectList<T> newNamedDomainObjectList(Class<T> elementType);
 
     /**
      * Creates a {@link CompositeDomainObjectSet} for managing a collection of {@link DomainObjectCollection} of the specified type.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.collections;
 import groovy.lang.Closure;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.internal.CompositeDomainObjectSet;
@@ -55,4 +56,6 @@ public interface DomainObjectCollectionFactory {
      * Creates a {@link CompositeDomainObjectSet} for managing a collection of {@link DomainObjectCollection} of the specified type.
      */
     <T> CompositeDomainObjectSet<T> newDomainObjectSet(Class<T> elementType, DomainObjectCollection<? extends T>... collections);
+
+    <T> ExtensiblePolymorphicDomainObjectContainer<T> newPolymorphicDomainObjectContainer(Class<T> elementType);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.model;
 
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
@@ -114,6 +115,11 @@ public class DefaultObjectFactory implements ObjectFactory {
     @Override
     public <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
         return domainObjectCollectionFactory.newNamedDomainObjectContainer(elementType, factory);
+    }
+
+    @Override
+    public <T> ExtensiblePolymorphicDomainObjectContainer<T> polymorphicDomainObjectContainer(Class<T> elementType) {
+        return domainObjectCollectionFactory.newPolymorphicDomainObjectContainer(elementType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -22,6 +22,8 @@ import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.NamedDomainObjectList;
+import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.Directory;
@@ -120,6 +122,16 @@ public class DefaultObjectFactory implements ObjectFactory {
     @Override
     public <T> ExtensiblePolymorphicDomainObjectContainer<T> polymorphicDomainObjectContainer(Class<T> elementType) {
         return domainObjectCollectionFactory.newPolymorphicDomainObjectContainer(elementType);
+    }
+
+    @Override
+    public <T> NamedDomainObjectSet<T> namedDomainObjectSet(Class<T> elementType) {
+        return domainObjectCollectionFactory.newNamedDomainObjectSet(elementType);
+    }
+
+    @Override
+    public <T> NamedDomainObjectList<T> namedDomainObjectList(Class<T> elementType) {
+        return domainObjectCollectionFactory.newNamedDomainObjectList(elementType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -20,6 +20,8 @@ import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.NamedDomainObjectList;
+import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
@@ -79,6 +81,16 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
     @Override
     public <T> DomainObjectSet<T> domainObjectSet(Class<T> elementType) {
         throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing domain object sets");
+    }
+
+    @Override
+    public <T> NamedDomainObjectSet<T> namedDomainObjectSet(Class<T> elementType) {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object sets");
+    }
+
+    @Override
+    public <T> NamedDomainObjectList<T> namedDomainObjectList(Class<T> elementType) {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object lists");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.model;
 
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
@@ -62,17 +63,22 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
 
     @Override
     public <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType) {
-        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object container");
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object containers");
     }
 
     @Override
     public <T> NamedDomainObjectContainer<T> domainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
-        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object container with factory");
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object containers");
+    }
+
+    @Override
+    public <T> ExtensiblePolymorphicDomainObjectContainer<T> polymorphicDomainObjectContainer(Class<T> elementType) {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object containers");
     }
 
     @Override
     public <T> DomainObjectSet<T> domainObjectSet(Class<T> elementType) {
-        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing domain object set");
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing domain object sets");
     }
 
     @Override

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -19,6 +19,8 @@ TBD - Managed properties of type `DomainObjectSet<T>` now supported.
 ### New factory methods
 
 TBD - `ObjectFactory` has a method to create `ExtensiblePolymorphicDomainObjectContainer` instances.
+TBD - `ObjectFactory` has a method to create `NamedDomainObjectSet` instances.
+TBD - `ObjectFactory` has a method to create `NamedDomainObjectList` instances.
 
 ## Upgrade Instructions
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -12,6 +12,10 @@ Include only their name, impactful features should be called out separately belo
 
 ## Improvements for plugin authors
 
+### New managed property types
+
+TBD - Managed properties of type `DomainObjectSet<T>` now supported.
+
 ### New factory methods
 
 TBD - `ObjectFactory` has a method to create `ExtensiblePolymorphicDomainObjectContainer` instances.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -10,17 +10,11 @@ Include only their name, impactful features should be called out separately belo
 
 [Mark Nordhoff](https://github.com/MarkNordhoff)
 
-<!-- 
-## 1
+## Improvements for plugin authors
 
-details of 1
+### New factory methods
 
-## 2
-
-details of 2
-
-## n
--->
+TBD - `ObjectFactory` has a method to create `ExtensiblePolymorphicDomainObjectContainer` instances.
 
 ## Upgrade Instructions
 

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
@@ -109,6 +109,7 @@ In addition, the property type must have one of the following:
 - `MapProperty<K, V>`
 - `ConfigurableFileCollection`
 - `ConfigurableFileTree`
+- `DomainObjectSet<T>`
 - `NamedDomainObjectContainer<T>`
 
 Gradle creates values for read-only managed properties in the same way as link:{javadocPath}/org/gradle/api/model/ObjectFactory.html[ObjectFactory].
@@ -283,7 +284,7 @@ Gradle provides types for maintaining collections of objects, intended to work w
 
 === NamedDomainObjectContainer
 
-A link:{javadocPath}/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer] manages a set of objects, where each elements has a name associated with it.
+A link:{javadocPath}/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer] manages a set of objects, where each element has a name associated with it.
 The container takes care of creating and configuring the elements, and provides a DSL that build scripts can use to define and configure elements.
 It is intended to hold objects which are themselves configurable, for example a set of custom Gradle objects.
 
@@ -341,10 +342,30 @@ include::{samplesPath}/userguide/plugins/namedDomainObjectContainer/groovy/build
 ----
 ====
 
+=== ExtensiblePolymorphicDomainObjectContainer
+
+An link:{javadocPath}/org/gradle/api/ExtensiblePolymorphicDomainObjectContainer.html[ExtensiblePolymorphicDomainObjectContainer] is a `NamedDomainObjectContainer` that allows you to
+define instantiation strategies for different types of objects.
+
+You can create an instance using the link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#polymorphicDomainObjectContainer-java.lang.Class-[ObjectFactory.polymorphicDomainObjectContainer()] method.
+
+=== NamedDomainObjectSet
+
+A link:{javadocPath}/org/gradle/api/NamedDomainObjectSet.html[NamedDomainObjectSet] holds a set of configurable objects, where each element has a name associated with it.
+This is similar to `NamedDomainObjectContainer`, however a `NamedDomainObjectSet` doesn't manage the objects in the collection. They need to be created and added manually.
+
+You can create an instance using the link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#namedDomainObjectSet-java.lang.Class-[ObjectFactory.namedDomainObjectSet()] method.
+
+=== NamedDomainObjectList
+
+A link:{javadocPath}/org/gradle/api/NamedDomainObjectList.html[NamedDomainObjectList] holds a list of configurable objects, where each element has a name associated with it.
+This is similar to `NamedDomainObjectContainer`, however a `NamedDomainObjectList` doesn't manage the objects in the collection. They need to be created and added manually.
+
+You can create an instance using the link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#namedDomainObjectList-java.lang.Class-[ObjectFactory.namedDomainObjectList()] method.
+
 === DomainObjectSet
 
-A link:{javadocPath}/org/gradle/api/DomainObjectSet.html[DomainObjectSet] simply holds a set of objects.
-Compared to the `NamedDomainObjectContainer`, the `DomainObjectSet` doesn't manage the objects in the collection.
-They need to be created and added manually.
+A link:{javadocPath}/org/gradle/api/DomainObjectSet.html[DomainObjectSet] simply holds a set of configurable objects.
+Compared to `NamedDomainObjectContainer`, a `DomainObjectSet` doesn't manage the objects in the collection. They need to be created and added manually.
 
 You can create an instance using the link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#domainObjectSet-java.lang.Class-[ObjectFactory.domainObjectSet()] method.

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -71,14 +71,15 @@ class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionAnd
 
     def "android 3.6 minimal build clean assembleDebug"() {
         when:
-        executer.expectDeprecationWarning() // Coming from Android plugin
+        executer.expectDeprecationWarning("BuildListener#buildStarted(Gradle) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
         instantRun("assembleDebug")
 
         then:
         instantExecution.assertStateStored()
 
         when:
-        executer.expectDeprecationWarning() // Coming from Android plugin
+        executer.expectDeprecationWarning("BuildListener#buildStarted(Gradle) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
+        executer.expectDeprecationWarning("Internal API constructor DefaultDomainObjectSet(Class<T>) has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use ObjectFactory.domainObjectSet(Class<T>) instead.")
         run 'clean'
         // Instant execution avoid registering the listener inside Android plugin
         instantRun("assembleDebug")

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionJavaIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.instantexecution
 
 import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.junit.Test
-import spock.lang.Ignore
 
 class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
@@ -55,8 +54,7 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         jarFile.isFile()
 
         when:
-        classFile.delete()
-        jarFile.delete()
+        file("build").delete()
         instantRun "build"
 
         then:
@@ -126,8 +124,7 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         jarFile.isFile()
 
         when:
-        classFile.delete()
-        jarFile.delete()
+        file("build").delete()
         instantRun "assemble"
 
         then:
@@ -166,21 +163,16 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         and:
         file("b/build/classes/java/main/b/B.class").delete()
         def jarFile = file("b/build/libs/b.jar")
-        jarFile.delete()
+        jarFile.isFile()
 
         and:
+        file("build").delete()
         instantRun ":b:assemble"
 
         then:
         new ZipTestFixture(jarFile).assertContainsFile("b/B.class")
     }
 
-    /**
-     * TODO: Understand why it fails due to:
-     * ':processResources' is not up-to-date because:
-     *   Input property 'rootSpec$1' file /.../src/main/resources has been removed.
-     */
-    @Ignore("wip")
     def "processResources on single project Java build honors up-to-date check"() {
         given:
         buildFile << """
@@ -192,7 +184,7 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         instantRun ":processResources"
 
         and:
-        instantRun ":processResources" /*, "--info" */
+        instantRun ":processResources"
 
         then:
         file("build/resources/main/answer.txt").text == "42"
@@ -290,9 +282,7 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         assertTestsExecuted("ThingTest", "ok")
 
         when:
-        classFile.delete()
-        testClassFile.delete()
-        testResults.delete()
+        file("build").delete()
         instantRun "check"
 
         then:
@@ -325,10 +315,10 @@ class InstantExecutionJavaIntegrationTest extends AbstractInstantExecutionIntegr
         def classFile = file("build/classes/java/main/Thing.class")
         classFile.isFile()
         def jarFile = file("build/libs/someapp.jar")
-        jarFile.delete()
+        jarFile.isFile()
 
         when:
-        classFile.delete()
+        file("build").delete()
         instantRun "assemble"
 
         then:

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -29,6 +29,7 @@ import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.Transformer;
@@ -104,7 +105,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         RegularFileProperty.class,
         DirectoryProperty.class,
         Property.class,
-        NamedDomainObjectContainer.class
+        NamedDomainObjectContainer.class,
+        DomainObjectSet.class
     );
     private static final Object[] NO_PARAMS = new Object[0];
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ManagedObjectFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ManagedObjectFactory.java
@@ -18,6 +18,7 @@ package org.gradle.internal.instantiation.generator;
 
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Describable;
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
@@ -87,6 +88,9 @@ public class ManagedObjectFactory {
         }
         if (type.isAssignableFrom(NamedDomainObjectContainer.class)) {
             return attachOwner(owner, ownerDisplayName, propertyName, getObjectFactory().domainObjectContainer(paramType));
+        }
+        if (type.isAssignableFrom(DomainObjectSet.class)) {
+            return attachOwner(owner, ownerDisplayName, propertyName, getObjectFactory().domainObjectSet(paramType));
         }
         throw new IllegalArgumentException("Don't know how to create an instance of type " + type.getName());
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratedManagedStateTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
 import spock.lang.Unroll
 
+import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.*
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBean
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractBeanWithInheritedFields
 import static org.gradle.internal.instantiation.generator.AsmBackedClassGeneratorTest.AbstractClassWithTypeParamProperty
@@ -178,6 +179,16 @@ class AsmBackedClassGeneratedManagedStateTest extends AbstractClassGeneratorSpec
         bean.prop.empty
         bean.prop.register("one")
         bean.prop.names == ["one"] as Set
+    }
+
+    def canConstructInstanceOfInterfaceWithDomainObjectSetGetter() {
+        def bean = create(InterfaceDomainSetPropertyBean)
+
+        expect:
+        bean.prop.toString() == "[]"
+        bean.prop.empty
+        bean.prop.add(Stub(NamedBean))
+        bean.prop.size() == 1
     }
 
     def canConstructInstanceOfInterfaceWithNestedGetter() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
 import groovy.lang.MissingMethodException;
 import org.gradle.api.Action;
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -1872,6 +1873,10 @@ public class AsmBackedClassGeneratorTest {
 
     public interface InterfaceContainerPropertyBean {
         NamedDomainObjectContainer<NamedBean> getProp();
+    }
+
+    public interface InterfaceDomainSetPropertyBean {
+        DomainObjectSet<NamedBean> getProp();
     }
 
     public interface InterfaceWithDefaultMethods {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetContainer.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetContainer.java
@@ -37,8 +37,8 @@ public class DefaultSourceSetContainer extends AbstractValidatingNamedDomainObje
     private final Instantiator instantiator;
 
     @Inject
-    public DefaultSourceSetContainer(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator classGenerator, ObjectFactory objectFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
-        super(SourceSet.class, classGenerator, new Namer<SourceSet>() {
+    public DefaultSourceSetContainer(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, ObjectFactory objectFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(SourceSet.class, instantiator, new Namer<SourceSet>() {
             @Override
             public String determineName(SourceSet ss) {
                 return ss.getName();
@@ -46,7 +46,7 @@ public class DefaultSourceSetContainer extends AbstractValidatingNamedDomainObje
         }, collectionCallbackActionDecorator);
         this.fileResolver = fileResolver;
         this.fileCollectionFactory = fileCollectionFactory;
-        this.instantiator = classGenerator;
+        this.instantiator = instantiator;
         this.objectFactory = objectFactory;
     }
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorServicesIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorServicesIntegrationTest.groovy
@@ -161,7 +161,9 @@ class WorkerExecutorServicesIntegrationTest extends AbstractWorkerExecutorIntegr
             objectFactory.setProperty(String)
             objectFactory.mapProperty(String, String)
             objectFactory.named(Foo, "foo")
+            objectFactory.domainObjectSet(Foo)
             objectFactory.domainObjectContainer(Foo)
+            objectFactory.polymorphicDomainObjectContainer(Foo)
         """
         fixture.withWorkActionClassInBuildScript()
 


### PR DESCRIPTION

### Context

Add missing factory methods for all of the container types, and add nagging to the "backwards compatible" constructors on internal implementation types as these constructors do not instrument the containers for plugin attribution (plus we want people to use the factory methods instead of the internal types).

Also allow managed properties of type `DomainObjectSet<T>`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
