### PR TITLE
Maven publish: resolve project constraint versions from maven publications

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
@@ -33,7 +33,7 @@ import java.util.Collections;
  * platforms.
  */
 public class DefaultProjectDependencyConstraint implements DependencyConstraintInternal {
-    private final ProjectDependency projectDependency;
+    public final ProjectDependency projectDependency;
     private String reason;
     private boolean force;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
@@ -33,12 +33,16 @@ import java.util.Collections;
  * platforms.
  */
 public class DefaultProjectDependencyConstraint implements DependencyConstraintInternal {
-    public final ProjectDependency projectDependency;
+    private final ProjectDependency projectDependency;
     private String reason;
     private boolean force;
 
     public DefaultProjectDependencyConstraint(ProjectDependency projectDependency) {
         this.projectDependency = projectDependency;
+    }
+
+    public ProjectDependency getProjectDependency() {
+        return projectDependency;
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -42,6 +42,7 @@ import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MavenVersionUtils;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme;
@@ -315,11 +316,15 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
             Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(usageContext);
             for (DependencyConstraint dependency : usageContext.getDependencyConstraints()) {
-                if (seenConstraints.add(dependency) && dependency.getVersion() != null) {
-                    if (!versionMappingInUse && isVersionMavenIncompatible(dependency.getVersion())) {
-                        publicationWarningsCollector.addIncompatible(String.format("constraint %s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                if (seenConstraints.add(dependency)) {
+                    if (dependency instanceof DefaultProjectDependencyConstraint) {
+                        addDependencyConstraint((DefaultProjectDependencyConstraint) dependency, dependencyConstraints);
+                    } else if (dependency.getVersion() != null) {
+                        if (!versionMappingInUse && isVersionMavenIncompatible(dependency.getVersion())) {
+                            publicationWarningsCollector.addIncompatible(String.format("constraint %s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                        }
+                        addDependencyConstraint(dependency, dependencyConstraints);
                     }
-                    addDependencyConstraint(dependency, dependencyConstraints);
                 }
             }
             if (!usageContext.getCapabilities().isEmpty()) {
@@ -437,6 +442,11 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
     private void addDependencyConstraint(DependencyConstraint dependency, Set<MavenDependency> dependencies) {
         dependencies.add(new DefaultMavenDependency(dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+    }
+
+    private void addDependencyConstraint(DefaultProjectDependencyConstraint dependency, Set<MavenDependency> dependencies) {
+        ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, dependency.projectDependency);
+        dependencies.add(new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion()));
     }
 
     private static Set<ExcludeRule> getExcludeRules(Set<ExcludeRule> globalExcludes, ModuleDependency dependency) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -445,7 +445,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     private void addDependencyConstraint(DefaultProjectDependencyConstraint dependency, Set<MavenDependency> dependencies) {
-        ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, dependency.projectDependency);
+        ProjectDependency projectDependency = dependency.getProjectDependency();
+        ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, projectDependency);
         dependencies.add(new DefaultMavenDependency(identifier.getGroup(), identifier.getName(), identifier.getVersion()));
     }
 

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -443,8 +443,6 @@ public class GradleModuleMetadataWriter {
             if (variantVersionMappingStrategy != null) {
                 ModuleVersionIdentifier resolved = variantVersionMappingStrategy.maybeResolveVersion(identifier.getGroup(), identifier.getName());
                 if (resolved != null) {
-                    // vlsi: this looks like a bug. It causes identifier.getVersion() == resolvedVersion below
-                    // So either one of the variables should be removed or the below two lines should be swapped
                     identifier = resolved;
                     resolvedVersion = identifier.getVersion();
                 }
@@ -537,11 +535,11 @@ public class GradleModuleMetadataWriter {
         jsonWriter.beginObject();
         String group;
         String module;
-        // vlsi: please review. I've no idea what I'm doing here
         String resolvedVersion = null;
         if (dependencyConstraint instanceof DefaultProjectDependencyConstraint) {
             DefaultProjectDependencyConstraint dependency = (DefaultProjectDependencyConstraint) dependencyConstraint;
-            ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, dependency.projectDependency);
+            ProjectDependency projectDependency = dependency.getProjectDependency();
+            ModuleVersionIdentifier identifier = projectDependencyResolver.resolve(ModuleVersionIdentifier.class, projectDependency);
             group = identifier.getGroup();
             module = identifier.getName();
             resolvedVersion = identifier.getVersion();


### PR DESCRIPTION
Initially I thought it fixes https://github.com/gradle/gradle/issues/11299, however, it seems to fix another issue.

In other words: this PR adds an integration test for "project dependency constraint", however, my initial issue was re plain project dependencies.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
