### PR TITLE
Fix script loading performance regression and improve reliability of script classloading with instant execution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
@@ -17,9 +17,10 @@
 package org.gradle.api.internal.initialization;
 
 import org.gradle.initialization.ClassLoaderScopeId;
-import org.gradle.internal.Pair;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.hash.HashCode;
 
+import javax.annotation.Nullable;
 import java.util.function.Function;
 
 /**
@@ -97,16 +98,16 @@ public interface ClassLoaderScope {
     ClassLoaderScope createChild(String id);
 
     /**
+     * Creates a child scope that is immutable and ready to use. Uses the given factory to create the local ClassLoader if not already cached. The factory takes a parent ClassLoader produces a ClassLoader
+     */
+    ClassLoaderScope createLockedChild(String id, ClassPath localClasspath, @Nullable HashCode classpathImplementationHash, @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory);
+
+    /**
      * Signal that no more modifications are to come, allowing the structure to be optimised if possible.
      *
      * @return this
      */
     ClassLoaderScope lock();
-
-    /**
-     * Locks this scope, using the given factory to create the local ClassLoader if not already cached. The factory takes a parent ClassLoader and classpath and produces a ClassLoader
-     */
-    ClassLoaderScope lock(Function<Pair<ClassPath, ClassLoader>, ClassLoader> localClassLoaderFactory);
 
     boolean isLocked();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -151,12 +151,12 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
         return false;
     }
 
-    protected ClassLoader loader(ClassLoaderId id, ClassLoader parent, ClassPath classPath) {
+    protected ClassLoader loader(ClassLoaderId classLoaderId, ClassLoader parent, ClassPath classPath) {
         if (classPath.isEmpty()) {
             return parent;
         }
-        ClassLoader classLoader = classLoaderCache.get(id, classPath, parent, null);
-        listener.classloaderCreated(this.id, id, classLoader);
+        ClassLoader classLoader = classLoaderCache.get(classLoaderId, classPath, parent, null);
+        listener.classloaderCreated(this.id, classLoaderId, classLoader, classPath, null);
         if (ownLoaders == null) {
             ownLoaders = new ArrayList<>();
         }
@@ -178,7 +178,6 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
             local = local.plus(classPath);
         }
 
-        localClasspathAdded(classPath);
         return this;
     }
 
@@ -195,7 +194,6 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
             export = export.plus(classPath);
         }
 
-        exportClasspathAdded(classPath);
         return this;
     }
 
@@ -231,25 +229,15 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
         return locked;
     }
 
-    protected void exportClasspathAdded(ClassPath classPath) {
-        listener.exportClasspathAdded(id, classPath);
-    }
-
-    protected void localClasspathAdded(ClassPath classPath) {
-        listener.localClasspathAdded(id, classPath);
-    }
-
     @Override
     public void onReuse() {
         parent.onReuse();
         listener.childScopeCreated(parent.getId(), id);
         if (!export.isEmpty()) {
-            listener.exportClasspathAdded(id, export);
-            listener.classloaderCreated(this.id, id.exportId(), effectiveExportClassLoader);
+            listener.classloaderCreated(this.id, id.exportId(), effectiveExportClassLoader, export, null);
         }
         if (!local.isEmpty()) {
-            listener.localClasspathAdded(id, local);
-            listener.classloaderCreated(this.id, id.localId(), effectiveLocalClassLoader);
+            listener.classloaderCreated(this.id, id.localId(), effectiveLocalClassLoader, export, null);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.initialization;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderId;
 import org.gradle.initialization.ClassLoaderScopeRegistryListener;
-import org.gradle.internal.Pair;
 import org.gradle.internal.classloader.CachingClassLoader;
 import org.gradle.internal.classloader.MultiParentClassLoader;
 import org.gradle.internal.classpath.ClassPath;
@@ -27,7 +26,6 @@ import org.gradle.internal.classpath.ClassPath;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
 
@@ -42,8 +40,6 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     private ClassPath local = ClassPath.EMPTY;
     private List<ClassLoader> ownLoaders;
 
-    private Function<Pair<ClassPath, ClassLoader>, ClassLoader> localClassLoaderFactory;
-
     // If these are not null, we are pessimistic (loaders asked for before locking)
     private MultiParentClassLoader exportingClassLoader;
     private MultiParentClassLoader localClassLoader;
@@ -55,6 +51,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     public DefaultClassLoaderScope(ClassLoaderScopeIdentifier id, ClassLoaderScope parent, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
         super(id, classLoaderCache, listener);
         this.parent = parent;
+        listener.childScopeCreated(parent.getId(), id);
     }
 
     private ClassLoader loader(ClassLoaderId id, ClassLoader parent, ClassPath classPath, @Nullable List<ClassLoader> additionalLoaders) {
@@ -84,13 +81,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     }
 
     private ClassLoader localLoader(ClassLoaderId classLoaderId, ClassLoader parent, ClassPath classPath) {
-        if (localClassLoaderFactory == null) {
-            return this.loader(classLoaderId, parent, classPath);
-        } else {
-            ClassLoader loader = classLoaderCache.createIfAbsent(classLoaderId, classPath, parent, localClassLoaderFactory);
-            listener.classloaderCreated(id, classLoaderId, loader);
-            return loader;
-        }
+        return loader(classLoaderId, parent, classPath);
     }
 
     private void buildEffectiveLoaders() {
@@ -118,9 +109,6 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
             } else { // creating before locking, have to create the most flexible setup
                 if (Boolean.getBoolean(STRICT_MODE_PROPERTY)) {
                     throw new IllegalStateException("Attempt to define scope class loader before scope is locked, scope identifier is " + id);
-                }
-                if (localClassLoaderFactory != null) {
-                    throw new UnsupportedOperationException("Not implemented");
                 }
 
                 exportingClassLoader = multiLoader(id.exportId(), parent.getExportClassLoader(), export, exportLoaders);
@@ -236,13 +224,6 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     public ClassLoaderScope lock() {
         locked = true;
         return this;
-    }
-
-    @Override
-    public ClassLoaderScope lock(Function<Pair<ClassPath, ClassLoader>, ClassLoader> localClassLoaderFactory) {
-        assertNotLocked();
-        this.localClassLoaderFactory = localClassLoaderFactory;
-        return lock();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ImmutableClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ImmutableClassLoaderScope.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization;
+
+import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
+import org.gradle.api.internal.initialization.loadercache.ClassLoaderId;
+import org.gradle.initialization.ClassLoaderScopeRegistryListener;
+import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.hash.HashCode;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+/**
+ * A simplified scope that provides only a single local classpath and no exports, and that cannot be mutated.
+ */
+public class ImmutableClassLoaderScope extends AbstractClassLoaderScope {
+    private final ClassLoaderScope parent;
+    private final ClassPath classPath;
+    private final ClassLoader localClassLoader;
+
+    public ImmutableClassLoaderScope(ClassLoaderScopeIdentifier id, ClassLoaderScope parent, ClassPath classPath, @Nullable HashCode classpathImplementationHash,
+                                     @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
+        super(id, classLoaderCache, listener);
+        this.parent = parent;
+        this.classPath = classPath;
+        listener.childScopeCreated(parent.getId(), id);
+        ClassLoaderId classLoaderId = id.localId();
+        if (localClassLoaderFactory != null) {
+            localClassLoader = classLoaderCache.createIfAbsent(classLoaderId, classPath, parent.getExportClassLoader(), localClassLoaderFactory, classpathImplementationHash);
+        } else {
+            localClassLoader = classLoaderCache.get(classLoaderId, classPath, parent.getExportClassLoader(), null, classpathImplementationHash);
+        }
+        listener.localClasspathAdded(id, classPath);
+        listener.classloaderCreated(id, classLoaderId, localClassLoader);
+    }
+
+    @Override
+    public ClassLoaderScope getParent() {
+        return parent;
+    }
+
+    @Override
+    public ClassLoader getExportClassLoader() {
+        return parent.getExportClassLoader();
+    }
+
+    @Override
+    public ClassLoader getLocalClassLoader() {
+        return localClassLoader;
+    }
+
+    @Override
+    public boolean defines(Class<?> clazz) {
+        return localClassLoader.equals(clazz.getClassLoader());
+    }
+
+    @Override
+    public void onReuse() {
+        parent.onReuse();
+        listener.childScopeCreated(parent.getId(), id);
+        listener.localClasspathAdded(id, classPath);
+        listener.classloaderCreated(id, id.localId(), localClassLoader);
+    }
+
+    @Override
+    public ClassLoaderScope lock() {
+        return this;
+    }
+
+    @Override
+    public boolean isLocked() {
+        return true;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ImmutableClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ImmutableClassLoaderScope.java
@@ -31,6 +31,8 @@ import java.util.function.Function;
 public class ImmutableClassLoaderScope extends AbstractClassLoaderScope {
     private final ClassLoaderScope parent;
     private final ClassPath classPath;
+    @Nullable
+    private final HashCode classpathImplementationHash;
     private final ClassLoader localClassLoader;
 
     public ImmutableClassLoaderScope(ClassLoaderScopeIdentifier id, ClassLoaderScope parent, ClassPath classPath, @Nullable HashCode classpathImplementationHash,
@@ -38,6 +40,7 @@ public class ImmutableClassLoaderScope extends AbstractClassLoaderScope {
         super(id, classLoaderCache, listener);
         this.parent = parent;
         this.classPath = classPath;
+        this.classpathImplementationHash = classpathImplementationHash;
         listener.childScopeCreated(parent.getId(), id);
         ClassLoaderId classLoaderId = id.localId();
         if (localClassLoaderFactory != null) {
@@ -45,8 +48,7 @@ public class ImmutableClassLoaderScope extends AbstractClassLoaderScope {
         } else {
             localClassLoader = classLoaderCache.get(classLoaderId, classPath, parent.getExportClassLoader(), null, classpathImplementationHash);
         }
-        listener.localClasspathAdded(id, classPath);
-        listener.classloaderCreated(id, classLoaderId, localClassLoader);
+        listener.classloaderCreated(id, classLoaderId, localClassLoader, classPath, classpathImplementationHash);
     }
 
     @Override
@@ -73,8 +75,7 @@ public class ImmutableClassLoaderScope extends AbstractClassLoaderScope {
     public void onReuse() {
         parent.onReuse();
         listener.childScopeCreated(parent.getId(), id);
-        listener.localClasspathAdded(id, classPath);
-        listener.classloaderCreated(id, id.localId(), localClassLoader);
+        listener.classloaderCreated(id, id.localId(), localClassLoader, classPath, classpathImplementationHash);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootClassLoaderScope.java
@@ -18,11 +18,7 @@ package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.initialization.ClassLoaderScopeRegistryListener;
-import org.gradle.internal.Pair;
 import org.gradle.internal.classloader.CachingClassLoader;
-import org.gradle.internal.classpath.ClassPath;
-
-import java.util.function.Function;
 
 public class RootClassLoaderScope extends AbstractClassLoaderScope {
 
@@ -60,28 +56,8 @@ public class RootClassLoaderScope extends AbstractClassLoaderScope {
     }
 
     @Override
-    public ClassLoaderScope local(ClassPath classPath) {
-        throw new UnsupportedOperationException("root class loader scope is immutable");
-    }
-
-    @Override
-    public ClassLoaderScope export(ClassPath classPath) {
-        throw new UnsupportedOperationException("root class loader scope is immutable");
-    }
-
-    @Override
-    public ClassLoaderScope export(ClassLoader classLoader) {
-        throw new UnsupportedOperationException("root class loader scope is immutable");
-    }
-
-    @Override
     public ClassLoaderScope lock() {
         return this;
-    }
-
-    @Override
-    public ClassLoaderScope lock(Function<Pair<ClassPath, ClassLoader>, ClassLoader> localClassLoaderFactory) {
-        throw new UnsupportedOperationException("Root scope has already been created");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.initialization.loadercache;
 
-import org.gradle.internal.Pair;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
@@ -55,7 +54,7 @@ public interface ClassLoaderCache {
      * @param id the ID of the classloader.
      * @return the classloader.
      */
-    ClassLoader createIfAbsent(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, Function<Pair<ClassPath, ClassLoader>, ClassLoader> factoryFunction);
+    ClassLoader createIfAbsent(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, Function<ClassLoader, ClassLoader> factoryFunction, @Nullable HashCode implementationHash);
 
     /**
      * Discards the given classloader.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import org.gradle.initialization.SessionLifecycleListener;
-import org.gradle.internal.Pair;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.ClasspathHasher;
 import org.gradle.internal.classloader.FilteringClassLoader;
@@ -61,13 +60,13 @@ public class DefaultClassLoaderCache implements ClassLoaderCache, Stoppable, Ses
     }
 
     @Override
-    public ClassLoader get(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, @Nullable FilteringClassLoader.Spec filterSpec, HashCode implementationHash) {
+    public ClassLoader get(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, @Nullable FilteringClassLoader.Spec filterSpec, @Nullable HashCode implementationHash) {
         return doGet(id, classPath, parent, filterSpec, implementationHash, this::createClassLoader);
     }
 
     @Override
-    public ClassLoader createIfAbsent(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, Function<Pair<ClassPath, ClassLoader>, ClassLoader> factoryFunction) {
-        return doGet(id, classPath, parent, null, null, spec -> factoryFunction.apply(Pair.of(spec.classPath, spec.parent)));
+    public ClassLoader createIfAbsent(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, Function<ClassLoader, ClassLoader> factoryFunction, @Nullable HashCode implementationHash) {
+        return doGet(id, classPath, parent, null, implementationHash, spec -> factoryFunction.apply(spec.parent));
     }
 
     private ClassLoader doGet(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, @Nullable FilteringClassLoader.Spec filterSpec, @Nullable HashCode implementationHash, Function<ManagedClassLoaderSpec, ClassLoader> factoryFunction) {

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -364,9 +364,7 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
         private ClassLoaderScope prepareClassLoaderScope() {
             ClassPath scriptClassPath = DefaultClassPath.of(scriptCacheDir);
             String scopeName = "groovy-dsl:" + source.getFileName() + ":" + scriptBaseClass.getSimpleName();
-            return targetScope.createChild(scopeName)
-                .local(scriptClassPath)
-                .lock(spec -> new ScriptClassLoader(source, spec.right, spec.left, sourceHashCode));
+            return targetScope.createLockedChild(scopeName, scriptClassPath, sourceHashCode, parent -> new ScriptClassLoader(source, parent, scriptClassPath, sourceHashCode));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeRegistryListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeRegistryListener.java
@@ -18,6 +18,9 @@ package org.gradle.initialization;
 
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderId;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.hash.HashCode;
+
+import javax.annotation.Nullable;
 
 
 /**
@@ -35,11 +38,7 @@ public interface ClassLoaderScopeRegistryListener {
 
     void childScopeCreated(ClassLoaderScopeId parentId, ClassLoaderScopeId childId);
 
-    void localClasspathAdded(ClassLoaderScopeId scopeId, ClassPath localClassPath);
-
-    void exportClasspathAdded(ClassLoaderScopeId scopeId, ClassPath exportClassPath);
-
-    void classloaderCreated(ClassLoaderScopeId scopeId, ClassLoaderId classLoaderId, ClassLoader classLoader);
+    void classloaderCreated(ClassLoaderScopeId scopeId, ClassLoaderId classLoaderId, ClassLoader classLoader, ClassPath classPath, @Nullable HashCode implementationHash);
 
     ClassLoaderScopeRegistryListener NULL = new ClassLoaderScopeRegistryListener() {
         @Override
@@ -51,15 +50,7 @@ public interface ClassLoaderScopeRegistryListener {
         }
 
         @Override
-        public void localClasspathAdded(ClassLoaderScopeId scopeId, ClassPath localClassPath) {
-        }
-
-        @Override
-        public void exportClasspathAdded(ClassLoaderScopeId scopeId, ClassPath exportClassPath) {
-        }
-
-        @Override
-        public void classloaderCreated(ClassLoaderScopeId scopeId, ClassLoaderId classLoaderId, ClassLoader classLoader) {
+        public void classloaderCreated(ClassLoaderScopeId scopeId, ClassLoaderId classLoaderId, ClassLoader classLoader, ClassPath classPath, @Nullable HashCode implementationHash) {
         }
     };
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.initialization.loadercache
 
-import org.gradle.internal.Pair
+
 import org.gradle.internal.classloader.DefaultHashingClassLoaderFactory
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.classpath.ClassPath
@@ -26,6 +26,8 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
+
+import java.util.function.Function
 
 class DefaultClassLoaderCacheTest extends Specification {
 
@@ -188,14 +190,14 @@ class DefaultClassLoaderCacheTest extends Specification {
         def classPath = classPath("root")
 
         when:
-        def result = cache.createIfAbsent(id1, classPath, parent) { Pair<ClassPath, ClassLoader> spec -> loader }
+        def result = cache.createIfAbsent(id1, classPath, parent, { ClassLoader spec -> loader } as Function, null)
 
         then:
         result == loader
         cache.size() == 1
 
         when:
-        def result2 = cache.createIfAbsent(id1, classPath, parent) { throw new RuntimeException() }
+        def result2 = cache.createIfAbsent(id1, classPath, parent, { throw new RuntimeException() } as Function, null)
 
         then:
         result2 == loader

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.initialization.loadercache;
 
-import org.gradle.internal.Pair;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
@@ -38,8 +37,8 @@ public class DummyClassLoaderCache implements ClassLoaderCache {
     }
 
     @Override
-    public ClassLoader createIfAbsent(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, Function<Pair<ClassPath, ClassLoader>, ClassLoader> factoryFunction) {
-        return factoryFunction.apply(Pair.of(classPath, parent));
+    public ClassLoader createIfAbsent(ClassLoaderId id, ClassPath classPath, @Nullable ClassLoader parent, Function<ClassLoader, ClassLoader> factoryFunction, @Nullable HashCode implementationHash) {
+        return factoryFunction.apply(parent);
     }
 
     @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -24,6 +24,8 @@ import org.gradle.test.fixtures.file.TestFile
 trait TasksWithInputsAndOutputs {
     abstract TestFile getBuildFile()
 
+    abstract TestFile getBuildKotlinFile()
+
     def taskTypeWithOutputFileProperty() {
         buildFile << """
             class FileProducer extends DefaultTask {
@@ -39,6 +41,27 @@ trait TasksWithInputsAndOutputs {
                         file.delete()
                     } else {
                         file.text = content
+                    }
+                }
+            }
+        """
+    }
+
+    def kotlinTaskTypeWithOutputFileProperty() {
+        buildKotlinFile << """
+            abstract class FileProducer: DefaultTask() {
+                @get:OutputFile
+                abstract val output: RegularFileProperty
+                @get:Input
+                var content = "content" // set to empty string to delete file
+            
+                @TaskAction
+                fun go() {
+                    val file = output.get().asFile
+                    if (content.isBlank()) {
+                        file.delete()
+                    } else {
+                        file.writeText(content)
                     }
                 }
             }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Contexts.kt
@@ -26,6 +26,7 @@ import org.gradle.instantexecution.serialization.beans.BeanPropertyReader
 import org.gradle.instantexecution.serialization.beans.BeanPropertyWriter
 import org.gradle.instantexecution.serialization.beans.BeanStateReader
 import org.gradle.instantexecution.serialization.beans.BeanStateWriter
+import org.gradle.internal.hash.HashCode
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
@@ -103,10 +104,21 @@ class DefaultWriteContext(
                 writeScope(scope.parent)
                 writeString(scope.name)
                 writeClassPath(scope.localClassPath)
+                writeHashCode(scope.localImplementationHash)
                 writeClassPath(scope.exportClassPath)
             } else {
                 writeBoolean(false)
             }
+        }
+    }
+
+    private
+    fun writeHashCode(hashCode: HashCode?) {
+        if (hashCode == null) {
+            writeBoolean(false)
+        } else {
+            writeBoolean(true)
+            writeBinary(hashCode.toByteArray())
         }
     }
 
@@ -225,18 +237,26 @@ class DefaultReadContext(
             val parent = readScope()
             val name = readString()
             val localClassPath = readClassPath()
+            val localImplementationHash = readHashCode()
             val exportClassPath = readClassPath()
-            parent
-                .createChild(name)
-                .local(localClassPath)
-                .export(exportClassPath)
-                .lock()
+            if (localImplementationHash != null && exportClassPath.isEmpty) {
+                parent.createLockedChild(name, localClassPath, localImplementationHash, null)
+            } else {
+                parent.createChild(name).local(localClassPath).export(exportClassPath).lock()
+            }
         } else {
             isolate.owner.service(ClassLoaderScopeRegistry::class.java).coreAndPluginsScope
         }
         Workarounds.maybeSetDefaultStaticStateIn(newScope)
         scopes.putInstance(id, newScope)
         return newScope
+    }
+
+    private
+    fun readHashCode() = if (readBoolean()) {
+        HashCode.fromBytes(readBinary())
+    } else {
+        null
     }
 
     override fun getProject(path: String): ProjectInternal =

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -100,7 +100,7 @@ class AbstractIntegrationSpec extends Specification {
         testDirectory.file(getDefaultBuildFileName())
     }
 
-    protected TestFile getBuildKotlinFile() {
+    TestFile getBuildKotlinFile() {
         testDirectory.file(getDefaultBuildKotlinFileName())
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -303,10 +303,6 @@ class StandardKotlinScriptEvaluator(
         }
 
         private
-        fun prepareClassLoaderScope() = classLoaderScope
-            .createChild(childScopeId)
-            .local(DefaultClassPath.of(location))
-            .apply { accessorsClassPath?.let(::local) }
-            .lock()
+        fun prepareClassLoaderScope() = classLoaderScope.createLockedChild(childScopeId, DefaultClassPath.of(location).plus(accessorsClassPath ?: ClassPath.EMPTY), null, null)
     }
 }


### PR DESCRIPTION

### Context

Fix a performance regression introduced in https://github.com/gradle/gradle/pull/11415, and also ensure that tasks whose implementation class is defined in a Groovy DSL build script are up-to-date when first loaded from the instant execution cache and none of their inputs have changed (this was already working for Kotlin DSL).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
