### PR TITLE
Allow publication artifacts to be defined as files through providers

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
@@ -25,12 +25,17 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
     void "can publish custom artifacts"() {
         given:
         createBuildScripts("""
+            file("customFile.foo") << 'some foo'
+            file("customFile.bar") << 'some bar'
+
             publications {
                 ivy(IvyPublication) {
                     artifact "customFile.txt"
                     artifact customDocsTask.outputFile
                     artifact regularFileTask.outputFile
                     artifact customJar
+                    artifact provider { file("customFile.foo") }
+                    artifact provider { "customFile.bar" }
                 }
             }
 """, """
@@ -46,7 +51,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
 
         then:
         module.assertPublished()
-        module.assertArtifactsPublished("ivy-2.4.xml", "ivyPublish-2.4.txt", "ivyPublish-2.4.html", "ivyPublish-2.4.reg", "ivyPublish-2.4.jar")
+        module.assertArtifactsPublished("ivy-2.4.xml", "ivyPublish-2.4.txt",  "ivyPublish-2.4.foo", "ivyPublish-2.4.bar", "ivyPublish-2.4.html", "ivyPublish-2.4.reg", "ivyPublish-2.4.jar")
 
         and:
         def ivy = module.parsedIvy
@@ -54,11 +59,13 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
         ivy.expectArtifact('ivyPublish', 'html').hasType("html").hasConf(null)
         ivy.expectArtifact('ivyPublish', 'jar').hasType("jar").hasConf(null)
         ivy.expectArtifact('ivyPublish', 'reg').hasType("reg").hasConf(null)
+        ivy.expectArtifact('ivyPublish', 'foo').hasType("foo").hasConf(null)
+        ivy.expectArtifact('ivyPublish', 'bar').hasType("bar").hasConf(null)
 
         and:
         resolveArtifacts(module) {
             withoutModuleMetadata {
-                expectFiles "ivyPublish-2.4.html", "ivyPublish-2.4.jar", "ivyPublish-2.4.reg", "ivyPublish-2.4.txt"
+                expectFiles "ivyPublish-2.4.html", "ivyPublish-2.4.jar", "ivyPublish-2.4.reg", "ivyPublish-2.4.txt",  "ivyPublish-2.4.foo", "ivyPublish-2.4.bar"
             }
             withModuleMetadata {
                 noComponentPublished()

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishArtifactCustomizationIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishArtifactCustomizationIntegTest.groovy
@@ -23,11 +23,16 @@ class MavenPublishArtifactCustomizationIntegTest extends AbstractMavenPublishInt
     def "can attach custom artifacts"() {
         given:
         createBuildScripts("""
+            file("customFile.foo") << 'some foo'
+            file("customFile.bar") << 'some bar'
+
             publications {
                 mavenCustom(MavenPublication) {
                     artifact "customFile.txt"
                     artifact customJar
                     artifact regularFileTask.outputFile
+                    artifact provider { file("customFile.foo") }
+                    artifact provider { "customFile.bar" }
                 }
             }
 """)
@@ -37,7 +42,7 @@ class MavenPublishArtifactCustomizationIntegTest extends AbstractMavenPublishInt
         then:
         def module = mavenRepo.module("group", "projectText", "1.0")
         module.assertPublished()
-        module.assertArtifactsPublished("projectText-1.0.pom", "projectText-1.0.txt", "projectText-1.0-customjar.jar", "projectText-1.0.reg")
+        module.assertArtifactsPublished("projectText-1.0.pom", "projectText-1.0.txt", "projectText-1.0.foo", "projectText-1.0.bar", "projectText-1.0-customjar.jar", "projectText-1.0.reg")
 
         and:
         resolveArtifacts(module) {
@@ -47,6 +52,24 @@ class MavenPublishArtifactCustomizationIntegTest extends AbstractMavenPublishInt
             }
             withoutModuleMetadata {
                 expectFiles "projectText-1.0.txt"
+            }
+        }
+        resolveArtifacts(module) {
+            ext = 'foo'
+            withModuleMetadata {
+                noComponentPublished()
+            }
+            withoutModuleMetadata {
+                expectFiles "projectText-1.0.foo"
+            }
+        }
+        resolveArtifacts(module) {
+            ext = 'bar'
+            withModuleMetadata {
+                noComponentPublished()
+            }
+            withoutModuleMetadata {
+                expectFiles "projectText-1.0.bar"
             }
         }
         resolveArtifacts(module) {


### PR DESCRIPTION
This used to work in Gradle 5.5 (see #11054).

The combination of #9467 and #6775 broke this.

A builtBy dependency is added if the artifact is a TaskDependencyContainer,
which all Providers are (#9467). This dependency was silently doing
nothing in case of a plain File/String. This became an error (#6775)
because a File/String is nothing that can be resolved to a task.

We now only add a builtBy dependency, if the provider value or content is
actually produced by a task.
