### PR TITLE
Prepare CI pipeline to run integ tests with instant execution enabled

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -57,7 +57,8 @@ data class CIBuildModel(
             ),
             functionalTests = listOf(
                 TestCoverage(3, TestType.platform, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
-                TestCoverage(4, TestType.platform, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)),
+                TestCoverage(4, TestType.platform, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor),
+                TestCoverage(20, TestType.instant, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor)),
             performanceTests = listOf(PerformanceTestType.test),
             omitsSlowProjects = true),
         Stage(StageNames.READY_FOR_NIGHTLY,
@@ -404,6 +405,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     allVersionsCrossVersion(false, true, true, 240),
     parallel(false, true, false),
     noDaemon(false, true, false, 240),
+    instant(false, true, false),
     soak(false, false, false),
     forceRealizeDependencyManagement(false, true, false)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,11 @@ buildTypes {
         tasks("parallelIntegTest")
     }
 
+    // Run the integration tests using instant execution
+    create("instantTest") {
+        tasks("instantIntegTest")
+    }
+
     create("performanceTests") {
         tasks("performance:performanceTest")
     }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -67,6 +67,10 @@ fun Project.createTasks(sourceSet: SourceSet, testType: TestType) {
                 // (see CrossVersionTestsPlugin).
                 systemProperties["org.gradle.integtest.versions"] = "default"
             }
+            // TODO:instant-execution remove this once ready to enable
+            if (testType == TestType.INTEGRATION && executer == "instant") {
+                enabled = false
+            }
         })
     }
     // Use the default executer for the simply named task. This is what most developers will run when running check

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -15,7 +15,7 @@ import java.io.File
 
 
 enum class TestType(val prefix: String, val executers: List<String>, val libRepoRequired: Boolean) {
-    INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel"), false),
+    INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel", "instant"), false),
     CROSSVERSION("crossVersion", listOf("embedded", "forking"), true)
 }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
@@ -36,7 +36,8 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
         embedded(false),
         forking(true),
         noDaemon(true),
-        parallel(true, true);
+        parallel(true, true),
+        instant(true);
 
         final public boolean forks;
         final public boolean executeParallel;
@@ -73,6 +74,10 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
 
     public static boolean isParallel() {
         return getSystemPropertyExecuter().executeParallel;
+    }
+
+    public static boolean isInstant() {
+        return getSystemPropertyExecuter() == Executer.instant;
     }
 
     private GradleExecuter gradleExecuter;
@@ -118,6 +123,8 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
                 return new ParallelForkingGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
             case forking:
                 return new DaemonGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
+            case instant:
+                return new InstantExecutionGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
             default:
                 throw new RuntimeException("Not a supported executer type: " + executerType);
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
@@ -21,7 +21,7 @@ import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.GradleVersion
 
 
-class InstantExecutionGradleExecuter extends DaemonGradleExecuter {
+class InstantExecutionGradleExecuter extends InProcessGradleExecuter {
 
     InstantExecutionGradleExecuter(
         GradleDistribution distribution,

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import org.gradle.instantexecution.SystemProperties
+import org.gradle.test.fixtures.file.TestDirectoryProvider
+import org.gradle.util.GradleVersion
+
+
+class InstantExecutionGradleExecuter extends DaemonGradleExecuter {
+
+    InstantExecutionGradleExecuter(
+        GradleDistribution distribution,
+        TestDirectoryProvider testDirectoryProvider,
+        GradleVersion gradleVersion,
+        IntegrationTestBuildContext buildContext
+    ) {
+        super(distribution, testDirectoryProvider, gradleVersion, buildContext)
+    }
+
+    @Override
+    protected List<String> getAllArgs() {
+        return super.getAllArgs() + [
+            "-D${SystemProperties.isEnabled}=true",
+            "-D${SystemProperties.failOnProblems}=true"
+        ].collect { it.toString() }
+    }
+}


### PR DESCRIPTION
This PR sets up the CI pipeline for instant execution that needs to land on `master` first so that subsequent work can be done on a branch.

It introduces `InstantExecutionGradleExecuter` that run integration tests with instant execution enabled failing on any encountered problem.

It also adds an instant execution integration tests pipeline on Linux only for now at `Ready for Merge` to the CI configuration.

And it configures the build to create `instantIntegTest` tasks, disabled for now as many integration tests currently fail, waiting for another PR that will allow running those tasks by annotating tests to either expect failure or ignore them when instant execution is enabled.
