### PR TITLE
Preserve behaviour of `fileTree(mapOf(...))` for backward compatibility

### DIFF
--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -219,8 +219,7 @@ class KotlinBuildScriptIntegrationTest : AbstractKotlinIntegrationTest() {
 
         val fileTreeFromMap = """
             fileTree(mapOf("dir" to ".", "include" to listOf("*.txt")))
-                .map { it.name }
-                .joinToString()
+                .joinToString { it.name }
         """
 
         withFile("foo.txt")

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -4,6 +4,7 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.kotlin.dsl.fixtures.equalToMultiLineString
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
@@ -210,6 +211,41 @@ class KotlinBuildScriptIntegrationTest : AbstractKotlinIntegrationTest() {
                 STRING
                 ACTION
             """)
+        )
+    }
+
+    @Test
+    fun `can create fileTree from map for backward compatibility`() {
+
+        val fileTreeFromMap = """
+            fileTree(mapOf("dir" to ".", "include" to listOf("*.txt")))
+                .map { it.name }
+                .joinToString()
+        """
+
+        withFile("foo.txt")
+
+        val initScript = withFile("init.gradle.kts", """
+            println("INIT: " + $fileTreeFromMap)
+        """)
+
+        withSettings("""
+            println("SETTINGS: " + $fileTreeFromMap)
+        """)
+
+        withBuildScript("""
+            task("test") {
+                doLast { println("PROJECT: " + $fileTreeFromMap) }
+            }
+        """)
+
+        assertThat(
+            build("test", "-q", "-I", initScript.absolutePath).output.trim(),
+            equalToMultiLineString("""
+                INIT: foo.txt
+                SETTINGS: foo.txt
+                PROJECT: foo.txt
+            """.replaceIndent())
         )
     }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/DefaultKotlinScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/DefaultKotlinScript.kt
@@ -81,9 +81,11 @@ open class DefaultKotlinScript internal constructor(
         fileOperations.configurableFiles(paths).also(configuration::execute)
 
     override fun fileTree(baseDir: Any): ConfigurableFileTree =
-        @Suppress("unchecked_cast")
         when (baseDir) {
-            is Map<*, *> -> fileOperations.fileTree(baseDir as Map<String, *>)
+            is Map<*, *> -> {
+                @Suppress("unchecked_cast")
+                fileOperations.fileTree(baseDir as Map<String, *>)
+            }
             else -> fileOperations.fileTree(baseDir)
         }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/DefaultKotlinScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/DefaultKotlinScript.kt
@@ -81,7 +81,11 @@ open class DefaultKotlinScript internal constructor(
         fileOperations.configurableFiles(paths).also(configuration::execute)
 
     override fun fileTree(baseDir: Any): ConfigurableFileTree =
-        fileOperations.fileTree(baseDir)
+        @Suppress("unchecked_cast")
+        when (baseDir) {
+            is Map<*, *> -> fileOperations.fileTree(baseDir as Map<String, *>)
+            else -> fileOperations.fileTree(baseDir)
+        }
 
     override fun fileTree(baseDir: Any, configuration: Action<ConfigurableFileTree>): ConfigurableFileTree =
         fileOperations.fileTree(baseDir).also(configuration::execute)


### PR DESCRIPTION
See #11335