### PR TITLE
Generate checksum file for dependency verification

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashUtil.java
@@ -91,6 +91,10 @@ public class HashUtil {
         return createHash(inputStream, "SHA1");
     }
 
+    public static HashValue md5(File file) {
+        return createHash(file, "MD5");
+    }
+
     public static HashValue sha1(File file) {
         return createHash(file, "SHA1");
     }

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -96,6 +96,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean buildScan;
     private boolean noBuildScan;
     private boolean writeDependencyLocks;
+    private boolean writeDependencyVerifications;
     private List<String> lockedDependenciesToUpdate = emptyList();
 
     /**
@@ -249,6 +250,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.setMaxWorkerCount(getMaxWorkerCount());
         p.systemPropertiesArgs = new HashMap<>(systemPropertiesArgs);
         p.writeDependencyLocks = writeDependencyLocks;
+        p.writeDependencyVerifications = writeDependencyVerifications;
         p.lockedDependenciesToUpdate = new ArrayList<>(lockedDependenciesToUpdate);
         return p;
     }
@@ -844,6 +846,30 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     public void setLockedDependenciesToUpdate(List<String> lockedDependenciesToUpdate) {
         this.lockedDependenciesToUpdate = Lists.newArrayList(lockedDependenciesToUpdate);
         this.writeDependencyLocks = true;
+    }
+
+    /**
+     * Indicates if a dependency verification metadata file should be written at the
+     * end of this build.
+     *
+     * @since 6.1
+     */
+    @Incubating
+    public boolean isWriteDependencyVerifications() {
+        return writeDependencyVerifications;
+    }
+
+    /**
+     * Tells if a dependency verification metadata file should be written at the end
+     * of this build.
+     *
+     * @param writeDependencyVerifications if true, a dependency verification file will be written
+     *
+     * @since 6.1
+     */
+    @Incubating
+    public void setWriteDependencyVerifications(boolean writeDependencyVerifications) {
+        this.writeDependencyVerifications = writeDependencyVerifications;
     }
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -96,7 +96,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private boolean buildScan;
     private boolean noBuildScan;
     private boolean writeDependencyLocks;
-    private boolean writeDependencyVerifications;
+    private List<String> writeDependencyVerifications = emptyList();
     private List<String> lockedDependenciesToUpdate = emptyList();
 
     /**
@@ -850,12 +850,14 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     /**
      * Indicates if a dependency verification metadata file should be written at the
-     * end of this build.
+     * end of this build. If the list is not empty, then it means we need to generate
+     * or update the dependency verification file with the checksums specified in the
+     * list.
      *
      * @since 6.1
      */
     @Incubating
-    public boolean isWriteDependencyVerifications() {
+    public List<String> getWriteDependencyVerifications() {
         return writeDependencyVerifications;
     }
 
@@ -863,13 +865,13 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Tells if a dependency verification metadata file should be written at the end
      * of this build.
      *
-     * @param writeDependencyVerifications if true, a dependency verification file will be written
+     * @param checksums the list of checksums to generate
      *
      * @since 6.1
      */
     @Incubating
-    public void setWriteDependencyVerifications(boolean writeDependencyVerifications) {
-        this.writeDependencyVerifications = writeDependencyVerifications;
+    public void setWriteDependencyVerifications(List<String> checksums) {
+        this.writeDependencyVerifications = checksums;
     }
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
@@ -72,4 +72,12 @@ public interface DeprecatableConfiguration extends Configuration {
      * @return this configuration
      */
     DeprecatableConfiguration deprecateForResolution(String... alternativesForResolving);
+
+    default boolean canSafelyBeResolved() {
+        if (!isCanBeResolved()) {
+            return false;
+        }
+        List<String> resolutionAlternatives = getResolutionAlternatives();
+        return resolutionAlternatives == null;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -58,6 +58,7 @@ public class StartParameterBuildOptions {
         options.add(new BuildCacheDebugLoggingOption());
         options.add(new BuildScanOption());
         options.add(new DependencyLockingWriteOption());
+        options.add(new DependencyVerificationWriteOption());
         options.add(new DependencyLockingUpdateOption());
         StartParameterBuildOptions.options = Collections.unmodifiableList(options);
     }
@@ -305,6 +306,19 @@ public class StartParameterBuildOptions {
         @Override
         public void applyTo(StartParameterInternal settings, Origin origin) {
             settings.setWriteDependencyLocks(true);
+        }
+    }
+
+    public static class DependencyVerificationWriteOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
+        public static final String LONG_OPTION = "write-verification-metadata";
+
+        public DependencyVerificationWriteOption() {
+            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, "Persists dependency verification state").incubating());
+        }
+
+        @Override
+        public void applyTo(StartParameterInternal settings, Origin origin) {
+            settings.setWriteDependencyVerifications(true);
         }
     }
 

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -108,7 +108,9 @@ dependencies {
     testFixturesImplementation(project(":internalIntegTesting"))
     testFixturesImplementation(library("slf4j_api"))
     testFixturesImplementation(library("inject"))
-
+    testFixturesImplementation(library("guava")) {
+        because("Groovy compiler reflects on private field on TextUtil")
+    }
     crossVersionTestRuntimeOnly(project(":maven"))
 }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.verification
+
+import org.gradle.api.internal.artifacts.verification.DependencyVerificationFixture
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+
+class AbstractDependencyVerificationIntegTest extends AbstractHttpDependencyResolutionTest {
+    @Delegate
+    private final DependencyVerificationFixture verificationFile = new DependencyVerificationFixture(
+        file("gradle/verification-metadata.xml")
+    )
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = "dependency-verification"
+        """
+    }
+
+    protected GradleExecuter writeVerificationMetadata() {
+        executer.withArgument("--write-verification-metadata")
+    }
+
+    protected void javaLibrary(File f = buildFile) {
+        f << """
+            plugins {
+                id 'java-library'
+            }
+            
+            repositories {
+                maven {
+                    url "${mavenHttpRepo.uri}"
+                }
+            }
+        """
+        def projectName = "main"
+        if (f != buildFile) {
+            projectName = f.parentFile.name
+            settingsFile << """
+                include "$projectName"
+            """
+        }
+        file("${projectName == 'main' ? '' : "$projectName/"}src/main/java/com/acme/$projectName/Foo.java") << """
+        package com.acme.$projectName;
+        public class Foo {}
+        """
+
+    }
+
+    protected void uncheckedModule(String group, String name, String version = "1.0", @DelegatesTo(value = MavenHttpModule, strategy = Closure.DELEGATE_FIRST) Closure conf = null) {
+        def mod = mavenHttpRepo.module(group, name, version)
+            .allowAll()
+        if (conf) {
+            conf.resolveStrategy = Closure.DELEGATE_FIRST
+            conf.delegate = mod
+            conf()
+        }
+        mod.publish()
+    }
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
@@ -33,8 +33,8 @@ class AbstractDependencyVerificationIntegTest extends AbstractHttpDependencyReso
         """
     }
 
-    protected GradleExecuter writeVerificationMetadata() {
-        executer.withArgument("--write-verification-metadata")
+    protected GradleExecuter writeVerificationMetadata(String checksums = "sha1,sha512") {
+        executer.withArguments("--write-verification-metadata", checksums)
     }
 
     protected void javaLibrary(File f = buildFile) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegTest.groovy
@@ -1,0 +1,445 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.verification
+
+import org.gradle.test.fixtures.plugin.PluginBuilder
+import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
+import org.junit.Rule
+
+class DependencyVerificationIntegTest extends AbstractDependencyVerificationIntegTest {
+
+    @Rule
+    MavenHttpPluginRepository pluginRepo = MavenHttpPluginRepository.asGradlePluginPortal(executer, mavenRepo)
+
+    def "can generate an empty verification file"() {
+        when:
+        succeeds ':help'
+
+        then:
+        assertMetadataIsMissing()
+
+        when:
+        writeVerificationMetadata()
+        succeeds ':help'
+
+        then:
+        assertMetadataExists()
+        hasNoModules()
+
+        and:
+        outputContains("Dependency verification is an incubating feature.")
+    }
+
+    def "generates verification file for dependencies downloaded during build"() {
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo")
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        run ":compileJava"
+
+        then:
+        hasModules(["org:foo"])
+        module("org:foo") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "16e066e005a935ac60f06216115436ab97c5da02",
+                    sha512: "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
+                )
+            }
+        }
+    }
+
+    def "generates verification file for dependencies downloaded in previous build"() {
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo")
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        when:
+        run ":compileJava"
+        executer.stop()
+
+        then:
+        assertMetadataIsMissing()
+
+        when:
+        writeVerificationMetadata()
+        run ":compileJava"
+
+        then:
+        hasModules(["org:foo"])
+        module("org:foo") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "16e066e005a935ac60f06216115436ab97c5da02",
+                    sha512: "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
+                )
+            }
+        }
+    }
+
+    def "generates checksums for resolvable configurations only"() {
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0")
+        uncheckedModule("org", "foo", "1.1")
+        uncheckedModule("org", "bar", "1.0")
+
+        buildFile << """
+            configurations {
+                conf1 {
+                    canBeResolved = true
+                    canBeConsumed = false
+                }
+                conf2 {
+                    canBeResolved = false
+                    canBeConsumed = true
+                }
+            }
+            
+            dependencies {
+                conf1 "org:foo:1.0"
+                conf2 "org:bar:1.0"
+                implementation "org:foo:1.1"
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        run ":help"
+
+        then:
+        hasModules(["org:foo"])
+        module("org:foo:1.0") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "16e066e005a935ac60f06216115436ab97c5da02",
+                    sha512: "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
+                )
+            }
+        }
+        module("org:foo:1.1") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "4f61704d48102455b54b20e00bed598b51128184",
+                    sha512: "a140b3fa056a88cc228e155a717e4ea5dfbc519f91d9fc9d2a3ab9cdbee118edc834c04dc2abe96d62d2df225fa06083be6fce75a2a7aa0b59e3ae7118a284b1"
+                )
+            }
+        }
+    }
+
+    def "can generate checksum for secondary artifacts"() {
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            artifact(type: 'zip')
+            artifact(classifier: 'classy')
+        }
+        buildFile << """
+            configurations {
+                conf
+            }
+            dependencies {
+                implementation "org:foo:1.0"
+                implementation "org:foo:1.0:classy"
+                conf "org:foo:1.0@zip"
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        run ":compileJava"
+
+        then:
+        hasModules(["org:foo"])
+        module("org:foo") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "16e066e005a935ac60f06216115436ab97c5da02",
+                    sha512: "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
+                )
+            }
+            artifact("foo", "jar", "jar", "classy") {
+                declaresChecksums(
+                    sha1: "57e775f9a7cdbe42752dcb8a18fa1fdedb06a46f",
+                    sha512: "77ce252cbb2ffab6f1dc7d1fce84b933106a38f22f12cd21553d6f7be9846f8d53caf0be109f6a78eac0262f10c54651be9b293f805fe175c66f6e609e557e48"
+                )
+            }
+            artifact("foo", "zip", "zip") {
+                declaresChecksums(
+                    sha1: "d94282a5db10b302c7dfc3b685c3746584a06ee3",
+                    sha512: "6c9f16dc09b4b5ff9d02ac05418f865552a543633f9e60562b5086841850d0a69775ffa0ea1a618fdc5744840e98feb437560ae64aea097ed3fe385293fb59e8"
+                )
+            }
+        }
+    }
+
+    def "generates verification file for dependencies in subprojects"() {
+        def mod1 = file("mod1/build.gradle")
+        def mod2 = file("mod2/build.gradle")
+
+        given:
+        javaLibrary(mod1)
+        javaLibrary(mod2)
+        uncheckedModule("org", "foo")
+        uncheckedModule("org", "bar")
+        mod1 << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+        mod2 << """
+            dependencies {
+                implementation "org:bar:1.0"
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        run ":help"
+
+        then:
+        hasModules(["org:foo", "org:bar"])
+        module("org:foo") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "16e066e005a935ac60f06216115436ab97c5da02",
+                    sha512: "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
+                )
+            }
+        }
+        module("org:bar") {
+            artifact("bar") {
+                declaresChecksums(
+                    sha1: "42077067b52edb41c658839ab62a616740417814",
+                    sha512: "7bec2082e5447fbbd76285b458f2978194229360cc9aed75a0fc21e2a1b0033137ecf4cbd9883c0a3cfd8b11c176a915500b23d6622aa002c207f48e5043b3b2"
+                )
+            }
+        }
+    }
+
+    def "doesn't generate checksums for project and file dependencies"() {
+        def mod1 = file("mod1/build.gradle")
+        def mod2 = file("mod2/build.gradle")
+
+        given:
+        javaLibrary(mod1)
+        javaLibrary(mod2)
+        uncheckedModule("org", "foo")
+        uncheckedModule("org", "bar")
+        mod1 << """
+            dependencies {
+                implementation "org:foo:1.0"
+                api project(":mod2")
+            }
+        """
+        mod2 << """
+            dependencies {
+                implementation "org:bar:1.0"
+                api files("lib/something.jar")
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        run ":help"
+
+        then:
+        hasModules(["org:foo", "org:bar"])
+        module("org:foo") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "16e066e005a935ac60f06216115436ab97c5da02",
+                    sha512: "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
+                )
+            }
+        }
+        module("org:bar") {
+            artifact("bar") {
+                declaresChecksums(
+                    sha1: "42077067b52edb41c658839ab62a616740417814",
+                    sha512: "7bec2082e5447fbbd76285b458f2978194229360cc9aed75a0fc21e2a1b0033137ecf4cbd9883c0a3cfd8b11c176a915500b23d6622aa002c207f48e5043b3b2"
+                )
+            }
+        }
+    }
+
+    def "writes checksums of plugins using plugins block"() {
+        given:
+        addPlugin()
+        settingsFile.text = """
+        pluginManagement {
+            repositories {
+                maven {
+                    url '$pluginRepo.uri'
+                }
+            }
+        }
+        """ + settingsFile.text
+        buildFile << """
+          plugins {
+             id 'test-plugin' version '1.0'
+          }
+        """
+
+        when:
+        writeVerificationMetadata()
+        succeeds ':help'
+
+        then:
+        assertMetadataExists()
+        hasModules(["test-plugin:test-plugin.gradle.plugin", "com:myplugin"])
+    }
+
+    def "writes checksums of plugins using buildscript block"() {
+        given:
+        addPlugin()
+        buildFile << """
+          buildscript {
+             repositories {
+                maven { url "${pluginRepo.uri}" }
+             }
+             dependencies {
+                classpath 'com:myplugin:1.0'
+             }
+          }
+        """
+
+        when:
+        writeVerificationMetadata()
+        succeeds ':help'
+
+        then:
+        assertMetadataExists()
+        hasModules(["com:myplugin"])
+    }
+
+    def "shouldn't create local jars when computing checksums of external dependencies"() {
+        def m1 = file("mod1/build.gradle")
+        def m2 = file("mod2/build.gradle")
+        given:
+        javaLibrary(m1)
+        javaLibrary(m2)
+        uncheckedModule("org", "foo")
+
+        m1 << """
+            dependencies {
+                api project(":mod2")
+            }
+        """
+        m2 << """
+            dependencies {
+                api "org:foo:1.0"
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        succeeds ':help'
+
+        then:
+        notExecuted(":mod2:compileJava", ":mod2:jar")
+        assertMetadataExists()
+        module("org:foo") {
+            artifact("foo") {
+                declaresChecksums(
+                    sha1: "16e066e005a935ac60f06216115436ab97c5da02",
+                    sha512: "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
+                )
+            }
+        }
+    }
+
+    def "buildSrc dependencies should be included in the generated file"() {
+        given:
+        file("buildSrc/build.gradle") << """
+            repositories {
+                maven {
+                    url "${mavenHttpRepo.uri}"
+                }
+            }
+            dependencies {
+                implementation 'org:foo:1.0'
+            }
+        """
+        javaLibrary()
+        buildFile << """
+            dependencies {
+                implementation 'org:bar:1.0'
+            }
+        """
+        uncheckedModule("org", "foo")
+        uncheckedModule("org", "bar")
+
+        when:
+        writeVerificationMetadata()
+        succeeds ":help"
+
+        then:
+        hasModules(["org:foo", "org:bar"])
+
+    }
+
+    def "buildscript classpath dependencies should be included in the generated file"() {
+        given:
+        file("build.gradle") << """
+            buildscript {
+                repositories {
+                    maven {
+                        url "${mavenHttpRepo.uri}"
+                    }
+                }
+                dependencies {
+                    classpath 'org:foo:1.0'
+                }
+            }
+        """
+        javaLibrary()
+        buildFile << """
+            dependencies {
+                implementation 'org:bar:1.0'
+            }
+        """
+        uncheckedModule("org", "foo")
+        uncheckedModule("org", "bar")
+
+        when:
+        writeVerificationMetadata()
+        succeeds ":help"
+
+        then:
+        hasModules(["org:foo", "org:bar"])
+
+    }
+
+    private void addPlugin() {
+        def pluginBuilder = new PluginBuilder(file("some-plugin"))
+        pluginBuilder.addPlugin("println 'Hello, Gradle!'")
+        pluginBuilder.publishAs("com", "myplugin", "1.0", pluginRepo, executer).allowAll()
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.integtests.resolve.verification
 
-
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
 import org.junit.Rule
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificationIntegTest {
@@ -107,6 +107,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "generates verification file for dependencies downloaded in previous build"() {
         given:
         javaLibrary()
@@ -158,7 +159,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
                     canBeConsumed = true
                 }
             }
-            
+
             dependencies {
                 conf1 "org:foo:1.0"
                 conf2 "org:bar:1.0"
@@ -326,6 +327,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "writes checksums of plugins using plugins block"() {
         given:
         addPlugin()
@@ -353,6 +355,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         hasModules(["test-plugin:test-plugin.gradle.plugin", "com:myplugin"])
     }
 
+    @ToBeFixedForInstantExecution
     def "writes checksums of plugins using buildscript block"() {
         given:
         addPlugin()
@@ -549,11 +552,11 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             plugins {
                 id 'java-library'
             }
-            
+
             repositories {
                 maven { url "${mavenHttpRepo.uri}" }
             }
-            
+
             dependencies {
                 implementation "org:bar:1.0"
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -159,9 +159,9 @@ class DependencyManagementBuildScopeServices {
 
         return new DefaultDependencyFactory(
             DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation, stringInterner),
-                DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner),
-                new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
-                capabilityNotationParser, projectDependencyFactory,
+            DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner),
+            new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
+            capabilityNotationParser, projectDependencyFactory,
             attributesFactory);
     }
 
@@ -315,7 +315,8 @@ class DependencyManagementBuildScopeServices {
                                               ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                               RepositoryBlacklister repositoryBlacklister,
                                               VersionParser versionParser,
-                                              InstantiatorFactory instantiatorFactory) {
+                                              InstantiatorFactory instantiatorFactory,
+                                              BuildOperationExecutor buildOperationExecutor) {
         StartParameterResolutionOverride startParameterResolutionOverride = new StartParameterResolutionOverride(startParameter);
         return new ResolveIvyFactory(
             moduleRepositoryCacheProvider,
@@ -325,7 +326,9 @@ class DependencyManagementBuildScopeServices {
             moduleIdentifierFactory,
             repositoryBlacklister,
             versionParser,
-            instantiatorFactory);
+            instantiatorFactory,
+            buildOperationExecutor
+        );
     }
 
     ArtifactDependencyResolver createArtifactDependencyResolver(ResolveIvyFactory resolveIvyFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.InMemoryModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataSerializer;
@@ -309,25 +310,32 @@ class DependencyManagementBuildScopeServices {
         return new ConnectionFailureRepositoryBlacklister();
     }
 
-    ResolveIvyFactory createResolveIvyFactory(StartParameter startParameter, ModuleRepositoryCacheProvider moduleRepositoryCacheProvider,
+    StartParameterResolutionOverride createStartParameterResolutionOverride(StartParameter startParameter) {
+        return new StartParameterResolutionOverride(startParameter);
+    }
+
+    DependencyVerificationOverride createDependencyVerificationOverride(StartParameterResolutionOverride startParameterResolutionOverride, BuildOperationExecutor buildOperationExecutor) {
+        return startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor);
+    }
+
+    ResolveIvyFactory createResolveIvyFactory(StartParameterResolutionOverride startParameterResolutionOverride, ModuleRepositoryCacheProvider moduleRepositoryCacheProvider,
+                                              DependencyVerificationOverride dependencyVerificationOverride,
                                               BuildCommencedTimeProvider buildCommencedTimeProvider,
                                               VersionComparator versionComparator,
                                               ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                               RepositoryBlacklister repositoryBlacklister,
                                               VersionParser versionParser,
-                                              InstantiatorFactory instantiatorFactory,
-                                              BuildOperationExecutor buildOperationExecutor) {
-        StartParameterResolutionOverride startParameterResolutionOverride = new StartParameterResolutionOverride(startParameter);
+                                              InstantiatorFactory instantiatorFactory) {
         return new ResolveIvyFactory(
             moduleRepositoryCacheProvider,
             startParameterResolutionOverride,
+            dependencyVerificationOverride,
             buildCommencedTimeProvider,
             versionComparator,
             moduleIdentifierFactory,
             repositoryBlacklister,
             versionParser,
-            instantiatorFactory,
-            buildOperationExecutor
+            instantiatorFactory
         );
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
@@ -18,12 +18,12 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformationNodeRegistry;
 import org.gradle.api.internal.artifacts.transform.TransformationNodeDependencyResolver;
 import org.gradle.api.internal.artifacts.transform.TransformationNodeRegistry;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.service.ServiceRegistration;
@@ -69,13 +69,13 @@ public class DependencyServices extends AbstractPluginServiceRegistry {
             return new TransformationNodeDependencyResolver();
         }
 
-        void configure(ServiceRegistration serviceRegistration, ListenerManager listenerManager, ResolveIvyFactory resolveIvyFactory, Gradle gradle) {
+        void configure(ServiceRegistration serviceRegistration, ListenerManager listenerManager, GradleInternal gradle, DependencyVerificationOverride dependencyVerificationOverride) {
             // when we reach this code, the Gradle instance is not fully wired/configured, so we need to register
             // the callback via listenerManager, instead of calling Gradle#buildFinished
             listenerManager.addListener(new BuildAdapter() {
                 @Override
                 public void buildFinished(BuildResult result) {
-                    resolveIvyFactory.buildFinished(gradle);
+                    dependencyVerificationOverride.buildFinished(gradle);
                 }
             });
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
+
+import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ArtifactVerificationOperation;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
+import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
+import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.internal.action.InstantiatingAction;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
+import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
+import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
+import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
+import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class DependencyVerifyingModuleComponentRepository implements ModuleComponentRepository {
+    private final ModuleComponentRepository delegate;
+    private final ModuleComponentRepositoryAccess localAccess;
+    private final ModuleComponentRepositoryAccess remoteAccess;
+    private final ArtifactVerificationOperation operation;
+
+    public DependencyVerifyingModuleComponentRepository(ModuleComponentRepository delegate, ArtifactVerificationOperation operation) {
+        this.delegate = delegate;
+        this.localAccess = new VerifyingModuleComponentRepositoryAccess(delegate.getLocalAccess());
+        this.remoteAccess = new VerifyingModuleComponentRepositoryAccess(delegate.getRemoteAccess());
+        this.operation = operation;
+    }
+
+    @Override
+    public String getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public ModuleComponentRepositoryAccess getLocalAccess() {
+        return localAccess;
+    }
+
+    @Override
+    public ModuleComponentRepositoryAccess getRemoteAccess() {
+        return remoteAccess;
+    }
+
+    @Override
+    public Map<ComponentArtifactIdentifier, ResolvableArtifact> getArtifactCache() {
+        return delegate.getArtifactCache();
+    }
+
+    @Override
+    @Nullable
+    public InstantiatingAction<ComponentMetadataSupplierDetails> getComponentMetadataSupplier() {
+        return delegate.getComponentMetadataSupplier();
+    }
+
+    private class VerifyingModuleComponentRepositoryAccess implements ModuleComponentRepositoryAccess {
+        private final ModuleComponentRepositoryAccess delegate;
+
+        private VerifyingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void listModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
+            delegate.listModuleVersions(dependency, result);
+        }
+
+        @Override
+        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+            delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
+        }
+
+        @Override
+        public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
+            delegate.resolveArtifacts(component, variant, result);
+        }
+
+        @Override
+        public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+            delegate.resolveArtifactsWithType(component, artifactType, result);
+        }
+
+        @Override
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+            delegate.resolveArtifact(artifact, moduleSource, result);
+            if (result.hasResult()) {
+                ComponentArtifactIdentifier id = artifact.getId();
+                if (id instanceof ModuleComponentArtifactIdentifier) {
+                    ModuleComponentArtifactIdentifier mcai = (ModuleComponentArtifactIdentifier) id;
+                    operation.onArtifact(mcai, result.getResult());
+                }
+            }
+        }
+
+        @Override
+        public MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier) {
+            return delegate.estimateMetadataFetchingCost(moduleComponentIdentifier);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -115,11 +116,15 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
             delegate.resolveArtifact(artifact, moduleSource, result);
             if (result.hasResult()) {
                 ComponentArtifactIdentifier id = artifact.getId();
-                if (id instanceof ModuleComponentArtifactIdentifier) {
+                if (isExternalArtifactId(id)) {
                     ModuleComponentArtifactIdentifier mcai = (ModuleComponentArtifactIdentifier) id;
                     operation.onArtifact(mcai, result.getResult());
                 }
             }
+        }
+
+        private boolean isExternalArtifactId(ComponentArtifactIdentifier id) {
+            return id instanceof ModuleComponentArtifactIdentifier && !(id instanceof ComponentFileArtifactIdentifier);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -17,10 +17,8 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -30,18 +28,23 @@ import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePoli
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCacheProvider;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultComponentSelectionRules;
 import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository;
+import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -66,12 +69,17 @@ public class ResolveIvyFactory {
     private final VersionParser versionParser;
     private final InstantiatorFactory instantiatorFactory;
 
+    private final DependencyVerificationOverride dependencyVerificationOverride;
+
     public ResolveIvyFactory(ModuleRepositoryCacheProvider cacheProvider,
                              StartParameterResolutionOverride startParameterResolutionOverride,
                              BuildCommencedTimeProvider timeProvider,
-                             VersionComparator versionComparator, ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+                             VersionComparator versionComparator,
+                             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                              RepositoryBlacklister repositoryBlacklister,
-                             VersionParser versionParser, InstantiatorFactory instantiatorFactory) {
+                             VersionParser versionParser,
+                             InstantiatorFactory instantiatorFactory,
+                             BuildOperationExecutor buildOperationExecutor) {
         this.cacheProvider = cacheProvider;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
         this.timeProvider = timeProvider;
@@ -80,6 +88,7 @@ public class ResolveIvyFactory {
         this.repositoryBlacklister = repositoryBlacklister;
         this.versionParser = versionParser;
         this.instantiatorFactory = instantiatorFactory;
+        this.dependencyVerificationOverride = startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor);
     }
 
     public ComponentResolvers create(String resolveContextName,
@@ -129,6 +138,7 @@ public class ResolveIvyFactory {
             }
             moduleComponentRepository = new ErrorHandlingModuleComponentRepository(moduleComponentRepository, repositoryBlacklister);
             moduleComponentRepository = filterRepository(repository, moduleComponentRepository, resolveContextName, consumerAttributes);
+            moduleComponentRepository = dependencyVerificationOverride.overrideDependencyVerification(moduleComponentRepository);
             moduleResolver.add(moduleComponentRepository);
             parentModuleResolver.add(moduleComponentRepository);
         }
@@ -143,6 +153,10 @@ public class ResolveIvyFactory {
         }
         moduleComponentRepository = FilteredModuleComponentRepository.of(moduleComponentRepository, filter, consumerName, consumerAttributes);
         return moduleComponentRepository;
+    }
+
+    public void buildFinished(Gradle gradle) {
+        dependencyVerificationOverride.buildFinished(gradle);
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -37,14 +37,12 @@ import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.ArtifactType;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.instantiation.InstantiatorFactory;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -73,13 +71,13 @@ public class ResolveIvyFactory {
 
     public ResolveIvyFactory(ModuleRepositoryCacheProvider cacheProvider,
                              StartParameterResolutionOverride startParameterResolutionOverride,
+                             DependencyVerificationOverride dependencyVerificationOverride,
                              BuildCommencedTimeProvider timeProvider,
                              VersionComparator versionComparator,
                              ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                              RepositoryBlacklister repositoryBlacklister,
                              VersionParser versionParser,
-                             InstantiatorFactory instantiatorFactory,
-                             BuildOperationExecutor buildOperationExecutor) {
+                             InstantiatorFactory instantiatorFactory) {
         this.cacheProvider = cacheProvider;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
         this.timeProvider = timeProvider;
@@ -88,7 +86,7 @@ public class ResolveIvyFactory {
         this.repositoryBlacklister = repositoryBlacklister;
         this.versionParser = versionParser;
         this.instantiatorFactory = instantiatorFactory;
-        this.dependencyVerificationOverride = startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor);
+        this.dependencyVerificationOverride = dependencyVerificationOverride;
     }
 
     public ComponentResolvers create(String resolveContextName,
@@ -153,10 +151,6 @@ public class ResolveIvyFactory {
         }
         moduleComponentRepository = FilteredModuleComponentRepository.of(moduleComponentRepository, filter, consumerName, consumerAttributes);
         return moduleComponentRepository;
-    }
-
-    public void buildFinished(Gradle gradle) {
-        dependencyVerificationOverride.buildFinished(gradle);
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.StartParameter;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.WriteDependencyVerificationFile;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
@@ -28,6 +30,7 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
@@ -39,8 +42,10 @@ import org.gradle.internal.resource.ReadableContent;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
 import org.gradle.internal.resource.transfer.ExternalResourceConnector;
 import org.gradle.internal.resource.transfer.ExternalResourceReadResponse;
+import org.gradle.util.SingleMessageLogger;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -65,6 +70,15 @@ public class StartParameterResolutionOverride {
             return new OfflineModuleComponentRepository(original);
         }
         return original;
+    }
+
+    DependencyVerificationOverride dependencyVerificationOverride(BuildOperationExecutor buildOperationExecutor) {
+        File currentDir = startParameter.getCurrentDir();
+        if (startParameter.isWriteDependencyVerifications()) {
+            SingleMessageLogger.incubatingFeatureUsed("Dependency verification");
+            return new WriteDependencyVerificationFile(currentDir, buildOperationExecutor);
+        }
+        return DependencyVerificationOverride.NO_VERIFICATION;
     }
 
     private static class OfflineModuleComponentRepository extends BaseModuleComponentRepository {
@@ -165,4 +179,5 @@ public class StartParameterResolutionOverride {
             return new ResourceException(source, String.format("No cached resource '%s' available for offline mode.", source));
         }
     }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -72,7 +72,7 @@ public class StartParameterResolutionOverride {
         return original;
     }
 
-    DependencyVerificationOverride dependencyVerificationOverride(BuildOperationExecutor buildOperationExecutor) {
+    public DependencyVerificationOverride dependencyVerificationOverride(BuildOperationExecutor buildOperationExecutor) {
         File currentDir = startParameter.getCurrentDir();
         List<String> checksums = startParameter.getWriteDependencyVerifications();
         if (!checksums.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -74,9 +74,10 @@ public class StartParameterResolutionOverride {
 
     DependencyVerificationOverride dependencyVerificationOverride(BuildOperationExecutor buildOperationExecutor) {
         File currentDir = startParameter.getCurrentDir();
-        if (startParameter.isWriteDependencyVerifications()) {
+        List<String> checksums = startParameter.getWriteDependencyVerifications();
+        if (!checksums.isEmpty()) {
             SingleMessageLogger.incubatingFeatureUsed("Dependency verification");
-            return new WriteDependencyVerificationFile(currentDir, buildOperationExecutor);
+            return new WriteDependencyVerificationFile(currentDir, buildOperationExecutor, checksums);
         }
         return DependencyVerificationOverride.NO_VERIFICATION;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ArtifactVerificationOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ArtifactVerificationOperation.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
+
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+
+import java.io.File;
+
+public interface ArtifactVerificationOperation {
+    void onArtifact(ModuleComponentArtifactIdentifier artifact, File path);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
+
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
+import org.gradle.api.invocation.Gradle;
+
+import java.io.File;
+
+public interface DependencyVerificationOverride {
+    DependencyVerificationOverride NO_VERIFICATION = new DependencyVerificationOverride() {
+        @Override
+        public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original) {
+            return original;
+        }
+
+        public void buildFinished(Gradle gradle) {
+
+        }
+    };
+
+    static File dependencyVerificationsFile(File buildDirectory) {
+        File gradleDir = ensureGradleDirExists(buildDirectory);
+        return new File(gradleDir, "verification-metadata.xml");
+    }
+
+    static File ensureGradleDirExists(File buildDirectory) {
+        File gradleDir = new File(buildDirectory, "gradle");
+        if (!gradleDir.exists()) {
+            gradleDir.mkdirs();
+        }
+        return gradleDir;
+    }
+
+    ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original);
+
+    void buildFinished(Gradle gradle);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/WriteDependencyVerificationFile.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactView;
@@ -27,6 +28,7 @@ import org.gradle.api.internal.artifacts.verification.DependencyVerifierBuilder;
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlReader;
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlWriter;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
@@ -35,14 +37,17 @@ import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,7 +61,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     private final DependencyVerifierBuilder verificationsBuilder = new DependencyVerifierBuilder();
     private final File buildDirectory;
     private final BuildOperationExecutor buildOperationExecutor;
-    private final Map<CachedChecksum, String> cachedChecksums = Maps.newConcurrentMap();
+    private final Map<FileChecksum, String> cachedChecksums = Maps.newConcurrentMap();
+    private final Set<ChecksumEntry> entriesToBeWritten = Sets.newLinkedHashSetWithExpectedSize(512);
 
     public WriteDependencyVerificationFile(File buildDirectory, BuildOperationExecutor buildOperationExecutor) {
         this.buildDirectory = buildDirectory;
@@ -72,18 +78,57 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     public void buildFinished(Gradle gradle) {
         File verifFile = DependencyVerificationOverride.dependencyVerificationsFile(buildDirectory);
         try {
-            if (verifFile.exists()) {
-                LOGGER.info("Found dependency verification metadata file, updating");
-                DependencyVerificationsXmlReader.readFromXml(new FileInputStream(verifFile), verificationsBuilder);
-            }
-            gradle.allprojects(WriteDependencyVerificationFile::resolveAllConfigurationsAndForceDownload);
-            DependencyVerificationsXmlWriter.serialize(
-                verificationsBuilder.build(),
-                new FileOutputStream(verifFile)
-            );
+            maybeReadExistingFile(verifFile);
+            computeHashsConcurrently(gradle);
+            writeEntriesSerially();
+            serializeResult(verifFile);
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
+
+    private void serializeResult(File verifFile) throws IOException {
+        DependencyVerificationsXmlWriter.serialize(
+            verificationsBuilder.build(),
+            new FileOutputStream(verifFile)
+        );
+    }
+
+    private void maybeReadExistingFile(File verifFile) throws FileNotFoundException {
+        if (verifFile.exists()) {
+            LOGGER.info("Found dependency verification metadata file, updating");
+            DependencyVerificationsXmlReader.readFromXml(new FileInputStream(verifFile), verificationsBuilder);
+        }
+    }
+
+    private void writeEntriesSerially() {
+        entriesToBeWritten.stream()
+            .sorted()
+            .forEachOrdered(entry -> {
+                verificationsBuilder.addChecksum(entry.id, entry.checksumKind, entry.checksum);
+            });
+    }
+
+    private void computeHashsConcurrently(Gradle gradle) {
+        buildOperationExecutor.runAll(queue -> {
+            Set<Project> allprojects = gradle.getRootProject().getAllprojects();
+            for (Project project : allprojects) {
+                queue.add(new RunnableBuildOperation() {
+                    @Override
+                    public void run(BuildOperationContext context) {
+                        resolveAllConfigurationsAndForceDownload(project);
+                    }
+
+                    @Override
+                    public BuildOperationDescriptor.Builder description() {
+                        return BuildOperationDescriptor.displayName("Computing dependency verification metadata for " + project.getDisplayName());
+                    }
+                });
+            }
+        });
+        // We don't need this anymore and because we're going to sort
+        // elements to be added for reproducibility, we're freeing memory just in case
+        cachedChecksums.clear();
     }
 
     @Override
@@ -93,10 +138,10 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     private void addChecksum(ModuleComponentArtifactIdentifier id, File file, ChecksumKind kind) {
-        buildOperationExecutor.run(new RunnableBuildOperation() {
+        ChecksumEntry entry = buildOperationExecutor.call(new CallableBuildOperation<ChecksumEntry>() {
             @Override
-            public void run(BuildOperationContext context) {
-                verificationsBuilder.addChecksum(id, kind, () -> createHash(file, kind));
+            public ChecksumEntry call(BuildOperationContext context) {
+                return new ChecksumEntry(id, file, kind, createHash(file, kind));
             }
 
             @Override
@@ -104,35 +149,39 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
                 return BuildOperationDescriptor.displayName("Generate " + kind + " checksum for " + id);
             }
         });
-
+        synchronized (entriesToBeWritten) {
+            entriesToBeWritten.add(entry);
+        }
     }
 
     private String createHash(File file, ChecksumKind kind) {
-        return cachedChecksums.computeIfAbsent(new CachedChecksum(file, kind), key -> HashUtil.createHash(file, kind.getAlgorithm()).asHexString());
+        return cachedChecksums.computeIfAbsent(new FileChecksum(file, kind), key -> HashUtil.createHash(file, kind.getAlgorithm()).asHexString());
     }
 
     private static void resolveAllConfigurationsAndForceDownload(Project p) {
-        p.getConfigurations().all(cnf -> {
-            if (((DeprecatableConfiguration) cnf).canSafelyBeResolved()) {
-                try {
-                    resolveAndDownloadExternalFiles(cnf);
-                } catch (Exception e) {
-                    LOGGER.debug("Cannot resolve configuration {}: {}", cnf.getName(), e.getMessage());
+        ((ProjectInternal) p).getMutationState().withMutableState(() ->
+            p.getConfigurations().all(cnf -> {
+                if (((DeprecatableConfiguration) cnf).canSafelyBeResolved()) {
+                    try {
+                        resolveAndDownloadExternalFiles(cnf);
+                    } catch (Exception e) {
+                        LOGGER.debug("Cannot resolve configuration {}: {}", cnf.getName(), e.getMessage());
+                    }
                 }
-            }
-        });
+            })
+        );
     }
 
     private static void resolveAndDownloadExternalFiles(Configuration cnf) {
-        Set<File> files = cnf.getIncoming().artifactView(MODULE_COMPONENT_FILES).getFiles().getFiles();
+        cnf.getIncoming().artifactView(MODULE_COMPONENT_FILES).getFiles().getFiles();
     }
 
-    private static class CachedChecksum {
+    private static class FileChecksum {
         private final File file;
         private final ChecksumKind kind;
         private final int hashCode;
 
-        private CachedChecksum(File file, ChecksumKind kind) {
+        private FileChecksum(File file, ChecksumKind kind) {
             this.file = file;
             this.kind = kind;
             this.hashCode = precomputeHash();
@@ -147,7 +196,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
                 return false;
             }
 
-            CachedChecksum that = (CachedChecksum) o;
+            FileChecksum that = (FileChecksum) o;
 
             if (!file.equals(that.file)) {
                 return false;
@@ -164,6 +213,85 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             int result = file.hashCode();
             result = 31 * result + kind.hashCode();
             return result;
+        }
+    }
+
+    private static class ChecksumEntry implements Comparable<ChecksumEntry> {
+        private static final Comparator<ChecksumEntry> CHECKSUM_ENTRY_COMPARATOR = Comparator.comparing(ChecksumEntry::getGroup)
+            .thenComparing(ChecksumEntry::getModule)
+            .thenComparing(ChecksumEntry::getVersion)
+            .thenComparing(ChecksumEntry::getFile)
+            .thenComparing(ChecksumEntry::getChecksumKind);
+
+        private final ModuleComponentArtifactIdentifier id;
+        private final File file;
+        private final ChecksumKind checksumKind;
+        private final String checksum;
+        private final int hashCode;
+
+        private ChecksumEntry(ModuleComponentArtifactIdentifier id, File file, ChecksumKind checksumKind, String checksum) {
+            this.id = id;
+            this.file = file;
+            this.checksumKind = checksumKind;
+            this.checksum = checksum;
+            this.hashCode = precomputeHashCode();
+        }
+
+        private int precomputeHashCode() {
+            int result = id.hashCode();
+            result = 31 * result + file.getName().hashCode();
+            result = 31 * result + checksumKind.hashCode();
+            return result;
+        }
+
+        String getGroup() {
+            return id.getComponentIdentifier().getGroup();
+        }
+
+        String getModule() {
+            return id.getComponentIdentifier().getModule();
+        }
+
+        String getVersion() {
+            return id.getComponentIdentifier().getVersion();
+        }
+
+        @Override
+        public int compareTo(ChecksumEntry other) {
+            return CHECKSUM_ENTRY_COMPARATOR.compare(this, other);
+        }
+
+        ChecksumKind getChecksumKind() {
+            return checksumKind;
+        }
+
+        String getFile() {
+            return file.getName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ChecksumEntry that = (ChecksumEntry) o;
+
+            if (!id.equals(that.id)) {
+                return false;
+            }
+            if (!getFile().equals(that.getFile())) {
+                return false;
+            }
+            return checksumKind == that.checksumKind;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/WriteDependencyVerificationFile.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
+
+import com.google.common.collect.Maps;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyingModuleComponentRepository;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
+import org.gradle.api.internal.artifacts.verification.DependencyVerifierBuilder;
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlReader;
+import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlWriter;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.deprecation.DeprecatableConfiguration;
+import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+public class WriteDependencyVerificationFile implements DependencyVerificationOverride, ArtifactVerificationOperation {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WriteDependencyVerificationFile.class);
+    private static final Action<ArtifactView.ViewConfiguration> MODULE_COMPONENT_FILES = conf -> {
+        conf.componentFilter(id -> id instanceof ModuleComponentIdentifier);
+        conf.setLenient(true);
+    };
+
+    private final DependencyVerifierBuilder verificationsBuilder = new DependencyVerifierBuilder();
+    private final File buildDirectory;
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final Map<CachedChecksum, String> cachedChecksums = Maps.newConcurrentMap();
+
+    public WriteDependencyVerificationFile(File buildDirectory, BuildOperationExecutor buildOperationExecutor) {
+        this.buildDirectory = buildDirectory;
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    @Override
+    public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original) {
+        return new DependencyVerifyingModuleComponentRepository(original, this);
+    }
+
+    @Override
+    public void buildFinished(Gradle gradle) {
+        File verifFile = DependencyVerificationOverride.dependencyVerificationsFile(buildDirectory);
+        try {
+            if (verifFile.exists()) {
+                LOGGER.info("Found dependency verification metadata file, updating");
+                DependencyVerificationsXmlReader.readFromXml(new FileInputStream(verifFile), verificationsBuilder);
+            }
+            gradle.allprojects(WriteDependencyVerificationFile::resolveAllConfigurationsAndForceDownload);
+            DependencyVerificationsXmlWriter.serialize(
+                verificationsBuilder.build(),
+                new FileOutputStream(verifFile)
+            );
+        } catch (IOException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Override
+    public void onArtifact(ModuleComponentArtifactIdentifier id, File file) {
+        addChecksum(id, file, ChecksumKind.sha1);
+        addChecksum(id, file, ChecksumKind.sha512);
+    }
+
+    private void addChecksum(ModuleComponentArtifactIdentifier id, File file, ChecksumKind kind) {
+        buildOperationExecutor.run(new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                verificationsBuilder.addChecksum(id, kind, () -> createHash(file, kind));
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor.displayName("Generate " + kind + " checksum for " + id);
+            }
+        });
+
+    }
+
+    private String createHash(File file, ChecksumKind kind) {
+        return cachedChecksums.computeIfAbsent(new CachedChecksum(file, kind), key -> HashUtil.createHash(file, kind.getAlgorithm()).asHexString());
+    }
+
+    private static void resolveAllConfigurationsAndForceDownload(Project p) {
+        p.getConfigurations().all(cnf -> {
+            if (((DeprecatableConfiguration) cnf).canSafelyBeResolved()) {
+                try {
+                    resolveAndDownloadExternalFiles(cnf);
+                } catch (Exception e) {
+                    LOGGER.debug("Cannot resolve configuration {}: {}", cnf.getName(), e.getMessage());
+                }
+            }
+        });
+    }
+
+    private static void resolveAndDownloadExternalFiles(Configuration cnf) {
+        Set<File> files = cnf.getIncoming().artifactView(MODULE_COMPONENT_FILES).getFiles().getFiles();
+    }
+
+    private static class CachedChecksum {
+        private final File file;
+        private final ChecksumKind kind;
+        private final int hashCode;
+
+        private CachedChecksum(File file, ChecksumKind kind) {
+            this.file = file;
+            this.kind = kind;
+            this.hashCode = precomputeHash();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            CachedChecksum that = (CachedChecksum) o;
+
+            if (!file.equals(that.file)) {
+                return false;
+            }
+            return kind == that.kind;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        private int precomputeHash() {
+            int result = file.hashCode();
+            result = 31 * result + kind.hashCode();
+            return result;
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/DependencyVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/DependencyVerifier.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.api.internal.artifacts.verification.model.ComponentVerificationMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.hash.HashValue;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class DependencyVerifier {
+    private final Map<ComponentIdentifier, ComponentVerificationMetadata> verificationMetadata;
+
+    DependencyVerifier(Map<ComponentIdentifier, ComponentVerificationMetadata> verificationMetadata) {
+        this.verificationMetadata = ImmutableMap.copyOf(verificationMetadata);
+    }
+
+    public void verify(ModuleComponentArtifactIdentifier foundArtifact, File file, Action<VerificationFailure> onFailure) {
+        ComponentVerificationMetadata componentVerification = verificationMetadata.get(foundArtifact.getComponentIdentifier());
+        if (componentVerification != null) {
+            List<ArtifactVerificationMetadata> verifications = componentVerification.getArtifactVerifications();
+            for (ArtifactVerificationMetadata verification : verifications) {
+                ComponentArtifactIdentifier verifiedArtifact = verification.getArtifact();
+                if (verifiedArtifact.equals(foundArtifact)) {
+                    Map<ChecksumKind, String> checksums = verification.getChecksums();
+                    for (ChecksumKind value : ChecksumKind.mostSecureFirst()) {
+                        String checksum = checksums.get(value);
+                        if (checksum != null) {
+                            verify(value, file, checksum, onFailure);
+                        }
+                    }
+                    break; // we've found our artifact, no need to continue
+                }
+            }
+        }
+    }
+
+    private static void verify(ChecksumKind algorithm, File file, String expected, Action<VerificationFailure> onFailure) {
+        HashValue hashValue = null;
+        switch (algorithm) {
+            case md5:
+                hashValue = HashUtil.md5(file);
+                break;
+            case sha1:
+                hashValue = HashUtil.sha1(file);
+                break;
+            case sha256:
+                hashValue = HashUtil.sha256(file);
+                break;
+            case sha512:
+                hashValue = HashUtil.sha512(file);
+                break;
+        }
+        String actual = hashValue.asHexString();
+        if (!actual.equals(expected)) {
+            onFailure.execute(new VerificationFailure(algorithm, expected, actual));
+        }
+    }
+
+    public Collection<ComponentVerificationMetadata> getVerificationMetadata() {
+        return verificationMetadata.values();
+    }
+
+    public static class VerificationFailure {
+        private final ChecksumKind kind;
+        private final String expected;
+        private final String actual;
+
+        VerificationFailure(ChecksumKind kind, String expected, String actual) {
+            this.kind = kind;
+            this.expected = expected;
+            this.actual = actual;
+        }
+
+        public ChecksumKind getKind() {
+            return kind;
+        }
+
+        public String getExpected() {
+            return expected;
+        }
+
+        public String getActual() {
+            return actual;
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/DependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/DependencyVerifierBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.api.internal.artifacts.verification.model.ComponentVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.ImmutableArtifactVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.ImmutableComponentVerificationMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class DependencyVerifierBuilder {
+    private final Map<ModuleComponentIdentifier, ComponentVerificationsBuilder> byComponent = Maps.newLinkedHashMap();
+
+    public void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value) {
+        addChecksum(artifact, kind, () -> value);
+    }
+
+    public synchronized void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, Supplier<String> generator) {
+        ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
+        byComponent.computeIfAbsent(componentIdentifier, id -> new ComponentVerificationsBuilder(id))
+            .addChecksum(artifact, kind, generator);
+    }
+
+    public DependencyVerifier build() {
+        ImmutableMap.Builder<ComponentIdentifier, ComponentVerificationMetadata> builder = ImmutableMap.builderWithExpectedSize(byComponent.size());
+        for (Map.Entry<ModuleComponentIdentifier, ComponentVerificationsBuilder> entry : byComponent.entrySet()) {
+            builder.put(entry.getKey(), entry.getValue().build());
+        }
+        return new DependencyVerifier(builder.build());
+    }
+
+    private static class ComponentVerificationsBuilder {
+        private final ModuleComponentIdentifier component;
+        private final Map<ModuleComponentArtifactIdentifier, EnumMap<ChecksumKind, String>> checksums = Maps.newLinkedHashMap();
+
+        private ComponentVerificationsBuilder(ModuleComponentIdentifier component) {
+            this.component = component;
+        }
+
+        void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, Supplier<String> value) {
+            checksums.computeIfAbsent(artifact, id -> Maps.newEnumMap(ChecksumKind.class)).put(kind, value.get());
+        }
+
+        private static ArtifactVerificationMetadata toArtifactVerification(Map.Entry<ModuleComponentArtifactIdentifier, EnumMap<ChecksumKind, String>> entry) {
+            return new ImmutableArtifactVerificationMetadata(entry.getKey(), entry.getValue());
+        }
+
+        ComponentVerificationMetadata build() {
+            return new ImmutableComponentVerificationMetadata(component,
+                checksums.entrySet()
+                    .stream()
+                    .map(ComponentVerificationsBuilder::toArtifactVerification)
+                    .collect(Collectors.toList())
+                );
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/DependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/DependencyVerifierBuilder.java
@@ -28,20 +28,15 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactIdent
 
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class DependencyVerifierBuilder {
     private final Map<ModuleComponentIdentifier, ComponentVerificationsBuilder> byComponent = Maps.newLinkedHashMap();
 
     public void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value) {
-        addChecksum(artifact, kind, () -> value);
-    }
-
-    public synchronized void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, Supplier<String> generator) {
         ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
         byComponent.computeIfAbsent(componentIdentifier, id -> new ComponentVerificationsBuilder(id))
-            .addChecksum(artifact, kind, generator);
+            .addChecksum(artifact, kind, value);
     }
 
     public DependencyVerifier build() {
@@ -60,8 +55,8 @@ public class DependencyVerifierBuilder {
             this.component = component;
         }
 
-        void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, Supplier<String> value) {
-            checksums.computeIfAbsent(artifact, id -> Maps.newEnumMap(ChecksumKind.class)).put(kind, value.get());
+        void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value) {
+            checksums.computeIfAbsent(artifact, id -> Maps.newEnumMap(ChecksumKind.class)).put(kind, value);
         }
 
         private static ArtifactVerificationMetadata toArtifactVerification(Map.Entry<ModuleComponentArtifactIdentifier, EnumMap<ChecksumKind, String>> entry) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ArtifactVerificationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ArtifactVerificationMetadata.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.model;
+
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+
+import java.util.Map;
+
+public interface ArtifactVerificationMetadata {
+    ModuleComponentArtifactIdentifier getArtifact();
+
+    Map<ChecksumKind, String> getChecksums();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ChecksumKind.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ChecksumKind.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public enum ChecksumKind {
+    md5("MD5"),
+    sha1("SHA1"),
+    sha256("SHA-256"),
+    sha512("SHA-512");
+
+    private static final List<ChecksumKind> SORTED_BY_SECURITY = ImmutableList.of(sha512, sha256, sha1, md5);
+    private final String algorithm;
+
+    ChecksumKind(String algorithm) {
+
+        this.algorithm = algorithm;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    public static List<ChecksumKind> mostSecureFirst() {
+        return SORTED_BY_SECURITY;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ComponentVerificationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ComponentVerificationMetadata.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.model;
+
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+
+import java.util.List;
+
+public interface ComponentVerificationMetadata {
+    ModuleComponentIdentifier getComponentId();
+
+    List<ArtifactVerificationMetadata> getArtifactVerifications();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ImmutableArtifactVerificationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ImmutableArtifactVerificationMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.model;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+
+import java.util.Map;
+
+public class ImmutableArtifactVerificationMetadata implements ArtifactVerificationMetadata {
+    private final ModuleComponentArtifactIdentifier artifact;
+    private final Map<ChecksumKind, String> checksums;
+
+    public ImmutableArtifactVerificationMetadata(ModuleComponentArtifactIdentifier artifact, Map<ChecksumKind, String> checksums) {
+        this.artifact = artifact;
+        this.checksums = ImmutableMap.copyOf(checksums);
+    }
+
+    @Override
+    public ModuleComponentArtifactIdentifier getArtifact() {
+        return artifact;
+    }
+
+    @Override
+    public Map<ChecksumKind, String> getChecksums() {
+        return checksums;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ImmutableComponentVerificationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/model/ImmutableComponentVerificationMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+
+import java.util.List;
+
+public class ImmutableComponentVerificationMetadata implements ComponentVerificationMetadata {
+    private final ModuleComponentIdentifier component;
+    private final List<ArtifactVerificationMetadata> verifications;
+
+    public ImmutableComponentVerificationMetadata(ModuleComponentIdentifier component, List<ArtifactVerificationMetadata> verifications) {
+        this.component = component;
+        this.verifications = ImmutableList.copyOf(verifications);
+    }
+
+    @Override
+    public ModuleComponentIdentifier getComponentId() {
+        return component;
+    }
+
+    @Override
+    public List<ArtifactVerificationMetadata> getArtifactVerifications() {
+        return verifications;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationXmlTags.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationXmlTags.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.serializer;
+
+abstract class DependencyVerificationXmlTags {
+    static final String VERIFICATION_METADATA = "verification-metadata";
+    static final String COMPONENTS = "components";
+    static final String COMPONENT = "component";
+    static final String GROUP = "group";
+    static final String NAME = "name";
+    static final String VERSION = "version";
+    static final String ARTIFACT = "artifact";
+    static final String CLASSIFIER = "classifier";
+    static final String TYPE = "type";
+    static final String EXT = "ext";
+    static final String VALUE = "value";
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.verification.DependencyVerifier;
 import org.gradle.api.internal.artifacts.verification.DependencyVerifierBuilder;
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
@@ -36,6 +37,7 @@ import org.xml.sax.helpers.DefaultHandler;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import java.io.IOException;
 import java.io.InputStream;
 
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.ARTIFACT;
@@ -60,6 +62,12 @@ public class DependencyVerificationsXmlReader {
             xmlReader.parse(new InputSource(in));
         } catch (Exception e) {
             throw new InvalidUserDataException("Unable to read dependency verification metadata", e);
+        } finally {
+            try {
+                in.close();
+            } catch (IOException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.serializer;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.verification.DependencyVerifier;
+import org.gradle.api.internal.artifacts.verification.DependencyVerifierBuilder;
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.InputStream;
+
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.ARTIFACT;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.CLASSIFIER;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENT;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENTS;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.EXT;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.GROUP;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.NAME;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.TYPE;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.VALUE;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.VERIFICATION_METADATA;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.VERSION;
+
+public class DependencyVerificationsXmlReader {
+    public static void readFromXml(InputStream in, DependencyVerifierBuilder builder) {
+        try {
+            SAXParser saxParser = createSecureParser();
+            XMLReader xmlReader = saxParser.getXMLReader();
+            VerifiersHandler handler = new VerifiersHandler(builder);
+            xmlReader.setContentHandler(handler);
+            xmlReader.parse(new InputSource(in));
+        } catch (Exception e) {
+            throw new InvalidUserDataException("Unable to read dependency verification metadata", e);
+        }
+    }
+
+    public static DependencyVerifier readFromXml(InputStream in) {
+        DependencyVerifierBuilder builder = new DependencyVerifierBuilder();
+        readFromXml(in, builder);
+        return builder.build();
+    }
+
+    private static SAXParser createSecureParser() throws ParserConfigurationException, SAXException {
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        spf.setFeature("http://xml.org/sax/features/namespaces", false);
+        spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        return spf.newSAXParser();
+    }
+
+    private static class VerifiersHandler extends DefaultHandler {
+        private final Interner<String> stringInterner = Interners.newStrongInterner();
+        private final DependencyVerifierBuilder builder;
+        private boolean inMetadata;
+        private boolean inComponents;
+        private ModuleComponentIdentifier currentComponent;
+        private ModuleComponentArtifactIdentifier currentArtifact;
+
+        public VerifiersHandler(DependencyVerifierBuilder builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+            if (VERIFICATION_METADATA.equals(qName)) {
+                inMetadata = true;
+            } else if (COMPONENTS.equals(qName)) {
+                assertInMetadata();
+                inComponents = true;
+            } else if (COMPONENT.equals(qName)) {
+                assertInComponents();
+                currentComponent = createComponentId(attributes);
+            } else if (ARTIFACT.equals(qName)) {
+                assertValidComponent();
+                currentArtifact = createArtifactId(attributes);
+            } else {
+                if (currentArtifact != null) {
+                    ChecksumKind kind = ChecksumKind.valueOf(qName);
+                    builder.addChecksum(currentArtifact, kind, getAttribute(attributes, VALUE));
+                }
+            }
+        }
+
+        private void assertInComponents() {
+            assertContext(inComponents, "<component> must be found under the <components> tag");
+        }
+
+        private void assertInMetadata() {
+            assertContext(inMetadata, "<components> must be found under the <verification-metadata> tag");
+        }
+
+        private void assertValidComponent() {
+            assertContext(currentComponent != null, "<artifact> must be found  under the <component> tag");
+        }
+
+        private static void assertContext(boolean test, String message) {
+            if (!test) {
+                throw new InvalidUserDataException("Invalid dependency verification metadata file: " + message);
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) throws SAXException {
+            if (VERIFICATION_METADATA.equals(qName)) {
+                inMetadata = false;
+            } else if (COMPONENTS.equals(qName)) {
+                inComponents = false;
+            } else if (COMPONENT.equals(qName)) {
+                currentComponent = null;
+            } else if (ARTIFACT.equals(qName)) {
+                currentArtifact = null;
+            }
+        }
+
+        private DefaultModuleComponentArtifactIdentifier createArtifactId(Attributes attributes) {
+            return new DefaultModuleComponentArtifactIdentifier(
+                currentComponent,
+                getAttribute(attributes, NAME),
+                getNullableAttribute(attributes, TYPE),
+                getNullableAttribute(attributes, EXT),
+                getNullableAttribute(attributes, CLASSIFIER)
+            );
+        }
+
+        private ModuleComponentIdentifier createComponentId(Attributes attributes) {
+            return DefaultModuleComponentIdentifier.newId(
+                createModuleId(attributes),
+                getAttribute(attributes, VERSION)
+            );
+        }
+
+        private ModuleIdentifier createModuleId(Attributes attributes) {
+            return DefaultModuleIdentifier.newId(getAttribute(attributes, GROUP), getAttribute(attributes, NAME));
+        }
+
+        private String getAttribute(Attributes attributes, String name) {
+            String value = attributes.getValue(name);
+            assertContext(value != null, "Missing attribute: " + name);
+            return stringInterner.intern(value);
+        }
+
+        private String getNullableAttribute(Attributes attributes, String name) {
+            String value = attributes.getValue(name);
+            if (value == null) {
+                return null;
+            }
+            return stringInterner.intern(value);
+        }
+
+        DependencyVerifier toVerifier() {
+            return builder.build();
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.serializer;
+
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.verification.DependencyVerifier;
+import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.api.internal.artifacts.verification.model.ComponentVerificationMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.xml.SimpleXmlWriter;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.ARTIFACT;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.CLASSIFIER;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENT;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENTS;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.EXT;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.GROUP;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.NAME;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.TYPE;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.VALUE;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.VERIFICATION_METADATA;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.VERSION;
+
+public class DependencyVerificationsXmlWriter {
+    private static final String SPACES = "   ";
+    private final SimpleXmlWriter writer;
+
+    private DependencyVerificationsXmlWriter(OutputStream out) throws IOException {
+        this.writer = new SimpleXmlWriter(out, SPACES);
+    }
+
+    public static void serialize(DependencyVerifier verifier, OutputStream out) throws IOException {
+        DependencyVerificationsXmlWriter writer = new DependencyVerificationsXmlWriter(out);
+        writer.write(verifier);
+    }
+
+    private void write(DependencyVerifier verifier) throws IOException {
+        writer.startElement(VERIFICATION_METADATA);
+        writeVerifications(verifier.getVerificationMetadata());
+        writer.endElement();
+        writer.close();
+    }
+
+    private void writeVerifications(Collection<ComponentVerificationMetadata> verifications) throws IOException {
+        writer.startElement(COMPONENTS);
+        for (ComponentVerificationMetadata verification : verifications) {
+            writeVerification(verification);
+        }
+        writer.endElement();
+    }
+
+    private void writeVerification(ComponentVerificationMetadata verification) throws IOException {
+        ComponentIdentifier component = verification.getComponentId();
+        if (component instanceof ModuleComponentIdentifier) {
+            ModuleComponentIdentifier mci = (ModuleComponentIdentifier) component;
+            writer.startElement(COMPONENT);
+            writer.attribute(GROUP, mci.getGroup());
+            writer.attribute(NAME, mci.getModule());
+            writer.attribute(VERSION, mci.getVersion());
+            writeArtifactVerifications(verification.getArtifactVerifications());
+            writer.endElement();
+        }
+    }
+
+    private void writeArtifactVerifications(List<ArtifactVerificationMetadata> verifications) throws IOException {
+        for (ArtifactVerificationMetadata verification : verifications) {
+            writeArtifactVerification(verification);
+        }
+    }
+
+    private void writeArtifactVerification(ArtifactVerificationMetadata verification) throws IOException {
+        ComponentArtifactIdentifier artifact = verification.getArtifact();
+        if (artifact instanceof ModuleComponentArtifactIdentifier) {
+            ModuleComponentArtifactIdentifier mcai = (ModuleComponentArtifactIdentifier) artifact;
+            IvyArtifactName name = mcai.getName();
+            writer.startElement(ARTIFACT);
+            writer.attribute(NAME, name.getName());
+            writeAttributeIfNotNull(CLASSIFIER, name.getClassifier());
+            writeAttributeIfNotNull(TYPE, name.getType());
+            writeAttributeIfNotNull(EXT, name.getExtension());
+            writeChecksums(verification.getChecksums());
+            writer.endElement();
+        }
+    }
+
+    private void writeAttributeIfNotNull(String attributeName, @Nullable String value) throws IOException {
+        if (value != null) {
+            writer.attribute(attributeName, value);
+        }
+    }
+
+    private void writeChecksums(Map<ChecksumKind, String> checksums) throws IOException {
+        for (Map.Entry<ChecksumKind, String> entry : checksums.entrySet()) {
+            String kind = entry.getKey().name();
+            String value = entry.getValue();
+            writer.startElement(kind);
+            writer.attribute(VALUE, value);
+            writer.endElement();
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriter.java
@@ -54,8 +54,12 @@ public class DependencyVerificationsXmlWriter {
     }
 
     public static void serialize(DependencyVerifier verifier, OutputStream out) throws IOException {
-        DependencyVerificationsXmlWriter writer = new DependencyVerificationsXmlWriter(out);
-        writer.write(verifier);
+        try {
+            DependencyVerificationsXmlWriter writer = new DependencyVerificationsXmlWriter(out);
+            writer.write(verifier);
+        } finally {
+            out.close();
+        }
     }
 
     private void write(DependencyVerifier verifier) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentArtifactIdentifier.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.model.IvyArtifactName;
 
 /**
  * An immutable identifier for an artifact that belongs to some module version.
@@ -33,4 +34,6 @@ public interface ModuleComponentArtifactIdentifier extends ComponentArtifactIden
      * Returns a file base name that can be used for this artifact.
      */
     String getFileName();
+
+    IvyArtifactName getName();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentFileArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentFileArtifactIdentifier.java
@@ -18,6 +18,8 @@ package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.IvyArtifactName;
 
 public class ModuleComponentFileArtifactIdentifier extends ComponentFileArtifactIdentifier implements ModuleComponentArtifactIdentifier {
     public ModuleComponentFileArtifactIdentifier(ModuleComponentIdentifier componentId, String fileName) {
@@ -27,5 +29,10 @@ public class ModuleComponentFileArtifactIdentifier extends ComponentFileArtifact
     @Override
     public ModuleComponentIdentifier getComponentIdentifier() {
         return (ModuleComponentIdentifier) super.getComponentIdentifier();
+    }
+
+    @Override
+    public IvyArtifactName getName() {
+        return DefaultIvyArtifactName.forFileName(getFileName(), null);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
@@ -42,6 +42,10 @@ public class DefaultIvyArtifactName implements IvyArtifactName {
 
     public static DefaultIvyArtifactName forFile(File file, @Nullable String classifier) {
         String fileName = file.getName();
+        return forFileName(fileName, classifier);
+    }
+
+    public static DefaultIvyArtifactName forFileName(String fileName, @Nullable String classifier) {
         String name = Files.getNameWithoutExtension(fileName);
         String extension = Files.getFileExtension(fileName);
         return new DefaultIvyArtifactName(name, extension, extension, classifier);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultIvyArtifactName.java
@@ -30,6 +30,7 @@ public class DefaultIvyArtifactName implements IvyArtifactName {
     private final String type;
     private final String extension;
     private final String classifier;
+    private final int hashCode;
 
     public static DefaultIvyArtifactName forPublishArtifact(PublishArtifact publishArtifact) {
         String name = publishArtifact.getName();
@@ -60,6 +61,7 @@ public class DefaultIvyArtifactName implements IvyArtifactName {
         this.type = type;
         this.extension = extension;
         this.classifier = classifier;
+        this.hashCode = computeHashCode();
     }
 
     @Override
@@ -79,7 +81,15 @@ public class DefaultIvyArtifactName implements IvyArtifactName {
 
     @Override
     public int hashCode() {
-        return name.hashCode() ^ type.hashCode() ^ (extension == null ? 0 : extension.hashCode()) ^ (classifier == null ? 0 : classifier.hashCode());
+        return hashCode;
+    }
+
+    private int computeHashCode() {
+        int result = name.hashCode();
+        result = 31 * result + type.hashCode();
+        result = 31 * result + (extension != null ? extension.hashCode() : 0);
+        result = 31 * result + (classifier != null ? classifier.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 import com.google.common.collect.Lists
 import org.gradle.api.artifacts.ComponentMetadataListerDetails
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal
@@ -40,6 +41,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
+import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor
 import org.gradle.internal.resource.ExternalResourceRepository
@@ -65,6 +67,7 @@ class ResolveIvyFactoryTest extends Specification {
     RepositoryBlacklister repositoryBlacklister
     VersionParser versionParser
     InstantiatorFactory instantiatorFactory
+    BuildOperationExecutor buildOperationExecutor
 
     def setup() {
         moduleVersionsCache = Mock(ModuleVersionsCache)
@@ -75,6 +78,7 @@ class ResolveIvyFactoryTest extends Specification {
         cacheProvider = new ModuleRepositoryCacheProvider(caches, caches)
         startParameterResolutionOverride = Mock(StartParameterResolutionOverride) {
             _ * overrideModuleVersionRepository(_) >> { ModuleComponentRepository repository -> repository }
+            _ * dependencyVerificationOverride(_) >> DependencyVerificationOverride.NO_VERIFICATION
         }
         buildCommencedTimeProvider = Mock(BuildCommencedTimeProvider)
         moduleIdentifierFactory = Mock(ImmutableModuleIdentifierFactory)
@@ -82,8 +86,9 @@ class ResolveIvyFactoryTest extends Specification {
         repositoryBlacklister = Mock(RepositoryBlacklister)
         versionParser = new VersionParser()
         instantiatorFactory = Mock()
+        buildOperationExecutor = Mock()
 
-        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, instantiatorFactory)
+        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, instantiatorFactory, buildOperationExecutor)
     }
 
     def "returns an empty resolver when no repositories are configured" () {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
@@ -88,7 +88,7 @@ class ResolveIvyFactoryTest extends Specification {
         instantiatorFactory = Mock()
         buildOperationExecutor = Mock()
 
-        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, instantiatorFactory, buildOperationExecutor)
+        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor), buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, instantiatorFactory)
     }
 
     def "returns an empty resolver when no repositories are configured" () {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReaderTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.verification.serializer
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.internal.artifacts.verification.DependencyVerifier
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind
+import spock.lang.Specification
+
+class DependencyVerificationsXmlReaderTest extends Specification {
+    private DependencyVerifier verifier
+
+    def "reasonable error message when format is invalid"() {
+        when:
+        parse("invalid")
+
+        then:
+        InvalidUserDataException e = thrown()
+        e.message == "Unable to read dependency verification metadata"
+    }
+
+    def "reasonable error message when XML doesn't have the expected structure"() {
+        when:
+        parse """<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata>
+   <component/>
+</verification-metadata>"""
+
+        then:
+        InvalidUserDataException e = thrown()
+        e.message == "Unable to read dependency verification metadata"
+        e.cause.message == "Invalid dependency verification metadata file: <component> must be found under the <components> tag"
+    }
+
+    def "can parse dependency verification metadata"() {
+        when:
+        parse """<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata>
+   <components>
+      <component group="org" name="foo" version="1.0">
+         <artifact name="foo" type="jar" ext="jar">
+            <sha1 value="abc"/>
+            <sha256 value="bcd"/>
+         </artifact>
+      </component>
+      <component group="org" name="foo" version="1.1">
+         <artifact name="foo" type="jar" ext="jar">
+            <md5 value="1234"/>
+         </artifact>
+         <artifact name="foo" type="zip" ext="zip">
+            <sha1 value="5678"/>
+         </artifact>
+      </component>
+      <component group="org" name="bar" version="1.2">
+         <artifact name="bar" type="jar" ext="jar">
+            <sha1 value="9876"/>
+            <sha512 value="123def"/>
+         </artifact>
+         <artifact name="bar" type="jar" ext="jar" classifier="classy">
+            <sha512 value="5678abcd"/>
+         </artifact>
+      </component>
+   </components>
+</verification-metadata>
+"""
+        then:
+        verifier.verificationMetadata.size() == 3
+        def first = verifier.verificationMetadata[0]
+        first.componentId.group == "org"
+        first.componentId.module == "foo"
+        first.componentId.version == "1.0"
+        first.artifactVerifications.size() == 1
+        first.artifactVerifications[0].checksums[ChecksumKind.sha1] == "abc"
+        first.artifactVerifications[0].checksums[ChecksumKind.sha256] == "bcd"
+
+        def second = verifier.verificationMetadata[1]
+        second.componentId.group == "org"
+        second.componentId.module == "foo"
+        second.componentId.version == "1.1"
+        second.artifactVerifications.size() == 2
+        second.artifactVerifications[0].artifact.fileName == "foo-1.1.jar"
+        second.artifactVerifications[0].checksums[ChecksumKind.md5] == "1234"
+        second.artifactVerifications[1].artifact.fileName == "foo-1.1.zip"
+        second.artifactVerifications[1].checksums[ChecksumKind.sha1] == "5678"
+
+        def third = verifier.verificationMetadata[2]
+        third.componentId.group == "org"
+        third.componentId.module == "bar"
+        third.componentId.version == "1.2"
+        third.artifactVerifications.size() == 2
+        third.artifactVerifications[0].artifact.fileName == "bar-1.2.jar"
+        third.artifactVerifications[0].checksums[ChecksumKind.sha1] == "9876"
+        third.artifactVerifications[0].checksums[ChecksumKind.sha512] == "123def"
+        third.artifactVerifications[1].artifact.fileName == "bar-1.2-classy.jar"
+        third.artifactVerifications[1].checksums[ChecksumKind.sha512] == "5678abcd"
+    }
+
+    void parse(String xml) {
+        verifier = DependencyVerificationsXmlReader.readFromXml(
+            new ByteArrayInputStream(xml.getBytes("utf-8"))
+        )
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.verification.serializer
+
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.verification.DependencyVerifierBuilder
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind
+import org.gradle.integtests.tooling.fixture.TextUtil
+import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import spock.lang.Specification
+
+class DependencyVerificationsXmlWriterTest extends Specification {
+    private final DependencyVerifierBuilder builder = new DependencyVerifierBuilder()
+    private String contents
+
+    def "can write an empty file"() {
+        when:
+        serialize()
+
+        then:
+        contents == """<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata>
+   <components/>
+</verification-metadata>
+"""
+    }
+
+    // In context of future dependency verification file update, we try
+    // to preserve the order of insertion when building the file.
+    // There's the exception of checksums themselves, which are ordered
+    // based on the ChecksumKind enum.
+    // This documents the current behavior, not necessarily what should
+    // be done eventually.
+    def "order of declaration is preserved (except for checksums)"() {
+        given:
+        declareChecksum("org:foo:1.0", "sha1", "abc")
+        declareChecksum("org:foo:1.0", "sha256", "bcd")
+        declareChecksum("org:foo:1.1", "md5", "1234")
+        declareChecksum("org:bar:1.2", "sha512", "123def")
+        declareChecksum("org:bar:1.2", "sha1", "9876")
+
+        when:
+        serialize()
+
+        then:
+        contents == """<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata>
+   <components>
+      <component group="org" name="foo" version="1.0">
+         <artifact name="foo" type="jar" ext="jar">
+            <sha1 value="abc"/>
+            <sha256 value="bcd"/>
+         </artifact>
+      </component>
+      <component group="org" name="foo" version="1.1">
+         <artifact name="foo" type="jar" ext="jar">
+            <md5 value="1234"/>
+         </artifact>
+      </component>
+      <component group="org" name="bar" version="1.2">
+         <artifact name="bar" type="jar" ext="jar">
+            <sha1 value="9876"/>
+            <sha512 value="123def"/>
+         </artifact>
+      </component>
+   </components>
+</verification-metadata>
+"""
+    }
+
+    def "can declare checksums for secondary artifacts"() {
+        given:
+        declareChecksum("org:foo:1.0", "sha1", "abc")
+        declareChecksumOfArtifact("org", "foo", "1.0", "zip", "zip", null, "sha256", "def")
+        declareChecksumOfArtifact("org", "foo", "1.0", "jar", "jar", "classy", "sha1", "123")
+
+        when:
+        serialize()
+
+        then:
+        contents == """<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata>
+   <components>
+      <component group="org" name="foo" version="1.0">
+         <artifact name="foo" type="jar" ext="jar">
+            <sha1 value="abc"/>
+         </artifact>
+         <artifact name="foo" type="zip" ext="zip">
+            <sha256 value="def"/>
+         </artifact>
+         <artifact name="foo" classifier="classy" type="jar" ext="jar">
+            <sha1 value="123"/>
+         </artifact>
+      </component>
+   </components>
+</verification-metadata>
+"""
+    }
+
+    void declareChecksum(String id, String algorithm, String checksum) {
+        def (group, name, version) = id.split(":")
+        declareChecksumOfArtifact(group, name, version, "jar", "jar", null, algorithm, checksum)
+    }
+
+    private declareChecksumOfArtifact(String group, String name, version, String type, String ext, String classifier, String algorithm, String checksum) {
+        builder.addChecksum(
+            new DefaultModuleComponentArtifactIdentifier(
+                DefaultModuleComponentIdentifier.newId(
+                    DefaultModuleIdentifier.newId(group, name),
+                    version
+                ),
+                name,
+                type,
+                ext,
+                classifier
+            ),
+            ChecksumKind.valueOf(algorithm),
+            checksum
+        )
+    }
+
+    private void serialize() {
+        def out = new ByteArrayOutputStream()
+        DependencyVerificationsXmlWriter.serialize(builder.build(), out)
+        contents = TextUtil.normaliseLineSeparators(out.toString("utf-8"))
+    }
+}

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.verification
+
+import groovy.transform.CompileStatic
+import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind
+import org.gradle.api.internal.artifacts.verification.model.ComponentVerificationMetadata
+import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlReader
+
+@CompileStatic
+class DependencyVerificationFixture {
+    private final File verificationFile
+
+    private DependencyVerifier verifier
+
+    DependencyVerificationFixture(File verificationFile) {
+        this.verificationFile = verificationFile
+    }
+
+    void assertMetadataExists() {
+        assert verificationFile.exists(): "Verification file ${verificationFile} is missing"
+    }
+
+    void assertMetadataIsMissing() {
+        assert !verificationFile.exists() : "Expected verification file ${verificationFile} to be absent but it exists"
+    }
+
+    void hasModules(List<String> modules, boolean strictly = true) {
+        withVerifier {
+            def seenModules = verificationMetadata.collect {
+                "${it.componentId.group}:${it.componentId.module}" as String
+            } as Set<String>
+            if (strictly) {
+                def expectedModules = modules as Set<String>
+                assert expectedModules == seenModules
+            } else {
+                assert seenModules.containsAll(modules)
+            }
+        }
+    }
+
+    void hasNoModules() {
+        hasModules([])
+    }
+
+    private void withVerifier(@DelegatesTo(value = DependencyVerifier, strategy = Closure.DELEGATE_FIRST) Closure action) {
+        if (verifier == null) {
+            assertMetadataExists()
+            verifier = DependencyVerificationsXmlReader.readFromXml(verificationFile.newInputStream())
+        }
+        action.delegate = verifier
+        action.resolveStrategy = Closure.DELEGATE_FIRST
+        action()
+    }
+
+    void module(String id, @DelegatesTo(value = ComponentVerification, strategy = Closure.DELEGATE_FIRST) Closure action) {
+        withVerifier {
+            def list = id.split(":")
+            def group = list[0]
+            def name = list[1]
+            def version = list.size() == 3 ? list[2] : "1.0"
+            def md = verificationMetadata.find {
+                it.componentId.group == group && it.componentId.module == name && it.componentId.version == version
+            }
+            assert md: "Dependency verification file contains no information about module ${group:name:version}"
+            action.delegate = new ComponentVerification(md)
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action()
+        }
+    }
+
+    static class ComponentVerification {
+        private final ComponentVerificationMetadata metadata
+
+        ComponentVerification(ComponentVerificationMetadata md) {
+            this.metadata = md
+        }
+
+        void artifact(String name, String type="jar", String ext="jar", String classy = null, @DelegatesTo(value = ArtifactVerification, strategy = Closure.DELEGATE_FIRST) Closure action) {
+            def artifacts = metadata.artifactVerifications.findAll {
+                def ivy = it.artifact.name
+                ivy.name == name && ivy.type == type && ivy.extension == ext && ivy.classifier == classy
+            }
+            if (artifacts.size() > 1) {
+                throw new AssertionError("Expected only one artifact named ${name} for module ${metadata.componentId} but found ${artifacts}")
+            }
+            ArtifactVerificationMetadata md = artifacts ? artifacts[0] : null
+            assert md: "Artifact file $name not found in verification file for module ${metadata.componentId}. Artifact names: ${metadata.artifactVerifications.collect { it.artifact.name.name } }"
+            action.delegate = new ArtifactVerification(md)
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action()
+        }
+    }
+
+    static class ArtifactVerification {
+        private final ArtifactVerificationMetadata metadata
+
+        ArtifactVerification(ArtifactVerificationMetadata md) {
+            this.metadata = md
+        }
+
+        void declaresChecksum(String checksum, String algorithm = "sha1") {
+            def expectedChecksum = metadata.checksums.get(ChecksumKind.valueOf(algorithm))
+            assert expectedChecksum == checksum
+        }
+
+        void declaresChecksums(Map<String, String> checksums, boolean strict = true) {
+            checksums.forEach { algo, value ->
+                declaresChecksum(value, algo)
+            }
+            if (strict) {
+                def expectedChecksums = checksums.keySet()
+                def actualChecksums = metadata.checksums.keySet()*.name() as Set
+                assert expectedChecksums == actualChecksums
+            }
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
@@ -27,7 +27,7 @@ abstract class AbstractModule implements Module {
     /**
      Last modified date for writeZipped to be able to create zipFiles with identical hashes
      */
-    private static Date lmd = new Date()
+    private static Date lmd = new Date(0)
 
     private boolean hasModuleMetadata
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -118,6 +118,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isBuildScan());
             encoder.writeBoolean(startParameter.isNoBuildScan());
             encoder.writeBoolean(startParameter.isWriteDependencyLocks());
+            encoder.writeBoolean(startParameter.isWriteDependencyVerifications());
 
             // Deprecations (these should just be rendered on the client instead of being sent to the daemon to send them back again)
             stringSetSerializer.write(encoder, startParameter.getDeprecations());
@@ -188,6 +189,7 @@ public class BuildActionSerializer {
             startParameter.setBuildScan(decoder.readBoolean());
             startParameter.setNoBuildScan(decoder.readBoolean());
             startParameter.setWriteDependencyLocks(decoder.readBoolean());
+            startParameter.setWriteDependencyVerifications(decoder.readBoolean());
 
             for (String warning : stringSetSerializer.read(decoder)) {
                 startParameter.addDeprecation(warning);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -118,7 +118,7 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isBuildScan());
             encoder.writeBoolean(startParameter.isNoBuildScan());
             encoder.writeBoolean(startParameter.isWriteDependencyLocks());
-            encoder.writeBoolean(startParameter.isWriteDependencyVerifications());
+            stringListSerializer.write(encoder, startParameter.getWriteDependencyVerifications());
 
             // Deprecations (these should just be rendered on the client instead of being sent to the daemon to send them back again)
             stringSetSerializer.write(encoder, startParameter.getDeprecations());
@@ -189,7 +189,10 @@ public class BuildActionSerializer {
             startParameter.setBuildScan(decoder.readBoolean());
             startParameter.setNoBuildScan(decoder.readBoolean());
             startParameter.setWriteDependencyLocks(decoder.readBoolean());
-            startParameter.setWriteDependencyVerifications(decoder.readBoolean());
+            List<String> checksums = stringListSerializer.read(decoder);
+            if (!checksums.isEmpty()) {
+                startParameter.setWriteDependencyVerifications(checksums);
+            }
 
             for (String warning : stringSetSerializer.read(decoder)) {
                 startParameter.addDeprecation(warning);


### PR DESCRIPTION
## Context

This commit introduces the generation of a dependency
verification metadata file from the CLI. If the user
calls `--write-verification-metadata`, then an XML
file is generated (`gradle/verification-metadata.xml`).

This file will contain the checksums for all artifacts
required by a build, which includes:

- plugin artifacts
- jars and other artifacts requested via a `configuration`
- secondary artifacts (javadocs, classifiers, ...)

It does NOT include metadata of those artifacts (pom files,
ivy files, Gradle Module metadata).

It isn't required to resolve any configuration to get this
behavior: the build will automatically process all resolvable
configurations and _try_ to resolve them automatically. All
artifacts resolved during this process are going to be automatically
downloaded (if not already). Then SHA-1 and SHA-512 checksums
are computed for all those artifacts.

The current format is an XML file planned to support more than
just artifacts: module metadata AND signature information is
planned.

See #11398

