### PR TITLE
[Gradle Build] Make 'slf4jApi' and 'Guava' common dependencies defined in the platform

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/ClasspathManifest.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/build/ClasspathManifest.kt
@@ -16,6 +16,7 @@
 package org.gradle.build
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ProjectDependency
@@ -53,7 +54,7 @@ abstract class ClasspathManifest @Inject constructor(
     internal
     val runtime: Provider<String> = providers.provider {
         runtimeClasspath
-            .fileCollection { it is ExternalDependency || it is FileCollectionDependency }
+            .fileCollection { it is ExternalDependency || it is FileCollectionDependency || it.isPlatformProject() }
             .joinForProperties { it.name }
     }
 
@@ -105,6 +106,11 @@ abstract class ClasspathManifest @Inject constructor(
     private
     val runtimeClasspath
         get() = project.configurations["runtimeClasspath"]
+
+    private
+    fun Dependency.isPlatformProject(): Boolean {
+        return this is ProjectDependency && dependencyProject.plugins.hasPlugin("java-platform")
+    }
 
     private
     fun <T : Any> Iterable<T>.joinForProperties(transform: ((T) -> CharSequence)? = null) =

--- a/subprojects/antlr/antlr.gradle.kts
+++ b/subprojects/antlr/antlr.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(project(":files"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("inject"))
 
     compileOnly("antlr:antlr:2.7.7") {

--- a/subprojects/antlr/antlr.gradle.kts
+++ b/subprojects/antlr/antlr.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":workers"))
     implementation(project(":files"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("inject"))

--- a/subprojects/architecture-test/architecture-test.gradle.kts
+++ b/subprojects/architecture-test/architecture-test.gradle.kts
@@ -13,11 +13,9 @@ gradlebuildJava {
 dependencies {
     testImplementation(project(":baseServices"))
     testImplementation(project(":modelCore"))
-    
+
     testImplementation(testLibrary("archunit_junit4"))
     testImplementation(library("jsr305"))
-    testImplementation(library("guava"))
-
     publicProjects.forEach {
         testRuntimeOnly(it)
     }

--- a/subprojects/base-services-groovy/base-services-groovy.gradle.kts
+++ b/subprojects/base-services-groovy/base-services-groovy.gradle.kts
@@ -23,10 +23,8 @@ plugins {
 
 dependencies {
     implementation(project(":baseServices"))
-    
-    implementation(library("groovy"))
-    implementation(library("guava"))
 
+    implementation(library("groovy"))
     testImplementation(testFixtures(project(":core")))
 }
 

--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -20,14 +20,12 @@ dependencies {
     api(project(":hashing"))
     api(library("jsr305"))
 
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("asm"))
 
     integTestImplementation(project(":logging"))
 
-    testFixturesImplementation(library("guava"))
     testImplementation(testFixtures(project(":core")))
     testRuntimeOnly(library("xerces"))
 

--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     api(project(":hashing"))
     api(library("jsr305"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))

--- a/subprojects/build-cache-http/build-cache-http.gradle.kts
+++ b/subprojects/build-cache-http/build-cache-http.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":resourcesHttp"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_httpclient"))
     implementation(library("commons_lang"))

--- a/subprojects/build-cache-http/build-cache-http.gradle.kts
+++ b/subprojects/build-cache-http/build-cache-http.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":resourcesHttp"))
 
-    implementation(library("guava"))
     implementation(library("commons_httpclient"))
     implementation(library("commons_lang"))
     implementation(library("inject"))

--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":snapshots"))
 
     implementation(library("jsr305"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("commons_compress"))
@@ -40,7 +39,7 @@ dependencies {
     testImplementation(project(":processServices"))
     testImplementation(project(":fileCollections"))
     testImplementation(project(":resources"))
-    
+
     testImplementation(testFixtures(project(":baseServices")))
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":snapshots")))

--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":snapshots"))
 
     implementation(library("jsr305"))
-    implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("commons_compress"))
     implementation(library("commons_io"))

--- a/subprojects/build-cache/build-cache.gradle.kts
+++ b/subprojects/build-cache/build-cache.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":logging"))
 
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("inject"))
 

--- a/subprojects/build-cache/build-cache.gradle.kts
+++ b/subprojects/build-cache/build-cache.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":logging"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("inject"))

--- a/subprojects/build-init/build-init.gradle.kts
+++ b/subprojects/build-init/build-init.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(project(":wrapper"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))

--- a/subprojects/build-init/build-init.gradle.kts
+++ b/subprojects/build-init/build-init.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(project(":wrapper"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
     implementation("org.codehaus.plexus:plexus-container-default")

--- a/subprojects/build-profile/build-profile.gradle.kts
+++ b/subprojects/build-profile/build-profile.gradle.kts
@@ -29,8 +29,6 @@ dependencies {
     implementation(project(":coreApi"))
     implementation(project(":core"))
 
-    implementation(library("guava"))
-    
     testImplementation(project(":internalTesting"))
 
     integTestImplementation(project(":buildOption"))

--- a/subprojects/code-quality/code-quality.gradle.kts
+++ b/subprojects/code-quality/code-quality.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(project(":reporting"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("ant"))
 

--- a/subprojects/composite-builds/composite-builds.gradle.kts
+++ b/subprojects/composite-builds/composite-builds.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(project(":dependencyManagement"))
     implementation(project(":pluginUse"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
 
     testImplementation(testFixtures(project(":dependencyManagement")))

--- a/subprojects/composite-builds/composite-builds.gradle.kts
+++ b/subprojects/composite-builds/composite-builds.gradle.kts
@@ -32,8 +32,6 @@ dependencies {
     implementation(project(":dependencyManagement"))
     implementation(project(":pluginUse"))
 
-    implementation(library("guava"))
-
     testImplementation(testFixtures(project(":dependencyManagement")))
     testImplementation(testFixtures(project(":launcher")))
 

--- a/subprojects/core-api/core-api.gradle.kts
+++ b/subprojects/core-api/core-api.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(project(":processServices"))
     implementation(project(":resources"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("ant"))
     implementation(library("guava"))
@@ -41,7 +40,7 @@ dependencies {
     testImplementation(library("asm"))
     testImplementation(library("asm_commons"))
     testImplementation(testFixtures(project(":logging")))
-    
+
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":baseServices"))
 }

--- a/subprojects/core-api/core-api.gradle.kts
+++ b/subprojects/core-api/core-api.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
 
     implementation(library("groovy"))
     implementation(library("ant"))
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
     implementation(library("inject"))

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     implementation(library("inject"))
     implementation(library("asm"))
     implementation(library("asm_commons"))
-    implementation(library("slf4j_api"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
     implementation(library("nativePlatform"))
@@ -109,7 +108,6 @@ dependencies {
     testFixturesImplementation(project(":persistentCache"))
     testFixturesImplementation(project(":snapshots"))
     testFixturesImplementation(library("ivy"))
-    testFixturesImplementation(library("slf4j_api"))
     testFixturesImplementation(library("guava"))
     testFixturesImplementation(library("ant"))
 

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
 
     implementation(library("groovy"))
     implementation(library("ant"))
-    implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("asm"))
     implementation(library("asm_commons"))
@@ -108,7 +107,6 @@ dependencies {
     testFixturesImplementation(project(":persistentCache"))
     testFixturesImplementation(project(":snapshots"))
     testFixturesImplementation(library("ivy"))
-    testFixturesImplementation(library("guava"))
     testFixturesImplementation(library("ant"))
 
     testFixturesRuntimeOnly(project(":runtimeApiInfo"))

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     implementation(project(":snapshots"))
     implementation(project(":execution"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("asm"))
     implementation(library("asm_commons"))
@@ -106,7 +105,6 @@ dependencies {
     testFixturesImplementation(project(":messaging"))
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
-    testFixturesImplementation(library("slf4j_api"))
     testFixturesImplementation(library("inject"))
 
     crossVersionTestRuntimeOnly(project(":maven"))

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(library("asm"))
     implementation(library("asm_commons"))
     implementation(library("asm_util"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("commons_httpclient"))

--- a/subprojects/diagnostics/diagnostics.gradle.kts
+++ b/subprojects/diagnostics/diagnostics.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":dependencyManagement"))
     implementation(project(":baseServicesGroovy"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("commons_lang"))

--- a/subprojects/diagnostics/diagnostics.gradle.kts
+++ b/subprojects/diagnostics/diagnostics.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(project(":baseServicesGroovy"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
     implementation(library("jatl"))
@@ -55,8 +54,6 @@ dependencies {
     testFixturesImplementation(project(":baseServices"))
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
-    testFixturesImplementation(library("guava"))
-
     // These are only here for 'DiagnosticsComponentReportIntegrationTest.shows details of multiple components'
     integTestRuntimeOnly(project(":plugins"))
     integTestRuntimeOnly(project(":platformNative"))

--- a/subprojects/distributions-dependencies/distributions-dependencies.gradle.kts
+++ b/subprojects/distributions-dependencies/distributions-dependencies.gradle.kts
@@ -26,7 +26,14 @@
 plugins {
     `java-platform`
 }
+
+javaPlatform {
+    allowDependencies()
+}
+
 dependencies {
+    api(library("slf4j_api"))
+
     constraints {
         libraries.keys.forEach { libId ->
             api(library(libId)) {

--- a/subprojects/distributions-dependencies/distributions-dependencies.gradle.kts
+++ b/subprojects/distributions-dependencies/distributions-dependencies.gradle.kts
@@ -33,6 +33,7 @@ javaPlatform {
 
 dependencies {
     api(library("slf4j_api"))
+    api(library("guava"))
 
     constraints {
         libraries.keys.forEach { libId ->

--- a/subprojects/ear/ear.gradle.kts
+++ b/subprojects/ear/ear.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":platformJvm"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
 

--- a/subprojects/execution/execution.gradle.kts
+++ b/subprojects/execution/execution.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation(project(":buildCachePackaging"))
 
     implementation(library("jsr305"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))

--- a/subprojects/execution/execution.gradle.kts
+++ b/subprojects/execution/execution.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation(project(":buildCachePackaging"))
 
     implementation(library("jsr305"))
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
@@ -52,7 +51,6 @@ dependencies {
     testImplementation(testFixtures(project(":snapshots")))
     testImplementation(testFixtures(project(":core")))
 
-    testFixturesImplementation(library("guava"))
     testFixturesImplementation(project(":baseServices"))
     testFixturesImplementation(project(":buildCache"))
     testFixturesImplementation(project(":snapshots"))

--- a/subprojects/file-collections/file-collections.gradle.kts
+++ b/subprojects/file-collections/file-collections.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(project(":logging"))
     implementation(project(":native"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("commons_io"))

--- a/subprojects/file-collections/file-collections.gradle.kts
+++ b/subprojects/file-collections/file-collections.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":native"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
@@ -54,8 +53,6 @@ dependencies {
     testFixturesImplementation(project(":native"))
 
     testFixturesImplementation(project(":internalTesting"))
-
-    testFixturesImplementation(library("guava"))
 }
 
 java {

--- a/subprojects/files/files.gradle.kts
+++ b/subprojects/files/files.gradle.kts
@@ -25,7 +25,6 @@ description = "Base tools to work with files"
 dependencies {
     implementation(project(":pineapple"))
     implementation(library("jsr305"))
-    implementation(library("guava"))
     testImplementation(project(":native"))
     testImplementation(project(":baseServices")) {
         because("TextUtil is needed")

--- a/subprojects/files/files.gradle.kts
+++ b/subprojects/files/files.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
     implementation(project(":pineapple"))
     implementation(library("jsr305"))
     implementation(library("guava"))
-    implementation(library("slf4j_api"))
-
     testImplementation(project(":native"))
     testImplementation(project(":baseServices")) {
         because("TextUtil is needed")

--- a/subprojects/hashing/hashing.gradle.kts
+++ b/subprojects/hashing/hashing.gradle.kts
@@ -25,7 +25,6 @@ description = "Common shared classes without external dependencies"
 dependencies {
     implementation(project(":pineapple"))
     implementation(library("jsr305"))
-    implementation(library("guava"))
 }
 
 gradlebuildJava {

--- a/subprojects/ide-native/ide-native.gradle.kts
+++ b/subprojects/ide-native/ide-native.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(project(":testingNative"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
     implementation(library("plist"))
@@ -54,7 +53,6 @@ dependencies {
 
     testFixturesApi(testFixtures(project(":ide")))
     testFixturesImplementation(library("plist"))
-    testFixturesImplementation(library("guava"))
     testFixturesImplementation(testFixtures(project(":ide")))
 }
 

--- a/subprojects/ide-native/ide-native.gradle.kts
+++ b/subprojects/ide-native/ide-native.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(project(":testingNative"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))

--- a/subprojects/ide-play/ide-play.gradle.kts
+++ b/subprojects/ide-play/ide-play.gradle.kts
@@ -51,8 +51,6 @@ dependencies {
     implementation(project(":platformPlay"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
-
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":platformPlay")))
     testImplementation(testFixtures(project(":ide")))

--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))

--- a/subprojects/ide/ide.gradle.kts
+++ b/subprojects/ide/ide.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("inject"))

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":workers"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
 
     implementation(futureKotlin("stdlib-jdk8"))

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -31,8 +31,6 @@ dependencies {
     implementation(project(":workers"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
-
     implementation(futureKotlin("stdlib-jdk8"))
     implementation(futureKotlin("reflect"))
 
@@ -44,7 +42,6 @@ dependencies {
 
     integTestImplementation(project(":toolingApi"))
 
-    integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))
     integTestImplementation(library("inject"))
     integTestImplementation(testFixtures(project(":dependencyManagement")))

--- a/subprojects/integ-test/integ-test.gradle.kts
+++ b/subprojects/integ-test/integ-test.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     integTestImplementation(project(":bootstrap"))
     integTestImplementation(project(":launcher"))
     integTestImplementation(library("groovy"))
-    integTestImplementation(library("slf4j_api"))
     integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))
     integTestImplementation(testLibrary("jsoup"))

--- a/subprojects/integ-test/integ-test.gradle.kts
+++ b/subprojects/integ-test/integ-test.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     integTestImplementation(project(":bootstrap"))
     integTestImplementation(project(":launcher"))
     integTestImplementation(library("groovy"))
-    integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))
     integTestImplementation(testLibrary("jsoup"))
     integTestImplementation(testLibrary("jetty"))

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -57,7 +57,6 @@ dependencies {
     implementation(library("junit"))
     implementation(testLibrary("spock"))
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("joda"))
     implementation(library("jatl"))
     implementation(library("jgit"))

--- a/subprojects/internal-testing/internal-testing.gradle.kts
+++ b/subprojects/internal-testing/internal-testing.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(project(":native"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))

--- a/subprojects/internal-testing/internal-testing.gradle.kts
+++ b/subprojects/internal-testing/internal-testing.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(project(":native"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("ant"))

--- a/subprojects/ivy/ivy.gradle.kts
+++ b/subprojects/ivy/ivy.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     implementation(project(":dependencyManagement"))
 
     implementation(library("groovy")) // for 'Closure' and 'Task.property(String propertyName) throws groovy.lang.MissingPropertyException'
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
     implementation(library("ivy"))

--- a/subprojects/ivy/ivy.gradle.kts
+++ b/subprojects/ivy/ivy.gradle.kts
@@ -53,7 +53,6 @@ dependencies {
     testRuntimeOnly(project(":runtimeApiInfo"))
 
     integTestImplementation(project(":ear"))
-    integTestImplementation(library("slf4j_api"))
     integTestImplementation(testLibrary("jetty"))
 
     integTestRuntimeOnly(project(":resourcesS3"))
@@ -70,7 +69,6 @@ dependencies {
     testFixturesImplementation(project(":dependencyManagement"))
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
-    testFixturesImplementation(library("slf4j_api"))
     testLibraries("sshd").forEach { testFixturesImplementation(it) }
 
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))

--- a/subprojects/jacoco/jacoco.gradle.kts
+++ b/subprojects/jacoco/jacoco.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":reporting"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))

--- a/subprojects/jacoco/jacoco.gradle.kts
+++ b/subprojects/jacoco/jacoco.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":reporting"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
 

--- a/subprojects/javascript/javascript.gradle.kts
+++ b/subprojects/javascript/javascript.gradle.kts
@@ -32,13 +32,12 @@ dependencies {
     implementation(project(":dependencyManagement")) // Required by JavaScriptExtension#getGoogleApisRepository()
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("commons_io"))
     implementation(library("inject"))
     implementation(library("rhino"))
     implementation(library("gson")) // used by JsHint.coordinates
     implementation(library("simple")) // used by http package in envjs.coordinates
-    
+
     testImplementation(testFixtures(project(":core")))
 
     testRuntimeOnly(project(":runtimeApiInfo"))

--- a/subprojects/jvm-services/jvm-services.gradle.kts
+++ b/subprojects/jvm-services/jvm-services.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     testImplementation(project(":fileCollections"))
     testImplementation(project(":snapshots"))
     testImplementation(project(":resources"))
-    testImplementation(library("slf4j_api"))
     testImplementation(testFixtures(project(":core")))
 }
 

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     compileOnly(project(":pluginDevelopment"))
     compileOnly(project(":kotlinDsl"))
 
-    compileOnly(library("slf4j_api"))
     compileOnly(library("inject"))
 
     implementation(futureKotlin("stdlib-jdk8"))
@@ -77,7 +76,6 @@ dependencies {
     integTestImplementation(project(":internalTesting"))
     integTestImplementation(project(":internalIntegTesting"))
     integTestImplementation(project(":kotlinDslTestFixtures"))
-    integTestImplementation(library("slf4j_api"))
     integTestImplementation(testLibrary("mockito_kotlin"))
     integTestRuntimeOnly(project(":runtimeApiInfo"))
     integTestRuntimeOnly(project(":apiMetadata"))

--- a/subprojects/kotlin-dsl-provider-plugins/kotlin-dsl-provider-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-provider-plugins/kotlin-dsl-provider-plugins.gradle.kts
@@ -46,8 +46,6 @@ dependencies {
         isTransitive = false
     }
 
-    implementation(library("slf4j_api"))
-
     testImplementation(project(":kotlinDslTestFixtures"))
     testImplementation(testLibrary("mockito_kotlin2"))
 }

--- a/subprojects/kotlin-dsl-tooling-builders/kotlin-dsl-tooling-builders.gradle.kts
+++ b/subprojects/kotlin-dsl-tooling-builders/kotlin-dsl-tooling-builders.gradle.kts
@@ -47,7 +47,6 @@ dependencies {
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 
     crossVersionTestImplementation(project(":persistentCache"))
-    crossVersionTestImplementation(library("slf4j_api"))
     crossVersionTestImplementation(library("guava"))
     crossVersionTestImplementation(library("ant"))
     crossVersionTestRuntimeOnly(project(":pluginDevelopment"))

--- a/subprojects/kotlin-dsl-tooling-builders/kotlin-dsl-tooling-builders.gradle.kts
+++ b/subprojects/kotlin-dsl-tooling-builders/kotlin-dsl-tooling-builders.gradle.kts
@@ -47,7 +47,6 @@ dependencies {
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 
     crossVersionTestImplementation(project(":persistentCache"))
-    crossVersionTestImplementation(library("guava"))
     crossVersionTestImplementation(library("ant"))
     crossVersionTestRuntimeOnly(project(":pluginDevelopment"))
     crossVersionTestRuntimeOnly(project(":runtimeApiInfo"))

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("inject"))
 
     implementation(futureKotlin("scripting-common")) {

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("inject"))
 

--- a/subprojects/language-groovy/language-groovy.gradle.kts
+++ b/subprojects/language-groovy/language-groovy.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(project(":files"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("asm"))
     implementation(library("inject"))
 

--- a/subprojects/language-groovy/language-groovy.gradle.kts
+++ b/subprojects/language-groovy/language-groovy.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     implementation(project(":languageJava"))
     implementation(project(":files"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("asm"))

--- a/subprojects/language-java/language-java.gradle.kts
+++ b/subprojects/language-java/language-java.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("fastutil"))
     implementation(library("ant")) // for 'ZipFile' and 'ZipEntry'

--- a/subprojects/language-java/language-java.gradle.kts
+++ b/subprojects/language-java/language-java.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("fastutil"))
@@ -47,7 +46,7 @@ dependencies {
     testImplementation(testFixtures(project(":launcher")))
 
     testRuntimeOnly(project(":runtimeApiInfo"))
-    
+
     testFixturesApi(testFixtures(project(":languageJvm")))
     testFixturesImplementation(project(":baseServices"))
     testFixturesImplementation(project(":core"))
@@ -57,10 +56,8 @@ dependencies {
     testFixturesImplementation(project(":internalIntegTesting"))
     testFixturesImplementation(project(":platformBase"))
     testFixturesImplementation(project(":persistentCache"))
-    testFixturesImplementation(library("slf4j_api"))
-
     integTestRuntimeOnly(project(":testingJunitPlatform"))
-    
+
     // TODO - get rid of this cycle
     integTestRuntimeOnly(project(":plugins"))
 }

--- a/subprojects/language-jvm/language-jvm.gradle.kts
+++ b/subprojects/language-jvm/language-jvm.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     implementation(project(":platformJvm"))
 
     implementation(library("groovy")) // for 'Task.property(String propertyName) throws groovy.lang.MissingPropertyException'
-    implementation(library("guava"))
     implementation(library("inject"))
 
     testImplementation(project(":native"))
@@ -34,7 +33,6 @@ dependencies {
     testRuntimeOnly(project(":runtimeApiInfo"))
 
     testFixturesImplementation(library("commons_lang"))
-    testFixturesImplementation(library("guava"))
     testFixturesImplementation(project(":internalIntegTesting"))
     testFixturesImplementation(testFixtures(project(":core")))
     testFixturesImplementation(testFixtures(project(":launcher")))

--- a/subprojects/language-native/language-native.gradle.kts
+++ b/subprojects/language-native/language-native.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(project(":versionControl"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))

--- a/subprojects/language-native/language-native.gradle.kts
+++ b/subprojects/language-native/language-native.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(project(":versionControl"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("inject"))

--- a/subprojects/language-scala/language-scala.gradle.kts
+++ b/subprojects/language-scala/language-scala.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
 
     implementation(library("groovy")) // for 'Task.property(String propertyName) throws groovy.lang.MissingPropertyException'
     implementation(library("ant"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("inject"))
 

--- a/subprojects/language-scala/language-scala.gradle.kts
+++ b/subprojects/language-scala/language-scala.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
 
     implementation(library("groovy")) // for 'Task.property(String propertyName) throws groovy.lang.MissingPropertyException'
     implementation(library("ant"))
-    implementation(library("guava"))
     implementation(library("inject"))
 
     testImplementation(project(":fileCollections"))

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy")) // for 'ReleaseInfo.getVersion()'
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
     implementation(library("asm"))
@@ -52,7 +51,6 @@ dependencies {
 
     integTestImplementation(project(":persistentCache"))
     integTestImplementation(project(":internalIntegTesting"))
-    integTestImplementation(library("guava"))
     integTestImplementation(library("commons_lang"))
     integTestImplementation(library("commons_io"))
     integTestRuntimeOnly(project(":plugins"))

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -32,11 +32,6 @@ dependencies {
     implementation(library("asm"))
     implementation(library("ant"))
 
-    runtimeOnly(library("asm"))
-    runtimeOnly(library("commons_io"))
-    runtimeOnly(library("commons_lang"))
-    runtimeOnly(library("slf4j_api"))
-
     testImplementation(project(":internalIntegTesting"))
     testImplementation(project(":native"))
     testImplementation(project(":cli"))

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy")) // for 'ReleaseInfo.getVersion()'
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
@@ -53,7 +52,6 @@ dependencies {
 
     integTestImplementation(project(":persistentCache"))
     integTestImplementation(project(":internalIntegTesting"))
-    integTestImplementation(library("slf4j_api"))
     integTestImplementation(library("guava"))
     integTestImplementation(library("commons_lang"))
     integTestImplementation(library("commons_io"))

--- a/subprojects/logging/logging.gradle.kts
+++ b/subprojects/logging/logging.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(library("jul_to_slf4j"))
     implementation(library("ant"))
     implementation(library("commons_lang"))
-    implementation(library("guava"))
     implementation(library("jansi"))
 
     runtimeOnly(library("log4j_to_slf4j"))

--- a/subprojects/logging/logging.gradle.kts
+++ b/subprojects/logging/logging.gradle.kts
@@ -13,8 +13,6 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":cli"))
     implementation(project(":buildOption"))
-    implementation(library("slf4j_api"))
-
     implementation(project(":native"))
     implementation(library("jul_to_slf4j"))
     implementation(library("ant"))
@@ -26,7 +24,7 @@ dependencies {
     runtimeOnly(library("jcl_to_slf4j"))
 
     testImplementation(testFixtures(project(":core")))
-    
+
     integTestImplementation(library("ansi_control_sequence_util"))
 
     integTestRuntimeOnly(project(":apiMetadata"))
@@ -35,7 +33,6 @@ dependencies {
     integTestRuntimeOnly(project(":testingJunitPlatform"))
 
     testFixturesImplementation(project(":baseServices"))
-    testFixturesImplementation(library("slf4j_api"))
 }
 
 gradlebuildJava {

--- a/subprojects/maven/maven.gradle.kts
+++ b/subprojects/maven/maven.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation(project(":pluginUse"))
     implementation(project(":publish"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("commons_lang"))

--- a/subprojects/maven/maven.gradle.kts
+++ b/subprojects/maven/maven.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(project(":publish"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
     implementation(library("ant"))

--- a/subprojects/messaging/messaging.gradle.kts
+++ b/subprojects/messaging/messaging.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
     implementation(project(":baseServices"))
 
     implementation(library("fastutil"))
-    implementation(library("guava"))
     implementation(library("kryo"))
 
     testImplementation(testFixtures(project(":core")))

--- a/subprojects/messaging/messaging.gradle.kts
+++ b/subprojects/messaging/messaging.gradle.kts
@@ -7,17 +7,14 @@ plugins {
 
 dependencies {
     implementation(project(":baseServices"))
-    
+
     implementation(library("fastutil"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("kryo"))
 
     testImplementation(testFixtures(project(":core")))
 
     testFixturesImplementation(project(":baseServices"))
-    testFixturesImplementation(library("slf4j_api"))
-    
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }
 

--- a/subprojects/model-core/model-core.gradle.kts
+++ b/subprojects/model-core/model-core.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation(library("inject"))
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("asm"))
 
@@ -43,8 +42,6 @@ dependencies {
     testFixturesApi(testFixtures(project(":core")))
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
-    testFixturesImplementation(library("guava"))
-
     testImplementation(project(":processServices"))
     testImplementation(project(":fileCollections"))
     testImplementation(project(":native"))

--- a/subprojects/model-core/model-core.gradle.kts
+++ b/subprojects/model-core/model-core.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation(library("inject"))
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("asm"))

--- a/subprojects/model-groovy/model-groovy.gradle.kts
+++ b/subprojects/model-groovy/model-groovy.gradle.kts
@@ -32,8 +32,6 @@ dependencies {
     implementation(project(":baseServicesGroovy"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
-
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":modelCore")))
 

--- a/subprojects/native/native.gradle.kts
+++ b/subprojects/native/native.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(project(":baseServices"))
 
     implementation(library("nativePlatform"))
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("jansi"))
 

--- a/subprojects/native/native.gradle.kts
+++ b/subprojects/native/native.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(project(":baseServices"))
 
     implementation(library("nativePlatform"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("jansi"))

--- a/subprojects/performance/performance.gradle
+++ b/subprojects/performance/performance.gradle
@@ -27,7 +27,6 @@ dependencies {
     performanceTestImplementation project(":coreApi")
     performanceTestImplementation project(":buildOption")
     performanceTestImplementation project(":internalIntegTesting")
-    performanceTestImplementation libraries.slf4j_api.coordinates
     performanceTestImplementation libraries.commons_io.coordinates
     performanceTestImplementation libraries.commons_compress.coordinates
     performanceTestImplementation testLibraries.jetty

--- a/subprojects/persistent-cache/persistent-cache.gradle.kts
+++ b/subprojects/persistent-cache/persistent-cache.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":logging"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))

--- a/subprojects/persistent-cache/persistent-cache.gradle.kts
+++ b/subprojects/persistent-cache/persistent-cache.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":logging"))
 
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
 

--- a/subprojects/platform-base/platform-base.gradle.kts
+++ b/subprojects/platform-base/platform-base.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(project(":execution"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
 
     testImplementation(testFixtures(project(":core")))
@@ -31,7 +30,6 @@ dependencies {
     testFixturesApi(project(":core"))
     testFixturesApi(project(":fileCollections"))
     testFixturesApi(testFixtures(project(":modelCore")))
-    testFixturesImplementation(library("guava"))
     testFixturesApi(testFixtures(project(":modelCore")))
     testFixturesApi(testFixtures(project(":diagnostics")))
 }

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
     testImplementation(testFixtures(project(":platformNative")))
 
     testRuntimeOnly(project(":runtimeApiInfo"))
-
-    integTestImplementation(library("slf4j_api"))
 }
 
 gradlebuildJava {

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     implementation(project(":diagnostics"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("inject"))

--- a/subprojects/platform-native/platform-native.gradle.kts
+++ b/subprojects/platform-native/platform-native.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
 
     implementation(library("nativePlatform"))
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("snakeyaml"))
@@ -59,7 +58,6 @@ dependencies {
     testFixturesImplementation(project(":fileCollections"))
     testFixturesImplementation(project(":processServices"))
     testFixturesImplementation(project(":snapshots"))
-    testFixturesImplementation(library("guava"))
     testFixturesImplementation(library("nativePlatform"))
     testFixturesImplementation(library("commons_lang"))
     testFixturesImplementation(library("commons_io"))

--- a/subprojects/platform-native/platform-native.gradle.kts
+++ b/subprojects/platform-native/platform-native.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
 
     implementation(library("nativePlatform"))
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))

--- a/subprojects/platform-play/platform-play.gradle.kts
+++ b/subprojects/platform-play/platform-play.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
     implementation(project(":reporting"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
@@ -78,7 +77,6 @@ dependencies {
     testFixturesImplementation(project(":processServices"))
     testFixturesImplementation(library("commons_io"))
     testFixturesImplementation(library("commons_httpclient"))
-    testFixturesImplementation(library("slf4j_api"))
     testFixturesApi(testFixtures(project(":languageScala")))
     testFixturesApi(testFixtures(project(":languageJava")))
 

--- a/subprojects/platform-play/platform-play.gradle.kts
+++ b/subprojects/platform-play/platform-play.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
     implementation(project(":reporting"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
 

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":workers"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("commons_io"))
     implementation(library("guava"))

--- a/subprojects/plugin-development/plugin-development.gradle.kts
+++ b/subprojects/plugin-development/plugin-development.gradle.kts
@@ -47,7 +47,6 @@ dependencies {
 
     implementation(library("groovy"))
     implementation(library("commons_io"))
-    implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("asm"))
 

--- a/subprojects/plugin-use/plugin-use.gradle.kts
+++ b/subprojects/plugin-use/plugin-use.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
     runtimeOnly(project(":resourcesHttp"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
-
     testImplementation(testFixtures(project(":resourcesHttp")))
 
     integTestImplementation(project(":baseServicesGroovy"))

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation(project(":testingJvm"))
     implementation(project(":snapshots"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("ant"))
     implementation(library("asm"))

--- a/subprojects/plugins/plugins.gradle.kts
+++ b/subprojects/plugins/plugins.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(library("groovy"))
     implementation(library("ant"))
     implementation(library("asm"))
-    implementation(library("guava"))
     implementation(library("commons_io"))
     implementation(library("commons_lang"))
     implementation(library("inject"))
@@ -74,8 +73,6 @@ dependencies {
     testFixturesImplementation(project(":fileCollections"))
     testFixturesImplementation(project(":languageJvm"))
     testFixturesImplementation(project(":internalIntegTesting"))
-    testFixturesImplementation(library("guava"))
-
     testImplementation(testLibrary("jsoup"))
 
     integTestRuntimeOnly(project(":maven"))

--- a/subprojects/process-services/process-services.gradle.kts
+++ b/subprojects/process-services/process-services.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":native"))
 
-    implementation(library("guava"))
     implementation(library("nativePlatform"))
 
     testImplementation(testFixtures(project(":core")))

--- a/subprojects/process-services/process-services.gradle.kts
+++ b/subprojects/process-services/process-services.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":native"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("nativePlatform"))
 

--- a/subprojects/publish/publish.gradle.kts
+++ b/subprojects/publish/publish.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(project(":baseServicesGroovy")) // for 'Specs'
     implementation(project(":dependencyManagement"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
@@ -38,7 +37,7 @@ dependencies {
     implementation(library("inject"))
 
     testImplementation(testFixtures(project(":core")))
-    
+
     testRuntimeOnly(project(":runtimeApiInfo"))
     testRuntimeOnly(project(":workers"))
 

--- a/subprojects/publish/publish.gradle.kts
+++ b/subprojects/publish/publish.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(project(":dependencyManagement"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("gson"))
     implementation(library("inject"))

--- a/subprojects/reporting/reporting.gradle.kts
+++ b/subprojects/reporting/reporting.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     implementation(project(":core"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("jatl"))
 
@@ -31,7 +30,7 @@ dependencies {
     testImplementation(project(":baseServicesGroovy"))
     testImplementation(testLibrary("jsoup"))
     testImplementation(testFixtures(project(":core")))
-    
+
     testRuntimeOnly(project(":runtimeApiInfo"))
     testRuntimeOnly(project(":workers"))
     testRuntimeOnly(project(":dependencyManagement"))

--- a/subprojects/resources-gcs/resources-gcs.gradle.kts
+++ b/subprojects/resources-gcs/resources-gcs.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(project(":resourcesHttp"))
     implementation(project(":core"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("jackson_core"))

--- a/subprojects/resources-gcs/resources-gcs.gradle.kts
+++ b/subprojects/resources-gcs/resources-gcs.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(project(":resourcesHttp"))
     implementation(project(":core"))
 
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("jackson_core"))
     implementation(library("jackson_annotations"))

--- a/subprojects/resources-http/resources-http.gradle.kts
+++ b/subprojects/resources-http/resources-http.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(library("commons_httpclient"))
     implementation(library("jcl_to_slf4j"))
     implementation(library("jcifs"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("xerces"))

--- a/subprojects/resources-http/resources-http.gradle.kts
+++ b/subprojects/resources-http/resources-http.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(project(":logging"))
 
     implementation(library("commons_httpclient"))
-    implementation(library("slf4j_api"))
     implementation(library("jcl_to_slf4j"))
     implementation(library("jcifs"))
     implementation(library("guava"))
@@ -50,7 +49,6 @@ dependencies {
     testFixturesImplementation(project(":logging"))
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
-    testFixturesImplementation(library("slf4j_api"))
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }
 

--- a/subprojects/resources-s3/resources-s3.gradle.kts
+++ b/subprojects/resources-s3/resources-s3.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":resourcesHttp"))
 
-    implementation(library("guava"))
     implementation(library("nativePlatform"))
     implementation(library("awsS3_core"))
     implementation(library("awsS3_s3"))

--- a/subprojects/resources-s3/resources-s3.gradle.kts
+++ b/subprojects/resources-s3/resources-s3.gradle.kts
@@ -13,8 +13,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":resources"))
     implementation(project(":resourcesHttp"))
-    
-    implementation(library("slf4j_api"))
+
     implementation(library("guava"))
     implementation(library("nativePlatform"))
     implementation(library("awsS3_core"))

--- a/subprojects/resources-sftp/resources-sftp.gradle.kts
+++ b/subprojects/resources-sftp/resources-sftp.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":core"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("jsch"))
     implementation(library("commons_io"))

--- a/subprojects/resources-sftp/resources-sftp.gradle.kts
+++ b/subprojects/resources-sftp/resources-sftp.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":core"))
 
-    implementation(library("guava"))
     implementation(library("jsch"))
     implementation(library("commons_io"))
 

--- a/subprojects/resources/resources.gradle.kts
+++ b/subprojects/resources/resources.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":native"))
 
-    implementation(library("guava"))
     implementation(library("commons_io"))
 
     testImplementation(project(":processServices"))

--- a/subprojects/resources/resources.gradle.kts
+++ b/subprojects/resources/resources.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":native"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_io"))
 
@@ -24,7 +23,7 @@ dependencies {
     testImplementation(project(":snapshots"))
 
     testImplementation(testFixtures(project(":core")))
-    
+
     integTestImplementation(project(":internalIntegTesting"))
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }

--- a/subprojects/samples/samples.gradle.kts
+++ b/subprojects/samples/samples.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     integTestImplementation(project(":processServices"))
     integTestImplementation(project(":persistentCache"))
     integTestImplementation(library("groovy"))
-    integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))
     integTestImplementation(testLibrary("sampleCheck")) {
         exclude(group = "org.codehaus.groovy", module = "groovy-all")

--- a/subprojects/samples/samples.gradle.kts
+++ b/subprojects/samples/samples.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     integTestImplementation(project(":processServices"))
     integTestImplementation(project(":persistentCache"))
     integTestImplementation(library("groovy"))
-    integTestImplementation(library("slf4j_api"))
     integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))
     integTestImplementation(testLibrary("sampleCheck")) {

--- a/subprojects/scala/scala.gradle.kts
+++ b/subprojects/scala/scala.gradle.kts
@@ -39,7 +39,6 @@ dependencies {
     implementation(project(":dependencyManagement"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("inject"))
 
     testImplementation(project(":baseServicesGroovy"))

--- a/subprojects/scala/scala.gradle.kts
+++ b/subprojects/scala/scala.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
 
     testImplementation(project(":baseServicesGroovy"))
     testImplementation(project(":files"))
-    testImplementation(library("slf4j_api"))
     testImplementation(library("commons_io"))
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":plugins")))

--- a/subprojects/signing/signing.gradle.kts
+++ b/subprojects/signing/signing.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":maven"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("bouncycastle_pgp"))

--- a/subprojects/signing/signing.gradle.kts
+++ b/subprojects/signing/signing.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":maven"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("bouncycastle_pgp"))
 

--- a/subprojects/snapshots/snapshots.gradle.kts
+++ b/subprojects/snapshots/snapshots.gradle.kts
@@ -28,8 +28,6 @@ dependencies {
     implementation(project(":files"))
     implementation(project(":hashing"))
     implementation(project(":pineapple"))
-    implementation(library("slf4j_api"))
-
     testImplementation(project(":processServices"))
     testImplementation(project(":resources"))
     testImplementation(project(":native"))

--- a/subprojects/snapshots/snapshots.gradle.kts
+++ b/subprojects/snapshots/snapshots.gradle.kts
@@ -23,7 +23,6 @@ plugins {
 description = "Tools to take immutable, comparable snapshots of files and other things"
 
 dependencies {
-    implementation(library("guava"))
     implementation(library("jsr305"))
     implementation(project(":files"))
     implementation(project(":hashing"))

--- a/subprojects/soak/soak.gradle.kts
+++ b/subprojects/soak/soak.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     integTestImplementation(project(":logging"))
     integTestImplementation(project(":persistentCache"))
     integTestImplementation(project(":launcher"))
-    integTestImplementation(library("slf4j_api"))
     integTestImplementation(testLibrary("jetty"))
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))

--- a/subprojects/test-kit/test-kit.gradle.kts
+++ b/subprojects/test-kit/test-kit.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     integTestImplementation(project(":launcher"))
     integTestImplementation(project(":buildOption"))
     integTestImplementation(project(":jvmServices"))
-    integTestImplementation(library("slf4j_api"))
     integTestRuntimeOnly(project(":toolingApiBuilders"))
     integTestRuntimeOnly(project(":pluginDevelopment"))
     integTestRuntimeOnly(project(":runtimeApiInfo"))

--- a/subprojects/test-kit/test-kit.gradle.kts
+++ b/subprojects/test-kit/test-kit.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
 
     runtimeOnly(project(":native"))
 
-    testImplementation(library("guava"))
     testImplementation(testFixtures(project(":core")))
 
     integTestImplementation(project(":native"))

--- a/subprojects/testing-base/testing-base.gradle.kts
+++ b/subprojects/testing-base/testing-base.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":reporting"))
     implementation(project(":platformBase"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("commons_lang"))

--- a/subprojects/testing-base/testing-base.gradle.kts
+++ b/subprojects/testing-base/testing-base.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(project(":platformBase"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("kryo"))
@@ -55,7 +54,6 @@ dependencies {
     testFixturesImplementation(project(":modelCore"))
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
-    testFixturesImplementation(library("guava"))
     testFixturesImplementation(testLibrary("jsoup"))
 
     integTestRuntimeOnly(project(":testingJunitPlatform"))

--- a/subprojects/testing-jvm/testing-jvm.gradle.kts
+++ b/subprojects/testing-jvm/testing-jvm.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
     implementation(project(":languageJava"))
     implementation(project(":testingBase"))
 
-    implementation(library("slf4j_api"))
     implementation(library("groovy"))
     implementation(library("guava"))
     implementation(library("commons_lang"))

--- a/subprojects/testing-jvm/testing-jvm.gradle.kts
+++ b/subprojects/testing-jvm/testing-jvm.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
     implementation(project(":testingBase"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("asm"))

--- a/subprojects/testing-native/testing-native.gradle.kts
+++ b/subprojects/testing-native/testing-native.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     implementation(project(":testingBase"))
 
     implementation(library("groovy"))
-    implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))
     implementation(library("inject"))

--- a/subprojects/testing-native/testing-native.gradle.kts
+++ b/subprojects/testing-native/testing-native.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     implementation(project(":testingBase"))
 
     implementation(library("groovy"))
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("commons_lang"))
     implementation(library("commons_io"))

--- a/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
+++ b/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation(project(":toolingApi"))
 
     implementation(library("groovy")) // for 'Closure'
-    implementation(library("guava"))
     implementation(library("commons_io"))
 
     testImplementation(project(":fileCollections"))

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -59,8 +59,6 @@ dependencies {
     testFixturesImplementation(project(":internalTesting"))
     testFixturesImplementation(project(":internalIntegTesting"))
     testFixturesImplementation(library("commons_io"))
-    testFixturesImplementation(library("slf4j_api"))
-
     integTestImplementation(project(":jvmServices"))
     integTestImplementation(project(":persistentCache"))
     integTestRuntimeOnly(project(":toolingApiBuilders"))

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -47,8 +47,6 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":wrapper"))
 
-    implementation(library("guava"))
-
     publishImplementation(library("slf4j_api")) { version { prefer(libraryVersion("slf4j_api")) } }
 
     testFixturesImplementation(project(":coreApi"))

--- a/subprojects/tooling-native/tooling-native.gradle.kts
+++ b/subprojects/tooling-native/tooling-native.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
     implementation(project(":toolingApi"))
     implementation(project(":ide")) // To pick up various builders (which should live somewhere else)
 
-    implementation(library("guava"))
-
     testImplementation(testFixtures(project(":platformNative")))
 
     testRuntimeOnly(project(":runtimeApiInfo"))

--- a/subprojects/version-control/version-control.gradle.kts
+++ b/subprojects/version-control/version-control.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":dependencyManagement"))
 
-    implementation(library("guava"))
     implementation(library("inject"))
     implementation(library("jgit"))
     implementation(library("commons_httpclient"))
@@ -52,8 +51,6 @@ dependencies {
     testFixturesImplementation(library("commons_io"))
     testFixturesImplementation(library("commons_httpclient"))
     testFixturesImplementation(library("jsch"))
-    testFixturesImplementation(library("guava"))
-
     integTestImplementation(project(":launcher"))
     integTestRuntimeOnly(project(":pluginDevelopment"))
     integTestRuntimeOnly(project(":testKit"))

--- a/subprojects/worker-processes/worker-processes.gradle.kts
+++ b/subprojects/worker-processes/worker-processes.gradle.kts
@@ -12,8 +12,6 @@ dependencies {
     implementation(project(":native"))
     implementation(project(":processServices"))
 
-    implementation(library("slf4j_api"))
-
     testImplementation(testFixtures(project(":core")))
 }
 

--- a/subprojects/workers/workers.gradle.kts
+++ b/subprojects/workers/workers.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation(project(":native"))
     implementation(project(":resources"))
 
-    implementation(library("slf4j_api"))
     implementation(library("guava"))
     implementation(library("inject"))
 

--- a/subprojects/workers/workers.gradle.kts
+++ b/subprojects/workers/workers.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation(project(":native"))
     implementation(project(":resources"))
 
-    implementation(library("guava"))
     implementation(library("inject"))
 
     testImplementation(project(":native"))


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/2411

This is the comparison of the dependency graphs before and after the change:
https://e.grdev.net/c/ukqzvu3ies5xe/5l4rcnmpxt6no/dependencies

As expected, `slf4j` and `guava` are now "everywhere".