### PR TITLE
Fix instant execution to support gradle-profiler --measure-build-op

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BuildOperationListenersCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BuildOperationListenersCodec.kt
@@ -31,7 +31,7 @@ import java.lang.reflect.Field
 /**
  * Captures a white list of listeners.
  *
- * Only for gradle-profiler --benchmark-config-time for now.
+ * Only for gradle-profiler --measure-config-time for now.
  *
  * Makes assumptions on the manager implementation.
  */
@@ -42,9 +42,8 @@ class BuildOperationListenersCodec {
 
         private
         val classNameWhitelist = setOf(
-            // Remove whitelisting this listener class when https://github.com/gradle/gradle-profiler/pull/140 has been merged
-            "org.gradle.trace.buildops.BuildOperationTrace${'$'}RecordingListener",
-            "org.gradle.trace.buildops.BuildOperationTrace${'$'}TimeToFirstTaskRecordingListener"
+            "org.gradle.trace.buildops.BuildOperationTrace${'$'}TimeToFirstTaskRecordingListener",
+            "org.gradle.trace.buildops.BuildOperationTrace${'$'}BuildOperationDurationRecordingListener"
         )
     }
 


### PR DESCRIPTION
This is a follow up to https://github.com/gradle/gradle-profiler/pull/140 especially https://github.com/gradle/gradle-profiler/commit/4831099af1a7ff232fb0e5465c769972cb8421ae#diff-8fb187dbf48e8558e622fee4141fe2ccL19-R40

This PR doesn't change what build operations are emitted when instant execution loads the work graph.