### PR TITLE
Make query methods for deprecation state of core configurations public

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
@@ -26,6 +27,7 @@ import org.gradle.internal.HasInternalProtocol;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -539,4 +541,48 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      */
     boolean isCanBeResolved();
 
+    /**
+     * This method can be used to determine if a configuration of a Gradle core plugin is deprecated
+     * for declaring dependencies. If it is the case, the method returns a list, if not it returns 'null'.
+     *
+     * @return configurations that should be used to declare dependencies instead of this configuration or 'null'
+     * @since 6.1
+     */
+    @Incubating
+    @Nullable
+    List<String> getDeclarationAlternatives();
+
+    /**
+     * This method can be used to determine if a configuration of a Gradle core plugin is deprecated
+     * for consumption (i.e., {@link #isCanBeConsumed()} will return false in the future.
+     * If it is the case, the method returns a list, if not it returns 'null'.
+     *
+     * @return configurations that should be used for consumption instead of this configuration or 'null'
+     * @since 6.1
+     */
+    @Incubating
+    @Nullable
+    List<String> getConsumptionAlternatives();
+
+    /**
+     * This method can be used to determine if a configuration of a Gradle core plugin is deprecated
+     * for resolution (i.e., {@link #isCanBeResolved()} will return false in the future}.
+     * If it is the case, the method returns a list, if not it returns 'null'.
+     *
+     * @return configurations that should be used for resolution instead of this configuration or 'null'
+     * @since 6.1
+     */
+    @Incubating
+    @Nullable
+    List<String> getResolutionAlternatives();
+
+    /**
+     * If this is a Gradle core plugin configuration: Is all functionality either deprecated or
+     * disabled (via {@link #setCanBeConsumed(boolean)} ()} and/or {@link #setCanBeResolved(boolean)})?
+     *
+     * @return true, if all functionality of the configuration is either deprecated or disabled
+     * @since 6.1
+     */
+    @Incubating
+    boolean isFullyDeprecated();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.initialization.ProjectAccessListener;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
@@ -85,11 +84,11 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         if (!selectedConfiguration.isCanBeConsumed()) {
             throw new ConfigurationNotConsumableException(dependencyProject.getDisplayName(), selectedConfiguration.getName());
         }
-        warnIfConfigurationIsDeprecated((DeprecatableConfiguration) selectedConfiguration);
+        warnIfConfigurationIsDeprecated(selectedConfiguration);
         return selectedConfiguration;
     }
 
-    private void warnIfConfigurationIsDeprecated(DeprecatableConfiguration selectedConfiguration) {
+    private void warnIfConfigurationIsDeprecated(Configuration selectedConfiguration) {
         List<String> alternatives = selectedConfiguration.getConsumptionAlternatives();
         if (alternatives != null) {
             DeprecationLogger.nagUserOfReplacedConfiguration(selectedConfiguration.getName(), DeprecationLogger.ConfigurationDeprecationType.CONSUMPTION, alternatives);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.DependencyConstraintSet;
 import org.gradle.api.internal.DelegatingDomainObjectSet;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.util.DeprecationLogger;
 
 import java.util.Collection;
@@ -49,7 +48,7 @@ public class DefaultDependencyConstraintSet extends DelegatingDomainObjectSet<De
     }
 
     private void warnIfConfigurationIsDeprecated() {
-        List<String> alternatives = ((DeprecatableConfiguration) clientConfiguration).getDeclarationAlternatives();
+        List<String> alternatives = clientConfiguration.getDeclarationAlternatives();
         if (alternatives != null) {
             DeprecationLogger.nagUserOfReplacedConfiguration(clientConfiguration.getName(), DeprecationLogger.ConfigurationDeprecationType.DEPENDENCY_DECLARATION, alternatives);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependency;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Actions;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.util.DeprecationLogger;
 
 import java.util.Collection;
@@ -69,7 +68,7 @@ public class DefaultDependencySet extends DelegatingDomainObjectSet<Dependency> 
     }
 
     private void warnIfConfigurationIsDeprecated() {
-        List<String> alternatives = ((DeprecatableConfiguration) clientConfiguration).getDeclarationAlternatives();
+        List<String> alternatives = clientConfiguration.getDeclarationAlternatives();
         if (alternatives != null) {
             DeprecationLogger.nagUserOfReplacedConfiguration(clientConfiguration.getName(), DeprecationLogger.ConfigurationDeprecationType.DEPENDENCY_DECLARATION, alternatives);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.internal.Actions;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.internal.metaobject.MethodMixIn;
@@ -54,14 +53,14 @@ public class DefaultArtifactHandler implements ArtifactHandler, MethodMixIn {
     }
 
     private PublishArtifact pushArtifact(Configuration configuration, Object notation, Action<? super ConfigurablePublishArtifact> configureAction) {
-        warnIfConfigurationIsDeprecated((DeprecatableConfiguration) configuration);
+        warnIfConfigurationIsDeprecated(configuration);
         ConfigurablePublishArtifact publishArtifact = publishArtifactFactory.parseNotation(notation);
         configuration.getArtifacts().add(publishArtifact);
         configureAction.execute(publishArtifact);
         return publishArtifact;
     }
 
-    private void warnIfConfigurationIsDeprecated(DeprecatableConfiguration configuration) {
+    private void warnIfConfigurationIsDeprecated(Configuration configuration) {
         if (configuration.isFullyDeprecated()) {
             DeprecationLogger.nagUserOfReplacedConfiguration(configuration.getName(), DeprecationLogger.ConfigurationDeprecationType.ARTIFACT_DECLARATION,
                 GUtil.flattenElements(configuration.getDeclarationAlternatives(), configuration.getConsumptionAlternatives()));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
@@ -18,36 +18,7 @@ package org.gradle.internal.deprecation;
 
 import org.gradle.api.artifacts.Configuration;
 
-import javax.annotation.Nullable;
-import java.util.List;
-
 public interface DeprecatableConfiguration extends Configuration {
-
-    /**
-     * @return configurations that should be used to declare dependencies instead of this configuration.
-     *         Returns 'null' if this configuration is not deprecated for declaration.
-     */
-    @Nullable
-    List<String> getDeclarationAlternatives();
-
-    /**
-     * @return configurations that should be used to consume a component instead of consuming this configuration.
-     *         Returns 'null' if this configuration is not deprecated for consumption.
-     */
-    @Nullable
-    List<String> getConsumptionAlternatives();
-
-    /**
-     * @return configurations that should be used to consume a component instead of consuming this configuration.
-     *         Returns 'null' if this configuration is not deprecated for resolution.
-     */
-    @Nullable
-    List<String> getResolutionAlternatives();
-
-    /**
-     * @return true, if all functionality of the configuration is either disabled or deprecated
-     */
-    boolean isFullyDeprecated();
 
     /**
      * Allows plugins to deprecate a configuration that will be removed in the next major Gradle version.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandlerTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.api.internal.artifacts.dsl
 
 import org.gradle.api.Action
 import org.gradle.api.artifacts.ConfigurablePublishArtifact
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.PublishArtifactSet
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
-import org.gradle.internal.deprecation.DeprecatableConfiguration
 import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -33,7 +33,7 @@ class DefaultArtifactHandlerTest extends Specification {
 
     private ConfigurationContainer configurationContainerStub = Mock()
     private NotationParser<Object, PublishArtifact> artifactFactoryStub = Mock()
-    private DeprecatableConfiguration configurationMock = Mock()
+    private Configuration configurationMock = Mock()
     private PublishArtifactSet artifactsMock = Mock()
 
     private DefaultArtifactHandler artifactHandler = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultArtifactHandler, configurationContainerStub, artifactFactoryStub)

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/JsonProjectDependencyRenderer.java
@@ -36,7 +36,6 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependenc
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableModuleResult;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvableConfigurationResult;
 import org.gradle.api.tasks.diagnostics.internal.insight.DependencyInsightReporter;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.GradleVersion;
 
@@ -149,7 +148,7 @@ public class JsonProjectDependencyRenderer {
     private List<Configuration> getNonDeprecatedConfigurations(Project project) {
         List<Configuration> filteredConfigurations = new ArrayList<Configuration>();
         for (Configuration configuration : project.getConfigurations()) {
-            if (!((DeprecatableConfiguration) configuration).isFullyDeprecated()) {
+            if (!configuration.isFullyDeprecated()) {
                 filteredConfigurations.add(configuration);
             }
         }
@@ -157,7 +156,7 @@ public class JsonProjectDependencyRenderer {
     }
 
     private boolean canBeResolved(Configuration configuration) {
-        boolean isDeprecatedForResolving = ((DeprecatableConfiguration) configuration).getResolutionAlternatives() != null;
+        boolean isDeprecatedForResolving = configuration.getResolutionAlternatives() != null;
         return configuration.isCanBeResolved() && !isDeprecatedForResolving;
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
@@ -23,7 +23,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer;
 import org.gradle.api.tasks.diagnostics.internal.ReportRenderer;
 import org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -105,9 +104,9 @@ public abstract class AbstractDependencyReportTask extends AbstractReportTask {
     }
 
     private Set<Configuration> getNonDeprecatedTaskConfigurations() {
-        Set<Configuration> filteredConfigurations = new HashSet<Configuration>();
+        Set<Configuration> filteredConfigurations = new HashSet<>();
         for (Configuration configuration : getTaskConfigurations()) {
-            if (!((DeprecatableConfiguration) configuration).isFullyDeprecated()) {
+            if (!configuration.isFullyDeprecated()) {
                 filteredConfigurations.add(configuration);
             }
         }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRenderer.java
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependenc
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableModuleResult;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvableConfigurationResult;
 import org.gradle.initialization.StartParameterBuildOptions;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.graph.GraphRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.util.GUtil;
@@ -101,7 +100,7 @@ public class AsciiDependencyReportRenderer extends TextReportRenderer implements
     }
 
     private boolean canBeResolved(Configuration configuration) {
-        boolean isDeprecatedForResolving = ((DeprecatableConfiguration) configuration).getResolutionAlternatives() != null;
+        boolean isDeprecatedForResolving = configuration.getResolutionAlternatives() != null;
         return configuration.isCanBeResolved() && !isDeprecatedForResolving;
     }
 

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRendererTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/dependencies/AsciiDependencyReportRendererTest.groovy
@@ -15,9 +15,9 @@
  */
 package org.gradle.api.tasks.diagnostics.internal.dependencies
 
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphsRenderer
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.SimpleDependency
-import org.gradle.internal.deprecation.DeprecatableConfiguration
 import org.gradle.internal.logging.text.TestStyledTextOutput
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
@@ -39,11 +39,11 @@ class AsciiDependencyReportRendererTest extends AbstractProjectBuilderSpec {
     }
 
     def "shows configuration header"() {
-        DeprecatableConfiguration configuration1 = Mock()
+        Configuration configuration1 = Mock()
         configuration1.getName() >> 'config1'
         configuration1.getDescription() >> 'description'
         configuration1.isCanBeResolved() >> true
-        DeprecatableConfiguration configuration2 = Mock()
+        Configuration configuration2 = Mock()
         configuration2.getName() >> 'config2'
         configuration2.isCanBeResolved() >> true
 

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
@@ -28,7 +28,6 @@ import org.gradle.api.reflect.TypeOf
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
-import org.gradle.internal.deprecation.DeprecatableConfiguration
 import org.gradle.kotlin.dsl.accessors.ConfigurationEntry
 import org.gradle.kotlin.dsl.accessors.ProjectSchema
 import org.gradle.kotlin.dsl.accessors.ProjectSchemaEntry
@@ -247,7 +246,7 @@ fun accessibleConfigurationsOf(project: Project) =
 
 
 private
-fun toConfigurationEntry(configuration: Configuration) = (configuration as DeprecatableConfiguration).run {
+fun toConfigurationEntry(configuration: Configuration) = configuration.run {
     ConfigurationEntry(name, declarationAlternatives ?: listOf())
 }
 


### PR DESCRIPTION
This is to allow plugin authors to make use of this information.

The methods to actually deprecate configurations stay internal,
as they are bound to the deprecation mechanism of Gradle core.
And thus they may only be used for configurations of Gradle's core
plugins.