### PR TITLE
Fix Groovy samples about transitive dependencies

### DIFF
--- a/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/groovy/utilities/build.gradle
+++ b/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/groovy/utilities/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'java-library'
     id 'groovy'
 }
 
@@ -7,6 +8,6 @@ repositories {
 }
 
 dependencies {
-    compile project(':list')
+    api project(':list')
     implementation 'org.codehaus.groovy:groovy-all:2.5.7'
 }

--- a/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/kotlin/utilities/build.gradle.kts
+++ b/subprojects/docs/src/samples/next-gen/groovy/transitive-dependencies/kotlin/utilities/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    `java-library`
     groovy
 }
 
@@ -7,6 +8,6 @@ repositories {
 }
 
 dependencies {
-    compile(project(":list"))
+    api(project(":list"))
     implementation("org.codehaus.groovy:groovy-all:2.5.7")
 }


### PR DESCRIPTION
It was using the deprecated `compile` instead of using `api` through the
 application of the `java-library` plugin.