### PR TITLE
Add samples dir as samples:integTest input

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
@@ -19,6 +19,8 @@ package org.gradle.gradlebuild.test.integrationtests
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.gradlebuild.BuildEnvironment
 import java.util.Timer
 import java.util.concurrent.TimeUnit
@@ -33,7 +35,8 @@ import kotlin.concurrent.timerTask
 @CacheableTask
 open class IntegrationTest : DistributionTest() {
 
-    @get:InputDirectory
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     val samplesDir = gradleInstallationForTest.gradleSamplesDir
 
     override fun executeTests() {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
@@ -18,6 +18,7 @@ package org.gradle.gradlebuild.test.integrationtests
 
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.gradlebuild.BuildEnvironment
 import java.util.Timer
 import java.util.concurrent.TimeUnit
@@ -31,6 +32,9 @@ import kotlin.concurrent.timerTask
  */
 @CacheableTask
 open class IntegrationTest : DistributionTest() {
+
+    @get:InputDirectory
+    val samplesDir = gradleInstallationForTest.gradleSamplesDir
 
     override fun executeTests() {
         printStacktracesAfterTimeout { super.executeTests() }

--- a/subprojects/samples/samples.gradle.kts
+++ b/subprojects/samples/samples.gradle.kts
@@ -36,6 +36,9 @@ gradlebuildJava {
 val integTestTasks: DomainObjectCollection<IntegrationTest> by extra
 integTestTasks.configureEach {
     libsRepository.required = true
+    inputs.files(gradleInstallationForTest.gradleSamplesDir.asFileTree)
+        .withPropertyName("samplesDir")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 testFilesCleanup {

--- a/subprojects/samples/samples.gradle.kts
+++ b/subprojects/samples/samples.gradle.kts
@@ -36,9 +36,6 @@ gradlebuildJava {
 val integTestTasks: DomainObjectCollection<IntegrationTest> by extra
 integTestTasks.configureEach {
     libsRepository.required = true
-    inputs.files(gradleInstallationForTest.gradleSamplesDir.asFileTree)
-        .withPropertyName("samplesDir")
-        .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 testFilesCleanup {


### PR DESCRIPTION
### Context

Previously samples dir wasn't input of samples:integTest, which
caused some unexpected cache hit.