### PR TITLE
Fix Maven local version listing

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -359,6 +359,36 @@ Required by:
         hasArtifact(moduleARemote)
     }
 
+    @Issue("gradle/gradle#11321")
+    def "mavenLocal version listing works without weaking metadata source configuration"() {
+        given:
+        m2.mavenRepo().module('group', 'projectA', '1.1').publish()
+        def module = m2.mavenRepo().module('group', 'projectA', '1.2').publish()
+
+        and:
+        buildFile.text = """
+                repositories {
+                    mavenLocal()
+                }
+                configurations { compile }
+                dependencies {
+                    compile 'group:projectA:[1.0,2.0['
+                }
+
+                task retrieve(type: Sync) {
+                    from configurations.compile
+                    into 'build'
+                }
+        """
+
+        when:
+        run 'retrieve'
+
+        then:
+        hasArtifact(module)
+
+    }
+
     def hasArtifact(MavenModule module) {
         def buildDir = file('build')
         def artifactName = module.artifactFile.name

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -293,7 +293,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
             sources.add(gradleModuleMetadataSource);
         }
         if (metadataSources.mavenPom) {
-            DefaultMavenPomMetadataSource pomMetadataSource = new DefaultMavenPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
+            DefaultMavenPomMetadataSource pomMetadataSource = getPomMetadataSource(mavenMetadataLoader, fileResourceRepository);
             if (metadataSources.ignoreGradleMetadataRedirection) {
                 sources.add(pomMetadataSource);
             } else {
@@ -306,11 +306,15 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         return new DefaultImmutableMetadataSources(sources.build());
     }
 
+    protected DefaultMavenPomMetadataSource getPomMetadataSource(MavenMetadataLoader mavenMetadataLoader, FileResourceRepository fileResourceRepository) {
+        return new DefaultMavenPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
+    }
+
     protected DefaultMavenPomMetadataSource.MavenMetadataValidator getMetadataValidationServices() {
         return NO_OP_VALIDATION_SERVICES;
     }
 
-    private MetaDataParser<MutableMavenModuleResolveMetadata> getPomParser() {
+    MetaDataParser<MutableMavenModuleResolveMetadata> getPomParser() {
         return pomParser;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -293,7 +293,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
             sources.add(gradleModuleMetadataSource);
         }
         if (metadataSources.mavenPom) {
-            DefaultMavenPomMetadataSource pomMetadataSource = getPomMetadataSource(mavenMetadataLoader, fileResourceRepository);
+            DefaultMavenPomMetadataSource pomMetadataSource = createPomMetadataSource(mavenMetadataLoader, fileResourceRepository);
             if (metadataSources.ignoreGradleMetadataRedirection) {
                 sources.add(pomMetadataSource);
             } else {
@@ -306,7 +306,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         return new DefaultImmutableMetadataSources(sources.build());
     }
 
-    protected DefaultMavenPomMetadataSource getPomMetadataSource(MavenMetadataLoader mavenMetadataLoader, FileResourceRepository fileResourceRepository) {
+    protected DefaultMavenPomMetadataSource createPomMetadataSource(MavenMetadataLoader mavenMetadataLoader, FileResourceRepository fileResourceRepository) {
         return new DefaultMavenPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -87,7 +87,7 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
     }
 
     @Override
-    protected DefaultMavenPomMetadataSource getPomMetadataSource(MavenMetadataLoader mavenMetadataLoader, FileResourceRepository fileResourceRepository) {
+    protected DefaultMavenPomMetadataSource createPomMetadataSource(MavenMetadataLoader mavenMetadataLoader, FileResourceRepository fileResourceRepository) {
         return new MavenLocalPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories;
 
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenLocalPomMetadataSource;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
@@ -83,6 +84,11 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
             resolver.addArtifactLocation(repoUrl);
         }
         return resolver;
+    }
+
+    @Override
+    protected DefaultMavenPomMetadataSource getPomMetadataSource(MavenMetadataLoader mavenMetadataLoader, FileResourceRepository fileResourceRepository) {
+        return new MavenLocalPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
@@ -86,7 +86,7 @@ public class DefaultArtifactMetadataSource extends AbstractMetadataSource<Mutabl
         versionLister.listVersions(module, dependencyArtifact, artifactPatterns, result);
     }
 
-    private static IvyArtifactName getPrimaryDependencyArtifact(ModuleDependencyMetadata dependency) {
+    static IvyArtifactName getPrimaryDependencyArtifact(ModuleDependencyMetadata dependency) {
         String moduleName = dependency.getSelector().getModule();
         List<IvyArtifactName> artifacts = dependency.getArtifacts();
         if (artifacts.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenLocalPomMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenLocalPomMetadataSource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories.metadata;
+
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
+import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
+import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
+import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
+import org.gradle.internal.resource.local.FileResourceRepository;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.gradle.api.internal.artifacts.repositories.metadata.DefaultArtifactMetadataSource.getPrimaryDependencyArtifact;
+
+public class MavenLocalPomMetadataSource extends DefaultMavenPomMetadataSource {
+
+    @Inject
+    public MavenLocalPomMetadataSource(MetadataArtifactProvider metadataArtifactProvider, MetaDataParser<MutableMavenModuleResolveMetadata> pomParser, FileResourceRepository fileResourceRepository, MavenMetadataValidator validator, MavenMetadataLoader mavenMetadataLoader) {
+        super(metadataArtifactProvider, pomParser, fileResourceRepository, validator, mavenMetadataLoader);
+    }
+
+    @Override
+    public void listModuleVersions(ModuleDependencyMetadata dependency, ModuleIdentifier module, List<ResourcePattern> ivyPatterns, List<ResourcePattern> artifactPatterns, VersionLister versionLister, BuildableModuleVersionListingResolveResult result) {
+        IvyArtifactName dependencyArtifact = getPrimaryDependencyArtifact(dependency);
+        versionLister.listVersions(module, dependencyArtifact, artifactPatterns, result);
+    }
+}


### PR DESCRIPTION
There is no way to rely on a `maven-metadata.xml` for Maven local
version listing.
Since Gradle 6.0 removed the default `artifact()` metadata source, this
causes all dynamic version resolution to fail with Maven local.
This commit changes the way Maven local is handled to _always_ do
version listing through directory listing.