### PR TITLE
Recompute selected component when removing a selector

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -411,7 +411,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('core') alignsTo('2.9.4') byPublishedPlatform()
             module('databind') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
-            module('annotations') tries('2.7.9', '2.9.0') alignsTo('2.9.4') byPublishedPlatform()
+            module('annotations') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
             module('kt') alignsTo('2.9.4.1') byPublishedPlatform()
 
             doesNotGetPlatform("org", "platform", "2.7.9") // because of conflict resolution
@@ -1019,7 +1019,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('core') alignsTo('2.9.4') byPublishedPlatform()
             module('databind') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
-            module('annotations') tries('2.7.9', '2.9.0') alignsTo('2.9.4') byPublishedPlatform()
+            module('annotations') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
             module('kt') alignsTo('2.9.4.1') byPublishedPlatform()
 
             doesNotGetPlatform("org", "platform", "2.7.9") // because of conflict resolution

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -134,7 +134,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     public void selectAndRestartModule() {
-        module.restart(this);
+        module.replaceWith(this);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -267,7 +267,7 @@ public class DependencyGraphBuilder {
             SelectorState selector = dependency.getSelector();
             ModuleResolveState module = selector.getTargetModule();
 
-            if (!selector.isResolved()) {
+            if (selector.canResolve()) {
                 // Have an unprocessed/new selector for this module. Need to re-select the target version.
                 performSelection(resolveState, module);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -1023,7 +1023,13 @@ public class NodeState implements DependencyGraphNode {
      * There may be some incoming edges left at that point, but they must all be coming from constraints.
      */
     public void clearConstraintEdges(PendingDependencies pendingDependencies, NodeState backToPendingSource) {
-        for (EdgeState incomingEdge : incomingEdges) {
+        if (incomingEdges.isEmpty()) {
+            return;
+        }
+        // Cleaning has to be done on a copied collection because of the recompute happening on selector removal
+        List<EdgeState> remainingIncomingEdges = ImmutableList.copyOf(incomingEdges);
+        clearIncomingEdges();
+        for (EdgeState incomingEdge : remainingIncomingEdges) {
             assert isConstraint(incomingEdge);
             NodeState from = incomingEdge.getFrom();
             if (from != backToPendingSource) {
@@ -1034,7 +1040,6 @@ public class NodeState implements DependencyGraphNode {
             }
             pendingDependencies.addNode(from);
         }
-        clearIncomingEdges();
     }
 
     void forEachCapability(CapabilitiesConflictHandler capabilitiesConflictHandler, Action<? super Capability> action) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
@@ -31,7 +31,7 @@ class ReplaceSelectionWithConflictResultAction implements Action<ConflictResolut
         result.withParticipatingModules(moduleIdentifier -> {
             // Restart each configuration. For the evicted configuration, this means moving incoming dependencies across to the
             // matching selected configuration. For the select configuration, this mean traversing its dependencies.
-            resolveState.getModule(moduleIdentifier).restart(result.getSelected());
+            resolveState.getModule(moduleIdentifier).replaceWith(result.getSelected());
         });
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -77,6 +77,8 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private boolean forced;
     private boolean softForced;
     private boolean fromLock;
+    private boolean reusable;
+    private boolean markedReusableAlready;
 
     // The following state needs to be tracked to consistently construct `ComponentOverrideMetadata` independent of the order dependencies are visited
     private IvyArtifactName firstDependencyArtifact;
@@ -211,6 +213,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     private boolean requiresResolve(ComponentIdResolveResult previousResult, VersionSelector allRejects) {
+        this.reusable = false;
         // If we've never resolved, must resolve
         if (previousResult == null) {
             return true;
@@ -244,11 +247,44 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     /**
+     * Marks a selector for reuse,
+     * indicating it could be used again for resolution
+     *
+     * @return {@code true} if that selector has been marked for reuse before, {@code false} otherwise
+     */
+    boolean markForReuse() {
+        if (!resolved) {
+            // Selector was marked for deferred selection - let's not trigger selection now
+            return true;
+        }
+        this.reusable = true;
+        if (markedReusableAlready) {
+            return true;
+        } else {
+            markedReusableAlready = true;
+            return false;
+        }
+    }
+
+    /**
+     * Checks if the selector can be used for resolution.
+     *
+     * @return {@code true} if the selector can resolve, {@code false} otherwise
+     */
+    boolean canResolve() {
+        if (reusable) {
+            return true;
+        }
+        return !resolved;
+    }
+
+    /**
      * Overrides the component that is the chosen for this selector.
      * This happens when the `ModuleResolveState` is restarted, during conflict resolution or version range merging.
      */
     public void overrideSelection(ComponentState selected) {
         this.resolved = true;
+        this.reusable = false;
 
         // Target module can change, if this is called as the result of a module replacement conflict.
         this.targetModule = selected.getModule();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CandidateModule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CandidateModule.java
@@ -36,5 +36,5 @@ public interface CandidateModule {
      */
     Collection<? extends ComponentResolutionState> getVersions();
 
-    void restart(ComponentState selected);
+    void replaceWith(ComponentState selected);
 }


### PR DESCRIPTION
Previously, once a component was selected, removing a selector would not
change the resolution result, potentially keeping a selection that no
longer applied.
Now upon removal of a selector, the selected component may be updated.

This is a revive of an old PR that had serious performance impact. Checking where we stand without any attempt at working it differently.