### PR TITLE
Use build service abstraction to fix some parts of the build logic that do not work with instant execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,7 +177,6 @@ allprojects {
 }
 
 apply(plugin = "gradlebuild.cleanup")
-apply(plugin = "gradlebuild.available-java-installations")
 apply(plugin = "gradlebuild.buildscan")
 apply(from = "gradle/versioning.gradle")
 apply(from = "gradle/dependencies.gradle")

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -80,7 +80,7 @@ gradle.settingsEvaluated {
     }
 
     if (!JavaVersion.current().isJava9Compatible) {
-        throw GradleException("JDK 9+ is required to perform this build. It's currently ${getBuildJavaHome()}.")
+        throw GradleException("JDK 9+ is required to perform this build. It's currently Java ${JavaVersion.current()} at ${getBuildJavaHome()}.")
     }
 }
 

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/VerifyBuildEnvironmentPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/VerifyBuildEnvironmentPlugin.kt
@@ -3,22 +3,25 @@ package org.gradle.gradlebuild.buildquality
 import availableJavaInstallations
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import java.nio.charset.Charset
 import org.gradle.api.tasks.compile.AbstractCompile
+import org.gradle.gradlebuild.java.AvailableJavaInstallationsPlugin
 import org.gradle.kotlin.dsl.*
+import java.nio.charset.Charset
 
 
 open class VerifyBuildEnvironmentPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
+        project.plugins.apply(AvailableJavaInstallationsPlugin::class.java)
         validateForProductionEnvironments(project)
         validateForAllCompileTasks(project)
     }
 
     private
-    fun validateForProductionEnvironments(rootProject: Project) =
-        rootProject.tasks.register("verifyIsProductionBuildEnvironment") {
+    fun validateForProductionEnvironments(project: Project) =
+        project.tasks.register("verifyIsProductionBuildEnvironment") {
+            val availableJavaInstallations = project.availableJavaInstallations
             doLast {
-                rootProject.availableJavaInstallations.validateForProductionEnvironment()
+                availableJavaInstallations.get().validateForProductionEnvironment()
                 val systemCharset = Charset.defaultCharset().name()
                 assert(systemCharset == "UTF-8") {
                     "Platform encoding must be UTF-8. Is currently $systemCharset. Set -Dfile.encoding=UTF-8"
@@ -27,14 +30,15 @@ open class VerifyBuildEnvironmentPlugin : Plugin<Project> {
         }
 
     private
-    fun validateForAllCompileTasks(rootProject: Project) {
-        val verifyBuildEnvironment = rootProject.tasks.register("verifyBuildEnvironment") {
+    fun validateForAllCompileTasks(project: Project) {
+        val verifyBuildEnvironment = project.tasks.register("verifyBuildEnvironment") {
+            val availableJavaInstallations = project.availableJavaInstallations
             doLast {
-                rootProject.availableJavaInstallations.validateForCompilation()
+                availableJavaInstallations.get().validateForCompilation()
             }
         }
 
-        rootProject.subprojects {
+        project.subprojects {
             tasks.withType<AbstractCompile>().configureEach {
                 dependsOn(verifyBuildEnvironment)
             }

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/VerifyBuildEnvironmentPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/VerifyBuildEnvironmentPlugin.kt
@@ -1,6 +1,6 @@
 package org.gradle.gradlebuild.buildquality
 
-import availableJavaInstallations
+import buildJvms
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.AbstractCompile
@@ -19,9 +19,9 @@ open class VerifyBuildEnvironmentPlugin : Plugin<Project> {
     private
     fun validateForProductionEnvironments(project: Project) =
         project.tasks.register("verifyIsProductionBuildEnvironment") {
-            val availableJavaInstallations = project.availableJavaInstallations
+            val javaInstallations = project.buildJvms.javaInstallations
             doLast {
-                availableJavaInstallations.get().validateForProductionEnvironment()
+                javaInstallations.get().validateForProductionEnvironment()
                 val systemCharset = Charset.defaultCharset().name()
                 assert(systemCharset == "UTF-8") {
                     "Platform encoding must be UTF-8. Is currently $systemCharset. Set -Dfile.encoding=UTF-8"
@@ -32,7 +32,7 @@ open class VerifyBuildEnvironmentPlugin : Plugin<Project> {
     private
     fun validateForAllCompileTasks(project: Project) {
         val verifyBuildEnvironment = project.tasks.register("verifyBuildEnvironment") {
-            val availableJavaInstallations = project.availableJavaInstallations
+            val availableJavaInstallations = project.buildJvms.javaInstallations
             doLast {
                 availableJavaInstallations.get().validateForCompilation()
             }

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -45,11 +45,19 @@ class ProbedLocalJavaInstallation(private val javaHome: File) : LocalJavaInstall
 
     override fun getName() = name
     override fun getDisplayName() = displayName
-    override fun setDisplayName(displayName: String) { this.displayName = displayName }
+    override fun setDisplayName(displayName: String) {
+        this.displayName = displayName
+    }
+
     override fun getJavaVersion() = javaVersion
-    override fun setJavaVersion(javaVersion: JavaVersion) { this.javaVersion = javaVersion }
+    override fun setJavaVersion(javaVersion: JavaVersion) {
+        this.javaVersion = javaVersion
+    }
+
     override fun getJavaHome() = javaHome
-    override fun setJavaHome(javaHome: File) { throw UnsupportedOperationException("JavaHome cannot be changed") }
+    override fun setJavaHome(javaHome: File) {
+        throw UnsupportedOperationException("JavaHome cannot be changed")
+    }
 }
 
 
@@ -60,16 +68,19 @@ private
 const val productionJdkName = "AdoptOpenJDK 11"
 
 
-interface AvailableJavaInstallationsParameters: BuildServiceParameters {
+interface AvailableJavaInstallationsParameters : BuildServiceParameters {
     var testJavaProperty: String?
 }
 
 
-abstract class AvailableJavaInstallations: BuildService<AvailableJavaInstallationsParameters>, AutoCloseable {
+abstract class AvailableJavaInstallations : BuildService<AvailableJavaInstallationsParameters>, AutoCloseable {
     // TODO - extract a public service for locating JVM/JDK instances and querying their metadata
-    private val services = ServiceRegistryBuilder.builder().parent(NativeServices.getInstance()).provider(GlobalScopeServices(false)).build()
-    private val jvmVersionDetector = CachingJvmVersionDetector(DefaultJvmVersionDetector(services.get(ExecHandleFactory::class.java)))
-    private val javaInstallationProbe = JavaInstallationProbe(services.get(ExecActionFactory::class.java))
+    private
+    val services = ServiceRegistryBuilder.builder().parent(NativeServices.getInstance()).provider(GlobalScopeServices(false)).build()
+    private
+    val jvmVersionDetector = CachingJvmVersionDetector(DefaultJvmVersionDetector(services.get(ExecHandleFactory::class.java)))
+    private
+    val javaInstallationProbe = JavaInstallationProbe(services.get(ExecActionFactory::class.java))
 
     val currentJavaInstallation: JavaInstallation = JavaInstallation(true, Jvm.current(), JavaVersion.current(), javaInstallationProbe).also {
         println("-> CURRENT JVM = ${it.javaHome}")
@@ -147,6 +158,7 @@ abstract class AvailableJavaInstallations: BuildService<AvailableJavaInstallatio
 
     private
     fun resolveJavaHomePath(propertyName: String, overrideValue: String?): String? = when {
+        // TODO:instant-execution - these should be marked as a build input in some way
         overrideValue != null -> overrideValue
         System.getProperty(propertyName) != null -> System.getProperty(propertyName)
         System.getenv(propertyName) != null -> System.getenv(propertyName)

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
@@ -4,12 +4,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 
-// TODO We should not add this to the root project but a single instance to every subproject
 open class AvailableJavaInstallationsPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         val availableInstallations = gradle.sharedServices.maybeRegister("availableJavaInstallations", AvailableJavaInstallations::class.java) {
+            // TODO:instant-execution - this should be marked as a build input in some way
             parameters.testJavaProperty = project.findProperty(testJavaHomePropertyName)?.toString()
         }
-        extensions.add("availableJavaInstallations", availableInstallations)
+        extensions.create("buildJvms", BuildJvms::class.java, availableInstallations)
     }
 }

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
@@ -2,22 +2,14 @@ package org.gradle.gradlebuild.java
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.internal.jvm.inspection.JvmVersionDetector
-import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
-import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.support.serviceOf
 
 
 // TODO We should not add this to the root project but a single instance to every subproject
 open class AvailableJavaInstallationsPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
-        val javaInstallationProbe = project.serviceOf<JavaInstallationProbe>()
-        val jvmVersionDetector = project.serviceOf<JvmVersionDetector>()
-        extensions.create<AvailableJavaInstallations>(
-            "availableJavaInstallations",
-            project,
-            javaInstallationProbe,
-            jvmVersionDetector
-        )
+        val availableInstallations = gradle.sharedServices.maybeRegister("availableJavaInstallations", AvailableJavaInstallations::class.java) {
+            parameters.testJavaProperty = project.findProperty(testJavaHomePropertyName)?.toString()
+        }
+        extensions.add("availableJavaInstallations", availableInstallations)
     }
 }

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/BuildJvms.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/BuildJvms.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.java
+
+import org.gradle.api.provider.Provider
+
+
+/**
+ * Provides access to the different JVMs that are used to build, compile and test.
+ */
+open class BuildJvms(val javaInstallations: Provider<AvailableJavaInstallations>) {
+    val buildJvm = javaInstallations.map { it.currentJavaInstallation }
+
+    val compileJvm = javaInstallations.map { it.javaInstallationForCompilation }
+
+    val testJvm = javaInstallations.map { it.javaInstallationForTest }
+}

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -7,7 +7,6 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.gradlebuild.java.AvailableJavaInstallations
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
@@ -186,8 +185,3 @@ fun Project.configureIde(testType: TestType) {
         }
     }
 }
-
-
-internal
-val Project.currentTestJavaVersion
-    get() = rootProject.the<AvailableJavaInstallations>().javaInstallationForTest.javaVersion

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -184,7 +184,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
     fun Test.configureJvmForTest() {
         val jvmForTest = project.buildJvms.testJvm.get()
         jvmArgumentProviders.add(createCiEnvironmentProvider(this))
-        executable = jvmForTest.jvm.javaExecutable.absolutePath
+        executable = jvmForTest.javaExecutable.absolutePath
         environment["JAVA_HOME"] = jvmForTest.javaHome.absolutePath
         if (jvmForTest.javaVersion.isJava7) {
             // enable class unloading

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -101,7 +101,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
     private
     fun Project.configureCompile() {
         afterEvaluate {
-            val availableJavaInstallations = rootProject.the<AvailableJavaInstallations>()
+            val availableJavaInstallations = rootProject.availableJavaInstallations.get()
 
             tasks.withType<JavaCompile>().configureEach {
                 configureCompileTask(this, options, availableJavaInstallations)
@@ -184,7 +184,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
 
     private
     fun Test.configureJvmForTest() {
-        val javaInstallationForTest = project.rootProject.availableJavaInstallations.javaInstallationForTest
+        val javaInstallationForTest = project.rootProject.availableJavaInstallations.get().javaInstallationForTest
         jvmArgumentProviders.add(createCiEnvironmentProvider(this))
         executable = javaInstallationForTest.jvm.javaExecutable.absolutePath
         environment["JAVA_HOME"] = javaInstallationForTest.javaHome.absolutePath

--- a/buildSrc/subprojects/plugins/src/main/kotlin/plugins-extensions.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/plugins-extensions.kt
@@ -15,6 +15,7 @@
  */
 
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.gradlebuild.unittestandcompile.UnitTestAndCompileExtension
 import org.gradle.gradlebuild.java.AvailableJavaInstallations
 import org.gradle.kotlin.dsl.*
@@ -23,16 +24,12 @@ import org.gradle.kotlin.dsl.*
 // This file contains Kotlin extensions for the gradle/gradle build
 
 
-fun Project.availableJavaInstallations(configure: AvailableJavaInstallations.() -> Unit): Unit =
-    extensions.configure("availableJavaInstallations", configure)
-
-
 fun Project.gradlebuildJava(configure: UnitTestAndCompileExtension.() -> Unit): Unit =
     extensions.configure("gradlebuildJava", configure)
 
 
 val Project.availableJavaInstallations
-    get() = extensions.getByName<AvailableJavaInstallations>("availableJavaInstallations")
+    get() = extensions.getByName<Provider<AvailableJavaInstallations>>("availableJavaInstallations")
 
 
 val Project.gradlebuildJava

--- a/buildSrc/subprojects/plugins/src/main/kotlin/plugins-extensions.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/plugins-extensions.kt
@@ -15,9 +15,8 @@
  */
 
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
+import org.gradle.gradlebuild.java.BuildJvms
 import org.gradle.gradlebuild.unittestandcompile.UnitTestAndCompileExtension
-import org.gradle.gradlebuild.java.AvailableJavaInstallations
 import org.gradle.kotlin.dsl.*
 
 
@@ -28,8 +27,8 @@ fun Project.gradlebuildJava(configure: UnitTestAndCompileExtension.() -> Unit): 
     extensions.configure("gradlebuildJava", configure)
 
 
-val Project.availableJavaInstallations
-    get() = extensions.getByName<Provider<AvailableJavaInstallations>>("availableJavaInstallations")
+val Project.buildJvms
+    get() = extensions.getByType<BuildJvms>()
 
 
 val Project.gradlebuildJava

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-rc-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.1-20191107041826+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -74,12 +74,10 @@ dependencies {
     testFixturesImplementation(project(":internalIntegTesting"))
 }
 
-val availableJavaInstallations = rootProject.availableJavaInstallations
-
 // Needed for testing debug command line option (JDWPUtil) - 'CommandLineIntegrationSpec.can debug with org.gradle.debug=true'
-val toolsJar = availableJavaInstallations.map { installations ->
-    if (!installations.javaInstallationForTest.javaVersion.isJava9Compatible) {
-        listOf(installations.javaInstallationForTest.toolsJar).filterNotNull()
+val toolsJar = buildJvms.testJvm.map { jvm ->
+    if (!jvm.javaVersion.isJava9Compatible) {
+        listOf(jvm.toolsJar).filterNotNull()
     } else {
         emptyList()
     }

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -75,14 +75,7 @@ dependencies {
 }
 
 // Needed for testing debug command line option (JDWPUtil) - 'CommandLineIntegrationSpec.can debug with org.gradle.debug=true'
-val toolsJar = buildJvms.testJvm.map { jvm ->
-    if (!jvm.javaVersion.isJava9Compatible) {
-        listOf(jvm.toolsJar).filterNotNull()
-    } else {
-        emptyList()
-    }
-}
-println("-> TOOLS JARS = ${toolsJar.get()}")
+val toolsJar = buildJvms.testJvm.map { jvm -> jvm.toolsClasspath }
 dependencies {
     integTestRuntimeOnly(files(toolsJar))
 }

--- a/subprojects/launcher/launcher.gradle.kts
+++ b/subprojects/launcher/launcher.gradle.kts
@@ -77,11 +77,16 @@ dependencies {
 val availableJavaInstallations = rootProject.availableJavaInstallations
 
 // Needed for testing debug command line option (JDWPUtil) - 'CommandLineIntegrationSpec.can debug with org.gradle.debug=true'
-val javaInstallationForTest = availableJavaInstallations.javaInstallationForTest
-if (!javaInstallationForTest.javaVersion.isJava9Compatible) {
-    dependencies {
-        integTestRuntimeOnly(files(javaInstallationForTest.toolsJar))
+val toolsJar = availableJavaInstallations.map { installations ->
+    if (!installations.javaInstallationForTest.javaVersion.isJava9Compatible) {
+        listOf(installations.javaInstallationForTest.toolsJar).filterNotNull()
+    } else {
+        emptyList()
     }
+}
+println("-> TOOLS JARS = ${toolsJar.get()}")
+dependencies {
+    integTestRuntimeOnly(files(toolsJar))
 }
 
 gradlebuildJava {


### PR DESCRIPTION

### Context

Use the APIs added in https://github.com/gradle/gradle/pull/11256 to fix some instant execution compatibility issues in the build logic of the Gradle build.

In particular, model the state used to locate and validate the build, compilation and testing JVMs as a build service.

Also make some simplifications and structural tweaks.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
