### PR TITLE
Add `ANDROID_HOME` for Windows

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -36,10 +36,15 @@ class FunctionalTest(model: CIBuildModel, uuid: String, name: String, descriptio
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.openjdk.64bit%")
         when (testCoverage.os) {
-            Os.linux -> param("env.ANDROID_HOME", "/opt/android/sdk")
+            Os.linux -> {
+                param("env.ANDROID_HOME", "/opt/android/sdk")
+            }
             // Use fewer parallel forks on macOs, since the agents are not very powerful.
-            Os.macos -> param("maxParallelForks", "2")
-            else -> {
+            Os.macos -> {
+                param("maxParallelForks", "2")
+            }
+            Os.windows -> {
+                param("env.ANDROID_HOME", """C:\Program Files\android\sdk""")
             }
         }
     }

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -39,8 +39,9 @@ class FunctionalTest(model: CIBuildModel, uuid: String, name: String, descriptio
             Os.linux -> {
                 param("env.ANDROID_HOME", "/opt/android/sdk")
             }
-            // Use fewer parallel forks on macOs, since the agents are not very powerful.
             Os.macos -> {
+                param("env.ANDROID_HOME", "/opt/android/sdk")
+                // Use fewer parallel forks on macOs, since the agents are not very powerful.
                 param("maxParallelForks", "2")
             }
             Os.windows -> {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -17,9 +17,10 @@
 package org.gradle.instantexecution
 
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.junit.Rule
 
-
+@LeaksFileHandles
 class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionAndroidIntegrationTest {
 
     @Rule

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionAndroidIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.junit.Rule
 
-@LeaksFileHandles
+@LeaksFileHandles("TODO: AGP (intentionally) does not get a ‘build finished’ event and so does not close some files")
 class InstantExecutionAndroidIntegrationTest extends AbstractInstantExecutionAndroidIntegrationTest {
 
     @Rule

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
@@ -16,12 +16,14 @@
 
 package org.gradle.instantexecution
 
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Unroll
 
 
 /**
  * Integration test Santa Tracker android app against AGP nightly.
  */
+@LeaksFileHandles
 class InstantExecutionSantaTrackerIntegrationTest extends AbstractInstantExecutionAndroidIntegrationTest {
 
     def setup() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionSantaTrackerIntegrationTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Unroll
 /**
  * Integration test Santa Tracker android app against AGP nightly.
  */
-@LeaksFileHandles
+@LeaksFileHandles("TODO: AGP (intentionally) does not get a ‘build finished’ event and so does not close some files")
 class InstantExecutionSantaTrackerIntegrationTest extends AbstractInstantExecutionAndroidIntegrationTest {
 
     def setup() {


### PR DESCRIPTION
Allows running Android tests on Windows by setting the Android Home there as well.