### PR TITLE
Implement missing optimizations

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
@@ -83,6 +83,26 @@ class Intersections {
             return intersectModuleIdSet((ModuleIdSetExclude) left, right);
         } else if (right instanceof ModuleIdSetExclude) {
             return intersectModuleIdSet((ModuleIdSetExclude) right, left);
+        } else if (left instanceof ModuleSetExclude) {
+            return intersectModuleSet((ModuleSetExclude) left, right);
+        } else if (right instanceof ModuleSetExclude) {
+            return intersectModuleSet((ModuleSetExclude) right, left);
+        }
+        return null;
+    }
+
+    private ExcludeSpec intersectModuleSet(ModuleSetExclude left, ExcludeSpec right) {
+        if (right instanceof ModuleSetExclude) {
+            ModuleSetExclude msr = (ModuleSetExclude) right;
+            Set<String> modules = Sets.newHashSet(left.getModules());
+            modules.retainAll(msr.getModules());
+            if (modules.isEmpty()) {
+                return factory.nothing();
+            }
+            if (modules.size() == 1) {
+                return factory.module(modules.iterator().next());
+            }
+            return factory.moduleSet(modules);
         }
         return null;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Unions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Unions.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.factories;
+
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.GroupExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.GroupSetExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleIdExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleIdSetExclude;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ModuleSetExclude;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class Unions {
+    private final ExcludeFactory factory;
+
+    public Unions(ExcludeFactory factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * Tries to compute an union of 2 specs.
+     * The result MUST be a simplification, otherwise this method returns null.
+     */
+    ExcludeSpec tryUnion(ExcludeSpec left, ExcludeSpec right) {
+        if (left.equals(right)) {
+            return left;
+        }
+        if (left instanceof ModuleExclude) {
+            return tryModuleUnion((ModuleExclude) left, right);
+        } else if (right instanceof ModuleExclude) {
+            return tryModuleUnion((ModuleExclude) right, left);
+        }
+        if (left instanceof GroupExclude) {
+            return tryGroupUnion((GroupExclude) left, right);
+        } else if (right instanceof GroupExclude) {
+            return tryGroupUnion((GroupExclude) right, left);
+        }
+        if (left instanceof ModuleSetExclude) {
+            return tryModuleSetUnion((ModuleSetExclude) left, right);
+        } else if (right instanceof ModuleSetExclude) {
+            return tryModuleSetUnion((ModuleSetExclude) right, left);
+        }
+        if (left instanceof GroupSetExclude) {
+            return tryGroupSetUnion((GroupSetExclude) left, right);
+        } else if (right instanceof GroupSetExclude) {
+            return tryGroupSetUnion((GroupSetExclude) right, left);
+        }
+        return null;
+    }
+
+    private ExcludeSpec tryModuleUnion(ModuleExclude left, ExcludeSpec right) {
+        String leftModule = left.getModule();
+        if (right instanceof ModuleIdExclude) {
+            ModuleIdExclude mie = (ModuleIdExclude) right;
+            if (mie.getModuleId().getName().equals(leftModule)) {
+                return left;
+            }
+        }
+        if (right instanceof ModuleIdSetExclude) {
+            ModuleIdSetExclude ids = (ModuleIdSetExclude) right;
+            Set<ModuleIdentifier> items = ids.getModuleIds().stream().filter(id -> !id.getName().equals(leftModule)).collect(Collectors.toSet());
+            if (items.size() == 1) {
+                return factory.anyOf(left, factory.moduleId(items.iterator().next()));
+            }
+            if (items.isEmpty()) {
+                return left;
+            }
+            if (items.size() != ids.getModuleIds().size()) {
+                return factory.anyOf(left, factory.moduleIdSet(items));
+            }
+        }
+        return null;
+    }
+
+    private ExcludeSpec tryGroupUnion(GroupExclude left, ExcludeSpec right) {
+        String leftGroup = left.getGroup();
+        if (right instanceof ModuleIdExclude) {
+            ModuleIdExclude mie = (ModuleIdExclude) right;
+            if (mie.getModuleId().getGroup().equals(leftGroup)) {
+                return left;
+            }
+        }
+        if (right instanceof ModuleIdSetExclude) {
+            ModuleIdSetExclude ids = (ModuleIdSetExclude) right;
+            Set<ModuleIdentifier> items = ids.getModuleIds().stream().filter(id -> !id.getGroup().equals(leftGroup)).collect(Collectors.toSet());
+            if (items.size() == 1) {
+                return factory.anyOf(left, factory.moduleId(items.iterator().next()));
+            }
+            if (items.isEmpty()) {
+                return left;
+            }
+            if (items.size() != ids.getModuleIds().size()) {
+                return factory.anyOf(left, factory.moduleIdSet(items));
+            }
+        }
+        return null;
+    }
+
+    private ExcludeSpec tryModuleSetUnion(ModuleSetExclude left, ExcludeSpec right) {
+        Set<String> leftModules = left.getModules();
+        if (right instanceof ModuleIdExclude) {
+            ModuleIdExclude mie = (ModuleIdExclude) right;
+            if (leftModules.contains(mie.getModuleId().getName())) {
+                return left;
+            }
+        }
+        if (right instanceof ModuleIdSetExclude) {
+            ModuleIdSetExclude ids = (ModuleIdSetExclude) right;
+            Set<ModuleIdentifier> items = ids.getModuleIds().stream().filter(id -> !leftModules.contains(id.getName())).collect(Collectors.toSet());
+            if (items.size() == 1) {
+                return factory.anyOf(left, factory.moduleId(items.iterator().next()));
+            }
+            if (items.isEmpty()) {
+                return left;
+            }
+            if (items.size() != ids.getModuleIds().size()) {
+                return factory.anyOf(left, factory.moduleIdSet(items));
+            }
+        }
+        return null;
+    }
+
+    private ExcludeSpec tryGroupSetUnion(GroupSetExclude left, ExcludeSpec right) {
+        Set<String> leftGroups = left.getGroups();
+        if (right instanceof ModuleIdExclude) {
+            ModuleIdExclude mie = (ModuleIdExclude) right;
+            if (leftGroups.contains(mie.getModuleId().getGroup())) {
+                return left;
+            }
+        }
+        if (right instanceof ModuleIdSetExclude) {
+            ModuleIdSetExclude ids = (ModuleIdSetExclude) right;
+            Set<ModuleIdentifier> items = ids.getModuleIds().stream().filter(id -> !leftGroups.contains(id.getGroup())).collect(Collectors.toSet());
+            if (items.size() == 1) {
+                return factory.anyOf(left, factory.moduleId(items.iterator().next()));
+            }
+            if (items.isEmpty()) {
+                return left;
+            }
+            if (items.size() != ids.getModuleIds().size()) {
+                return factory.anyOf(left, factory.moduleIdSet(items));
+            }
+        }
+        return null;
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/ExcludeTestSupport.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/ExcludeTestSupport.groovy
@@ -53,6 +53,13 @@ trait ExcludeTestSupport {
         factory.moduleIdSet(RandomizedIteratorHashSet.of(ids.collect { newId(it[0], it[1]) } as Set))
     }
 
+    ExcludeSpec moduleIdSet(String... ids) {
+        factory.moduleIdSet(RandomizedIteratorHashSet.of(ids.collect {
+            def split = it.split(':')
+            newId(split[0], split[1])
+        } as Set))
+    }
+
     ExcludeSpec anyOf(ExcludeSpec... specs) {
         switch (specs.length) {
             case 0:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/NormalizingExcludeFactoryTest.groovy
@@ -39,24 +39,45 @@ class NormalizingExcludeFactoryTest extends Specification implements ExcludeTest
         factory.anyOf(right, left) == expected
 
         where:
-        left                                        | right                                       | expected
-        everything()                                | nothing()                                   | everything()
-        everything()                                | everything()                                | everything()
-        nothing()                                   | nothing()                                   | nothing()
-        everything()                                | group("foo")                                | everything()
-        nothing()                                   | group("foo")                                | group("foo")
-        group("foo")                                | group("bar")                                | groupSet("foo", "bar")
-        group("foo")                                | module("bar")                               | anyOf(group("foo"), module("bar"))
-        anyOf(group("foo"), group("bar"))           | group("foo")                                | groupSet("foo", "bar")
-        anyOf(group("foo"), module("bar"))          | module("bar")                               | anyOf(module("bar"), group("foo"))
-        moduleId("org", "a")                        | moduleId("org", "b")                        | moduleIdSet(["org", "a"], ["org", "b"])
-        module("org")                               | module("org2")                              | moduleSet("org", "org2")
-        groupSet("org", "org2")                     | groupSet("org3", "org4")                    | groupSet("org", "org2", "org3", "org4")
-        moduleSet("mod", "mod2")                    | moduleSet("mod3", "mod4")                   | moduleSet("mod", "mod2", "mod3", "mod4")
-        moduleIdSet(["org", "foo"], ["org", "bar"]) | moduleIdSet(["org", "baz"], ["org", "quz"]) | moduleIdSet(["org", "foo"], ["org", "bar"], ["org", "baz"], ["org", "quz"])
-        module("mod")                               | moduleSet("m1", "m2")                       | moduleSet("m1", "m2", "mod")
-        group("g1")                                 | groupSet("g2", "g3")                        | groupSet("g1", "g2", "g3")
-        moduleId("g1", "m1")                        | moduleIdSet(["g2", "m2"], ["g3", "m3"])     | moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"])
+        left                                                                | right                                       | expected
+        everything()                                                        | nothing()                                   | everything()
+        everything()                                                        | everything()                                | everything()
+        nothing()                                                           | nothing()                                   | nothing()
+        everything()                                                        | group("foo")                                | everything()
+        nothing()                                                           | group("foo")                                | group("foo")
+        group("foo")                                                        | group("bar")                                | groupSet("foo", "bar")
+        group("foo")                                                        | module("bar")                               | anyOf(group("foo"), module("bar"))
+        anyOf(group("foo"), group("bar"))                                   | group("foo")                                | groupSet("foo", "bar")
+        anyOf(group("foo"), module("bar"))                                  | module("bar")                               | anyOf(module("bar"), group("foo"))
+        moduleId("org", "a")                                                | moduleId("org", "b")                        | moduleIdSet(["org", "a"], ["org", "b"])
+        module("org")                                                       | module("org2")                              | moduleSet("org", "org2")
+        groupSet("org", "org2")                                             | groupSet("org3", "org4")                    | groupSet("org", "org2", "org3", "org4")
+        moduleSet("mod", "mod2")                                            | moduleSet("mod3", "mod4")                   | moduleSet("mod", "mod2", "mod3", "mod4")
+        moduleIdSet(["org", "foo"], ["org", "bar"])                         | moduleIdSet(["org", "baz"], ["org", "quz"]) | moduleIdSet(["org", "foo"], ["org", "bar"], ["org", "baz"], ["org", "quz"])
+        module("mod")                                                       | moduleSet("m1", "m2")                       | moduleSet("m1", "m2", "mod")
+        group("g1")                                                         | groupSet("g2", "g3")                        | groupSet("g1", "g2", "g3")
+        moduleId("g1", "m1")                                                | moduleIdSet(["g2", "m2"], ["g3", "m3"])     | moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"])
+
+        moduleId("g1", "m1")                                                | module("m1")                                | module("m1")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"])                             | module("m1")                                | anyOf(module("m1"), moduleId("g2", "m2"))
+        moduleIdSet(["g1", "m1"], ["g2", "m1"])                             | module("m1")                                | module("m1")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"])               | module("m1")                                | anyOf(module("m1"), moduleIdSet(["g2", "m2"], ["g3", "m3"]))
+
+        moduleId("g1", "m1")                                                | group("g1")                                 | group("g1")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"])                             | group("g1")                                 | anyOf(group("g1"), moduleId("g2", "m2"))
+        moduleIdSet(["g1", "m1"], ["g1", "m2"])                             | group("g1")                                 | group("g1")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"])               | group("g1")                                 | anyOf(group("g1"), moduleIdSet(["g2", "m2"], ["g3", "m3"]))
+
+        moduleId("g1", "m1")                                                | moduleSet("m1", "m2")                       | moduleSet("m1", "m2")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"])                             | moduleSet("m1", "m2")                       | moduleSet("m1", "m2")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"])               | moduleSet("m1", "m2")                       | anyOf(moduleId("g3", "m3"), moduleSet("m1", "m2"))
+        moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"], ["g4", "m4"]) | moduleSet("m1", "m2")                       | anyOf(moduleIdSet(["g3", "m3"], ["g4", "m4"]), moduleSet("m1", "m2"))
+
+        moduleId("g1", "m1")                                                | groupSet("g1", "g2")                        | groupSet("g1", "g2")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"])                             | groupSet("g1", "g2")                        | groupSet("g1", "g2")
+        moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"])               | groupSet("g1", "g2")                        | anyOf(moduleId("g3", "m3"), groupSet("g1", "g2"))
+        moduleIdSet(["g1", "m1"], ["g2", "m2"], ["g3", "m3"], ["g4", "m4"]) | groupSet("g1", "g2")                        | anyOf(moduleIdSet(["g3", "m3"], ["g4", "m4"]), groupSet("g1", "g2"))
+
     }
 
     @Unroll("#one ∪ #two ∪ #three = #expected")
@@ -84,15 +105,16 @@ class NormalizingExcludeFactoryTest extends Specification implements ExcludeTest
         factory.allOf(right, left) == expected
 
         where:
-        left                               | right         | expected
-        everything()                       | nothing()     | nothing()
-        everything()                       | everything()  | everything()
-        nothing()                          | nothing()     | nothing()
-        everything()                       | group("foo")  | group("foo")
-        nothing()                          | group("foo")  | nothing()
-        group("foo")                       | group("foo")  | group("foo")
-        allOf(group("foo"), group("foo2")) | module("bar") | nothing()
-        allOf(group("foo"), module("bar")) | module("bar") | moduleId("foo", "bar")
+        left                               | right                 | expected
+        everything()                       | nothing()             | nothing()
+        everything()                       | everything()          | everything()
+        nothing()                          | nothing()             | nothing()
+        everything()                       | group("foo")          | group("foo")
+        nothing()                          | group("foo")          | nothing()
+        group("foo")                       | group("foo")          | group("foo")
+        allOf(group("foo"), group("foo2")) | module("bar")         | nothing()
+        allOf(group("foo"), module("bar")) | module("bar")         | moduleId("foo", "bar")
+        moduleSet("m1", "m2", "m3")        | moduleSet("m1", "m3") | moduleSet("m1", "m3")
     }
 
     @Unroll("#one ∩ #two ∩ #three = #expected")
@@ -114,5 +136,140 @@ class NormalizingExcludeFactoryTest extends Specification implements ExcludeTest
         anyOf(moduleId("org", "foo"), moduleId("org", "bar")) | ivy("org", "mod", artifact("mod"), "exact") | anyOf(group("org"), module("bar"))                                         | allOf(moduleIdSet(["org", "foo"], ["org", "bar"]), ivy("org", "mod", artifact("mod"), "exact"))
         anyOf(moduleId("org", "foo"), moduleId("org", "bar")) | ivy("org", "mod", artifact("mod"), "exact") | anyOf(moduleId("org", "foo"), module("bar"))                               | allOf(moduleIdSet(["org", "foo"], ["org", "bar"]), ivy("org", "mod", artifact("mod"), "exact"))
         anyOf(moduleId("org", "foo"), moduleId("org", "bar")) | ivy("org", "mod", artifact("mod"), "exact") | anyOf(moduleId("org", "foo"), ivy("org", "mod", artifact("mod"), "exact")) | allOf(anyOf(moduleId("org", "foo"), moduleId("org", "bar")), ivy("org", "mod", artifact("mod"), "exact"))
+    }
+
+    def "adhoc verification of code generated from ExcludeJsonLogToCode"() {
+
+        def operand0 = moduleId('shake', 'grain')
+        def operand1 = moduleId('root', 'rain')
+        def operand2 = moduleId('cover', 'cover')
+        def operand3 = moduleId('crib', 'lunchroom')
+        def operand4 = moduleId('root', 'sort')
+        def operand5 = moduleId('crib', 'building')
+        def operand6 = moduleId('fact', 'grass')
+        def operand7 = moduleId('crib', 'planes')
+        def operand8 = moduleId('stove', 'pull')
+        def operand9 = moduleId('calculator', 'suggestion')
+        def operand10 = moduleId('beginner', 'plough')
+        def operand11 = moduleId('insurance', 'hat')
+        def operand12 = moduleId('toys', 'plant')
+        def operand13 = moduleId('trail', 'wing')
+        def operand14 = moduleId('ring', 'desk')
+        def operand15 = moduleId('yak', 'teaching')
+        def operand16 = moduleId('street', 'cattle')
+        def operand17 = group('sun')
+        def operand18 = moduleId('crib', 'wealth')
+        def operand19 = moduleId('cabbage', 'playground')
+        def operand20 = moduleId('wren', 'flowers')
+        def operand21 = moduleId('insurance', 'cobweb')
+        def operand22 = moduleId('crib', 'shame')
+        def operand23 = moduleId('plate', 'authority')
+        def operand24 = moduleId('stove', 'cave')
+        def operand25 = moduleId('floor', 'shelf')
+        def operand26 = moduleId('snakes', 'snakes')
+        def operand27 = moduleId('crib', 'ants')
+        def operand28 = moduleId('comparison', 'comparison')
+        def operand29 = moduleId('quicksand', 'eyes')
+        def operand30 = moduleId('crib', 'thumb')
+        def operand31 = module('church')
+        def operand32 = moduleId('needle', 'celery')
+        def operand33 = moduleId('crib', 'competition')
+        def operand34 = moduleId('metal', 'box')
+        def operand35 = moduleId('root', 'industry')
+        def operand36 = group('brother')
+        def operand37 = moduleId('crib', 'deer')
+        def operand38 = moduleId('root', 'waves')
+        def operand39 = moduleId('advice', 'acoustics')
+        def operand40 = moduleId('ring', 'nut')
+        def operand41 = moduleId('store', 'finger')
+        def operand42 = moduleId('plate', 'null')
+        def operand43 = moduleId('crib', 'word65')
+        def operand44 = moduleId('stove', 'word66')
+        def operand45 = moduleId('word67', 'word68')
+        def operand46 = moduleId('word69', 'word70')
+        def operand47 = moduleId('word69', 'word71')
+        def operand48 = moduleId('shake', 'finger')
+        def operand49 = moduleId('word72', 'word73')
+        def operand50 = moduleId('crib', 'word74')
+        def operand51 = moduleId('word75', 'word76')
+        def operand52 = moduleId('word77', 'word78')
+        def operand53 = moduleId('word79', 'word80')
+        def operand54 = moduleId('stove', 'word81')
+        def operand55 = moduleId('word82', 'word83')
+        def operand56 = moduleId('word84', 'word85')
+        def operand57 = moduleId('stove', 'word86')
+        def operand58 = moduleId('root', 'word87')
+        def operand59 = moduleId('root', 'word88')
+        def operand60 = moduleId('root', 'word89')
+        def operand61 = moduleId('root', 'word90')
+        def operation = factory.anyOf([
+            operand0,
+            operand1,
+            operand2,
+            operand3,
+            operand4,
+            operand5,
+            operand6,
+            operand7,
+            operand8,
+            operand9,
+            operand10,
+            operand11,
+            operand12,
+            operand13,
+            operand14,
+            operand15,
+            operand16,
+            operand17,
+            operand18,
+            operand19,
+            operand20,
+            operand21,
+            operand22,
+            operand23,
+            operand24,
+            operand25,
+            operand26,
+            operand27,
+            operand28,
+            operand29,
+            operand30,
+            operand31,
+            operand32,
+            operand33,
+            operand34,
+            operand35,
+            operand36,
+            operand37,
+            operand38,
+            operand39,
+            operand40,
+            operand41,
+            operand42,
+            operand43,
+            operand44,
+            operand45,
+            operand46,
+            operand47,
+            operand48,
+            operand49,
+            operand50,
+            operand51,
+            operand52,
+            operand53,
+            operand54,
+            operand55,
+            operand56,
+            operand57,
+            operand58,
+            operand59,
+            operand60,
+            operand61
+        ] as Set)
+
+
+        expect:
+        operation
+
     }
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/ExcludeJsonLogToCode.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/ExcludeJsonLogToCode.groovy
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.factories
+
+import groovy.json.JsonSlurper
+
+class ExcludeJsonLogToCode {
+    private final static List<String> WORDS = [
+        "shake",
+        "grain",
+        "root",
+        "rain",
+        "cover",
+        "crib",
+        "lunchroom",
+        "sort",
+        "building",
+        "fact",
+        "grass",
+        "planes",
+        "stove",
+        "pull",
+        "calculator",
+        "suggestion",
+        "beginner",
+        "plough",
+        "insurance",
+        "hat",
+        "toys",
+        "plant",
+        "trail",
+        "wing",
+        "ring",
+        "desk",
+        "yak",
+        "teaching",
+        "street",
+        "cattle",
+        "sun",
+        "wealth",
+        "cabbage",
+        "playground",
+        "wren",
+        "flowers",
+        "cobweb",
+        "shame",
+        "plate",
+        "authority",
+        "cave",
+        "floor",
+        "shelf",
+        "snakes",
+        "ants",
+        "comparison",
+        "quicksand",
+        "eyes",
+        "thumb",
+        "church",
+        "needle",
+        "celery",
+        "competition",
+        "metal",
+        "box",
+        "industry",
+        "brother",
+        "deer",
+        "waves",
+        "advice",
+        "acoustics",
+        "nut",
+        "store",
+        "finger"
+    ]
+
+    private final Map<String, String> mappingCache = [:].withDefault {
+        def size = mappingCache.size()
+        size >WORDS.size() ? "word${size}" : WORDS[size]
+    }
+
+    /**
+     * Converts an operation dumped as JSON into code which can be used to
+     * check the result, to be used in {@link NormalizingExcludeFactory}
+     *
+     * @param json
+     * @return
+     */
+    String toCode(String json) {
+        def slurper = new JsonSlurper().parse(json.trim().getBytes("utf-8"))
+        def operation = slurper.operation.name
+        def operands = slurper.operation.operands.collect { e ->
+            "${toExclude(e)}"
+        }
+        """
+${operands.indexed().collect { i, e -> "def operand$i = $e" }.join("\n")}
+def operation = factory.$operation([
+   ${operands.indexed().collect { i, e -> "operand$i" }.join(",\n   ")}
+] as Set)
+"""
+    }
+
+    private String toExclude(it) {
+        assert it instanceof Map
+        assert it.keySet().size() == 1
+        String key = it.keySet()[0]
+        Object value = it[key]
+        toExclude(key, value)
+    }
+
+    private void collectOperands(Object value, List<String> collector) {
+        if (value instanceof List) {
+            value.each {
+                collectOperands(it, collector)
+            }
+        } else {
+            collector << toExclude(value)
+        }
+    }
+
+    private String toExclude(String opType, Object value) {
+        switch (opType) {
+            case "any of":
+                def operands = []
+                collectOperands(value, operands)
+                return "anyOf(${operands.join(', ')})"
+            case "all of":
+                def operands = []
+                collectOperands(value, operands)
+                return "allOf(${operands.join(', ')})"
+            case "exclude group":
+                return "group('${anonymize(value)}')"
+                break
+            case "exclude module":
+                return "module('${anonymize(value)}')"
+            case "exclude module id":
+                def (group, name) = value.split(':')
+                return "moduleId('${anonymize(group)}', '${anonymize(name)}')"
+            case "module set":
+                return "moduleSet('${anonymize(value)}')"
+            case "module ids":
+                return "moduleIdSet(${value.collect { "'${anonymize(it)}'" }.join(', ')})"
+            default:
+                throw new UnsupportedOperationException("Not yet implemented for $opType")
+        }
+    }
+
+    private String anonymize(String value) {
+        value.split(":").collect {
+            mappingCache[it]
+        }.join(':')
+    }
+
+    static void main(String[] args) {
+        def code = new ExcludeJsonLogToCode().toCode("""
+
+PASTE SOME JSON HERE
+
+""")
+
+        println(code)
+    }
+}


### PR DESCRIPTION
### Context

This commit introduces some missing union optimizations during
exclude rule merging. Those weren't implemented because we didn't
see them in our test cases, but we had customer logs showing such
operations.

It's worth noting this commit adds an utility class which transforms
a JSON dump from a log entry into code which can be used to create
test cases.
