### PR TITLE
Add OS as inputs for unit tests

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -40,12 +40,6 @@ import java.util.concurrent.Callable
  */
 open class DistributionTest : Test() {
 
-    @get:Input
-    val operatingSystem by lazy {
-        // the version currently differs between our dev infrastructure, so we only track the name and the architecture
-        "${OperatingSystem.current().name} ${System.getProperty("os.arch")}"
-    }
-
     @Internal
     val binaryDistributions = BinaryDistributions(project.objects)
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -203,7 +203,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
 
     private
     fun Test.addOsAsInputs() {
-        // https://github.com/gradle/gradle-private/issues/2831
+        // Add OS as inputs since tests on different OS may behave differently https://github.com/gradle/gradle-private/issues/2831
+        // the version currently differs between our dev infrastructure, so we only track the name and the architecture
         inputs.property("operatingSystem", "${OperatingSystem.current().name} ${System.getProperty("os.arch")}")
     }
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -37,6 +37,7 @@ import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.BuildEnvironment.agentNum
 import org.gradle.gradlebuild.java.AvailableJavaInstallationsPlugin
 import org.gradle.gradlebuild.java.JavaInstallation
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
@@ -201,11 +202,18 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
     }
 
     private
+    fun Test.addOsAsInputs() {
+        // https://github.com/gradle/gradle-private/issues/2831
+        inputs.property("operatingSystem", "${OperatingSystem.current().name} ${System.getProperty("os.arch")}")
+    }
+
+    private
     fun Project.configureTests() {
         tasks.withType<Test>().configureEach {
             maxParallelForks = project.maxParallelForks
 
             configureJvmForTest()
+            addOsAsInputs()
 
             doFirst {
                 if (BuildEnvironment.isCiServer) {


### PR DESCRIPTION
### Context

This closes https://github.com/gradle/gradle-private/issues/2831

Previously we only add OS as inputs for integration tests but not for unit tests. This results in missing test coverage for some unit tests, for example, this test has been failing on mac agents for a long time: https://e.grdev.net/s/cqljg7qhfleg6 but is ignored by FROM-CACHE: https://e.grdev.net/s/yvzdsbrezu7zk/timeline?taskFilter=messaging:test#5g5tyzhv25sla

We need to add OS as inputs of unit test task as well.