### PR TITLE
Include output of all failed suites in HTML report

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/AbstractTestDescriptor.java
@@ -62,9 +62,4 @@ public abstract class AbstractTestDescriptor implements TestDescriptorInternal {
     public String getClassDisplayName() {
         return getClassName();
     }
-
-    @Override
-    public boolean isRoot() {
-        return false;
-    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DecoratingTestDescriptor.java
@@ -76,9 +76,4 @@ public class DecoratingTestDescriptor implements TestDescriptorInternal {
     public boolean isComposite() {
         return descriptor.isComposite();
     }
-
-    @Override
-    public boolean isRoot() {
-        return descriptor.isRoot();
-    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestDescriptorInternal.java
@@ -41,9 +41,4 @@ public interface TestDescriptorInternal extends TestDescriptor {
      * @return the class name for display.
      */
     String getClassDisplayName();
-
-    /**
-     * Whether or not this is the test execution root test suite.
-     */
-    boolean isRoot();
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
@@ -79,10 +79,5 @@ public class TestMainAction implements Runnable {
         public String toString() {
             return getName();
         }
-
-        @Override
-        public boolean isRoot() {
-            return true;
-        }
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/UnknownTestDescriptor.java
@@ -61,9 +61,4 @@ public class UnknownTestDescriptor implements TestDescriptorInternal {
     public String getClassDisplayName() {
         return getClassName();
     }
-
-    @Override
-    public boolean isRoot() {
-        return false;
-    }
 }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollectorSpec.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestReportDataCollectorSpec.groovy
@@ -102,6 +102,21 @@ class TestReportDataCollectorSpec extends Specification {
         0 * writer._
     }
 
+    def "writes test outputs for failed suite"() {
+        def suite = new DefaultTestSuiteDescriptor("1", "Suite")
+        def failure = new RuntimeException("failure")
+        def result = new DefaultTestResult(FAILURE, 0, 0, 0, 0, 0, [failure])
+
+        when:
+        collector.beforeSuite(suite)
+        collector.onOutput(suite, new DefaultTestOutputEvent(StdOut, "suite-out"))
+        collector.afterSuite(suite, result)
+
+        then:
+        1 * writer.onOutput(_, _, new DefaultTestOutputEvent(StdOut, "suite-out"))
+        0 * writer._
+    }
+
     def "collects failures for test"() {
         def test = new DefaultTestDescriptor("1.1.1", "FooTest", "testMethod")
         def failure1 = new RuntimeException("failure1")

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/SimpleTestDescriptor.groovy
@@ -23,7 +23,6 @@ class SimpleTestDescriptor implements TestDescriptorInternal {
     String className = "ClassName"
     String classDisplayName = "ClassName"
     boolean composite = false
-    boolean root = false
     TestDescriptorInternal parent = null
     Object ownerBuildOperationId = null
     Object getId() {


### PR DESCRIPTION
Prior to this commit, only the output of the root `TestDescriptor` was
included in the HTML report even though all failed suites were included
with their exceptions.