### PR TITLE
Some refinements to the build services API

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/services/BuildService.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/BuildService.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
  * to improve performance. Or, as another example, a service implementation might represent a web service that the build starts and
  * uses.
  *
- * <p>To create a service, create an abstract subclass of this interface and use {@link BuildServiceRegistry#maybeRegister(String, Class, Action)}
+ * <p>To create a service, create an abstract subclass of this interface and use {@link BuildServiceRegistry#registerIfAbsent(String, Class, Action)}
  * to register one or more instances. This method returns a {@link org.gradle.api.provider.Provider} that you can use to connect
  * the service to tasks.</p>
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceParameters.java
@@ -25,4 +25,14 @@ import org.gradle.api.Incubating;
  */
 @Incubating
 public interface BuildServiceParameters {
+    /**
+     * Used for services without parameters.
+     *
+     * @since 6.1
+     */
+    @Incubating
+    final class None implements BuildServiceParameters {
+        private None() {
+        }
+    }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceRegistry.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceRegistry.java
@@ -37,7 +37,7 @@ public interface BuildServiceRegistry {
     NamedDomainObjectSet<BuildServiceRegistration<?, ?>> getRegistrations();
 
     /**
-     * Registers a service, if not already registered. The service is not created until required.
+     * Registers a service, if a service with the given name is not already registered. The service is not created until required.
      *
      * @param name A name to use to identify the service.
      * @param implementationType The service implementation type. Instances of the service are created as for {@link org.gradle.api.model.ObjectFactory#newInstance(Class, Object...)}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceRegistry.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceRegistry.java
@@ -44,5 +44,8 @@ public interface BuildServiceRegistry {
      * @param configureAction An action to configure the registration. You can use this to provide parameters to the service instance.
      * @return A {@link Provider} that will create the service instance when queried.
      */
+    <T extends BuildService<P>, P extends BuildServiceParameters> Provider<T> registerIfAbsent(String name, Class<T> implementationType, Action<? super BuildServiceSpec<P>> configureAction);
+
+    // TODO - remove this once the Gradle build has been updated to a new nightly
     <T extends BuildService<P>, P extends BuildServiceParameters> Provider<T> maybeRegister(String name, Class<T> implementationType, Action<? super BuildServiceSpec<P>> configureAction);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ContainerElementServiceInjectionIntegrationTest.groovy
@@ -68,7 +68,7 @@ class ContainerElementServiceInjectionIntegrationTest extends AbstractIntegratio
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Bean.")
-        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of interface Unknown, or no service of type interface Unknown")
+        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of type Unknown, or no service of type Unknown")
     }
 
     def "container element can receive services through getter method"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
@@ -62,7 +62,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of class java.lang.String, or no service of type class java.lang.String")
+        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of type String, or no service of type String")
     }
 
     def "fails when non-static inner class provided"() {
@@ -77,7 +77,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Things\$Thing.")
-        failure.assertHasCause("Class Things\$Thing is a non-static inner class.")
+        failure.assertHasCause("Class Things.Thing is a non-static inner class.")
     }
 
     def "fails when mismatched construction parameters provided"() {
@@ -93,7 +93,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("Unable to determine constructor argument #2: value 12 not assignable to class java.lang.String")
+        failure.assertHasCause("Unable to determine constructor argument #2: value 12 not assignable to type String")
     }
 
     def "fails when mismatched construction parameters provided when there are multiple constructors"() {
@@ -111,7 +111,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("No constructors of class Thing match parameters: ['a', 12]")
+        failure.assertHasCause("No constructors of type Thing match parameters: ['a', 12]")
     }
 
     def "fails when constructor is ambiguous"() {
@@ -129,7 +129,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("Multiple constructors of class Thing match parameters: ['a', 'b']")
+        failure.assertHasCause("Multiple constructors of type Thing match parameters: ['a', 'b']")
     }
 
     def "fails when too many construction parameters provided"() {
@@ -145,7 +145,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("Too many parameters provided for constructor for class Thing. Expected 2, received 3.")
+        failure.assertHasCause("Too many parameters provided for constructor for type Thing. Expected 2, received 3.")
     }
 
     @Unroll
@@ -503,7 +503,7 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("Too many parameters provided for constructor for interface Thing. Expected 0, received 1.")
+        failure.assertHasCause("Too many parameters provided for constructor for type Thing. Expected 0, received 1.")
     }
 
     def "generates a display name for extension when it does not provide a toString() implementation"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/PluginServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/PluginServiceInjectionIntegrationTest.groovy
@@ -73,7 +73,7 @@ class PluginServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         fails()
         failure.assertHasCause("Failed to apply plugin [class 'CustomPlugin']")
         failure.assertHasCause("Could not create plugin of type 'CustomPlugin'.")
-        failure.assertHasCause("The constructor for class CustomPlugin should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type CustomPlugin should be annotated with @Inject.")
     }
 
     def "fails when plugin constructor requests unknown service"() {
@@ -96,7 +96,7 @@ class PluginServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         fails()
         failure.assertHasCause("Failed to apply plugin [class 'CustomPlugin']")
         failure.assertHasCause("Could not create plugin of type 'CustomPlugin'.")
-        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of interface Unknown, or no service of type interface Unknown")
+        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of type Unknown, or no service of type Unknown")
     }
 
     def "can inject service using getter method"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -153,7 +153,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("Could not generate a decorated class for interface Thing.")
+        failure.assertHasCause("Could not generate a decorated class for type Thing.")
         failure.assertHasCause("Cannot have abstract method Thing.getProp().")
     }
 
@@ -370,7 +370,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause('Could not create an instance of type Thing.')
-        failure.assertHasCause('Too many parameters provided for constructor for class Thing. Expected 0, received 1.')
+        failure.assertHasCause('Too many parameters provided for constructor for type Thing. Expected 0, received 1.')
     }
 
     def "object creation fails with ObjectInstantiationException when construction parameters provided for interface"() {
@@ -390,7 +390,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause('Could not create an instance of type Thing.')
-        failure.assertHasCause('Too many parameters provided for constructor for interface Thing. Expected 0, received 1.')
+        failure.assertHasCause('Too many parameters provided for constructor for type Thing. Expected 0, received 1.')
     }
 
     def "object creation fails with ObjectInstantiationException given non-static inner class"() {
@@ -413,7 +413,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause('Could not create an instance of type Things$Thing.')
-        failure.assertHasCause('Class Things$Thing is a non-static inner class.')
+        failure.assertHasCause('Class Things.Thing is a non-static inner class.')
     }
 
     def "object creation fails with ObjectInstantiationException given unknown service requested as constructor parameter"() {
@@ -438,7 +438,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause('Could not create an instance of type Thing.')
-        failure.assertHasCause('Unable to determine constructor argument #1: missing parameter of interface Unknown, or no service of type interface Unknown')
+        failure.assertHasCause('Unable to determine constructor argument #1: missing parameter of type Unknown, or no service of type Unknown')
     }
 
     def "object creation fails with ObjectInstantiationException when constructor throws an exception"() {
@@ -482,7 +482,7 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause('Could not create an instance of type Thing.')
-        failure.assertHasCause('The constructor for class Thing should be annotated with @Inject.')
+        failure.assertHasCause('The constructor for type Thing should be annotated with @Inject.')
     }
 
     def "object creation fails with ObjectInstantiationException when type has multiple constructors not annotated"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -27,7 +27,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
     def "service is created once per build on first use and stopped at the end of the build"() {
         serviceImplementation()
         buildFile << """
-            def provider = gradle.sharedServices.maybeRegister("counter", CountingService) {
+            def provider = gradle.sharedServices.registerIfAbsent("counter", CountingService) {
                 parameters.initial = 10
             }
             
@@ -80,7 +80,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
     def "tasks can use mapped value of service"() {
         serviceImplementation()
         buildFile << """
-            def provider = gradle.sharedServices.maybeRegister("counter", CountingService) {
+            def provider = gradle.sharedServices.registerIfAbsent("counter", CountingService) {
                 parameters.initial = 10
             }
             
@@ -130,7 +130,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
     def "service can be used at configuration and execution time"() {
         serviceImplementation()
         buildFile << """
-            def provider = gradle.sharedServices.maybeRegister("counter", CountingService) {
+            def provider = gradle.sharedServices.registerIfAbsent("counter", CountingService) {
                 parameters.initial = 10
             }
             
@@ -179,7 +179,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
     def "service used at configuration and execution time can be used with instant execution"() {
         serviceImplementation()
         buildFile << """
-            def provider = gradle.sharedServices.maybeRegister("counter", CountingService) {
+            def provider = gradle.sharedServices.registerIfAbsent("counter", CountingService) {
                 parameters.initial = 10
             }
             
@@ -233,7 +233,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             class CounterPlugin implements Plugin<Project> {
                 void apply(Project project) {
-                    def provider = project.gradle.sharedServices.maybeRegister("counter", CountingService) {
+                    def provider = project.gradle.sharedServices.registerIfAbsent("counter", CountingService) {
                         parameters.initial = 10
                     }
                     project.tasks.register("count") {
@@ -285,10 +285,10 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
             }
             apply plugin: CounterConventionPlugin
 
-            def counter1 = project.gradle.sharedServices.maybeRegister("counter1", CountingService) {
+            def counter1 = project.gradle.sharedServices.registerIfAbsent("counter1", CountingService) {
                 parameters.initial = 0
             }
-            def counter2 = project.gradle.sharedServices.maybeRegister("counter2", CountingService) {
+            def counter2 = project.gradle.sharedServices.registerIfAbsent("counter2", CountingService) {
                 parameters.initial = 10
             }
             task count {
@@ -327,10 +327,10 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
     def "service is stopped even if build fails"() {
         serviceImplementation()
         buildFile << """
-            def counter1 = project.gradle.sharedServices.maybeRegister("counter1", CountingService) {
+            def counter1 = project.gradle.sharedServices.registerIfAbsent("counter1", CountingService) {
                 parameters.initial = 0
             }
-            def counter2 = project.gradle.sharedServices.maybeRegister("counter2", CountingService) {
+            def counter2 = project.gradle.sharedServices.registerIfAbsent("counter2", CountingService) {
                 parameters.initial = 10
             }
             task count {
@@ -363,10 +363,10 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
     def "reports failure to create the service instance"() {
         brokenServiceImplementation()
         buildFile << """
-            def provider1 = gradle.sharedServices.maybeRegister("counter1", CountingService) {
+            def provider1 = gradle.sharedServices.registerIfAbsent("counter1", CountingService) {
                 parameters.initial = 10
             }
-            def provider2 = gradle.sharedServices.maybeRegister("counter2", CountingService) {
+            def provider2 = gradle.sharedServices.registerIfAbsent("counter2", CountingService) {
                 parameters.initial = 10
             }
             
@@ -415,10 +415,10 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
     def "reports failure to stop the service instance"() {
         brokenStopServiceImplementation()
         buildFile << """
-            def provider1 = gradle.sharedServices.maybeRegister("counter1", CountingService) {
+            def provider1 = gradle.sharedServices.registerIfAbsent("counter1", CountingService) {
                 parameters.initial = 10
             }
-            def provider2 = gradle.sharedServices.maybeRegister("counter2", CountingService) {
+            def provider2 = gradle.sharedServices.registerIfAbsent("counter2", CountingService) {
                 parameters.initial = 10
             }
             

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -687,7 +687,7 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
-        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of int, or no service of type int")
+        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of type int, or no service of type int")
     }
 
     def "fails to create custom task if all constructor arguments missing"() {
@@ -701,7 +701,7 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
-        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of class java.lang.String, or no service of type class java.lang.String")
+        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of type String, or no service of type String")
     }
 
     @Unroll

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -324,7 +324,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
-        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of int, or no service of type int")
+        failure.assertHasCause("Unable to determine constructor argument #2: missing parameter of type int, or no service of type int")
 
         where:
         description   | script
@@ -344,7 +344,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
-        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of class java.lang.String, or no service of type class java.lang.String")
+        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of type String, or no service of type String")
 
         where:
         description   | script
@@ -435,7 +435,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'MyTask'.")
-        failure.assertHasCause("Class MyPlugin\$MyTask is a non-static inner class.")
+        failure.assertHasCause("Class MyPlugin.MyTask is a non-static inner class.")
     }
 
     @Requires(KOTLIN_SCRIPT)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskServiceInjectionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskServiceInjectionIntegrationTest.groovy
@@ -163,7 +163,7 @@ class TaskServiceInjectionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Could not create task ':myTask'.")
         failure.assertHasCause("Could not create task of type 'CustomTask'.")
-        failure.assertHasCause("The constructor for class CustomTask should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type CustomTask should be annotated with @Inject.")
     }
 
     def "task creation fails when service getter is not public or protected"() {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -36,7 +36,7 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
     private final P parameters;
     private Try<T> instance;
 
-    public BuildServiceProvider(String name, Class<T> implementationType, Class<P> parametersType, P parameters, InstantiationScheme instantiationScheme, IsolatableFactory isolatableFactory) {
+    public BuildServiceProvider(String name, Class<T> implementationType, Class<P> parametersType, @Nullable P parameters, InstantiationScheme instantiationScheme, IsolatableFactory isolatableFactory) {
         this.name = name;
         this.implementationType = implementationType;
         this.parametersType = parametersType;
@@ -53,6 +53,7 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
         return implementationType;
     }
 
+    @Nullable
     public P getParameters() {
         return parameters;
     }
@@ -83,7 +84,9 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
                 DefaultServiceRegistry services = new DefaultServiceRegistry();
                 // TODO - should hold the project lock to do the isolation. Should work the same way as artifact transforms (a work node does the isolation, etc)
                 P isolatedParameters = isolatableFactory.isolate(parameters).isolate();
-                services.add(parametersType, isolatedParameters);
+                if (isolatedParameters != null) {
+                    services.add(parametersType, isolatedParameters);
+                }
                 try {
                     instance = Try.successful(instantiationScheme.withServices(services).instantiator().newInstance(implementationType));
                 } catch (Exception e) {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -21,6 +21,7 @@ import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.internal.Try;
 import org.gradle.internal.instantiation.InstantiationScheme;
+import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.service.DefaultServiceRegistry;
 
 import javax.annotation.Nullable;
@@ -30,16 +31,18 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
     private final String name;
     private final Class<T> implementationType;
     private final InstantiationScheme instantiationScheme;
+    private final IsolatableFactory isolatableFactory;
     private final Class<P> parametersType;
     private final P parameters;
     private Try<T> instance;
 
-    public BuildServiceProvider(String name, Class<T> implementationType, Class<P> parametersType, P parameters, InstantiationScheme instantiationScheme) {
+    public BuildServiceProvider(String name, Class<T> implementationType, Class<P> parametersType, P parameters, InstantiationScheme instantiationScheme, IsolatableFactory isolatableFactory) {
         this.name = name;
         this.implementationType = implementationType;
         this.parametersType = parametersType;
         this.parameters = parameters;
         this.instantiationScheme = instantiationScheme;
+        this.isolatableFactory = isolatableFactory;
     }
 
     public String getName() {
@@ -78,7 +81,9 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
             if (instance == null) {
                 // TODO - extract a ServiceLookup implementation to reuse
                 DefaultServiceRegistry services = new DefaultServiceRegistry();
-                services.add(parametersType, parameters);
+                // TODO - should hold the project lock to do the isolation. Should work the same way as artifact transforms (a work node does the isolation, etc)
+                P isolatedParameters = isolatableFactory.isolate(parameters).isolate();
+                services.add(parametersType, isolatedParameters);
                 try {
                     instance = Try.successful(instantiationScheme.withServices(services).instantiator().newInstance(implementationType));
                 } catch (Exception e) {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -54,6 +54,11 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
 
     @Override
     public <T extends BuildService<P>, P extends BuildServiceParameters> Provider<T> maybeRegister(String name, Class<T> implementationType, Action<? super BuildServiceSpec<P>> configureAction) {
+        return registerIfAbsent(name, implementationType, configureAction);
+    }
+
+    @Override
+    public <T extends BuildService<P>, P extends BuildServiceParameters> Provider<T> registerIfAbsent(String name, Class<T> implementationType, Action<? super BuildServiceSpec<P>> configureAction) {
         BuildServiceRegistration<?, ?> existing = registrations.findByName(name);
         if (existing != null) {
             // TODO - assert same type

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -84,6 +84,7 @@ import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.id.UniqueId;
 import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -277,8 +278,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return new SplitFileContentCacheFactory(globalCacheFactory, localCacheFactory, wellKnownFileLocations);
     }
 
-    BuildServiceRegistryInternal createSharedServiceRegistry(Instantiator instantiator, DomainObjectCollectionFactory factory, InstantiatorFactory instantiatorFactory, ServiceRegistry services, ListenerManager listenerManager) {
-        return instantiator.newInstance(DefaultBuildServicesRegistry.class, factory, instantiatorFactory, services, listenerManager);
+    BuildServiceRegistryInternal createSharedServiceRegistry(Instantiator instantiator, DomainObjectCollectionFactory factory, InstantiatorFactory instantiatorFactory, ServiceRegistry services, ListenerManager listenerManager, IsolatableFactory isolatableFactory) {
+        return instantiator.newInstance(DefaultBuildServicesRegistry.class, factory, instantiatorFactory, services, listenerManager, isolatableFactory);
     }
 
     protected BuildOutputCleanupRegistry createBuildOutputCleanupRegistry(FileCollectionFactory fileCollectionFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/services/internal/DefaultBuildServicesRegistryTest.groovy
@@ -35,7 +35,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
 
     def "can lazily create service instance"() {
         when:
-        def provider = registry.maybeRegister("service", ServiceImpl) {}
+        def provider = registry.registerIfAbsent("service", ServiceImpl) {}
 
         then:
         ServiceImpl.instances.empty
@@ -57,7 +57,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
 
     def "service provider always has value present"() {
         when:
-        def provider = registry.maybeRegister("service", ServiceImpl) {}
+        def provider = registry.registerIfAbsent("service", ServiceImpl) {}
 
         then:
         provider.present
@@ -66,7 +66,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
 
     def "wraps and memoizes service instantiation failure"() {
         when:
-        def provider = registry.maybeRegister("service", BrokenServiceImpl) {}
+        def provider = registry.registerIfAbsent("service", BrokenServiceImpl) {}
 
         then:
         noExceptionThrown()
@@ -91,7 +91,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
 
     def "can locate registration by name"() {
         when:
-        def provider = registry.maybeRegister("service", ServiceImpl) {}
+        def provider = registry.registerIfAbsent("service", ServiceImpl) {}
         def registration = registry.registrations.getByName("service")
 
         then:
@@ -101,8 +101,8 @@ class DefaultBuildServicesRegistryTest extends Specification {
 
     def "reuses registration with same name"() {
         when:
-        def provider1 = registry.maybeRegister("service", ServiceImpl) {}
-        def provider2 = registry.maybeRegister("service", ServiceImpl) {}
+        def provider1 = registry.registerIfAbsent("service", ServiceImpl) {}
+        def provider2 = registry.registerIfAbsent("service", ServiceImpl) {}
 
         then:
         provider1.is(provider2)
@@ -110,7 +110,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
 
     def "can provide parameters to the service"() {
         when:
-        def provider = registry.maybeRegister("service", ServiceImpl) {
+        def provider = registry.registerIfAbsent("service", ServiceImpl) {
             it.parameters.prop = "value"
         }
         def service = provider.get()
@@ -121,7 +121,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
 
     def "can tweak parameters via the registration"() {
         when:
-        def provider = registry.maybeRegister("service", ServiceImpl) {
+        def provider = registry.registerIfAbsent("service", ServiceImpl) {
             it.parameters.prop = "value 1"
         }
         def parameters = registry.registrations.getByName("service").parameters
@@ -138,9 +138,9 @@ class DefaultBuildServicesRegistryTest extends Specification {
     }
 
     def "stops service at end of build if it implements AutoCloseable"() {
-        def provider1 = registry.maybeRegister("one", ServiceImpl) {}
-        def provider2 = registry.maybeRegister("two", StoppableServiceImpl) {}
-        def provider3 = registry.maybeRegister("three", StoppableServiceImpl) {}
+        def provider1 = registry.registerIfAbsent("one", ServiceImpl) {}
+        def provider2 = registry.registerIfAbsent("two", StoppableServiceImpl) {}
+        def provider3 = registry.registerIfAbsent("three", StoppableServiceImpl) {}
 
         when:
         def notStoppable = provider1.get()
@@ -158,7 +158,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
     }
 
     def "does not attempt to stop an unused service at the end of build"() {
-        registry.maybeRegister("service", ServiceImpl) {}
+        registry.registerIfAbsent("service", ServiceImpl) {}
 
         when:
         buildFinished()
@@ -168,7 +168,7 @@ class DefaultBuildServicesRegistryTest extends Specification {
     }
 
     def "reports failure to stop service"() {
-        def provider = registry.maybeRegister("service", BrokenStopServiceImpl) {}
+        def provider = registry.registerIfAbsent("service", BrokenStopServiceImpl) {}
         provider.get()
 
         when:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -1157,7 +1157,7 @@ All of them match the consumer attributes:
         failure.assertHasCause("Could not resolve project :b.")
         failure.assertHasCause("Could not determine whether value paid is compatible with value free using FlavorCompatibilityRule.")
         failure.assertHasCause("Could not create an instance of type FlavorCompatibilityRule.")
-        failure.assertHasCause("The constructor for class FlavorCompatibilityRule should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type FlavorCompatibilityRule should be annotated with @Inject.")
     }
 
     def "user receives reasonable error message when compatibility rule fails"() {
@@ -1289,7 +1289,7 @@ All of them match the consumer attributes:
         failure.assertHasCause("Could not resolve project :b.")
         failure.assertHasCause("Could not select value from candidates [free, paid] using FlavorSelectionRule.")
         failure.assertHasCause("Could not create an instance of type FlavorSelectionRule.")
-        failure.assertHasCause("The constructor for class FlavorSelectionRule should be annotated with @Inject.")
+        failure.assertHasCause("The constructor for type FlavorSelectionRule should be annotated with @Inject.")
     }
 
     def "user receives reasonable error message when disambiguation rule fails"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1947,7 +1947,7 @@ Found the following transforms:
 
         and:
         failure.assertHasDescription("A problem occurred evaluating root project 'root'.")
-        failure.assertHasCause("Cannot register artifact transform Custom with parameters [<custom>]")
+        failure.assertHasCause("Could not register artifact transform Custom (from {usage=any} to {usage=any})")
         failure.assertHasCause("Could not serialize value of type 'CustomType'")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -414,7 +414,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         then:
         failure.assertHasDescription('A problem occurred evaluating root project')
         failure.assertHasCause('Could not create an instance of type MakeGreen$Parameters.')
-        failure.assertHasCause('Could not generate a decorated class for interface MakeGreen$Parameters.')
+        failure.assertHasCause('Could not generate a decorated class for type MakeGreen.Parameters.')
         failure.assertHasCause("Cannot use @${annotation.simpleName} annotation on method Parameters.getBad().")
 
         where:
@@ -728,7 +728,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project")
-        failure.assertHasCause("Cannot register artifact transform MakeGreen (from {color=blue} to {color=green})")
+        failure.assertHasCause("Could not register artifact transform MakeGreen (from {color=blue} to {color=green})")
         failure.assertHasCause("Cannot use @InputArtifact annotation on property MakeGreen.getInput() of type ${typeName}. Allowed property types: java.io.File, org.gradle.api.provider.Provider<org.gradle.api.file.FileSystemLocation>.")
 
         where:
@@ -765,7 +765,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project")
-        failure.assertHasCause("Cannot register artifact transform MakeGreen (from {color=blue} to {color=green})")
+        failure.assertHasCause("Could not register artifact transform MakeGreen (from {color=blue} to {color=green})")
         failure.assertHasCause("Cannot use @InputArtifactDependencies annotation on property MakeGreen.getDependencies() of type ${propertyType.name}. Allowed property types: org.gradle.api.file.FileCollection.")
 
         where:
@@ -864,7 +864,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
         fails('broken')
         failure.assertHasDescription("A problem occurred evaluating root project")
         failure.assertHasCause("Could not create task of type 'MyTask'.")
-        failure.assertHasCause("Could not generate a decorated class for class MyTask.")
+        failure.assertHasCause("Could not generate a decorated class for type MyTask.")
         failure.assertHasCause("Cannot use @${annotation.simpleName} annotation on method MyTask.getThing().")
 
         where:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -36,11 +36,10 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolated.IsolationScheme;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.model.internal.type.ModelType;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.List;
 
 public class DefaultVariantTransformRegistry implements VariantTransformRegistry {
@@ -51,7 +50,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     private final InstantiatorFactory instantiatorFactory;
     private final InstantiationScheme parametersInstantiationScheme;
     private final TransformationRegistrationFactory registrationFactory;
-    private final IsolationScheme<TransformAction, TransformParameters> isolationScheme = new IsolationScheme<>(TransformAction.class);
+    private final IsolationScheme<TransformAction, TransformParameters> isolationScheme = new IsolationScheme<>(TransformAction.class, TransformParameters.class, TransformParameters.None.class);
 
     public DefaultVariantTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory immutableAttributesFactory, ServiceRegistry services, TransformationRegistrationFactory registrationFactory, InstantiationScheme parametersInstantiationScheme) {
         this.instantiatorFactory = instantiatorFactory;
@@ -63,60 +62,88 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
 
     @Override
     public void registerTransform(Action<? super VariantTransform> registrationAction) {
-        UntypedRegistration registration = instantiatorFactory.decorateLenient().newInstance(UntypedRegistration.class, immutableAttributesFactory, instantiatorFactory);
-        registrationAction.execute(registration);
-
-        validateActionType(registration.actionType);
-        validateAttributes(registration);
-
-        Object[] parameters = registration.getTransformParameters();
         try {
-            ArtifactTransformRegistration finalizedRegistration = registrationFactory.create(registration.from.asImmutable(), registration.to.asImmutable(), registration.actionType, parameters);
-            transforms.add(finalizedRegistration);
+            UntypedRegistration registration = instantiatorFactory.decorateLenient().newInstance(UntypedRegistration.class, immutableAttributesFactory, instantiatorFactory);
+            registrationAction.execute(registration);
+
+            validateActionType(registration.actionType);
+            try {
+                validateAttributes(registration);
+
+                Object[] parameters = registration.getTransformParameters();
+                ArtifactTransformRegistration finalizedRegistration = registrationFactory.create(registration.from.asImmutable(), registration.to.asImmutable(), registration.actionType, parameters);
+                transforms.add(finalizedRegistration);
+            } catch (Exception e) {
+                TreeFormatter formatter = new TreeFormatter();
+                formatter.node("Could not register artifact transform ");
+                formatter.appendType(registration.actionType);
+                formatter.append(" (from ");
+                formatter.appendValue(registration.from);
+                formatter.append(" to ");
+                formatter.appendValue(registration.to);
+                formatter.append(").");
+                throw new VariantTransformConfigurationException(formatter.toString(), e);
+            }
+        } catch (VariantTransformConfigurationException e) {
+            throw e;
         } catch (Exception e) {
-            throw new VariantTransformConfigurationException(String.format("Cannot register artifact transform %s with parameters %s", ModelType.of(registration.actionType).getDisplayName(), Arrays.toString(parameters)), e);
+            throw new VariantTransformConfigurationException("Could not register artifact transform.", e);
         }
     }
 
     @Override
     public <T extends TransformParameters> void registerTransform(Class<? extends TransformAction<T>> actionType, Action<? super TransformSpec<T>> registrationAction) {
-        Class<T> parameterType = isolationScheme.parameterTypeFor(actionType);
-        if (parameterType == TransformParameters.class) {
-            throw new VariantTransformConfigurationException(String.format("Could not register transform: must use a sub-type of %s as parameter type. Use %s for transforms without parameters.", ModelType.of(TransformParameters.class).getDisplayName(), ModelType.of(TransformParameters.None.class).getDisplayName()));
+        try {
+            Class<T> parameterType = isolationScheme.parameterTypeFor(actionType);
+            T parameterObject = parameterType == null ? null : parametersInstantiationScheme.withServices(services).instantiator().newInstance(parameterType);
+            TypedRegistration<T> registration = Cast.uncheckedNonnullCast(instantiatorFactory.decorateLenient().newInstance(TypedRegistration.class, parameterObject, immutableAttributesFactory));
+            registrationAction.execute(registration);
+            register(registration, actionType, parameterObject);
+        } catch (VariantTransformConfigurationException e) {
+            throw e;
+        } catch (Exception e) {
+            TreeFormatter formatter = new TreeFormatter();
+            formatter.node("Could not register artifact transform ");
+            formatter.appendType(actionType);
+            formatter.append(".");
+            throw new VariantTransformConfigurationException(formatter.toString(), e);
         }
-        T parameterObject = parameterType == TransformParameters.None.class ? null : parametersInstantiationScheme.withServices(services).instantiator().newInstance(parameterType);
-        TypedRegistration<T> registration = Cast.uncheckedNonnullCast(instantiatorFactory.decorateLenient().newInstance(TypedRegistration.class, parameterObject, immutableAttributesFactory));
-        registrationAction.execute(registration);
-
-        register(registration, actionType, parameterObject);
     }
 
     private <T extends TransformParameters> void register(RecordingRegistration registration, Class<? extends TransformAction> actionType, @Nullable T parameterObject) {
         validateActionType(actionType);
-        validateAttributes(registration);
         try {
+            validateAttributes(registration);
             ArtifactTransformRegistration finalizedRegistration = registrationFactory.create(registration.from.asImmutable(), registration.to.asImmutable(), actionType, parameterObject);
             transforms.add(finalizedRegistration);
         } catch (Exception e) {
-            throw new VariantTransformConfigurationException(String.format("Cannot register artifact transform %s (from %s to %s)", ModelType.of(actionType).getDisplayName(), registration.from, registration.to), e);
+            TreeFormatter formatter = new TreeFormatter();
+            formatter.node("Could not register artifact transform ");
+            formatter.appendType(actionType);
+            formatter.append(" (from ");
+            formatter.appendValue(registration.from);
+            formatter.append(" to ");
+            formatter.appendValue(registration.to);
+            formatter.append(").");
+            throw new VariantTransformConfigurationException(formatter.toString(), e);
         }
     }
 
     private static <T> void validateActionType(@Nullable Class<T> actionType) {
         if (actionType == null) {
-            throw new VariantTransformConfigurationException("Could not register transform: an artifact transform action must be provided.");
+            throw new IllegalArgumentException("An artifact transform action type must be provided.");
         }
     }
 
     private static void validateAttributes(RecordingRegistration registration) {
         if (registration.to.isEmpty()) {
-            throw new VariantTransformConfigurationException("Could not register transform: at least one 'to' attribute must be provided.");
+            throw new IllegalArgumentException("At least one 'to' attribute must be provided.");
         }
         if (registration.from.isEmpty()) {
-            throw new VariantTransformConfigurationException("Could not register transform: at least one 'from' attribute must be provided.");
+            throw new IllegalArgumentException("At least one 'from' attribute must be provided.");
         }
         if (!registration.from.keySet().containsAll(registration.to.keySet())) {
-            throw new VariantTransformConfigurationException("Could not register transform: each 'to' attribute must be included as a 'from' attribute.");
+            throw new IllegalArgumentException("Each 'to' attribute must be included as a 'from' attribute.");
         }
     }
 
@@ -163,7 +190,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         @Override
         public void artifactTransform(Class<? extends ArtifactTransform> type, @Nullable Action<? super ActionConfiguration> config) {
             if (this.actionType != null) {
-                throw new VariantTransformConfigurationException("Could not register transform: only one ArtifactTransform may be provided for registration.");
+                throw new IllegalStateException("Only one ArtifactTransform may be provided for registration.");
             }
             this.actionType = type;
             this.configAction = config;
@@ -191,7 +218,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         @Override
         public T getParameters() {
             if (parameterObject == null) {
-                throw new VariantTransformConfigurationException("Cannot query parameters for artifact transform without parameters.");
+                throw new IllegalStateException("Cannot query parameters for artifact transform without parameters.");
             }
             return parameterObject;
         }
@@ -199,7 +226,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         @Override
         public void parameters(Action<? super T> action) {
             if (parameterObject == null) {
-                throw new VariantTransformConfigurationException("Cannot configure parameters for artifact transform without parameters.");
+                throw new IllegalStateException("Cannot configure parameters for artifact transform without parameters.");
             }
             action.execute(parameterObject);
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -193,8 +193,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == 'Could not register transform: must use a sub-type of TransformParameters as parameter type. Use TransformParameters.None for transforms without parameters.'
-        e.cause == null
+        e.message == 'Could not register artifact transform DefaultVariantTransformRegistryTest.UnspecifiedTestTransform.'
+        e.cause.message == 'Could not create the parameters for DefaultVariantTransformRegistryTest.UnspecifiedTestTransform: must use a sub-type of TransformParameters as the parameters type. Use TransformParameters.None as the parameters type for implementations that do not take parameters.'
     }
 
     def "cannot configure parameters for parameterless action"() {
@@ -208,8 +208,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == 'Cannot configure parameters for artifact transform without parameters.'
-        e.cause == null
+        e.message == 'Could not register artifact transform DefaultVariantTransformRegistryTest.ParameterlessTestTransform.'
+        e.cause.message == 'Cannot configure parameters for artifact transform without parameters.'
     }
 
     def "cannot query parameters object for parameterless action"() {
@@ -222,8 +222,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == 'Cannot query parameters for artifact transform without parameters.'
-        e.cause == null
+        e.message == 'Could not register artifact transform DefaultVariantTransformRegistryTest.ParameterlessTestTransform.'
+        e.cause.message == 'Cannot query parameters for artifact transform without parameters.'
     }
 
     def "delegates are DSL decorated but not extensible when registering with config object"() {
@@ -254,8 +254,9 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
 
         then:
-        def e = thrown(RuntimeException)
-        e == failure
+        def e = thrown(VariantTransformConfigurationException)
+        e.message == 'Could not register artifact transform DefaultVariantTransformRegistryTest.TestArtifactTransform (from {TEST=from} to {TEST=to}).'
+        e.cause == failure
     }
 
     def "fails when no artifactTransform provided for registration"() {
@@ -265,8 +266,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == 'Could not register transform: an artifact transform action must be provided.'
-        e.cause == null
+        e.message == 'Could not register artifact transform.'
+        e.cause.message == 'An artifact transform action type must be provided.'
     }
 
     def "fails when multiple artifactTransforms are provided for registration"() {
@@ -278,8 +279,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == 'Could not register transform: only one ArtifactTransform may be provided for registration.'
-        e.cause == null
+        e.message == 'Could not register artifact transform.'
+        e.cause.message == 'Only one ArtifactTransform may be provided for registration.'
     }
 
     def "fails when no from attributes are provided for legacy registration"() {
@@ -291,8 +292,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == "Could not register transform: at least one 'from' attribute must be provided."
-        e.cause == null
+        e.message == "Could not register artifact transform DefaultVariantTransformRegistryTest.TestArtifactTransform (from {} to {TEST=to})."
+        e.cause.message == "At least one 'from' attribute must be provided."
     }
 
     def "fails when no from attributes are provided for registerTransform"() {
@@ -303,8 +304,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == "Could not register transform: at least one 'from' attribute must be provided."
-        e.cause == null
+        e.message == "Could not register artifact transform DefaultVariantTransformRegistryTest.TestTransform (from {} to {TEST=to})."
+        e.cause.message == "At least one 'from' attribute must be provided."
     }
 
     def "fails when no to attributes are provided for legacy registration"() {
@@ -316,8 +317,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == "Could not register transform: at least one 'to' attribute must be provided."
-        e.cause == null
+        e.message == "Could not register artifact transform DefaultVariantTransformRegistryTest.TestArtifactTransform (from {TEST=from} to {})."
+        e.cause.message == "At least one 'to' attribute must be provided."
     }
 
     def "fails when no to attributes are provided for registerTransform"() {
@@ -328,8 +329,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == "Could not register transform: at least one 'to' attribute must be provided."
-        e.cause == null
+        e.message == "Could not register artifact transform DefaultVariantTransformRegistryTest.TestTransform (from {TEST=from} to {})."
+        e.cause.message == "At least one 'to' attribute must be provided."
     }
 
     def "fails when to attributes are not a subset of from attributes for legacy registration"() {
@@ -344,8 +345,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == "Could not register transform: each 'to' attribute must be included as a 'from' attribute."
-        e.cause == null
+        e.message == "Could not register artifact transform DefaultVariantTransformRegistryTest.TestArtifactTransform (from {TEST=from, from2=from} to {TEST=to, other=12})."
+        e.cause.message == "Each 'to' attribute must be included as a 'from' attribute."
     }
 
     def "fails when to attributes are not a subset of from attributes for registerTransform"() {
@@ -359,8 +360,8 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
         then:
         def e = thrown(VariantTransformConfigurationException)
-        e.message == "Could not register transform: each 'to' attribute must be included as a 'from' attribute."
-        e.cause == null
+        e.message == "Could not register artifact transform DefaultVariantTransformRegistryTest.TestTransform (from {TEST=from, from2=from} to {TEST=to, other=12})."
+        e.cause.message == "Each 'to' attribute must be included as a 'from' attribute."
     }
 
     static class UnAnnotatedTestTransformConfig {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ProviderCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ProviderCodecs.kt
@@ -104,7 +104,7 @@ BuildServiceProviderCodec(private val serviceRegistry: BuildServiceRegistryInter
         return decodePreservingIdentity(sharedIdentities) { id ->
             val name = readString()
             val implementationType = readClass() as Class<BuildService<*>>
-            val parameters = read() as BuildServiceParameters
+            val parameters = read() as BuildServiceParameters?
             val provider = serviceRegistry.register(name, implementationType, parameters)
             sharedIdentities.putInstance(id, provider)
             provider

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.internal.logging.text
 
 import spock.lang.Specification
 
+import java.util.function.Consumer
+
 import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class TreeFormatterTest extends Specification {
@@ -290,7 +292,7 @@ Some thing.''')
         formatter.appendType(String.class)
 
         then:
-        formatter.toString() == toPlatformLineSeparators("thing class java.lang.String")
+        formatter.toString() == toPlatformLineSeparators("thing String")
     }
 
     def "can append interface name"() {
@@ -299,7 +301,34 @@ Some thing.''')
         formatter.appendType(List.class)
 
         then:
-        formatter.toString() == toPlatformLineSeparators("thing interface java.util.List")
+        formatter.toString() == toPlatformLineSeparators("thing List")
+    }
+
+    def "can append inner class name"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendType(Thing.Nested.Inner.class)
+
+        then:
+        formatter.toString() == toPlatformLineSeparators("thing TreeFormatterTest.Thing.Nested.Inner")
+    }
+
+    def "can append parameterized type name"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendType(Thing.genericInterfaces[0])
+
+        then:
+        formatter.toString() == toPlatformLineSeparators("thing List<TreeFormatterTest.Thing.Nested>")
+    }
+
+    def "can append wildcard type name"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendType(Thing.genericInterfaces[1])
+
+        then:
+        formatter.toString() == toPlatformLineSeparators("thing Map<TreeFormatterTest.Thing.Nested, ? extends java.util.function.Consumer<? super T>>")
     }
 
     def "can append method name"() {
@@ -387,5 +416,11 @@ Some thing.''')
         then:
         def e = thrown(IllegalStateException)
         e.message == 'Cannot append text to node.'
+    }
+
+    interface Thing<T> extends List<Nested>, Map<Nested, ? extends Consumer<? super T>> {
+        interface Nested {
+            class Inner {}
+        }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -218,7 +218,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             throw e;
         } catch (Throwable e) {
             TreeFormatter formatter = new TreeFormatter();
-            formatter.node("Could not generate a decorated class for ");
+            formatter.node("Could not generate a decorated class for type ");
             formatter.appendType(type);
             formatter.append(".");
             throw new ClassGenerationException(formatter.toString(), e);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DependencyInjectingInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/DependencyInjectingInstantiator.java
@@ -109,7 +109,7 @@ class DependencyInjectingInstantiator implements InstanceGenerator {
         Class<?>[] parameterTypes = constructor.getParameterTypes();
         if (parameterTypes.length < parameters.length) {
             TreeFormatter formatter = new TreeFormatter();
-            formatter.node("Too many parameters provided for constructor for ");
+            formatter.node("Too many parameters provided for constructor for type ");
             formatter.appendType(type);
             formatter.append(String.format(". Expected %s, received %s.", parameterTypes.length, parameters.length));
             throw new IllegalArgumentException(formatter.toString());
@@ -140,8 +140,9 @@ class DependencyInjectingInstantiator implements InstanceGenerator {
                 TreeFormatter formatter = new TreeFormatter();
                 formatter.node("Unable to determine constructor argument #" + (i + 1) + ": value ");
                 formatter.appendValue(currentParameter);
-                formatter.append(" not assignable to ");
+                formatter.append(" not assignable to type ");
                 formatter.appendType(parameterTypes[i]);
+                formatter.append(".");
                 throw new IllegalArgumentException(formatter.toString());
             }
         }
@@ -150,8 +151,9 @@ class DependencyInjectingInstantiator implements InstanceGenerator {
 
     private void nullPrimitiveType(int index, Class<?> paramType) {
         TreeFormatter formatter = new TreeFormatter();
-        formatter.node("Unable to determine constructor argument #" + (index + 1) + ": null value is not assignable to ");
+        formatter.node("Unable to determine constructor argument #" + (index + 1) + ": null value is not assignable to type ");
         formatter.appendType(paramType);
+        formatter.append(".");
         throw new IllegalArgumentException(formatter.toString());
     }
 
@@ -187,14 +189,15 @@ class DependencyInjectingInstantiator implements InstanceGenerator {
             if (pos < parameters.length) {
                 formatter.append("value ");
                 formatter.appendValue(parameters[pos]);
-                formatter.append(" is not assignable to ");
+                formatter.append(" is not assignable to type ");
                 formatter.appendType(parameterTypes[i]);
             } else {
-                formatter.append("missing parameter of ");
+                formatter.append("missing parameter of type ");
                 formatter.appendType(parameterTypes[i]);
             }
             formatter.append(", or no service of type ");
-            formatter.append(serviceType.toString());
+            formatter.appendType(serviceType);
+            formatter.append(".");
             throw new IllegalArgumentException(formatter.toString());
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/InjectUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/InjectUtil.java
@@ -45,13 +45,13 @@ class InjectUtil {
             }
             if (constructor.getParameterTypes().length == 0) {
                 TreeFormatter formatter = new TreeFormatter();
-                formatter.node("The constructor for ");
+                formatter.node("The constructor for type ");
                 formatter.appendType(reportAs);
                 formatter.append(" should be public or package protected or annotated with @Inject.");
                 throw new IllegalArgumentException(formatter.toString());
             } else {
                 TreeFormatter formatter = new TreeFormatter();
-                formatter.node("The constructor for ");
+                formatter.node("The constructor for type ");
                 formatter.appendType(reportAs);
                 formatter.append(" should be annotated with @Inject.");
                 throw new IllegalArgumentException(formatter.toString());

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
@@ -86,7 +86,7 @@ class ParamsMatchingConstructorSelector implements ConstructorSelector {
                     match = constructor;
                 } else if (parameterTypes.length == match.getParameterTypes().length) {
                     TreeFormatter formatter = new TreeFormatter();
-                    formatter.node("Multiple constructors of ");
+                    formatter.node("Multiple constructors of type ");
                     formatter.appendType(type);
                     formatter.append(" match parameters: ");
                     formatter.appendValues(params);
@@ -99,7 +99,7 @@ class ParamsMatchingConstructorSelector implements ConstructorSelector {
         }
 
         TreeFormatter formatter = new TreeFormatter();
-        formatter.node("No constructors of ");
+        formatter.node("No constructors of type ");
         formatter.appendType(type);
         formatter.append(" match parameters: ");
         formatter.appendValues(params);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -18,18 +18,45 @@ package org.gradle.internal.isolated;
 
 import com.google.common.reflect.TypeToken;
 import org.gradle.internal.Cast;
+import org.gradle.internal.logging.text.TreeFormatter;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.ParameterizedType;
 
 public class IsolationScheme<IMPLEMENTATION, PARAMS> {
     private final Class<IMPLEMENTATION> interfaceType;
+    private final Class<PARAMS> paramsType;
+    private final Class<? extends PARAMS> noParamsType;
 
-    public IsolationScheme(Class<IMPLEMENTATION> interfaceType) {
+    public IsolationScheme(Class<IMPLEMENTATION> interfaceType, Class<PARAMS> paramsType, Class<? extends PARAMS> noParamsType) {
         this.interfaceType = interfaceType;
+        this.paramsType = paramsType;
+        this.noParamsType = noParamsType;
     }
 
+    /**
+     * Determines the parameters type for the given implementation.
+     *
+     * @return The parameters type, or {@code null} when the implementation takes no parameters.
+     */
+    @Nullable
     public <T extends IMPLEMENTATION, P extends PARAMS> Class<P> parameterTypeFor(Class<T> implementationType) {
         ParameterizedType superType = (ParameterizedType) TypeToken.of(implementationType).getSupertype(interfaceType).getType();
-        return Cast.uncheckedNonnullCast(TypeToken.of(superType.getActualTypeArguments()[0]).getRawType());
+        Class<P> parametersType = Cast.uncheckedNonnullCast(TypeToken.of(superType.getActualTypeArguments()[0]).getRawType());
+        if (parametersType == paramsType) {
+            TreeFormatter formatter = new TreeFormatter();
+            formatter.node("Could not create the parameters for ");
+            formatter.appendType(implementationType);
+            formatter.append(": must use a sub-type of ");
+            formatter.appendType(parametersType);
+            formatter.append(" as the parameters type. Use ");
+            formatter.appendType(noParamsType);
+            formatter.append(" as the parameters type for implementations that do not take parameters.");
+            throw new IllegalArgumentException(formatter.toString());
+        }
+        if (parametersType == noParamsType) {
+            return null;
+        }
+        return parametersType;
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/isolated/IsolationScheme.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.isolated;
+
+import com.google.common.reflect.TypeToken;
+import org.gradle.internal.Cast;
+
+import java.lang.reflect.ParameterizedType;
+
+public class IsolationScheme<IMPLEMENTATION, PARAMS> {
+    private final Class<IMPLEMENTATION> interfaceType;
+
+    public IsolationScheme(Class<IMPLEMENTATION> interfaceType) {
+        this.interfaceType = interfaceType;
+    }
+
+    public <T extends IMPLEMENTATION, P extends PARAMS> Class<P> parameterTypeFor(Class<T> implementationType) {
+        ParameterizedType superType = (ParameterizedType) TypeToken.of(implementationType).getSupertype(interfaceType).getType();
+        return Cast.uncheckedNonnullCast(TypeToken.of(superType.getActualTypeArguments()[0]).getRawType());
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -413,7 +413,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(PrivateBean.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Class " + PrivateBean.class.getName() + " is private."));
+            assertThat(e.getMessage(), equalTo("Class AsmBackedClassGeneratorTest.PrivateBean is private."));
         }
     }
 
@@ -423,7 +423,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(FinalBean.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Class " + FinalBean.class.getName() + " is final."));
+            assertThat(e.getMessage(), equalTo("Class AsmBackedClassGeneratorTest.FinalBean is final."));
         }
     }
 
@@ -433,7 +433,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(AbstractMethodBean.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for class " + AbstractMethodBean.class.getName() + "."));
+            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for type AsmBackedClassGeneratorTest.AbstractMethodBean."));
             assertThat(e.getCause().getMessage(), equalTo("Cannot have abstract method AbstractMethodBean.implementMe()."));
         }
     }
@@ -444,7 +444,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(AbstractGetterBean.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for class " + AbstractGetterBean.class.getName() + "."));
+            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for type AsmBackedClassGeneratorTest.AbstractGetterBean."));
             assertThat(e.getCause().getMessage(), equalTo("Cannot have abstract method AbstractGetterBean.getThing()."));
         }
     }
@@ -455,7 +455,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(AbstractSetterBean.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for class " + AbstractSetterBean.class.getName() + "."));
+            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for type AsmBackedClassGeneratorTest.AbstractSetterBean."));
             assertThat(e.getCause().getMessage(), equalTo("Cannot have abstract method AbstractSetterBean.setThing()."));
         }
     }
@@ -466,7 +466,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(AbstractSetMethodBean.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for class " + AbstractSetMethodBean.class.getName() + "."));
+            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for type AsmBackedClassGeneratorTest.AbstractSetMethodBean."));
             assertThat(e.getCause().getMessage(), equalTo("Cannot have abstract method AbstractSetMethodBean.thing()."));
         }
     }
@@ -478,7 +478,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(GetterBeanInterface.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for interface " + GetterBeanInterface.class.getName() + "."));
+            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for type AsmBackedClassGeneratorTest.GetterBeanInterface."));
             assertThat(e.getCause().getMessage(), equalTo("Cannot have abstract method GetterBeanInterface.getThing()."));
         }
     }
@@ -489,7 +489,7 @@ public class AsmBackedClassGeneratorTest {
             newInstance(SetterBeanInterface.class);
             fail();
         } catch (ClassGenerationException e) {
-            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for interface " + SetterBeanInterface.class.getName() + "."));
+            assertThat(e.getMessage(), equalTo("Could not generate a decorated class for type AsmBackedClassGeneratorTest.SetterBeanInterface."));
             assertThat(e.getCause().getMessage(), equalTo("Cannot have abstract method SetterBeanInterface.setThing()."));
         }
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectingInstantiatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectingInstantiatorTest.groovy
@@ -128,7 +128,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Too many parameters provided for constructor for class $HasOneInjectConstructor.name. Expected 1, received 2."
+        e.cause.message == "Too many parameters provided for constructor for type DependencyInjectingInstantiatorTest.HasOneInjectConstructor. Expected 1, received 2."
     }
 
     def "fails when supplied parameters cannot be used to call constructor"() {
@@ -140,7 +140,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Unable to determine constructor argument #1: value string not assignable to class java.lang.Number"
+        e.cause.message == "Unable to determine constructor argument #1: value string not assignable to type Number."
     }
 
     def "fails on missing service"() {
@@ -153,7 +153,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Unable to determine constructor argument #1: value 12 is not assignable to class java.lang.String, or no service of type class java.lang.String"
+        e.cause.message == "Unable to determine constructor argument #1: value 12 is not assignable to type String, or no service of type String."
     }
 
     def "fails on non-static inner class"() {
@@ -163,7 +163,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Class ${NonStatic.name} is a non-static inner class."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.NonStatic is a non-static inner class."
     }
 
     def "fails when class has multiple constructors and none are annotated"() {
@@ -172,7 +172,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class $HasNoInjectConstructor.name has no constructor that is annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasNoInjectConstructor has no constructor that is annotated with @Inject."
     }
 
     def "fails when class has multiple constructors with different visibilities and none are annotated"() {
@@ -181,7 +181,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class $HasMixedConstructors.name has no constructor that is annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMixedConstructors has no constructor that is annotated with @Inject."
     }
 
     def "fails when class has multiple constructors that are annotated"() {
@@ -190,7 +190,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class $HasMultipleInjectConstructors.name has multiple constructors that are annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMultipleInjectConstructors has multiple constructors that are annotated with @Inject."
     }
 
     def "fails when class has multiple constructors with different visibilities that are annotated"() {
@@ -199,7 +199,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "Class $HasMixedInjectConstructors.name has multiple constructors that are annotated with @Inject."
+        e.cause.message == "Class DependencyInjectingInstantiatorTest.HasMixedInjectConstructors has multiple constructors that are annotated with @Inject."
     }
 
     def "fails when class has non-public zero args constructor that is not annotated"() {
@@ -211,7 +211,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "The constructor for class $HasNonPublicNoArgsConstructor.name should be public or package protected or annotated with @Inject."
+        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasNonPublicNoArgsConstructor should be public or package protected or annotated with @Inject."
     }
 
     def "fails when class has public constructor with args and that is not annotated"() {
@@ -223,7 +223,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "The constructor for class $HasSingleConstructorWithArgsAndNoAnnotation.name should be annotated with @Inject."
+        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasSingleConstructorWithArgsAndNoAnnotation should be annotated with @Inject."
     }
 
     def "fails when class has private constructor with args and that is not annotated"() {
@@ -232,7 +232,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
 
         then:
         ObjectInstantiationException e = thrown()
-        e.cause.message == "The constructor for class $HasPrivateArgsConstructor.name should be annotated with @Inject."
+        e.cause.message == "The constructor for type DependencyInjectingInstantiatorTest.HasPrivateArgsConstructor should be annotated with @Inject."
     }
 
     def "fails when null passed as constructor argument value"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
@@ -91,7 +91,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Unable to determine constructor argument #2: null value is not assignable to boolean"
+        e.cause.message == "Unable to determine constructor argument #2: null value is not assignable to type boolean."
     }
 
     def "fails when null value is provided for primitive parameter and services expected"() {
@@ -101,7 +101,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Unable to determine constructor argument #1: null value is not assignable to int"
+        e.cause.message == "Unable to determine constructor argument #1: null value is not assignable to type int."
     }
 
     def "fails when parameters do not match constructor"() {
@@ -111,7 +111,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Unable to determine constructor argument #2: value 'b' not assignable to class java.lang.Number"
+        e.cause.message == "Unable to determine constructor argument #2: value 'b' not assignable to type Number."
     }
 
     def "fails when no constructors match parameters"() {
@@ -121,7 +121,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "No constructors of class $HasConstructors.name match parameters: ['a', 'b']"
+        e.cause.message == "No constructors of type DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors match parameters: ['a', 'b']"
     }
 
     def "fails when no constructors are ambiguous"() {
@@ -131,7 +131,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Multiple constructors of class $HasConstructors.name match parameters: ['a']"
+        e.cause.message == "Multiple constructors of type DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors match parameters: ['a']"
     }
 
     def "fails on non-static inner class when outer type not provided as first parameter"() {
@@ -147,7 +147,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Class ${NonStatic.name} is a non-static inner class."
+        e.cause.message == "Class DependencyInjectionUsingLenientConstructorSelectorTest.NonStatic is a non-static inner class."
     }
 
     def "fails on non-static inner class when outer type not provided as first parameter when type takes constructor params"() {
@@ -166,7 +166,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == "Class ${NonStaticWithParams.name} is a non-static inner class."
+        e.cause.message == "Class DependencyInjectionUsingLenientConstructorSelectorTest.NonStaticWithParams is a non-static inner class."
     }
 
     static class HasDefaultConstructor {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.isolated
+
+import spock.lang.Specification
+
+class IsolationSchemeTest extends Specification {
+    def scheme = new IsolationScheme(SomeAction)
+
+    def "can extract parameters type"() {
+        expect:
+        scheme.parameterTypeFor(DirectUsage) == CustomParams
+        scheme.parameterTypeFor(IndirectUsage) == CustomParams
+    }
+}
+
+interface SomeParams {
+}
+
+interface SomeAction<P extends SomeParams> {
+}
+
+interface CustomParams extends SomeParams {
+}
+
+class DirectUsage implements SomeAction<CustomParams> {
+}
+
+interface Indirect<P> extends SomeAction<CustomParams> {
+}
+
+class IndirectUsage implements Indirect<Number> {
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/isolated/IsolationSchemeTest.groovy
@@ -19,17 +19,39 @@ package org.gradle.internal.isolated
 import spock.lang.Specification
 
 class IsolationSchemeTest extends Specification {
-    def scheme = new IsolationScheme(SomeAction)
+    def scheme = new IsolationScheme(SomeAction, SomeParams, Nothing)
 
     def "can extract parameters type"() {
         expect:
         scheme.parameterTypeFor(DirectUsage) == CustomParams
         scheme.parameterTypeFor(IndirectUsage) == CustomParams
+        scheme.parameterTypeFor(NoParams) == null
+        scheme.parameterTypeFor(ParameterizedType) == CustomParams
+    }
+
+    def "fails when base parameters type is used"() {
+        when:
+        scheme.parameterTypeFor(BaseParams)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Could not create the parameters for BaseParams: must use a sub-type of SomeParams as the parameters type. Use Nothing as the parameters type for implementations that do not take parameters."
+    }
+
+    def "fails when parameters type has not been declared"() {
+        when:
+        scheme.parameterTypeFor(RawActionType)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Could not create the parameters for RawActionType: must use a sub-type of SomeParams as the parameters type. Use Nothing as the parameters type for implementations that do not take parameters."
     }
 }
 
 interface SomeParams {
 }
+
+interface Nothing extends SomeParams {}
 
 interface SomeAction<P extends SomeParams> {
 }
@@ -44,4 +66,16 @@ interface Indirect<P> extends SomeAction<CustomParams> {
 }
 
 class IndirectUsage implements Indirect<Number> {
+}
+
+class NoParams implements SomeAction<Nothing> {
+}
+
+class BaseParams implements SomeAction<SomeParams> {
+}
+
+class RawActionType implements SomeAction {
+}
+
+class ParameterizedType<T extends CustomParams> implements SomeAction<T> {
 }

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/binary/BaseBinarySpecTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/binary/BaseBinarySpecTest.groovy
@@ -70,7 +70,7 @@ class BaseBinarySpecTest extends PlatformBaseSpecification {
         e.cause instanceof ModelInstantiationException
         e.cause.message == "Could not create binary of type SampleBinary"
         e.cause.cause instanceof IllegalArgumentException
-        e.cause.cause.message == "Unable to determine constructor argument #1: missing parameter of class java.lang.String, or no service of type class java.lang.String"
+        e.cause.cause.message == "Unable to determine constructor argument #1: missing parameter of type String, or no service of type String."
     }
 
     def "can own source sets"() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.workers.IsolationMode
+import org.gradle.workers.WorkParameters
 import org.gradle.workers.fixtures.WorkerExecutorFixture
 import spock.lang.Unroll
 
@@ -308,7 +309,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         fails("runInWorker")
 
         then:
-        failure.assertHasCause("Could not create worker parameters: must use a sub-type of WorkParameters as parameter type. Use WorkParameters.None for executions without parameters.")
+        failure.assertHasCause("Could not create the parameters for BadWorkAction: must use a sub-type of WorkParameters as the parameters type. Use WorkParameters.None as the parameters type for implementations that do not take parameters.")
     }
 
     String getUnrecognizedOptionError() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
@@ -35,7 +35,7 @@ class WorkerExecutorInjectionIntegrationTest extends AbstractWorkerExecutorInteg
 
         and:
         failure.assertHasCause("Could not create an instance of type InjectingExecution.")
-        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of $forbiddenType, or no service of type $forbiddenType")
+        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of type $forbiddenType.simpleName, or no service of type $forbiddenType.simpleName")
 
         where:
         forbiddenType << [Project]

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLegacyApiIntegrationTest.groovy
@@ -132,7 +132,7 @@ class WorkerExecutorLegacyApiIntegrationTest extends AbstractIntegrationSpec {
         then:
         failureHasCause("A failure occurred while executing RunnableWithDifferentConstructor")
         failureHasCause("Could not create an instance of type RunnableWithDifferentConstructor.")
-        failureHasCause("Too many parameters provided for constructor for class RunnableWithDifferentConstructor. Expected 2, received 4.")
+        failureHasCause("Too many parameters provided for constructor for type RunnableWithDifferentConstructor. Expected 2, received 4.")
 
         where:
         isolationMode << ISOLATION_MODES

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
@@ -117,7 +117,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
 
         and:
         failure.assertHasCause("Could not create an instance of type FirstLevelExecution.")
-        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of interface org.gradle.workers.WorkerExecutor, or no service of type interface org.gradle.workers.WorkerExecutor")
+        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of type WorkerExecutor, or no service of type WorkerExecutor")
 
         where:
         nestedIsolationMode << ISOLATION_MODES
@@ -139,7 +139,7 @@ class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegra
 
         and:
         failure.assertHasCause("Could not create an instance of type FirstLevelExecution.")
-        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of interface org.gradle.workers.WorkerExecutor, or no service of type interface org.gradle.workers.WorkerExecutor")
+        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of type WorkerExecutor, or no service of type WorkerExecutor")
 
         where:
         nestedIsolationMode << ISOLATION_MODES

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorServicesIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorServicesIntegrationTest.groovy
@@ -36,7 +36,7 @@ class WorkerExecutorServicesIntegrationTest extends AbstractWorkerExecutorIntegr
         fails("runInWorker")
 
         and:
-        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of interface org.gradle.api.internal.file.FileOperations, or no service of type interface org.gradle.api.internal.file.FileOperations")
+        failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of type FileOperations, or no service of type FileOperations")
 
         where:
         isolationMode << ISOLATION_MODES

--- a/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/WorkQueue.java
@@ -36,10 +36,8 @@ public interface WorkQueue {
      * Work submitted using {@link WorkerExecutor#processIsolation()} will execute in an idle daemon that meets the requirements set
      * in the {@link ProcessWorkerSpec}.  If no idle daemons are available, a new daemon will be started.  Any errors
      * will be thrown from {@link #await()} or from the surrounding task action if {@link #await()} is not used.
-     *
-     *
      */
-    <T extends WorkParameters> void submit(Class<? extends WorkAction<T>> workActionClass, Action<T> parameterAction);
+    <T extends WorkParameters> void submit(Class<? extends WorkAction<T>> workActionClass, Action<? super T> parameterAction);
 
     /**
      * Blocks until all work associated with this queue is complete.  Note that when using this method inside


### PR DESCRIPTION

### Context

Refine the API added in https://github.com/gradle/gradle/pull/11256:

- Rename `BuildServiceRegistry.maybeRegister()` to `registerIfAbsent()`
- Add `BuildServiceParameters.None` to be used to indicate that a service implementation does not take any parameters.
- Inject isolated parameters into the service when instantiating it (in the previous PR these were not isolated)
- Start extracting some infrastructure to help implement this pattern, now that there are 3 different places that use it.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
