### PR TITLE
Make `--scan` work when settings script is written in Kotlin

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyKotlinIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanAutoApplyKotlinIntegrationTest.groovy
@@ -32,18 +32,20 @@ class BuildScanAutoApplyKotlinIntegrationTest extends KotlinScriptIntegrationTes
 
     def "can automatically apply plugin when --scan is provided on command-line"() {
         given:
+        file("settings.gradle").delete()
+        file("settings.gradle.kts") << """
+            rootProject.buildFileName = "$defaultBuildFileName"
+        """
+
         buildFile << """
             task("dummy")
         """
 
+        and:
         def initScript = file("init.gradle") << """
             beforeSettings {
                 it.with { ${fixture.pluginManagement()} }
             }
-        """
-
-        file("settings.gradle.kts") << """
-            gradleEnterprise {}
         """
 
         fixture.publishDummyPlugin(executer)

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigManager.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigManager.java
@@ -40,10 +40,8 @@ public class BuildScanConfigManager implements BuildScanConfigInit, BuildScanCon
 
     private static final VersionNumber FIRST_VERSION_AWARE_OF_UNSUPPORTED = VersionNumber.parse("1.11");
 
-    private static final String HELP_LINK = "https://gradle.com/scans/help/gradle-cli";
-
-    public static final String NO_PLUGIN_MSG = "Build scan cannot be created because the Gradle Enterprise plugin was not applied.\n"
-        + "For more information on how to apply the Gradle Enterprise plugin, please visit " + HELP_LINK + ".";
+    public static final String NO_PLUGIN_MSG = "An internal error occurred that prevented a build scan from being created.\n" +
+        "Please report this via https://github.com/gradle/gradle/issues";
 
     private static final String SYSPROP_KEY = "scan";
     private static final List<String> ENABLED_SYS_PROP_VALUES = Arrays.asList(null, "", "yes", "true");

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluator.kt
@@ -88,16 +88,15 @@ class PartialEvaluator(
                     )
                 }
 
-            else -> Static(CloseTargetScope)
+            else -> Static(defaultStageTransition())
         }
 
     private
     fun reduceBuildscriptProgram(program: Program.Buildscript): Static =
-
         Static(
             SetupEmbeddedKotlin,
             Eval(fragmentHolderSourceFor(program)),
-            CloseTargetScope
+            defaultStageTransition()
         )
 
     private
@@ -138,11 +137,19 @@ class PartialEvaluator(
                 }
             }
 
-            else -> Static(
-                CloseTargetScope,
-                Eval(program.source)
-            )
+            else -> {
+                Static(
+                    defaultStageTransition(),
+                    Eval(program.source)
+                )
+            }
         }
+
+    private
+    fun defaultStageTransition(): ResidualProgram.Instruction = when (programKind) {
+        ProgramKind.TopLevel -> ApplyDefaultPluginRequests
+        else -> CloseTargetScope
+    }
 
     private
     fun reduceStagedProgram(program: Program.Staged): Dynamic =
@@ -191,7 +198,7 @@ class PartialEvaluator(
         return Static(
             SetupEmbeddedKotlin,
             Eval(fragmentHolderSourceFor(program)),
-            CloseTargetScope
+            ApplyDefaultPluginRequests
         )
     }
 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
@@ -146,6 +146,27 @@ class PartialEvaluatorTest {
     }
 
     @Test
+    fun `a top-level Settings pluginManagement block`() {
+
+        val fragment = fragment("pluginManagement", "...")
+        val program = Program.PluginManagement(fragment)
+
+        assertThat(
+            "reduces to static program that evaluates pluginManagement block then applies default plugin requests",
+            partialEvaluationOf(
+                program,
+                ProgramKind.TopLevel,
+                ProgramTarget.Settings
+            ),
+            isResidualProgram(
+                Static(
+                    SetupEmbeddedKotlin,
+                    Eval(fragment.source),
+                    ApplyDefaultPluginRequests
+                )))
+    }
+
+    @Test
     fun `a top-level Project buildscript block followed by plugins block`() {
 
         val program =

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
@@ -297,6 +297,22 @@ class PartialEvaluatorTest {
     }
 
     @Test
+    fun `an empty Settings top-level script`() {
+
+        assertThat(
+            "reduces to static program that applies default plugin requests",
+            partialEvaluationOf(
+                Program.Empty,
+                ProgramKind.TopLevel,
+                ProgramTarget.Settings
+            ),
+            isResidualProgram(
+                Static(
+                    ApplyDefaultPluginRequests
+                )))
+    }
+
+    @Test
     fun `a non-empty Settings top-level script`() {
 
         val source =
@@ -311,7 +327,7 @@ class PartialEvaluatorTest {
             ),
             isResidualProgram(
                 Static(
-                    CloseTargetScope,
+                    ApplyDefaultPluginRequests,
                     Eval(source)
                 )))
     }
@@ -333,7 +349,7 @@ class PartialEvaluatorTest {
                 Static(
                     SetupEmbeddedKotlin,
                     Eval(fragment.source),
-                    CloseTargetScope
+                    ApplyDefaultPluginRequests
                 )))
     }
 
@@ -369,7 +385,7 @@ class PartialEvaluatorTest {
                     Static(
                         SetupEmbeddedKotlin,
                         Eval(expectedEvalSource),
-                        CloseTargetScope
+                        ApplyDefaultPluginRequests
                     ),
                     scriptSource
                 )))


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #11202
