### PR TITLE
Add a system property to disable publishing of SHA-256

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -319,8 +319,10 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
     private void publishChecksums(ExternalResourceName destination, File content) {
         publishChecksum(destination, content, "sha1", 40);
 
-        publishPossiblyUnsupportedChecksum(destination, content, "sha-256", 64);
-        publishPossiblyUnsupportedChecksum(destination, content, "sha-512", 128);
+        if (!ExternalResourceResolver.disableExtraChecksums()) {
+            publishPossiblyUnsupportedChecksum(destination, content, "sha-256", 64);
+            publishPossiblyUnsupportedChecksum(destination, content, "sha-512", 128);
+        }
     }
 
     private void publishPossiblyUnsupportedChecksum(ExternalResourceName destination, File content, String algorithm, int length) {
@@ -584,4 +586,9 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
             result.listed(versions);
         }
     }
+
+    public static boolean disableExtraChecksums() {
+        return Boolean.getBoolean("org.gradle.internal.publish.checksums.insecure");
+    }
+
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -276,6 +276,11 @@ Publication of SHA256 and SHA512 files is _not_ supported by the deprecated `mav
 
 In addition, the Gradle Module Metadata file also includes SHA256 and SHA512 checksums on referenced artifacts.
 
+Since 6.0.1, if your external repository doesn't support SHA256 and/or SHA512 checksums, it is possible to disable upload of those checksums:
+
+- add `-Dorg.gradle.internal.publish.checksums.insecure` to the CLI or
+- add `org.gradle.internal.publish.checksums.insecure=true` to your `gradle.properties` file
+
 ### Support for in-memory signing with subkeys
 
 Gradle now supports [in-memory signing](userguide/signing_plugin.html#sec:in-memory-keys) with subkeys.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -55,6 +55,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     String status = "integration"
     MetadataPublish metadataPublish = MetadataPublish.ALL
     boolean writeGradleMetadataRedirection = false
+    private boolean withExtraChecksums = true
 
     int publishCount = 1
     XmlTransformer transformer = new XmlTransformer()
@@ -244,6 +245,18 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     IvyModule withoutGradleMetadataRedirection() {
         writeGradleMetadataRedirection = false
         return this
+    }
+
+    @Override
+    IvyModule withoutExtraChecksums() {
+        withExtraChecksums = false
+        this
+    }
+
+    @Override
+    IvyModule withExtraChecksums() {
+        withExtraChecksums = true
+        this
     }
 
     IvyFileModule nonTransitive(String config) {
@@ -581,7 +594,10 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     void assertArtifactsPublished(String... names) {
         def expectedArtifacts = [] as Set
         for (name in names) {
-            expectedArtifacts.addAll([name, "${name}.sha1", "${name}.sha256", "${name}.sha512"])
+            expectedArtifacts.addAll([name, "${name}.sha1"])
+            if (withExtraChecksums) {
+                expectedArtifacts.addAll(["${name}.sha256", "${name}.sha512"])
+            }
         }
 
         List<String> publishedArtifacts = moduleDir.list().sort()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
@@ -59,6 +59,10 @@ public interface IvyModule extends Module {
 
     IvyModule withoutGradleMetadataRedirection();
 
+    IvyModule withoutExtraChecksums();
+
+    IvyModule withExtraChecksums();
+
     /**
      * Attributes:
      *  organisation

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -135,6 +135,18 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
     }
 
     @Override
+    public IvyModule withoutExtraChecksums() {
+        backingModule.withoutExtraChecksums();
+        return t();
+    }
+
+    @Override
+    public IvyModule withExtraChecksums() {
+        backingModule.withExtraChecksums();
+        return t();
+    }
+
+    @Override
     public IvyModule withBranch(String branch) {
         backingModule.withBranch(branch);
         return t();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/AbstractMavenPublisher.java
@@ -21,6 +21,7 @@ import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceResolver;
 import org.gradle.api.internal.artifacts.repositories.transport.NetworkOperationBackOffAndRetry;
 import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.internal.Factory;
@@ -257,9 +258,10 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
         private void publishChecksums(ExternalResourceName destination, File content) {
             publishChecksum(destination, content, "sha1", 40);
             publishChecksum(destination, content, "md5", 32);
-
-            publishPossiblyUnsupportedChecksum(destination, content, "sha-256", 64);
-            publishPossiblyUnsupportedChecksum(destination, content, "sha-512", 128);
+            if (!ExternalResourceResolver.disableExtraChecksums()) {
+                publishPossiblyUnsupportedChecksum(destination, content, "sha-256", 64);
+                publishPossiblyUnsupportedChecksum(destination, content, "sha-512", 128);
+            }
         }
 
         private void publishPossiblyUnsupportedChecksum(ExternalResourceName destination, File content, String algorithm, int length) {
@@ -295,4 +297,5 @@ abstract class AbstractMavenPublisher implements MavenPublisher {
             });
         }
     }
+
 }


### PR DESCRIPTION
This commit adds an internal system property which can be used as
a workaround whenever the remote repository doesn't accept SHA-256
and SHA-512 checksums. Gradle is fail-safe when it cannot upload
those files, however, in some situations, the remote repository may
not allow promoting the release if it finds such files. This is the
case in older repositories, or currently with Maven Central.

To disable publication of both SHA-256 and SHA-512 checksums, either:

- add `-Dorg.gradle.internal.publish.checksums.insecure` to the CLI or
- add `org.gradle.internal.publish.checksums.insecure=true` to your
`gradle.properties` file

Fixes #11308
