### PR TITLE
Upgrade instant execution AGP tested nightly

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/AbstractInstantExecutionAndroidIntegrationTest.groovy
@@ -20,19 +20,21 @@ import groovy.transform.CompileStatic
 import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.test.fixtures.file.TestFile
 
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.kotlinEapRepositoryDefinition
+
 
 /**
  * Base Android / Instant execution integration test.
  *
  * In order to iterate quickly on changes to AGP:
- * - change `AGP_VERSION` to `3.6.0-dev`
+ * - change `AGP_VERSION` to `4.0.0-dev`
  * - change the repository url in `AGP_NIGHTLY_REPOSITORY_DECLARATION` to `file:///path/to/agp-src/out/repo`
  * - run `./gradlew :publishAndroidGradleLocal` in `/path/to/agp-src/tools`
  */
 @CompileStatic
 abstract class AbstractInstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
-    static final String AGP_VERSION = "3.6.0-20190924221819+0200"
+    static final String AGP_VERSION = "4.0.0-20191103023549+0100"
 
     static final String AGP_NIGHTLY_REPOSITORY_DECLARATION = '''
         maven {
@@ -46,10 +48,12 @@ abstract class AbstractInstantExecutionAndroidIntegrationTest extends AbstractIn
             buildscript {
                 repositories {
                     $AGP_NIGHTLY_REPOSITORY_DECLARATION
+                    ${kotlinEapRepositoryDefinition()}
                 }
             }
             repositories {
                 $AGP_NIGHTLY_REPOSITORY_DECLARATION
+                ${kotlinEapRepositoryDefinition()}
             }
         }
     """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -71,17 +71,14 @@ class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionAnd
 
     def "android 3.6 minimal build clean assembleDebug"() {
         when:
-        executer.expectDeprecationWarning("BuildListener#buildStarted(Gradle) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
         instantRun("assembleDebug")
 
         then:
         instantExecution.assertStateStored()
 
         when:
-        executer.expectDeprecationWarning("BuildListener#buildStarted(Gradle) has been deprecated. This is scheduled to be removed in Gradle 7.0.")
         executer.expectDeprecationWarning("Internal API constructor DefaultDomainObjectSet(Class<T>) has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use ObjectFactory.domainObjectSet(Class<T>) instead.")
         run 'clean'
-        // Instant execution avoid registering the listener inside Android plugin
         instantRun("assembleDebug")
 
         then:


### PR DESCRIPTION
to `4.0.0-20191103023549+0100`
