### PR TITLE
Annotate command-line arg provider names with Internal

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -78,6 +78,7 @@ class LibsRepositoryEnvironmentProvider(objects: ObjectFactory) : CommandLineArg
         if (required) mapOf("integTest.libsRepo" to absolutePathOf(dir)).asSystemPropertyJvmArguments()
         else emptyList()
 
+    @Internal
     override fun getName() =
         "libsRepository"
 }
@@ -120,6 +121,7 @@ class GradleInstallationForTestEnvironmentProvider(project: Project) : CommandLi
             "integTest.toolingApiShadedJarDir" to absolutePathOf(toolingApiShadedJarDir)
         ).asSystemPropertyJvmArguments()
 
+    @Internal
     override fun getName() =
         "gradleInstallationForTest"
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -26,6 +26,7 @@ import org.gradle.api.Named
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.CompileOptions
@@ -227,6 +228,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
     private
     fun createCiEnvironmentProvider(test: Test): CommandLineArgumentProvider {
         return object : CommandLineArgumentProvider, Named {
+            @Internal
             override fun getName() = "ciEnvironment"
 
             override fun asArguments(): Iterable<String> {


### PR DESCRIPTION
to remove the deprecation warnings.

See https://e.grdev.net/s/33xyqeasajbue/deprecations?openUsages=WzIsMyw0LDUsNl0 for the emitted warnings.