### PR TITLE
Update to Gradle Enterprise plugin 3.1-rc-2 (#11320)

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.0")
+    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.1-rc-2")
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.5.0-rc-2")
     implementation("org.jsoup:jsoup:1.11.3")
     implementation(project(":configuration"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,10 +21,19 @@ pluginManagement {
         gradlePluginPortal()
         maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
     }
+
+    // No plugin marker for plugin RC - can be removed when going to a final version
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.gradle.enterprise") {
+                useModule("com.gradle:gradle-enterprise-gradle-plugin:${requested.version}")
+            }
+        }
+    }
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.0")
+    id("com.gradle.enterprise").version("3.1-rc-2")
 }
 
 apply(from = "gradle/build-cache-configuration.settings.gradle.kts")


### PR DESCRIPTION
This enables build scans on the release branch to be published, since we are now requiring authentication for publishing.