### PR TITLE
Gradle Module Metadata: fail publication when no version information

### DIFF
--- a/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md
@@ -66,6 +66,13 @@ This value must contain an array with zero or more elements. Each element must b
 - `files`: optional. When missing the variant is assumed to have no files. Must not be present when `available-at` is present.
 - `capabilities`: optional. When missing the variant is assumed to declared no specific capability.
 
+The following statements must hold for the variants:
+
+- Variant name must be unique per module
+- Each variant must have at least one attribute
+- Two variants cannot have the same attributes and capabilities
+- If there is at least one dependency in any variant, at least one must have version information
+
 ### `attributes` value
 
 This value, nested in `variants` or elements of `dependencies` or `dependencyConstraints` nodes, must contain an object with a value for each attribute.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
@@ -244,6 +244,17 @@ This means, if you are publishing libraries with Gradle and using the <<publishi
 
 The traditional metadata file will contain a marker so that Gradle knows that there is additional metadata to consume.
 
+==== Gradle Module Metadata has stricter validation
+
+The following rules are verified when publishing Gradle Module Metadata:
+
+* Variant names must be unique,
+* Each variant must have at least <<variant_attributes.adoc#,one attribute>>,
+* Two variants cannot have the <<variant_model.adoc#,exact same attributes and capabilities>>,
+* If there are dependencies, at least one, across all variants, must have carry <<rich_versions.adoc#,version information>>.
+
+These are documented in the link:https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md[specification] as well.
+
 ==== Maven or Ivy repositories are no longer queried for artifacts without metadata by default
 
 If Gradle fails to locate the metadata file (`.pom` or `ivy.xml`) of a module in a repository defined in the `repositories { }` section, it now assumes that the module does not exist in that repository.

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -53,7 +53,7 @@ class TestCapability implements Capability {
     allprojects {
         configurations { implementation }
     }
-    
+
     def testAttributes = project.services.get(org.gradle.api.internal.attributes.ImmutableAttributesFactory)
          .mutable()
          .attribute(Attribute.of('foo', String), 'value')
@@ -105,14 +105,14 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             comp.usages.add(new TestUsage(
                     name: 'impl',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -125,7 +125,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -152,14 +152,14 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             comp.usages.add(new TestUsage(
                     name: 'impl',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes,
                     capabilities: [new TestCapability(group:'org.test', name: 'test', version: '1')]))
 
@@ -173,7 +173,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -204,14 +204,14 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'impl'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'impl'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -224,7 +224,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -255,8 +255,8 @@ class TestCapability implements Capability {
 
             comp.usages.add(new TestUsage(
                     name: 'impl',
-                    usage: objects.named(Usage, 'impl'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'impl'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -269,7 +269,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -280,6 +280,51 @@ class TestCapability implements Capability {
         then:
         failure.assertHasCause """Invalid publication 'ivy':
   - Variant 'api' must declare at least one attribute."""
+    }
+
+    def "fails to generate Gradle metadata if no dependency have a version"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = 'root'
+        """
+        buildFile << """
+            apply plugin: 'ivy-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            dependencies {
+                implementation("org.test:test")
+            }
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'impl',
+                    usage: objects.named(Usage, 'impl'),
+                    dependencies: configurations.implementation.allDependencies,
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    ivy { url "${ivyRepo.uri}" }
+                }
+                publications {
+                    ivy(IvyPublication) {
+                        from comp
+                    }
+                }
+            }
+
+        """
+
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        when:
+        fails 'publish'
+
+        then:
+        failure.assertHasCause """Invalid publication 'ivy':
+  - Publication only contains dependencies and/or constraints without a version. You need to"""
     }
 
     def "publishes ivy status"() {
@@ -294,8 +339,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -332,7 +377,7 @@ class TestCapability implements Capability {
         buildFile << """
             allprojects {
                 apply plugin: 'ivy-publish'
-    
+
                 group = 'group'
                 version = '1.0'
 
@@ -346,8 +391,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             dependencies {
@@ -362,12 +407,12 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
             project(':a') {
                 publishing {
                     publications {
                         ivy(IvyPublication) {
-                            organisation = 'group.a' 
+                            organisation = 'group.a'
                             module = 'lib_a'
                             revision = '4.5'
                         }
@@ -378,7 +423,7 @@ class TestCapability implements Capability {
                 publishing {
                     publications {
                         ivy(IvyPublication) {
-                            organisation = 'group.b' 
+                            organisation = 'group.b'
                             module = 'utils'
                             revision = '0.01'
                         }
@@ -410,8 +455,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             dependencies {
@@ -483,7 +528,7 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
@@ -534,8 +579,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             dependencies {
@@ -593,16 +638,16 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
 
             dependencies {
                 implementation("org:foo:1.0") {
-                   because 'version 1.0 is tested'                
+                   because 'version 1.0 is tested'
                 }
-                constraints {                
+                constraints {
                     implementation("org:bar:2.0") {
                         because 'because 2.0 is cool'
                     }
@@ -649,7 +694,7 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     attributes: testAttributes,
                     capabilities: [new TestCapability(group:'org.test', name: 'test', version: '1')]))
 
@@ -689,10 +734,10 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             def attr1 = Attribute.of('custom', String)
             def attr2 = Attribute.of('nice', Boolean)
-            
+
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
@@ -703,7 +748,7 @@ class TestCapability implements Capability {
                       attribute(attr1, 'foo')
                    }
                 }
-                constraints {                
+                constraints {
                     implementation("org:bar:2.0") {
                         attributes {
                            attribute(attr2, true)
@@ -752,8 +797,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
 
@@ -838,8 +883,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -852,7 +897,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
             generateMetadataFileForIvyPublication.enabled = $enabled
         """
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -54,7 +54,7 @@ class TestCapability implements Capability {
     allprojects {
         configurations { implementation }
     }
-    
+
     def testAttributes = project.services.get(org.gradle.api.internal.attributes.ImmutableAttributesFactory)
          .mutable()
          .attribute(Attribute.of('foo', String), 'value')
@@ -106,14 +106,14 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             comp.usages.add(new TestUsage(
                     name: 'impl',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -126,7 +126,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -153,14 +153,14 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             comp.usages.add(new TestUsage(
                     name: 'impl',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes,
                     capabilities: [new TestCapability(group:'org.test', name: 'test', version: '1')]))
 
@@ -174,7 +174,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -205,14 +205,14 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'impl'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'impl'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -225,7 +225,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -256,8 +256,8 @@ class TestCapability implements Capability {
 
             comp.usages.add(new TestUsage(
                     name: 'impl',
-                    usage: objects.named(Usage, 'impl'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'impl'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -270,7 +270,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
         """
 
         settingsFile << "rootProject.name = 'publishTest' "
@@ -281,6 +281,51 @@ class TestCapability implements Capability {
         then:
         failure.assertHasCause """Invalid publication 'maven':
   - Variant 'api' must declare at least one attribute."""
+    }
+
+    def "fails to produce Gradle metadata if no dependencies have version information"() {
+        given:
+        settingsFile.text = """
+            rootProject.name = 'root'
+        """
+        buildFile << """
+            apply plugin: 'maven-publish'
+
+            group = 'group'
+            version = '1.0'
+
+            dependencies {
+                implementation("org.test:test")
+            }
+
+            def comp = new TestComponent()
+            comp.usages.add(new TestUsage(
+                    name: 'impl',
+                    usage: objects.named(Usage, 'impl'),
+                    dependencies: configurations.implementation.allDependencies,
+                    attributes: testAttributes))
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from comp
+                    }
+                }
+            }
+
+        """
+
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        when:
+        fails 'publish'
+
+        then:
+        failure.assertHasCause """Invalid publication 'maven':
+  - Publication only contains dependencies and/or constraints without a version. You need to"""
     }
 
     @Unroll
@@ -298,8 +343,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             publishing {
@@ -312,7 +357,7 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
             generateMetadataFileForMavenPublication.enabled = $enabled
         """
 
@@ -339,7 +384,7 @@ class TestCapability implements Capability {
         buildFile << """
             allprojects {
                 apply plugin: 'maven-publish'
-    
+
                 group = 'group'
                 version = '1.0'
 
@@ -353,8 +398,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             dependencies {
@@ -369,12 +414,12 @@ class TestCapability implements Capability {
                     }
                 }
             }
-            
+
             project(':a') {
                 publishing {
                     publications {
                         maven(MavenPublication) {
-                            groupId = 'group.a' 
+                            groupId = 'group.a'
                             artifactId = 'lib_a'
                             version = '4.5'
                         }
@@ -385,7 +430,7 @@ class TestCapability implements Capability {
                 publishing {
                     publications {
                         maven(MavenPublication) {
-                            groupId = 'group.b' 
+                            groupId = 'group.b'
                             artifactId = 'utils'
                             version = '0.01'
                         }
@@ -417,8 +462,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             dependencies {
@@ -490,7 +535,7 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
@@ -541,8 +586,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     attributes: testAttributes))
 
             dependencies {
@@ -599,16 +644,16 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
 
             dependencies {
                 implementation("org:foo:1.0") {
-                   because 'version 1.0 is tested'                
+                   because 'version 1.0 is tested'
                 }
-                constraints {                
+                constraints {
                     implementation("org:bar:2.0") {
                         because 'because 2.0 is cool'
                     }
@@ -655,7 +700,7 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     attributes: testAttributes,
                     capabilities: [new TestCapability(group:'org.test', name: 'test', version: '1')]))
 
@@ -695,10 +740,10 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             def attr1 = Attribute.of('custom', String)
             def attr2 = Attribute.of('nice', Boolean)
-            
+
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
+                    usage: objects.named(Usage, 'api'),
                     dependencies: configurations.implementation.allDependencies.withType(ModuleDependency),
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
@@ -709,7 +754,7 @@ class TestCapability implements Capability {
                       attribute(attr1, 'foo')
                    }
                 }
-                constraints {                
+                constraints {
                     implementation("org:bar:2.0") {
                         attributes {
                            attribute(attr2, true)
@@ -758,8 +803,8 @@ class TestCapability implements Capability {
             def comp = new TestComponent()
             comp.usages.add(new TestUsage(
                     name: 'api',
-                    usage: objects.named(Usage, 'api'), 
-                    dependencies: configurations.implementation.allDependencies, 
+                    usage: objects.named(Usage, 'api'),
+                    dependencies: configurations.implementation.allDependencies,
                     dependencyConstraints: configurations.implementation.allDependencyConstraints,
                     attributes: testAttributes))
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
@@ -80,6 +80,7 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
 
             dependencies {
                 api $dependencyNotation
+                api 'group:projectB:1.0'
             }
 
             publishing {
@@ -99,7 +100,7 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
 
         then:
         repoModule.assertPublished()
-        repoModule.assertApiDependencies("group:projectA:")
+        repoModule.assertApiDependencies("group:projectA:", "group:projectB:1.0")
         def dependency = repoModule.parsedPom.scopes.compile.dependencies.get("group:projectA:")
         dependency.groupId == "group"
         dependency.artifactId == "projectA"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
-import spock.lang.Issue
 
 class MavenPublishVersionRangeIntegTest extends AbstractMavenPublishIntegTest {
     def mavenModule = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
@@ -70,41 +69,6 @@ class MavenPublishVersionRangeIntegTest extends AbstractMavenPublishIntegTest {
             "group:projectD:[1.0,2.0)",
             "group:projectE:[1.0]"
         )
-    }
-
-    @Issue("GRADLE-3233")
-    def "publishes POM dependency for Gradle dependency with empty version"() {
-        settingsFile << "rootProject.name = 'publishTest' "
-        buildFile << """
-
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
-
-            group = 'org.gradle.test'
-            version = '1.9'
-
-            publishing {
-                repositories {
-                    maven { url "${mavenRepo.uri}" }
-                }
-                publications {
-                    maven(MavenPublication) {
-                        from components.java
-                    }
-                }
-            }
-
-            dependencies {
-                api "group:projectA"
-                api group:"group", name:"projectB", version:null
-            }"""
-
-        when:
-        run "publish"
-
-        then:
-        mavenModule.assertPublished()
-        mavenModule.assertApiDependencies("group:projectA:", "group:projectB:")
     }
 
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -40,6 +40,7 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.ComponentWithCoordinates;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
@@ -141,10 +142,12 @@ public class GradleModuleMetadataWriter {
         jsonWriter.endObject();
     }
 
-    private void writeVersionConstraint(ImmutableVersionConstraint immutableVersionConstraint, String resolvedVersion, JsonWriter jsonWriter) throws IOException {
+    private void writeVersionConstraint(ImmutableVersionConstraint immutableVersionConstraint, String resolvedVersion, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
+        checker.sawDependencyOrConstraint();
         if (resolvedVersion == null && DefaultImmutableVersionConstraint.of().equals(immutableVersionConstraint)) {
             return;
         }
+        checker.sawVersion();
 
         jsonWriter.name("version");
         jsonWriter.beginObject();
@@ -221,7 +224,7 @@ public class GradleModuleMetadataWriter {
                 jsonWriter.beginArray();
                 started = true;
             }
-            writeVariantHostedInThisModule(publication, usageContext, jsonWriter);
+            writeVariantHostedInThisModule(publication, usageContext, jsonWriter, checker);
         }
         if (component instanceof ComponentWithVariants) {
             for (SoftwareComponent childComponent : ((ComponentWithVariants) component).getVariants()) {
@@ -308,14 +311,14 @@ public class GradleModuleMetadataWriter {
         return path.toString();
     }
 
-    private void writeVariantHostedInThisModule(PublicationInternal publication, UsageContext variant, JsonWriter jsonWriter) throws IOException {
+    private void writeVariantHostedInThisModule(PublicationInternal publication, UsageContext variant, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         jsonWriter.beginObject();
         jsonWriter.name("name");
         jsonWriter.value(variant.getName());
         writeAttributes(variant.getAttributes(), jsonWriter);
         VersionMappingStrategyInternal versionMappingStrategy = publication.getVersionMappingStrategy();
-        writeDependencies(variant, versionMappingStrategy, jsonWriter);
-        writeDependencyConstraints(variant, jsonWriter, versionMappingStrategy);
+        writeDependencies(variant, versionMappingStrategy, jsonWriter, checker);
+        writeDependencyConstraints(variant, jsonWriter, versionMappingStrategy, checker);
         writeArtifacts(publication, variant, jsonWriter);
         writeCapabilities("capabilities", variant.getCapabilities(), jsonWriter);
 
@@ -392,7 +395,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.endObject();
     }
 
-    private void writeDependencies(UsageContext variant, VersionMappingStrategyInternal versionMappingStrategy, JsonWriter jsonWriter) throws IOException {
+    private void writeDependencies(UsageContext variant, VersionMappingStrategyInternal versionMappingStrategy, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         if (variant.getDependencies().isEmpty()) {
             return;
         }
@@ -402,10 +405,10 @@ public class GradleModuleMetadataWriter {
         VariantVersionMappingStrategyInternal variantVersionMappingStrategy = findVariantVersionMappingStrategy(variant, versionMappingStrategy);
         for (ModuleDependency moduleDependency : variant.getDependencies()) {
             if (moduleDependency.getArtifacts().isEmpty()) {
-                writeDependency(moduleDependency, additionalExcludes, jsonWriter, variantVersionMappingStrategy, null);
+                writeDependency(moduleDependency, additionalExcludes, jsonWriter, variantVersionMappingStrategy, null, checker);
             } else {
                 for (DependencyArtifact dependencyArtifact : moduleDependency.getArtifacts()) {
-                    writeDependency(moduleDependency, additionalExcludes, jsonWriter, variantVersionMappingStrategy, dependencyArtifact);
+                    writeDependency(moduleDependency, additionalExcludes, jsonWriter, variantVersionMappingStrategy, dependencyArtifact, checker);
                 }
             }
         }
@@ -421,7 +424,7 @@ public class GradleModuleMetadataWriter {
         return variantVersionMappingStrategy;
     }
 
-    private void writeDependency(ModuleDependency dependency, Set<ExcludeRule> additionalExcludes, JsonWriter jsonWriter, VariantVersionMappingStrategyInternal variantVersionMappingStrategy, DependencyArtifact dependencyArtifact) throws IOException {
+    private void writeDependency(ModuleDependency dependency, Set<ExcludeRule> additionalExcludes, JsonWriter jsonWriter, VariantVersionMappingStrategyInternal variantVersionMappingStrategy, DependencyArtifact dependencyArtifact, InvalidPublicationChecker checker) throws IOException {
         jsonWriter.beginObject();
         String resolvedVersion = null;
         if (dependency instanceof ProjectDependency) {
@@ -438,7 +441,7 @@ public class GradleModuleMetadataWriter {
             jsonWriter.value(identifier.getGroup());
             jsonWriter.name("module");
             jsonWriter.value(identifier.getName());
-            writeVersionConstraint(DefaultImmutableVersionConstraint.of(identifier.getVersion()), resolvedVersion, jsonWriter);
+            writeVersionConstraint(DefaultImmutableVersionConstraint.of(identifier.getVersion()), resolvedVersion, jsonWriter, checker);
         } else {
             String group = dependency.getGroup();
             String name = dependency.getName();
@@ -460,7 +463,7 @@ public class GradleModuleMetadataWriter {
             } else {
                 vc = DefaultImmutableVersionConstraint.of(Strings.nullToEmpty(dependency.getVersion()));
             }
-            writeVersionConstraint(vc, resolvedVersion, jsonWriter);
+            writeVersionConstraint(vc, resolvedVersion, jsonWriter, checker);
         }
         writeExcludes(dependency, additionalExcludes, jsonWriter);
         writeAttributes(dependency.getAttributes(), jsonWriter);
@@ -505,7 +508,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.endObject();
     }
 
-    private void writeDependencyConstraints(UsageContext variant, JsonWriter jsonWriter, VersionMappingStrategyInternal versionMappingStrategy) throws IOException {
+    private void writeDependencyConstraints(UsageContext variant, JsonWriter jsonWriter, VersionMappingStrategyInternal versionMappingStrategy, InvalidPublicationChecker checker) throws IOException {
         if (variant.getDependencyConstraints().isEmpty()) {
             return;
         }
@@ -513,12 +516,12 @@ public class GradleModuleMetadataWriter {
         jsonWriter.name("dependencyConstraints");
         jsonWriter.beginArray();
         for (DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
-            writeDependencyConstraint(dependencyConstraint, variantVersionMappingStrategy, jsonWriter);
+            writeDependencyConstraint(dependencyConstraint, variantVersionMappingStrategy, jsonWriter, checker);
         }
         jsonWriter.endArray();
     }
 
-    private void writeDependencyConstraint(DependencyConstraint dependencyConstraint, VariantVersionMappingStrategyInternal variantVersionMappingStrategy, JsonWriter jsonWriter) throws IOException {
+    private void writeDependencyConstraint(DependencyConstraint dependencyConstraint, VariantVersionMappingStrategyInternal variantVersionMappingStrategy, JsonWriter jsonWriter, InvalidPublicationChecker checker) throws IOException {
         jsonWriter.beginObject();
         String group = dependencyConstraint.getGroup();
         String module = dependencyConstraint.getName();
@@ -527,7 +530,7 @@ public class GradleModuleMetadataWriter {
         jsonWriter.value(resolvedVersion != null ? resolvedVersion.getGroup() : group);
         jsonWriter.name("module");
         jsonWriter.value(resolvedVersion != null ? resolvedVersion.getName() : module);
-        writeVersionConstraint(DefaultImmutableVersionConstraint.of(dependencyConstraint.getVersionConstraint()), resolvedVersion != null ? resolvedVersion.getVersion() : null, jsonWriter);
+        writeVersionConstraint(DefaultImmutableVersionConstraint.of(dependencyConstraint.getVersionConstraint()), resolvedVersion != null ? resolvedVersion.getVersion() : null, jsonWriter, checker);
         writeAttributes(dependencyConstraint.getAttributes(), jsonWriter);
         String reason = dependencyConstraint.getReason();
         if (StringUtils.isNotEmpty(reason)) {
@@ -591,9 +594,14 @@ public class GradleModuleMetadataWriter {
 
     @NotThreadSafe
     public static class InvalidPublicationChecker {
+
+        private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
+
         private final String publicationName;
         private final BiMap<String, VariantIdentity> variants = HashBiMap.create();
         private List<String> errors;
+        private boolean publicationHasVersion = false;
+        private boolean publicationHasDependencyOrConstraint = false;
 
         public InvalidPublicationChecker(String publicationName) {
             this.publicationName = publicationName;
@@ -616,10 +624,20 @@ public class GradleModuleMetadataWriter {
             }
         }
 
+        private void checkVariantDependencyVersions() {
+            if (publicationHasDependencyOrConstraint && !publicationHasVersion) {
+                // Previous variant did not declare any version
+                failWith("Publication only contains dependencies and/or constraints without a version. You need to add minimal version information, publish resolved versions ("
+                    + DOCUMENTATION_REGISTRY.getDocumentationFor("publishing_maven", "publishing_maven:resolved_dependencies") + ") or reference a platform ("
+                    + DOCUMENTATION_REGISTRY.getDocumentationFor("platforms") + ")");
+            }
+        }
+
         public void validate() {
             if (variants.isEmpty()) {
                 failWith("This publication must publish at least one variant");
             }
+            checkVariantDependencyVersions();
             if (errors != null) {
                 TreeFormatter formatter = new TreeFormatter();
                 formatter.node("Invalid publication '" + publicationName + "'");
@@ -637,6 +655,14 @@ public class GradleModuleMetadataWriter {
                 errors = Lists.newArrayList();
             }
             errors.add(message);
+        }
+
+        public void sawVersion() {
+            publicationHasVersion = true;
+        }
+
+        public void sawDependencyOrConstraint() {
+            publicationHasDependencyOrConstraint = true;
         }
 
         private static final class VariantIdentity {


### PR DESCRIPTION
With this change, it becomes illegal to create a Gradle Module Metadata
file that has depedencies or constraints declared without any version at
 all across all variants.