### PR TITLE
Pmd: Avoid sporadic NativeException by not using the ConsoleDetector

### DIFF
--- a/subprojects/code-quality/code-quality.gradle.kts
+++ b/subprojects/code-quality/code-quality.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 dependencies {
     implementation(project(":baseServices"))
     implementation(project(":logging"))
+    implementation(project(":native"))
     implementation(project(":processServices"))
     implementation(project(":coreApi"))
     implementation(project(":modelCore"))

--- a/subprojects/code-quality/code-quality.gradle.kts
+++ b/subprojects/code-quality/code-quality.gradle.kts
@@ -22,7 +22,6 @@ plugins {
 dependencies {
     implementation(project(":baseServices"))
     implementation(project(":logging"))
-    implementation(project(":native"))
     implementation(project(":processServices"))
     implementation(project(":coreApi"))
     implementation(project(":modelCore"))

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -42,9 +42,6 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
-import org.gradle.internal.nativeintegration.console.ConsoleDetector;
-import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
-import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.util.ClosureBackedAction;
 
 import javax.annotation.Nullable;
@@ -92,12 +89,6 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     @TaskAction
     public void run() {
         PmdInvoker.invoke(this);
-    }
-
-    public boolean stdOutIsAttachedToTerminal() {
-        ConsoleDetector consoleDetector = NativeServices.getInstance().get(ConsoleDetector.class);
-        ConsoleMetaData consoleMetaData = consoleDetector.getConsole();
-        return consoleMetaData != null && consoleMetaData.isStdOut();
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -42,6 +42,9 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
+import org.gradle.internal.nativeintegration.console.ConsoleDetector;
+import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
+import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.util.ClosureBackedAction;
 
 import javax.annotation.Nullable;
@@ -89,6 +92,13 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     @TaskAction
     public void run() {
         PmdInvoker.invoke(this);
+    }
+
+    @Deprecated //Issue: #11205
+    public boolean stdOutIsAttachedToTerminal() {
+        ConsoleDetector consoleDetector = NativeServices.getInstance().get(ConsoleDetector.class);
+        ConsoleMetaData consoleMetaData = consoleDetector.getConsole();
+        return consoleMetaData != null && consoleMetaData.isStdOut();
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
@@ -41,7 +41,6 @@ abstract class PmdInvoker {
         def classpath = pmdTask.classpath?.filter(new FileExistFilter())
         def reports = pmdTask.reports
         def consoleOutput = pmdTask.consoleOutput
-        def stdOutIsAttachedToTerminal = pmdTask.stdOutIsAttachedToTerminal()
         def ignoreFailures = pmdTask.ignoreFailures
         def logger = pmdTask.logger
         def incrementalAnalysis = pmdTask.incrementalAnalysis.get()
@@ -124,12 +123,8 @@ abstract class PmdInvoker {
                         }
 
                         if (consoleOutput) {
-                            def consoleOutputType = 'text'
-                            if (stdOutIsAttachedToTerminal) {
-                                consoleOutputType = 'textcolor'
-                            }
                             a.builder.saveStreams = false
-                            formatter(type: consoleOutputType, toConsole: true)
+                            formatter(type: 'text', toConsole: true)
                         }
                     }
                     def failureCount = ant.project.properties["pmdFailureCount"]


### PR DESCRIPTION
Fixes #11205

**Rationale** of the suggested fix: It is better that the Pmd task runs reliably than having a colorful console output. Anyway, when running the integration tests (on powershell) before the fix, the flag 'stdOutIsAttachedToTerminal' was false and 'text' was used.
**Actions:** Removed code only, hence no additional tests.
~~As a **positive side effect**, the dependency of project _code-quality_ to _native_ could be removed.~~

### Context
[Gradle Forum topic](https://discuss.gradle.org/t/pmdmain-fails-on-gradle-5-4-1-could-not-determine-if-stdout-is-a-console-could-not-get-handle-file-information-errno-1/31588) 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
