### PR TITLE
Update Gradle Enterprise Gradle plugin to version 3.1

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.1-rc-3")
+    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.1")
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.5.0-rc-2")
     implementation("org.jsoup:jsoup:1.11.3")
     implementation(project(":configuration"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,19 +21,10 @@ pluginManagement {
         gradlePluginPortal()
         maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
     }
-
-    // No plugin marker for plugin RC - can be removed when going to a final version
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "com.gradle.enterprise") {
-                useModule("com.gradle:gradle-enterprise-gradle-plugin:${requested.version}")
-            }
-        }
-    }
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.1-rc-3")
+    id("com.gradle.enterprise").version("3.1")
 }
 
 apply(from = "gradle/build-cache-configuration.settings.gradle.kts")

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedGradleEnterprisePlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "gradle-enterprise-gradle-plugin";
-    public static final String VERSION = "3.0";
+    public static final String VERSION = "3.1";
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.enterprise");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -44,7 +44,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
     ]
 
     private static final List<String> SUPPORTED = [
-        "3.0"
+        "3.0",
+        "3.1"
     ]
 
     @Unroll
@@ -93,7 +94,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 plugins {
                     id "com.gradle.enterprise" version "$version"
                 }
-    
+
                 gradleEnterprise {
                     buildScan {
                         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
@@ -106,7 +107,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 plugins {
                     id "com.gradle.build-scan" version "$version"
                 }
-    
+
                 buildScan {
                     termsOfServiceUrl = 'https://gradle.com/terms-of-service'
                     termsOfServiceAgree = 'yes'


### PR DESCRIPTION
### Context
Update Gradle Enterprise Gradle plugin to version 3.1

### Contributor Checklist

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
