### PR TITLE
Enable partial VFS invalidation for android perf experiment

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.regression.android
 
+import org.gradle.internal.service.scopes.VirtualFileSystemServices
 import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.fixture.BuildExperimentSpec
@@ -28,31 +29,37 @@ import static org.gradle.performance.regression.android.IncrementalAndroidTestPr
 
 @Category(PerformanceExperiment)
 class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPerformanceTest {
-    private static final String INSTANT_EXECUTION_PROPERTY = "-Dorg.gradle.unsafe.instant-execution=true"
 
     @Unroll
     def "faster incremental build on #testProject (build comparison)"() {
         given:
         runner.testGroup = "incremental android changes"
-        runner.buildSpec {
-            testProject.configureForNonAbiChange(it)
-            displayName("non abi change")
-        }
-        runner.buildSpec {
-            testProject.configureForAbiChange(it)
-            displayName("abi change")
-        }
-        if (testProject != SANTA_TRACKER_KOTLIN) {
-            // Kotlin is not supported for instant execution
+
+        // Kotlin is not supported for instant execution
+        def optimizations = testProject == SANTA_TRACKER_KOTLIN
+            ? [
+                "no optimizations": EnumSet.noneOf(Optimization),
+                "VFS retention": EnumSet.of(Optimization.VFS_RETENTION)
+            ]
+            : [
+                "no optimizations": EnumSet.noneOf(Optimization),
+                "VFS retention": EnumSet.of(Optimization.VFS_RETENTION),
+                "instant execution": EnumSet.of(Optimization.INSTANT_EXECUTION),
+                "all optimizations": EnumSet.allOf(Optimization)
+            ]
+
+        optimizations.each { name, Set<Optimization> enabledOptimizations ->
             runner.buildSpec {
                 testProject.configureForNonAbiChange(it)
-                configureFastIncrementalBuild(it)
-                displayName("instant non abi change")
+                passChangedFile(it, testProject)
+                invocation.args(*enabledOptimizations*.argument)
+                displayName("non abi change (${name})")
             }
             runner.buildSpec {
                 testProject.configureForAbiChange(it)
-                configureFastIncrementalBuild(it)
-                displayName("instant abi change")
+                passChangedFile(it, testProject)
+                invocation.args(*enabledOptimizations*.argument)
+                displayName("abi change (${name})")
             }
         }
 
@@ -72,7 +79,18 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
         }
     }
 
-    def configureFastIncrementalBuild(GradleBuildExperimentSpec.GradleBuilder builder) {
-        builder.invocation.args(INSTANT_EXECUTION_PROPERTY)
+    static void passChangedFile(GradleBuildExperimentSpec.GradleBuilder builder, IncrementalAndroidTestProject testProject) {
+        builder.invocation.args("-D${VirtualFileSystemServices.VFS_CHANGES_SINCE_LAST_BUILD_PROPERTY}=${testProject.pathToChange}")
+    }
+
+    enum Optimization {
+        INSTANT_EXECUTION("org.gradle.unsafe.instant-execution"),
+        VFS_RETENTION(VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY)
+
+        Optimization(String systemProperty) {
+            this.argument = "-D${systemProperty}=true"
+        }
+
+        final String argument
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.performance.AbstractCrossBuildPerformanceTest
 import org.gradle.performance.categories.PerformanceExperiment
 import org.gradle.performance.fixture.BuildExperimentSpec
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
+import org.gradle.performance.regression.java.JavaInstantExecutionPerformanceTest
 import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
@@ -84,7 +85,7 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     }
 
     enum Optimization {
-        INSTANT_EXECUTION("org.gradle.unsafe.instant-execution"),
+        INSTANT_EXECUTION(JavaInstantExecutionPerformanceTest.INSTANT_EXECUTION_ENABLED_PROPERTY),
         VFS_RETENTION(VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY)
 
         Optimization(String systemProperty) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaInstantExecutionPerformanceTest.groovy
@@ -35,6 +35,8 @@ import static org.junit.Assert.assertTrue
 @Category(PerformanceRegressionTest)
 class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInternalPerformanceTest {
 
+    public static final String INSTANT_EXECUTION_ENABLED_PROPERTY = "org.gradle.unsafe.instant-execution"
+
     private TestFile instantExecutionStateDir
 
     def setup() {
@@ -49,7 +51,7 @@ class JavaInstantExecutionPerformanceTest extends AbstractCrossVersionGradleInte
         runner.minimumBaseVersion = "5.6"
         runner.testProject = testProject.projectName
         runner.tasksToRun = ["assemble"]
-        runner.args = ["-Dorg.gradle.unsafe.instant-execution=true"]
+        runner.args = ["-D${INSTANT_EXECUTION_ENABLED_PROPERTY}=true"]
 
         and:
         runner.useDaemon = daemon == hot


### PR DESCRIPTION
Fixes #11246

---
cc: @gradle/build-cache