### PR TITLE
Let smoke tests segregate the partial distro generated api jars

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
@@ -91,9 +91,7 @@ class DistributionTestingPlugin : Plugin<Project> {
         gradleInstallationForTest.apply {
             val intTestImage: Sync by project.tasks
             gradleUserHomeDir.set(projectDirectory.dir("intTestHomeDir"))
-            gradleGeneratedApiJarCacheDir.set(providers.provider {
-                projectDirectory.dir("intTestHomeDir/generatedApiJars/${project.version}/${project.name}-$classpathHash")
-            })
+            gradleGeneratedApiJarCacheDir.set(providers.provider { generatedApiJarCacheDir(layout) })
             daemonRegistry.set(layout.buildDirectory.dir("daemon"))
             gradleHomeDir.set(dirWorkaround { intTestImage.destinationDir })
             gradleSamplesDir.set(layout.projectDirectory.dir("subprojects/docs/src/samples"))
@@ -111,14 +109,6 @@ class DistributionTestingPlugin : Plugin<Project> {
             distZipVersion = project.version.toString()
         }
     }
-
-    private
-    val DistributionTest.classpathHash
-        get() = project.classPathHashOf(classpath)
-
-    private
-    fun Project.classPathHashOf(files: FileCollection) =
-        serviceOf<ClasspathHasher>().hash(DefaultClassPath.of(files))
 
     private
     fun DistributionTest.setJvmArgsOfTestJvm() {
@@ -149,3 +139,17 @@ class DistributionTestingPlugin : Plugin<Project> {
         }
     }
 }
+
+
+fun DistributionTest.generatedApiJarCacheDir(layout: ProjectLayout) =
+    layout.projectDirectory.dir("intTestHomeDir/generatedApiJars/${project.version}/${project.name}-$classpathHash")
+
+
+private
+val DistributionTest.classpathHash
+    get() = project.classPathHashOf(classpath)
+
+
+private
+fun Project.classPathHashOf(files: FileCollection) =
+    serviceOf<ClasspathHasher>().hash(DefaultClassPath.of(files))

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
@@ -91,7 +91,7 @@ class DistributionTestingPlugin : Plugin<Project> {
         gradleInstallationForTest.apply {
             val intTestImage: Sync by project.tasks
             gradleUserHomeDir.set(projectDirectory.dir("intTestHomeDir"))
-            gradleGeneratedApiJarCacheDir.set(providers.provider { generatedApiJarCacheDir(layout) })
+            gradleGeneratedApiJarCacheDir.set(defaultGradleGeneratedApiJarCacheDirProvider())
             daemonRegistry.set(layout.buildDirectory.dir("daemon"))
             gradleHomeDir.set(dirWorkaround { intTestImage.destinationDir })
             gradleSamplesDir.set(layout.projectDirectory.dir("subprojects/docs/src/samples"))
@@ -141,8 +141,16 @@ class DistributionTestingPlugin : Plugin<Project> {
 }
 
 
-fun DistributionTest.generatedApiJarCacheDir(layout: ProjectLayout) =
-    layout.projectDirectory.dir("intTestHomeDir/generatedApiJars/${project.version}/${project.name}-$classpathHash")
+fun DistributionTest.defaultGradleGeneratedApiJarCacheDirProvider(): Provider<Directory> =
+    project.rootProject.providers.provider { defaultGeneratedGradleApiJarCacheDir() }
+
+
+/**
+ * Computes a project and classpath specific `intTestHomeDir/generatedApiJars` directory.
+ */
+private
+fun DistributionTest.defaultGeneratedGradleApiJarCacheDir(): Directory =
+    project.rootProject.layout.projectDirectory.dir("intTestHomeDir/generatedApiJars/${project.version}/${project.name}-$classpathHash")
 
 
 private

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -16,7 +16,7 @@
 import accessors.groovy
 import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.test.integrationtests.SmokeTest
-import org.gradle.gradlebuild.test.integrationtests.generatedApiJarCacheDir
+import org.gradle.gradlebuild.test.integrationtests.defaultGradleGeneratedApiJarCacheDirProvider
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
 import org.gradle.gradlebuild.versioning.DetermineCommitId
 import org.gradle.testing.performance.generator.tasks.RemoteProject
@@ -76,9 +76,9 @@ tasks.register<SmokeTest>("smokeTest") {
     testClassesDirs = smokeTest.output.classesDirs
     classpath = smokeTest.runtimeClasspath
     maxParallelForks = 1 // those tests are pretty expensive, we shouldn"t execute them concurrently
-    gradleInstallationForTest.gradleGeneratedApiJarCacheDir.set(providers.provider {
-        generatedApiJarCacheDir(rootProject.layout)
-    })
+    gradleInstallationForTest.gradleGeneratedApiJarCacheDir.set(
+        defaultGradleGeneratedApiJarCacheDirProvider()
+    )
 }
 
 plugins.withType<IdeaPlugin>().configureEach { // lazy as plugin not applied yet

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -16,6 +16,7 @@
 import accessors.groovy
 import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.test.integrationtests.SmokeTest
+import org.gradle.gradlebuild.test.integrationtests.generatedApiJarCacheDir
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
 import org.gradle.gradlebuild.versioning.DetermineCommitId
 import org.gradle.testing.performance.generator.tasks.RemoteProject
@@ -51,6 +52,7 @@ dependencies {
     smokeTestImplementation(project(":testKit"))
     smokeTestImplementation(project(":internalIntegTesting"))
     smokeTestImplementation(project(":launcher"))
+    smokeTestImplementation(project(":persistentCache"))
     smokeTestImplementation(library("commons_io"))
     smokeTestImplementation(library("jgit"))
     smokeTestImplementation(testLibrary("spock"))
@@ -74,6 +76,9 @@ tasks.register<SmokeTest>("smokeTest") {
     testClassesDirs = smokeTest.output.classesDirs
     classpath = smokeTest.runtimeClasspath
     maxParallelForks = 1 // those tests are pretty expensive, we shouldn"t execute them concurrently
+    gradleInstallationForTest.gradleGeneratedApiJarCacheDir.set(providers.provider {
+        generatedApiJarCacheDir(rootProject.layout)
+    })
 }
 
 plugins.withType<IdeaPlugin>().configureEach { // lazy as plugin not applied yet

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 import org.apache.commons.io.FileUtils
+import org.gradle.cache.internal.DefaultGeneratedGradleJarCache
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
@@ -163,7 +164,17 @@ abstract class AbstractSmokeTest extends Specification {
             .withProjectDir(testProjectDir.root)
             .forwardOutput()
             .withArguments(tasks.toList() + outputParameters() + repoMirrorParameters()) as DefaultGradleRunner
-        gradleRunner.withJvmArguments("-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError")
+        gradleRunner.withJvmArguments(
+            ["-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError"] + buildContextParameters()
+        )
+    }
+
+    private static List<String> buildContextParameters() {
+        def generatedApiJarCacheDir = IntegrationTestBuildContext.INSTANCE.gradleGeneratedApiJarCacheDir
+        if (generatedApiJarCacheDir == null) {
+            return []
+        }
+        return ["-D${DefaultGeneratedGradleJarCache.BASE_DIR_OVERRIDE_PROPERTY}=${generatedApiJarCacheDir.absolutePath}" as String]
     }
 
     private static List<String> outputParameters() {


### PR DESCRIPTION
instead of using a shared one from the global testkit user dir which cause some agents to fail running the tests because they were run against generated api jars from a different partial distribution.