### PR TITLE
Use note instead of Gradle IDE plugins in samples

### DIFF
--- a/subprojects/docs/src/samples/next-gen/groovy/basic-application/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/groovy/basic-application/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how a simple Groovy application can be built with Gradle.
 The application has no dependencies aside from the Groovy runtime and the build has minimal configuration.
 

--- a/subprojects/docs/src/samples/next-gen/groovy/basic-application/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/groovy/basic-application/groovy/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'groovy'
     id 'application'
-    id 'eclipse'
-    // See ??? for IntelliJ support
 }
 
 version = '1.0.2'

--- a/subprojects/docs/src/samples/next-gen/groovy/basic-application/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/groovy/basic-application/kotlin/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     groovy
     application
-    eclipse
-    // See ??? for IntelliJ support
 }
 
 version = "1.0.2"

--- a/subprojects/docs/src/samples/next-gen/groovy/basic-library/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/groovy/basic-library/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how a simple Groovy library can be built with Gradle.
 The library has no dependencies aside from the Groovy runtime and the build has minimal configuration.
 

--- a/subprojects/docs/src/samples/next-gen/groovy/basic-library/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/groovy/basic-library/groovy/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id 'groovy'
-    id 'eclipse'
-    // See ??? for IntelliJ support
 }
 
 version = '1.0.2'

--- a/subprojects/docs/src/samples/next-gen/groovy/basic-library/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/groovy/basic-library/kotlin/build.gradle.kts
@@ -1,7 +1,5 @@
 plugins {
     groovy
-    eclipse
-    // See ??? for IntelliJ support
 }
 
 version = "1.0.2"

--- a/subprojects/docs/src/samples/next-gen/groovy/components-with-spock-tests/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/groovy/components-with-spock-tests/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how to test Groovy projects using Spock Framework in Gradle.
 
 Applications can be configured as follow:

--- a/subprojects/docs/src/samples/next-gen/groovy/components-with-spock-tests/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/groovy/components-with-spock-tests/groovy/build.gradle
@@ -1,7 +1,4 @@
 allprojects {
-    apply plugin: 'eclipse'
-    // See ??? for IntelliJ support
-
     version = '1.0.2'
     group = 'org.gradle.sample'
 }

--- a/subprojects/docs/src/samples/next-gen/groovy/components-with-spock-tests/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/groovy/components-with-spock-tests/kotlin/build.gradle.kts
@@ -1,7 +1,4 @@
 allprojects {
-    apply(plugin = "eclipse")
-    // See ??? for IntelliJ support
-
     version = "1.0.2"
     group = "org.gradle.sample"
 }

--- a/subprojects/docs/src/samples/next-gen/groovy/library-publishing/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/groovy/library-publishing/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how a Groovy library can be publish with Gradle.
 
 ====

--- a/subprojects/docs/src/samples/next-gen/groovy/library-publishing/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/groovy/library-publishing/groovy/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'groovy'
     id 'maven-publish'
-    id 'eclipse'
-    // See ??? for IntelliJ support
 }
 
 version = '1.0.2'

--- a/subprojects/docs/src/samples/next-gen/groovy/library-publishing/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/groovy/library-publishing/kotlin/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     groovy
     `maven-publish`
-    eclipse
-    // See ??? for IntelliJ support
 }
 
 version = "1.0.2"

--- a/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how transitive dependencies work with Java projects in Gradle.
 
 The `application` project has an implementation dependency on the `utilities` project:

--- a/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/groovy/build.gradle
@@ -1,6 +1,4 @@
 allprojects {
-    apply plugin: 'eclipse'
-    // See ??? for IntelliJ support
 
     version = '1.0.2'
     group = 'org.gradle.sample'

--- a/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/kotlin/build.gradle.kts
@@ -1,7 +1,4 @@
 allprojects {
-    apply(plugin = "eclipse")
-    // See ??? for IntelliJ support
-
     version = "1.0.2"
     group = "org.gradle.sample"
 }

--- a/subprojects/docs/src/samples/next-gen/java/basic-application/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/java/basic-application/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how a simple Java application can be built with Gradle.
 The application has no dependencies and the build has minimal configuration.
 

--- a/subprojects/docs/src/samples/next-gen/java/basic-application/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/java/basic-application/groovy/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id 'application'
-    id 'eclipse'
-    // See ??? for IntelliJ support
 }
 
 version = '1.0.2'

--- a/subprojects/docs/src/samples/next-gen/java/basic-application/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/java/basic-application/kotlin/build.gradle.kts
@@ -1,7 +1,5 @@
 plugins {
     application
-    eclipse
-    // See ??? for IntelliJ support
 }
 
 version = "1.0.2"

--- a/subprojects/docs/src/samples/next-gen/java/basic-library/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/java/basic-library/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how a simple Java library can be built with Gradle.
 The library has no dependencies and the build has minimal configuration.
 

--- a/subprojects/docs/src/samples/next-gen/java/basic-library/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/java/basic-library/groovy/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id 'java-library'
-    id 'eclipse'
-    // See ??? for IntelliJ support
 }
 
 version = '1.0.2'

--- a/subprojects/docs/src/samples/next-gen/java/basic-library/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/java/basic-library/kotlin/build.gradle.kts
@@ -1,7 +1,5 @@
 plugins {
     `java-library`
-    eclipse
-    // See ??? for IntelliJ support
 }
 
 version = "1.0.2"

--- a/subprojects/docs/src/samples/next-gen/java/components-with-junit-4-tests/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/java/components-with-junit-4-tests/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how to test Java projects using JUnit 4 in Gradle.
 
 Applications can be configured as follow:

--- a/subprojects/docs/src/samples/next-gen/java/components-with-junit-4-tests/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/java/components-with-junit-4-tests/groovy/build.gradle
@@ -1,7 +1,4 @@
 allprojects {
-    apply plugin: 'eclipse'
-    // See ??? for IntelliJ support
-
     version = '1.0.2'
     group = 'org.gradle.sample'
 }

--- a/subprojects/docs/src/samples/next-gen/java/components-with-junit-4-tests/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/java/components-with-junit-4-tests/kotlin/build.gradle.kts
@@ -1,7 +1,4 @@
 allprojects {
-    apply(plugin = "eclipse")
-    // See ??? for IntelliJ support
-
     version = "1.0.2"
     group = "org.gradle.sample"
 }

--- a/subprojects/docs/src/samples/next-gen/java/components-with-spock-tests/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/java/components-with-spock-tests/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how to test Java projects using Spock Framework in Gradle.
 
 Applications can be configured as follow:

--- a/subprojects/docs/src/samples/next-gen/java/components-with-spock-tests/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/java/components-with-spock-tests/groovy/build.gradle
@@ -1,7 +1,4 @@
 allprojects {
-    apply plugin: 'eclipse'
-    // See ??? for IntelliJ support
-
     version = '1.0.2'
     group = 'org.gradle.sample'
 }

--- a/subprojects/docs/src/samples/next-gen/java/components-with-spock-tests/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/java/components-with-spock-tests/kotlin/build.gradle.kts
@@ -1,7 +1,4 @@
 allprojects {
-    apply(plugin = "eclipse")
-    // See ??? for IntelliJ support
-
     version = "1.0.2"
     group = "org.gradle.sample"
 }

--- a/subprojects/docs/src/samples/next-gen/java/library-publishing/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/java/library-publishing/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 This sample shows how a simple Java library can be built with Gradle.
 The library has no dependencies and the build has minimal configuration.
 

--- a/subprojects/docs/src/samples/next-gen/java/library-publishing/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/java/library-publishing/groovy/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'eclipse'
-    // See ??? for IntelliJ support
 }
 
 version = '1.0.2'

--- a/subprojects/docs/src/samples/next-gen/java/library-publishing/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/java/library-publishing/kotlin/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     `java-library`
     `maven-publish`
-    eclipse
-    // See ??? for IntelliJ support
 }
 
 version = "1.0.2"

--- a/subprojects/docs/src/samples/next-gen/java/transitive-dependencies/README.adoc
+++ b/subprojects/docs/src/samples/next-gen/java/transitive-dependencies/README.adoc
@@ -5,6 +5,8 @@ ifndef::env-github[]
 - link:{zip-base-file-name}-kotlin-dsl.zip[Download Kotlin DSL ZIP]
 endif::[]
 
+NOTE: You can open the samples inside an IDE using the https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start[IntelliJ native importer] or https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship].
+
 The `application` project has an implementation dependency on the `utilities` project:
 
 ====

--- a/subprojects/docs/src/samples/next-gen/java/transitive-dependencies/groovy/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/java/transitive-dependencies/groovy/build.gradle
@@ -1,7 +1,4 @@
 allprojects {
-    apply plugin: 'eclipse'
-    // See ??? for IntelliJ support
-
     group = 'org.gradle.sample'
     version = '1.2'
 }

--- a/subprojects/docs/src/samples/next-gen/java/transitive-dependencies/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/java/transitive-dependencies/kotlin/build.gradle.kts
@@ -1,7 +1,4 @@
 allprojects {
-    apply(plugin = "eclipse")
-    // See ??? for IntelliJ support
-
     group = "org.gradle.sample"
     version = "1.2"
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/11236

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Ffavor-ide-note-instead-of-plugins)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
