### PR TITLE
Add incubating messages for VFS retention and partial invalidation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -73,6 +73,7 @@ import org.gradle.internal.snapshot.WellKnownFileLocations;
 import org.gradle.internal.vfs.VirtualFileSystem;
 import org.gradle.internal.vfs.impl.DefaultVirtualFileSystem;
 import org.gradle.internal.vfs.impl.RoutingVirtualFileSystem;
+import org.gradle.util.DeprecationLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,12 +175,16 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                     public void afterStart(GradleInternal gradle) {
                         Map<String, String> systemPropertiesArgs = gradle.getStartParameter().getSystemPropertiesArgs();
                         if (isRetentionEnabled(systemPropertiesArgs)) {
+                            DeprecationLogger.incubatingFeatureUsed("Virtual File System Retention");
                             Iterable<String> changedPathsSinceLastBuild = getChangedPathsSinceLastBuild(systemPropertiesArgs);
                             for (String changedPathSinceLastBuild : changedPathsSinceLastBuild) {
                                 LOGGER.warn("Marking as changed since last build: {}", changedPathSinceLastBuild);
                             }
                             virtualFileSystem.update(changedPathsSinceLastBuild, () -> {});
                         } else {
+                            if (isPartialInvalidationEnabled(systemPropertiesArgs)) {
+                                DeprecationLogger.incubatingFeatureUsed("Partial Virtual File System Invalidation");
+                            }
                             virtualFileSystem.invalidateAll();
                         }
                     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -74,6 +74,7 @@ import org.gradle.internal.vfs.VirtualFileSystem;
 import org.gradle.internal.vfs.impl.DefaultVirtualFileSystem;
 import org.gradle.internal.vfs.impl.RoutingVirtualFileSystem;
 import org.gradle.util.DeprecationLogger;
+import org.gradle.util.SingleMessageLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -175,7 +176,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                     public void afterStart(GradleInternal gradle) {
                         Map<String, String> systemPropertiesArgs = gradle.getStartParameter().getSystemPropertiesArgs();
                         if (isRetentionEnabled(systemPropertiesArgs)) {
-                            DeprecationLogger.incubatingFeatureUsed("Virtual File System Retention");
+                            SingleMessageLogger.incubatingFeatureUsed("Virtual file system retention");
                             Iterable<String> changedPathsSinceLastBuild = getChangedPathsSinceLastBuild(systemPropertiesArgs);
                             for (String changedPathSinceLastBuild : changedPathsSinceLastBuild) {
                                 LOGGER.warn("Marking as changed since last build: {}", changedPathSinceLastBuild);
@@ -183,7 +184,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                             virtualFileSystem.update(changedPathsSinceLastBuild, () -> {});
                         } else {
                             if (isPartialInvalidationEnabled(systemPropertiesArgs)) {
-                                DeprecationLogger.incubatingFeatureUsed("Partial Virtual File System Invalidation");
+                                SingleMessageLogger.incubatingFeatureUsed("Partial virtual file system invalidation");
                             }
                             virtualFileSystem.invalidateAll();
                         }

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemPartialInvalidationIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemPartialInvalidationIntegrationTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.vfs
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY
+
+class VirtualFileSystemPartialInvalidationIntegrationTest extends AbstractIntegrationSpec {
+
+    def "incubating message is shown for partial invalidation"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+        def incubatingMessage = "Partial virtual file system invalidation is an incubating feature"
+
+        when:
+        run("assemble", "-D${VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY}")
+        then:
+        outputContains(incubatingMessage)
+
+        when:
+        run("assemble")
+        then:
+        outputDoesNotContain(incubatingMessage)
+    }
+}

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
 import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_CHANGES_SINCE_LAST_BUILD_PROPERTY
+import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY
 import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY
 
 // The whole test makes no sense if there isn't a daemon to retain the state.
@@ -172,6 +173,40 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         then:
         outputContains "Hello VFS!"
         executedAndNotSkipped ":compileJava", ":classes", ":run"
+    }
+
+    def "incubating message is shown for retention"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+        def incubatingMessage = "Virtual File System Retention is an incubating feature"
+
+        when:
+        withRetention().run("assemble")
+        then:
+        outputContains(incubatingMessage)
+
+        when:
+        run("assemble")
+        then:
+        outputDoesNotContain(incubatingMessage)
+    }
+
+    def "incubating message is shown for partial invalidation"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+        def incubatingMessage = "Partial Virtual File System Invalidation is an incubating feature"
+
+        when:
+        run("assemble", "-D${VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY}")
+        then:
+        outputContains(incubatingMessage)
+
+        when:
+        run("assemble")
+        then:
+        outputDoesNotContain(incubatingMessage)
     }
 
     private def withRetention() {

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -192,23 +192,6 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         outputDoesNotContain(incubatingMessage)
     }
 
-    def "incubating message is shown for partial invalidation"() {
-        buildFile << """
-            apply plugin: "java"
-        """
-        def incubatingMessage = "Partial virtual file system invalidation is an incubating feature"
-
-        when:
-        run("assemble", "-D${VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY}")
-        then:
-        outputContains(incubatingMessage)
-
-        when:
-        run("assemble")
-        then:
-        outputDoesNotContain(incubatingMessage)
-    }
-
     private def withRetention() {
         executer.withArgument  "-D${VFS_RETENTION_ENABLED_PROPERTY}"
         this

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -179,7 +179,7 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         buildFile << """
             apply plugin: "java"
         """
-        def incubatingMessage = "Virtual File System Retention is an incubating feature"
+        def incubatingMessage = "Virtual file system retention is an incubating feature"
 
         when:
         withRetention().run("assemble")
@@ -196,7 +196,7 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         buildFile << """
             apply plugin: "java"
         """
-        def incubatingMessage = "Partial Virtual File System Invalidation is an incubating feature"
+        def incubatingMessage = "Partial virtual file system invalidation is an incubating feature"
 
         when:
         run("assemble", "-D${VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY}")


### PR DESCRIPTION
So it is easier to see if the system properties are picked up.