### PR TITLE
Desugar producer attribute if the requesting attribute is desugared

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributes.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributes.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.attributes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import org.gradle.api.Named;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.Cast;
@@ -162,6 +163,19 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
         return value.isolate();
     }
 
+    private String desugar() {
+        // We support desugaring for all non-primitive types supported in GradleModuleMetadataWriter.writeAttributes(), which are:
+        // - Named
+        // - Enum
+        if (Named.class.isAssignableFrom(attribute.getType())) {
+            return ((Named) get()).getName();
+        }
+        if (Enum.class.isAssignableFrom(attribute.getType())) {
+            return ((Enum<?>) get()).name();
+        }
+        return null;
+    }
+
     @Nullable
     private <S> S coerce(Class<S> type) {
         if (value != null) {
@@ -181,20 +195,32 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
     }
 
     private <S> S uncachedCoerce(Attribute<S> otherAttribute) {
-        Class<S> attributeType = otherAttribute.getType();
-        if (attributeType.isAssignableFrom(attribute.getType())) {
+        Class<S> otherAttributeType = otherAttribute.getType();
+        // If attribute types are already compatible, go with it. There are two cases covered here:
+        // 1) Both attributes are strongly typed and match, usually the case if both are sourced from the local build
+        // 2) Both attributes are desugared, usually the case if both are sourced from published metadata
+        if (otherAttributeType.isAssignableFrom(attribute.getType())) {
             return (S) get();
         }
 
-        S converted = coerce(attributeType);
+        // Attempt to coerce myself into the other attribute's type
+        // - I am desugared and the other attribute is strongly typed, usually the case if I am sourced from published metadata and the other from the local build
+        S converted = coerce(otherAttributeType);
         if (converted != null) {
             return converted;
+        } else if (otherAttributeType.isAssignableFrom(String.class)) {
+            // Attempt to desugar myself
+            // - I am strongly typed and the other is desugared, usually the case if I am sourced from the local build and the other is sourced from published metadata
+            converted = (S) desugar();
+            if (converted != null) {
+                return converted;
+            }
         }
         String foundType = get().getClass().getName();
-        if (foundType.equals(attributeType.getName())) {
+        if (foundType.equals(otherAttributeType.getName())) {
             foundType += " with a different ClassLoader";
         }
-        throw new IllegalArgumentException(String.format("Unexpected type for attribute '%s' provided. Expected a value of type %s but found a value of type %s.", attribute.getName(), attributeType.getName(), foundType));
+        throw new IllegalArgumentException(String.format("Unexpected type for attribute '%s' provided. Expected a value of type %s but found a value of type %s.", attribute.getName(), otherAttributeType.getName(), foundType));
     }
 
     @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter
+import org.gradle.internal.state.DefaultManagedFactoryRegistry
 
 class SnapshotTestUtil {
     static ValueSnapshotter valueSnapshotter() {
@@ -29,6 +30,6 @@ class SnapshotTestUtil {
             HashCode getClassLoaderHash(ClassLoader classLoader) {
                 return HashCode.fromInt(classLoader.hashCode())
             }
-        }, null)
+        }, new DefaultManagedFactoryRegistry(null))
     }
 }


### PR DESCRIPTION
This can be the case if an attribute on a dependency is published and the resolved target of the dependency is a local project. For example, a published platform dependency to a local java-platform project.

This case was not handled so far.

It would seem that the better solution is to _coerce_ the requesting attribute instead of _desugar_ the candidate. The problem is that the current code structure (which contains quite some performance optimization) is not designed for it. At least I did not find a good way to do that, as is is not clear which direction we need to go. If a value is of type String for example, does it mean it is _desugared_ or not (we don't know)? So if there is a missmatch between the types, we do not know which one is the "right" type. We can only assume that the one that is not-String is the real one. So in the end there is a bit of trial and error in here in any case.
 Also, we already accept and work with the case where both attributes are _desugared_.

The solution in this PR seems to be the simplest, and least risky, to start with.