### PR TITLE
Implement 'belongsTo' for published platforms through real platform dependencies

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -558,8 +558,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, namedObjectInstantiator, platformSupport);
         }
 
-        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor) {
-            DefaultComponentMetadataHandler componentMetadataHandler = instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory, componentMetadataRuleExecutor);
+        DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor, PlatformSupport platformSupport) {
+            DefaultComponentMetadataHandler componentMetadataHandler = instantiator.newInstance(DefaultComponentMetadataHandler.class, instantiator, moduleIdentifierFactory, interner, attributesFactory, isolatableFactory, componentMetadataRuleExecutor, platformSupport);
             if (domainObjectContext.isScript()) {
                 componentMetadataHandler.setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy());
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.MetadataResolutionContext;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -71,6 +72,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     private final ImmutableAttributesFactory attributesFactory;
     private final IsolatableFactory isolatableFactory;
     private final ComponentMetadataRuleExecutor ruleExecutor;
+    private final PlatformSupport platformSupport;
 
     DefaultComponentMetadataHandler(Instantiator instantiator,
                                     RuleActionAdapter ruleActionAdapter,
@@ -78,7 +80,8 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
                                     Interner<String> stringInterner,
                                     ImmutableAttributesFactory attributesFactory,
                                     IsolatableFactory isolatableFactory,
-                                    ComponentMetadataRuleExecutor ruleExecutor) {
+                                    ComponentMetadataRuleExecutor ruleExecutor,
+                                    PlatformSupport platformSupport) {
         this.instantiator = instantiator;
         this.ruleActionAdapter = ruleActionAdapter;
         this.moduleIdentifierNotationParser = NotationParserBuilder
@@ -92,10 +95,11 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
         this.attributesFactory = attributesFactory;
         this.isolatableFactory = isolatableFactory;
         this.metadataRuleContainer = new ComponentMetadataRuleContainer();
+        this.platformSupport = platformSupport;
     }
 
-    public DefaultComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, Interner<String> stringInterner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor ruleExecutor) {
-        this(instantiator, createAdapter(), moduleIdentifierFactory, stringInterner, attributesFactory, isolatableFactory, ruleExecutor);
+    public DefaultComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, Interner<String> stringInterner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor ruleExecutor, PlatformSupport platformSupport) {
+        this(instantiator, createAdapter(), moduleIdentifierFactory, stringInterner, attributesFactory, isolatableFactory, ruleExecutor, platformSupport);
     }
 
     private static RuleActionAdapter createAdapter() {
@@ -199,7 +203,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
 
     @Override
     public ComponentMetadataProcessor createComponentMetadataProcessor(MetadataResolutionContext resolutionContext) {
-        return new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, attributesFactory, ruleExecutor, resolutionContext);
+        return new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, attributesFactory, ruleExecutor, platformSupport, resolutionContext);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -67,8 +67,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.gradle.api.internal.artifacts.repositories.resolver.VirtualComponentHelper.makeVirtual;
-
 public class DefaultComponentMetadataProcessor implements ComponentMetadataProcessor {
 
     private final static boolean FORCE_REALIZE = Boolean.getBoolean("org.gradle.integtest.force.realize.metadata");
@@ -316,7 +314,6 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         private boolean changing;
         private List<String> statusScheme;
         private AttributeContainerInternal attributes;
-        private final List<ComponentIdentifier> owners;
 
         public ShallowComponentMetadataAdapter(NotationParser<Object, ComponentIdentifier> componentIdentifierNotationParser, ComponentMetadata source, ImmutableAttributesFactory attributesFactory) {
             this.componentIdentifierNotationParser = componentIdentifierNotationParser;
@@ -324,7 +321,6 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
             changing = source.isChanging();
             statusScheme = source.getStatusScheme();
             attributes = attributesFactory.mutable((AttributeContainerInternal) source.getAttributes());
-            owners = Lists.newArrayListWithExpectedSize(1);
         }
 
         @Override
@@ -364,16 +360,12 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
 
         @Override
         public void belongsTo(Object notation) {
-            belongsTo(notation, true);
+
         }
 
         @Override
         public void belongsTo(Object notation, boolean virtual) {
-            if (virtual) {
-                ComponentIdentifier id = componentIdentifierNotationParser.parseNotation(notation);
-                id = makeVirtual(id);
-                owners.add(id);
-            }
+
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.ComponentMetadataContext;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
@@ -38,6 +39,7 @@ class WrappingComponentMetadataContext implements ComponentMetadataContext {
     private final NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
     private final NotationParser<Object, ComponentIdentifier> componentIdentifierParser;
+    private final PlatformSupport platformSupport;
 
     private MutableModuleComponentResolveMetadata mutableMetadata;
     private ComponentMetadataDetails details;
@@ -45,12 +47,14 @@ class WrappingComponentMetadataContext implements ComponentMetadataContext {
     public WrappingComponentMetadataContext(ModuleComponentResolveMetadata metadata, Instantiator instantiator,
                                             NotationParser<Object, DirectDependencyMetadataImpl> dependencyMetadataNotationParser,
                                             NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser,
-                                            NotationParser<Object, ComponentIdentifier> componentIdentifierParser) {
+                                            NotationParser<Object, ComponentIdentifier> componentIdentifierParser,
+                                            PlatformSupport platformSupport) {
         this.metadata = metadata;
         this.instantiator = instantiator;
         this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
         this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
         this.componentIdentifierParser = componentIdentifierParser;
+        this.platformSupport = platformSupport;
     }
 
     @Override
@@ -68,7 +72,7 @@ class WrappingComponentMetadataContext implements ComponentMetadataContext {
     public ComponentMetadataDetails getDetails() {
         createMutableMetadataIfNeeded();
         if (details == null) {
-            details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierParser);
+            details = instantiator.newInstance(ComponentMetadataDetailsAdapter.class, mutableMetadata, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierParser, platformSupport);
 
         }
         return details;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -46,6 +46,10 @@ public class PlatformSupport {
         return regularPlatform.equals(category) || enforcedPlatform.equals(category);
     }
 
+    public Category getRegularPlatformCategory() {
+        return regularPlatform;
+    }
+
     public void configureSchema(AttributesSchema attributesSchema) {
         configureCategoryDisambiguationRule(attributesSchema);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -35,6 +35,7 @@ import org.gradle.internal.component.external.model.ModuleComponentResolveMetada
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadataWrapper;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -175,7 +176,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
 
         @Override
-        public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+        public ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners() {
             return ImmutableList.of();
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.internal.component.external.model.AbstractLazyModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
-import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultVirtualModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.ExternalDependencyDescriptor;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
@@ -89,19 +88,19 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
         int len = decoder.readSmallInt();
         if (len>0) {
             for (int i=0; i<len; i++) {
-                ComponentIdentifier moduleComponentIdentifier = readModuleIdentifier(decoder);
+                VirtualComponentIdentifier moduleComponentIdentifier = readModuleIdentifier(decoder);
                 mutable.belongsTo(moduleComponentIdentifier);
             }
         }
     }
 
-    private ModuleComponentIdentifier readModuleIdentifier(Decoder decoder) throws IOException {
-        boolean virtual = decoder.readBoolean();
+    private VirtualComponentIdentifier readModuleIdentifier(Decoder decoder) throws IOException {
+        decoder.readBoolean();
         String group = decoder.readString();
         String module = decoder.readString();
         String version = decoder.readString();
         ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(group, module);
-        return virtual ? new DefaultVirtualModuleComponentIdentifier(moduleIdentifier, version) : DefaultModuleComponentIdentifier.newId(moduleIdentifier, version);
+        return new DefaultVirtualModuleComponentIdentifier(moduleIdentifier, version);
     }
 
     @Override
@@ -121,15 +120,15 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
         }
     }
 
-    private void writeOwners(Encoder encoder, ImmutableList<? extends ComponentIdentifier> platformOwners) throws IOException {
+    private void writeOwners(Encoder encoder, ImmutableList<? extends VirtualComponentIdentifier> platformOwners) throws IOException {
         encoder.writeSmallInt(platformOwners.size());
         for (ComponentIdentifier platformOwner : platformOwners) {
-            writeComponentIdentifier(encoder, (ModuleComponentIdentifier)platformOwner);
+            writeComponentIdentifier(encoder, (ModuleComponentIdentifier) platformOwner);
         }
     }
 
     private void writeComponentIdentifier(Encoder encoder, ModuleComponentIdentifier platformOwner) throws IOException {
-        encoder.writeBoolean(platformOwner instanceof VirtualComponentIdentifier);
+        encoder.writeBoolean(true);
         encoder.writeString(platformOwner.getGroup());
         encoder.writeString(platformOwner.getModule());
         encoder.writeString(platformOwner.getVersion());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -19,7 +19,6 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -34,6 +33,7 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.RealisedConfigurationMetadata;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ModuleSource;
@@ -145,7 +145,7 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
     }
 
     @Override
-    public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+    public ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners() {
         return ImmutableList.of();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
@@ -47,6 +46,7 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ShadowedCapability;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -492,10 +492,10 @@ public class NodeState implements DependencyGraphNode {
      * @param discoveredEdges the collection of edges for this component
      */
     private void visitOwners(Collection<EdgeState> discoveredEdges) {
-        ImmutableList<? extends ComponentIdentifier> owners = component.getMetadata().getPlatformOwners();
+        ImmutableList<? extends VirtualComponentIdentifier> owners = component.getMetadata().getPlatformOwners();
         if (!owners.isEmpty()) {
             PendingDependenciesVisitor visitor = resolveState.newPendingDependenciesVisitor();
-            for (ComponentIdentifier owner : owners) {
+            for (VirtualComponentIdentifier owner : owners) {
                 if (owner instanceof ModuleComponentIdentifier) {
                     ModuleComponentIdentifier platformId = (ModuleComponentIdentifier) owner;
                     final ModuleComponentSelector cs = DefaultModuleComponentSelector.newSelector(platformId.getModuleIdentifier(), platformId.getVersion());
@@ -516,7 +516,6 @@ public class NodeState implements DependencyGraphNode {
         ComponentResolveMetadata metadata = potentialEdge.metadata;
         VirtualPlatformState virtualPlatformState = null;
         if (metadata == null || metadata instanceof LenientPlatformResolveMetadata) {
-
             virtualPlatformState = potentialEdge.component.getModule().getPlatformState();
             virtualPlatformState.participatingModule(component.getModule());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VariantMetadata;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -39,16 +40,19 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     private final NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser;
     private final NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser;
     private final NotationParser<Object, ComponentIdentifier> componentIdentifierParser;
+    private final PlatformSupport platformSupport;
 
     public ComponentMetadataDetailsAdapter(MutableModuleComponentResolveMetadata metadata, Instantiator instantiator,
                                            NotationParser<Object, DirectDependencyMetadata> dependencyMetadataNotationParser,
                                            NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintMetadataNotationParser,
-                                           NotationParser<Object, ComponentIdentifier> dependencyNotationParser) {
+                                           NotationParser<Object, ComponentIdentifier> dependencyNotationParser,
+                                           PlatformSupport platformSupport) {
         this.metadata = metadata;
         this.instantiator = instantiator;
         this.dependencyMetadataNotationParser = dependencyMetadataNotationParser;
         this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
         this.componentIdentifierParser = dependencyNotationParser;
+        this.platformSupport = platformSupport;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -20,7 +20,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
@@ -48,7 +47,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final ImmutableList<? extends ComponentVariant> variants;
     private final HashValue originalContentHash;
     private final ImmutableAttributes attributes;
-    private final ImmutableList<? extends ComponentIdentifier> platformOwners;
+    private final ImmutableList<? extends VirtualComponentIdentifier> platformOwners;
     private final AttributesSchemaInternal schema;
 
     public AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
@@ -63,7 +62,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         originalContentHash = metadata.getContentHash();
         attributes = extractAttributes(metadata);
         variants = metadata.getVariants();
-        platformOwners = metadata.getPlatformOwners() == null ? ImmutableList.<ComponentIdentifier>of() : ImmutableList.copyOf(metadata.getPlatformOwners());
+        platformOwners = metadata.getPlatformOwners() == null ? ImmutableList.of() : ImmutableList.copyOf(metadata.getPlatformOwners());
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ImmutableList<? extends ComponentVariant> variants) {
@@ -196,7 +195,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     @Override
-    public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+    public ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners() {
         return platformOwners;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
@@ -74,7 +73,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
 
     private List<MutableComponentVariant> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
-    private Set<ComponentIdentifier> owners;
+    private Set<VirtualComponentIdentifier> owners;
 
     protected AbstractMutableModuleComponentResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier moduleVersionId, ModuleComponentIdentifier componentIdentifier, AttributesSchemaInternal schema) {
         this.attributesFactory = attributesFactory;
@@ -256,7 +255,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     }
 
     @Override
-    public void belongsTo(ComponentIdentifier platform) {
+    public void belongsTo(VirtualComponentIdentifier platform) {
         if (owners == null) {
             owners = Sets.newLinkedHashSet();
         }
@@ -264,7 +263,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     }
 
     @Override
-    public Set<? extends ComponentIdentifier> getPlatformOwners() {
+    public Set<? extends VirtualComponentIdentifier> getPlatformOwners() {
         return owners;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -91,13 +90,13 @@ public interface MutableModuleComponentResolveMetadata {
     VariantMetadataRules getVariantMetadataRules();
 
     /**
-     * Declares that this component belongs to a platform.
-     * @param platform the identifier of the platform
+     * Declares that this component belongs to a virtual platform.
+     * @param platform the identifier of the virtual platform
      */
-    void belongsTo(ComponentIdentifier platform);
+    void belongsTo(VirtualComponentIdentifier platform);
 
     @Nullable
-    Set<? extends ComponentIdentifier> getPlatformOwners();
+    Set<? extends VirtualComponentIdentifier> getPlatformOwners();
 
     List<? extends MutableComponentVariant> getMutableVariants();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -40,6 +40,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -212,7 +213,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
-    public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
+    public ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners() {
         return ImmutableList.of();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -94,7 +95,7 @@ public interface ComponentResolveMetadata extends HasAttributes {
 
     List<String> getStatusScheme();
 
-    ImmutableList<? extends ComponentIdentifier> getPlatformOwners();
+    ImmutableList<? extends VirtualComponentIdentifier> getPlatformOwners();
 
     @Override
     ImmutableAttributes getAttributes();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.MetadataResolutionContext
-import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.api.specs.Specs
 import org.gradle.cache.CacheRepository
@@ -60,11 +59,10 @@ class DefaultComponentMetadataHandlerTest extends Specification {
 
     // For testing ComponentMetadataHandler capabilities
     def executor = new ComponentMetadataRuleExecutor(Stub(CacheRepository), Stub(InMemoryCacheDecoratorFactory), Stub(ValueSnapshotter), new BuildCommencedTimeProvider(), Stub(Serializer))
-    CachePolicy cachePolicy = Mock()
     def stringInterner = SimpleMapInterner.notThreadSafe()
-    def handler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.valueSnapshotter(), executor)
+    def handler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.valueSnapshotter(), executor, DependencyManagementTestUtil.platformSupport())
     RuleActionAdapter adapter = Mock(RuleActionAdapter)
-    def mockedHandler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), adapter, moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.valueSnapshotter(), executor)
+    def mockedHandler = new DefaultComponentMetadataHandler(TestUtil.instantiatorFactory().decorateLenient(), adapter, moduleIdentifierFactory, stringInterner, AttributeTestUtil.attributesFactory(), SnapshotTestUtil.valueSnapshotter(), executor, DependencyManagementTestUtil.platformSupport())
     def ruleAction = Stub(RuleAction)
     def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
     def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -94,7 +94,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     }
 
     def "does nothing when no rules registered"() {
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
         def metadata = ivyMetadata().asImmutable()
 
         expect:
@@ -106,7 +106,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         context.injectingInstantiator >> instantiator
         String notation = "${GROUP}:${MODULE}"
         addRuleForModule(notation)
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
 
 
         when:
@@ -122,7 +122,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         String notation = "${GROUP}:${MODULE}"
         addRuleForModuleWithParams(notation, "foo", 42L)
 
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
 
         when:
         processor.processMetadata(ivyMetadata().asImmutable())
@@ -133,7 +133,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
     }
 
     def "processing fails when status is not present in status scheme"() {
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
         def metadata = ivyMetadata()
         metadata.status = "green"
         metadata.statusScheme = ["alpha", "beta"]
@@ -158,7 +158,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
                 addRuleForModule(notation)
             }
         }
-        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, context)
+        def processor = new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, AttributeTestUtil.attributesFactory(), executor, DependencyManagementTestUtil.platformSupport(), context)
 
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -56,9 +56,9 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
 
     def gradleMetadata
-    def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser)
-    def adapterOnIvyMetadata = new ComponentMetadataDetailsAdapter(ivyComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser)
-    def adapterOnGradleMetadata = new ComponentMetadataDetailsAdapter(gradleComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser)
+    def adapterOnMavenMetadata = new ComponentMetadataDetailsAdapter(mavenComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, DependencyManagementTestUtil.platformSupport())
+    def adapterOnIvyMetadata = new ComponentMetadataDetailsAdapter(ivyComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, DependencyManagementTestUtil.platformSupport())
+    def adapterOnGradleMetadata = new ComponentMetadataDetailsAdapter(gradleComponentMetadata(), instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, DependencyManagementTestUtil.platformSupport())
 
     private ivyComponentMetadata() {
         ivyMetadataFactory.create(componentIdentifier, [], [new Configuration("configurationDefinedInIvyMetadata", true, true, [])], [], [])

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.integtests.fixtures.publish
 
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.Usage
 import org.gradle.test.fixtures.HttpModule
 import org.gradle.test.fixtures.HttpRepository
 import org.gradle.test.fixtures.Module
@@ -131,6 +133,24 @@ class ModuleVersionSpec {
         spec.resolveStrategy = Closure.DELEGATE_FIRST
         spec()
         variants << variant
+    }
+
+    void asPlatform() {
+        variant('apiElements') {
+            useDefaultArtifacts = false
+            noArtifacts = true
+            attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
+            attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+        }
+        variant('runtimeElements') {
+            useDefaultArtifacts = false
+            noArtifacts = true
+            attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
+            attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+        }
+        withModule(MavenModule) {
+            hasPackaging("pom")
+        }
     }
 
     void dependsOn(coord) {

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
@@ -266,7 +266,6 @@ include::sample[dir="userguide/dependencyManagement/customizingResolution/metada
 include::sample[dir="userguide/dependencyManagement/customizingResolution/metadataRule/kotlin",files="build.gradle.kts[tags=guice-dependencies]"]
 ====
 
-
 == Adding missing capabilities to detect conflicts
 
 Another usage of capabilities is to express that two different modules, for example `log4j` and `log4j-over-slf4j`, provide alternative implementations of the same thing.
@@ -298,7 +297,7 @@ While all the examples above made modifications to variants of a component, ther
 This information can influence the <<dependency_resolution.adoc#,version selection>> process for a module during dependency resolution, which is performed _before_ one or multiple variants of a component are selected.
 
 The first API available on the component is `belongsTo()` to create virtual platforms for aligning versions of multiple modules without Gradle Module Metadata.
-It is explained in detail in the section on <<dependency_version_alignment.adoc#sec:align-versions-virtual,aligning versions of modules not published with Gradle>>.
+It is explained in detail in the section on <<dependency_version_alignment.adoc#sec:align-versions-unpublished,aligning versions of modules not published with Gradle>>.
 
 [[sec:custom_status_scheme]]
 == Modifying metadata on the component level for version selection based on status

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_version_alignment.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_version_alignment.adoc
@@ -72,10 +72,50 @@ Then we conflict resolve between `core:1.0` and `core:1.1`, which means that `co
 
 NOTE: This behavior is enforced for published components only if you use Gradle Module Metadata.
 
-[[sec:align-versions-virtual]]
+[[sec:align-versions-unpublished]]
 == Aligning versions of modules not published with Gradle
 
-Whenever the publisher doesn't use Gradle, like in our Jackson example, we can explain to Gradle that that all Jackson modules "belong to" the same platform and benefit from the same behavior as with native alignment:
+Whenever the publisher doesn't use Gradle, like in our Jackson example, we can explain to Gradle that that all Jackson modules "belong to" the same platform and benefit from the same behavior as with native alignment.
+There are are two options to express that a set of modules belong to a platform:
+
+1. A platform is **published** as a <<platforms.adoc#sub:bom_import,BOM>> and can be used:
+   For example, `com.fasterxml.jackson:jackson-bom` can be used as platform.
+   The information missing to Gradle in that case is that the platform should be added to the dependencies if one of its members is used.
+2. No existing platform can be used. Instead, a **virtual platform** should be created by Gradle:
+   In this case, Gradle builds up the platform itself based on all the members that are used.
+
+To provide the missing information to Gradle, you can define <<component_metadata_rules.adoc#,component metadata rules>> as explained in the following.
+
+[[sec:align_bom_platform]]
+=== Align versions of modules using a published BOM
+
+.A dependency version alignment rule
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/groovy",files="build.gradle[tags=bom-alignment-rule]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin",files="build.gradle.kts[tags=bom-alignment-rule]"]
+====
+
+By using the `belongsTo` with `false` (**not** virtual), we declare that all modules belong to the same _published platform_.
+In this case, the platform is `com.fasterxml.jackson:jackson-bom` and Gradle will look for it, as for any other module, in the declared repositories.
+
+.Making use of a dependency version alignment rule
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/groovy",files="build.gradle[tags=use_bom_rule]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin",files="build.gradle.kts[tags=use_bom_rule]"]
+====
+
+Using the rule, the versions in the example above align to whatever the selected version of `com.fasterxml.jackson:jackson-bom` defines.
+In this case, `com.fasterxml.jackson:jackson-bom:2.9.5` will be selected as `2.9.5` is the highest version of a module selected.
+In that BOM, the following versions are defined and will be used:
+`jackson-core:2.9.5`,
+`jackson-databind:2.9.5` and
+`jackson-annotation:2.9.0`.
+The lower versions of `jackson-annotation` here might be the desired result as the it is what the BOM recommends.
+
+NOTE: This behavior is working reliable since Gradle 6.1. Effectively, it is similar to a <<component_metadata_rules.adoc#,component metadata rule>> that adds a platform dependency to all members of the platform using `withDependencies`.
+
+[[sec:virtual_platform]]
+=== Align versions of modules without a published platform
 
 .A dependency version alignment rule
 ====
@@ -83,7 +123,10 @@ include::sample[dir="userguide/dependencyManagement/managingTransitiveDependenci
 include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin",files="build.gradle.kts[tags=alignment-rule]"]
 ====
 
-By using the `belongsTo` keyword, we declare that all modules belong to the same _virtual platform_, which is treated specially by the engine, in particular with regards to alignment. We can use the rule we just created by registering it:
+By using the `belongsTo` keyword without further parameter (platform **is** virtual), we declare that all modules belong to the same _virtual platform_, which is treated specially by the engine.
+A virtual platform will not be retrieved from a repository.
+The identifier, in this case `com.fasterxml.jackson:jackson-virtual-platform`, is something you as the build author define yourself.
+The "content" of the platform is then created by Gradle on the fly by collecting all `belongsTo` statements pointing at the same virtual platform.
 
 .Making use of a dependency version alignment rule
 ====
@@ -91,7 +134,10 @@ include::sample[dir="userguide/dependencyManagement/managingTransitiveDependenci
 include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin",files="build.gradle.kts[tags=use_rule]"]
 ====
 
-Then all versions in the example above would align to `2.9.5`. However, Gradle would let you override that choice by specifying a dependency on the Jackson platform:
+Using the rule, all versions in the example above would align to `2.9.5`.
+In this case, also `jackson-annotation:2.9.5` will be taken, as that is how we defined our local virtual platform.
+
+For both published and virtual platforms, Gradle lets you override the version choice of the platform itself by specifying an _enforced_ dependency on the platform:
 
 .Forceful platform downgrade
 ====
@@ -99,10 +145,3 @@ include::sample[dir="userguide/dependencyManagement/managingTransitiveDependenci
 include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin",files="build.gradle.kts[tags=enforced_platform]"]
 ====
 
-[[sec:virtual_platform]]
-== Virtual vs published platforms
-
-A platform defined by a component metadata rule for which the `belongsTo` target module isn't published on a repository is called a virtual platform.
-A virtual platform is considered specially by the engine and participates in dependency resolution like a published module, but triggers dependency version alignment.
-On the other hand, we can find "real" platforms published on public repositories. Typical examples include BOMs, like the Spring BOM. They differ in the sense that a published platform may refer to modules which are effectively different things.
-For example the Spring BOM declares dependencies on Spring as well as Apache Groovy. Obviously those things are versioned differently, so it doesn't make sense to align in this case. In other words, if a platform is _published_, Gradle trusts its metadata, and will not try to align dependency versions of this platform.

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/align-dependency-versions.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/align-dependency-versions.sample.conf
@@ -1,9 +1,26 @@
 commands: [{
     execution-subdirectory: groovy
     executable: gradle
-    args: tasks
+    args: -PuseBom dependencies --configuration compileClasspath
+    flags: --quiet
+    expected-output-file: dependenciesWithBOM.out
+}, {
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: -PuseBom dependencies --configuration compileClasspath
+    flags: --quiet
+    expected-output-file: dependenciesWithBOM.out
+},{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: dependencies --configuration compileClasspath
+    flags: --quiet
+    expected-output-file: dependenciesWithEnforcedVirtualPlatform.out
 }, {
     execution-subdirectory: kotlin
     executable: gradle
     args: tasks
+    args: dependencies --configuration compileClasspath
+    flags: --quiet
+    expected-output-file: dependenciesWithEnforcedVirtualPlatform.out
 }]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/dependenciesWithBOM.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/dependenciesWithBOM.out
@@ -1,0 +1,52 @@
+
+------------------------------------------------------------
+Root project
+------------------------------------------------------------
+
+compileClasspath - Compile classpath for source set 'main'.
++--- com.fasterxml.jackson.core:jackson-databind:2.8.9 -> 2.9.5
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.9.0
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.9.0 -> 2.9.5
+|    |         +--- com.fasterxml.jackson:jackson-bom:2.9.5 (*)
+|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.9.0 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-core:2.9.5 (c)
+|    |         \--- com.fasterxml.jackson.core:jackson-databind:2.9.5 (c)
+|    +--- com.fasterxml.jackson.core:jackson-core:2.9.5
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.9.5 (*)
+|    \--- com.fasterxml.jackson:jackson-bom:2.9.5 (*)
+\--- io.vertx:vertx-core:3.5.3
+     +--- io.netty:netty-common:4.1.19.Final
+     +--- io.netty:netty-buffer:4.1.19.Final
+     |    \--- io.netty:netty-common:4.1.19.Final
+     +--- io.netty:netty-transport:4.1.19.Final
+     |    +--- io.netty:netty-buffer:4.1.19.Final (*)
+     |    \--- io.netty:netty-resolver:4.1.19.Final
+     |         \--- io.netty:netty-common:4.1.19.Final
+     +--- io.netty:netty-handler:4.1.19.Final
+     |    +--- io.netty:netty-buffer:4.1.19.Final (*)
+     |    +--- io.netty:netty-transport:4.1.19.Final (*)
+     |    \--- io.netty:netty-codec:4.1.19.Final
+     |         \--- io.netty:netty-transport:4.1.19.Final (*)
+     +--- io.netty:netty-handler-proxy:4.1.19.Final
+     |    +--- io.netty:netty-transport:4.1.19.Final (*)
+     |    +--- io.netty:netty-codec-socks:4.1.19.Final
+     |    |    \--- io.netty:netty-codec:4.1.19.Final (*)
+     |    \--- io.netty:netty-codec-http:4.1.19.Final
+     |         \--- io.netty:netty-codec:4.1.19.Final (*)
+     +--- io.netty:netty-codec-http:4.1.19.Final (*)
+     +--- io.netty:netty-codec-http2:4.1.19.Final
+     |    +--- io.netty:netty-codec-http:4.1.19.Final (*)
+     |    \--- io.netty:netty-handler:4.1.19.Final (*)
+     +--- io.netty:netty-resolver:4.1.19.Final (*)
+     +--- io.netty:netty-resolver-dns:4.1.19.Final
+     |    +--- io.netty:netty-resolver:4.1.19.Final (*)
+     |    +--- io.netty:netty-codec-dns:4.1.19.Final
+     |    |    \--- io.netty:netty-codec:4.1.19.Final (*)
+     |    \--- io.netty:netty-transport:4.1.19.Final (*)
+     +--- com.fasterxml.jackson.core:jackson-core:2.9.5 (*)
+     \--- com.fasterxml.jackson.core:jackson-databind:2.9.5 (*)
+
+(c) - dependency constraint
+(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/dependenciesWithEnforcedVirtualPlatform.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/dependenciesWithEnforcedVirtualPlatform.out
@@ -1,0 +1,44 @@
+
+------------------------------------------------------------
+Root project
+------------------------------------------------------------
+
+compileClasspath - Compile classpath for source set 'main'.
++--- com.fasterxml.jackson.core:jackson-databind:2.8.9
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.8.0 -> 2.8.9
+|    \--- com.fasterxml.jackson.core:jackson-core:2.8.9
+\--- io.vertx:vertx-core:3.5.3
+     +--- io.netty:netty-common:4.1.19.Final
+     +--- io.netty:netty-buffer:4.1.19.Final
+     |    \--- io.netty:netty-common:4.1.19.Final
+     +--- io.netty:netty-transport:4.1.19.Final
+     |    +--- io.netty:netty-buffer:4.1.19.Final (*)
+     |    \--- io.netty:netty-resolver:4.1.19.Final
+     |         \--- io.netty:netty-common:4.1.19.Final
+     +--- io.netty:netty-handler:4.1.19.Final
+     |    +--- io.netty:netty-buffer:4.1.19.Final (*)
+     |    +--- io.netty:netty-transport:4.1.19.Final (*)
+     |    \--- io.netty:netty-codec:4.1.19.Final
+     |         \--- io.netty:netty-transport:4.1.19.Final (*)
+     +--- io.netty:netty-handler-proxy:4.1.19.Final
+     |    +--- io.netty:netty-transport:4.1.19.Final (*)
+     |    +--- io.netty:netty-codec-socks:4.1.19.Final
+     |    |    \--- io.netty:netty-codec:4.1.19.Final (*)
+     |    \--- io.netty:netty-codec-http:4.1.19.Final
+     |         \--- io.netty:netty-codec:4.1.19.Final (*)
+     +--- io.netty:netty-codec-http:4.1.19.Final (*)
+     +--- io.netty:netty-codec-http2:4.1.19.Final
+     |    +--- io.netty:netty-codec-http:4.1.19.Final (*)
+     |    \--- io.netty:netty-handler:4.1.19.Final (*)
+     +--- io.netty:netty-resolver:4.1.19.Final (*)
+     +--- io.netty:netty-resolver-dns:4.1.19.Final
+     |    +--- io.netty:netty-resolver:4.1.19.Final (*)
+     |    +--- io.netty:netty-codec-dns:4.1.19.Final
+     |    |    \--- io.netty:netty-codec:4.1.19.Final (*)
+     |    \--- io.netty:netty-transport:4.1.19.Final (*)
+     +--- com.fasterxml.jackson.core:jackson-core:2.9.5 -> 2.8.9
+     \--- com.fasterxml.jackson.core:jackson-databind:2.9.5 -> 2.8.9 (*)
+
+(*) - dependencies omitted (listed previously)
+
+A web-based, searchable dependency report is available by adding the --scan option.

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/groovy/build.gradle
@@ -16,6 +16,12 @@ dependencies {
 }
 // end::dependencies[]
 
+// tag::use_bom_rule[]
+dependencies {
+    components.all(JacksonBomAlignmentRule)
+}
+// end::use_bom_rule[]
+
 // tag::use_rule[]
 dependencies {
     components.all(JacksonAlignmentRule)
@@ -24,10 +30,23 @@ dependencies {
 
 // tag::enforced_platform[]
 dependencies {
-    // Forcefully downgrade the Jackson platform to 2.8.9
-    implementation enforcedPlatform('com.fasterxml.jackson:jackson-platform:2.8.9')
+    // Forcefully downgrade the virtual Jackson platform to 2.8.9
+    implementation enforcedPlatform('com.fasterxml.jackson:jackson-virtual-platform:2.8.9')
 }
 // end::enforced_platform[]
+
+// tag::bom-alignment-rule[]
+class JacksonBomAlignmentRule implements ComponentMetadataRule {
+    void execute(ComponentMetadataContext ctx) {
+        ctx.details.with {
+            if (id.group.startsWith("com.fasterxml.jackson")) {
+                // declare that Jackson modules belong to the platform defined by the Jackson BOM
+                belongsTo("com.fasterxml.jackson:jackson-bom:${id.version}", false)
+            }
+        }
+    }
+}
+// end::bom-alignment-rule[]
 
 // tag::alignment-rule[]
 class JacksonAlignmentRule implements ComponentMetadataRule {

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/groovy/build.gradle
@@ -16,24 +16,25 @@ dependencies {
 }
 // end::dependencies[]
 
+if (project.hasProperty("useBom")) {
 // tag::use_bom_rule[]
 dependencies {
     components.all(JacksonBomAlignmentRule)
 }
 // end::use_bom_rule[]
-
+} else {
 // tag::use_rule[]
 dependencies {
     components.all(JacksonAlignmentRule)
 }
 // end::use_rule[]
-
 // tag::enforced_platform[]
 dependencies {
     // Forcefully downgrade the virtual Jackson platform to 2.8.9
     implementation enforcedPlatform('com.fasterxml.jackson:jackson-virtual-platform:2.8.9')
 }
 // end::enforced_platform[]
+}
 
 // tag::bom-alignment-rule[]
 class JacksonBomAlignmentRule implements ComponentMetadataRule {
@@ -54,7 +55,7 @@ class JacksonAlignmentRule implements ComponentMetadataRule {
         ctx.details.with {
             if (id.group.startsWith("com.fasterxml.jackson")) {
                 // declare that Jackson modules all belong to the Jackson virtual platform
-                belongsTo("com.fasterxml.jackson:jackson-platform:${id.version}")
+                belongsTo("com.fasterxml.jackson:jackson-virtual-platform:${id.version}")
             }
         }
     }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin/build.gradle.kts
@@ -32,18 +32,37 @@ dependencies {
 }
 // end::dependencies[]
 
+// tag::use_bom_rule[]
+dependencies {
+    components.all<JacksonBomAlignmentRule>()
+}
+// end::use_bom_rule[]
+
 // tag::use_rule[]
 dependencies {
-    components.all(JacksonAlignmentRule::class.java)
+    components.all<JacksonAlignmentRule>()
 }
 // end::use_rule[]
 
 // tag::enforced_platform[]
 dependencies {
-    // Forcefully downgrade the Jackson platform to 2.8.9
-    implementation(enforcedPlatform("com.fasterxml.jackson:jackson-platform:2.8.9"))
+    // Forcefully downgrade the virtual Jackson platform to 2.8.9
+    implementation(enforcedPlatform("com.fasterxml.jackson:jackson-virtual-platform:2.8.9"))
 }
 // end::enforced_platform[]
+
+// tag::bom-alignment-rule[]
+open class JacksonBomAlignmentRule: ComponentMetadataRule {
+    override fun execute(ctx: ComponentMetadataContext) {
+        ctx.details.run {
+            if (id.group.startsWith("com.fasterxml.jackson")) {
+                // declare that Jackson modules belong to the platform defined by the Jackson BOM
+                belongsTo("com.fasterxml.jackson:jackson-bom:${id.version}", false)
+            }
+        }
+    }
+}
+// end::bom-alignment-rule[]
 
 // tag::alignment-rule[]
 open class JacksonAlignmentRule: ComponentMetadataRule {
@@ -51,7 +70,7 @@ open class JacksonAlignmentRule: ComponentMetadataRule {
         ctx.details.run {
             if (id.group.startsWith("com.fasterxml.jackson")) {
                 // declare that Jackson modules all belong to the Jackson virtual platform
-                belongsTo("com.fasterxml.jackson:jackson-platform:${id.version}")
+                belongsTo("com.fasterxml.jackson:jackson-virtual-platform:${id.version}")
             }
         }
     }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignment/kotlin/build.gradle.kts
@@ -32,24 +32,25 @@ dependencies {
 }
 // end::dependencies[]
 
+if (project.hasProperty("useBom")) {
 // tag::use_bom_rule[]
 dependencies {
     components.all<JacksonBomAlignmentRule>()
 }
 // end::use_bom_rule[]
-
+} else {
 // tag::use_rule[]
 dependencies {
     components.all<JacksonAlignmentRule>()
 }
 // end::use_rule[]
-
 // tag::enforced_platform[]
 dependencies {
     // Forcefully downgrade the virtual Jackson platform to 2.8.9
     implementation(enforcedPlatform("com.fasterxml.jackson:jackson-virtual-platform:2.8.9"))
 }
 // end::enforced_platform[]
+}
 
 // tag::bom-alignment-rule[]
 open class JacksonBomAlignmentRule: ComponentMetadataRule {


### PR DESCRIPTION
This is to fix #11457 and to detangle the complex mix of "virtual" and "real" nodes and edges a bit.

See single commits for more details.

This also updates docs for clarification and extends the test coverage.
