### PR TITLE
Automatically split TeamCity builds into buckets

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -2,21 +2,33 @@ package configurations
 
 import common.Os
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2018_2.BuildSteps
 import model.CIBuildModel
 import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, uuid: String, name: String, description: String, testCoverage: TestCoverage, stage: Stage, subProjects: List<String> = listOf(), extraParameters: String = "") : BaseGradleBuildType(model, stage = stage, init = {
+class FunctionalTest(
+    model: CIBuildModel,
+    uuid: String,
+    name: String,
+    description: String,
+    testCoverage: TestCoverage,
+    stage: Stage,
+    subprojects: List<String> = listOf(),
+    extraParameters: String = "",
+    extraBuildSteps: BuildSteps.() -> Unit = {},
+    preBuildSteps: BuildSteps.() -> Unit = {}
+) : BaseGradleBuildType(model, stage = stage, init = {
     this.uuid = uuid
     this.name = name
     this.description = description
     id = AbsoluteId(uuid)
     val testTaskName = "${testCoverage.testType.name}Test"
-    val testTasks = if (subProjects.isEmpty())
+    val testTasks = if (subprojects.isEmpty())
         testTaskName
     else
-        subProjects.joinToString(" ") { "$it:$testTaskName" }
+        subprojects.joinToString(" ") { "$it:$testTaskName" }
     val quickTest = testCoverage.testType == TestType.quick
     val buildScanTags = listOf("FunctionalTest")
     val buildScanValues = mapOf(
@@ -31,7 +43,9 @@ class FunctionalTest(model: CIBuildModel, uuid: String, name: String, descriptio
                 buildScanValues.map { buildScanCustomValue(it.key, it.value) } +
                 extraParameters
             ).filter { it.isNotBlank() }.joinToString(separator = " "),
-        timeout = testCoverage.testType.timeout)
+        timeout = testCoverage.testType.timeout,
+        extraSteps = extraBuildSteps,
+        preSteps = preBuildSteps)
 
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.openjdk.64bit%")

--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -161,12 +161,27 @@ fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTas
     applyDefaultDependencies(model, buildType, notQuick)
 }
 
-fun applyTestDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTasks: String, notQuick: Boolean = false, os: Os = Os.linux, extraParameters: String = "", timeout: Int = 90, extraSteps: BuildSteps.() -> Unit = {}, daemon: Boolean = true) {
+fun applyTestDefaults(
+    model: CIBuildModel,
+    buildType: BaseGradleBuildType,
+    gradleTasks: String,
+    notQuick: Boolean = false,
+    os: Os = Os.linux,
+    extraParameters: String = "",
+    timeout: Int = 90,
+    extraSteps: BuildSteps.() -> Unit = {}, // the steps after runner steps
+    daemon: Boolean = true,
+    preSteps: BuildSteps.() -> Unit = {} // the steps before runner steps
+) {
     if (os == Os.macos) {
         buildType.params.param("env.REPO_MIRROR_URLS", "")
     }
 
     buildType.applyDefaultSettings(os, timeout)
+
+    buildType.steps {
+        preSteps()
+    }
 
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
     buildType.killProcessStepIfNecessary("KILL_PROCESSES_STARTED_BY_GRADLE", os)

--- a/.teamcity/Gradle_Check/model/BucketProvider.kt
+++ b/.teamcity/Gradle_Check/model/BucketProvider.kt
@@ -1,0 +1,274 @@
+package Gradle_Check.model
+
+import com.alibaba.fastjson.JSON
+import com.alibaba.fastjson.JSONArray
+import com.alibaba.fastjson.JSONObject
+import common.Os
+import configurations.FunctionalTest
+import jetbrains.buildServer.configs.kotlin.v2018_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2018_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2018_2.buildSteps.script
+import model.BuildTypeBucket
+import model.CIBuildModel
+import model.GradleSubproject
+import model.Stage
+import model.TestCoverage
+import model.TestType
+import java.io.File
+
+const val BUCKET_NUMBER = 40
+
+typealias BuildProjectToSubprojectTestClassTimes = Map<String, Map<String, List<TestClassTime>>>
+
+interface GradleBuildBucketProvider {
+    fun createFunctionalTestsFor(stage: Stage, testCoverage: TestCoverage): List<FunctionalTest>
+
+    fun createDeferredFunctionalTestsFor(stage: Stage): List<FunctionalTest>
+}
+
+class StatisticBasedGradleBuildBucketProvider(private val model: CIBuildModel, testTimeDataJson: File) : GradleBuildBucketProvider {
+    private val buckets: Map<TestCoverage, List<BuildTypeBucket>> = buildBuckets(testTimeDataJson, model)
+
+    override fun createFunctionalTestsFor(stage: Stage, testCoverage: TestCoverage): List<FunctionalTest> {
+        return buckets.getValue(testCoverage).map { it.createFunctionalTestsFor(model, stage, testCoverage) }
+    }
+
+    override fun createDeferredFunctionalTestsFor(stage: Stage): List<FunctionalTest> {
+        // The first stage which doesn't omit slow projects
+        val deferredStage = model.stages.find { !it.omitsSlowProjects }!!
+        val deferredStageIndex = model.stages.indexOfFirst { !it.omitsSlowProjects }
+        return if (stage.stageName != deferredStage.stageName) {
+            emptyList()
+        } else {
+            val stages = model.stages.subList(0, deferredStageIndex)
+            val deferredTests = mutableListOf<FunctionalTest>()
+            stages.forEach { eachStage ->
+                eachStage.functionalTests.forEach { testConfig ->
+                    deferredTests.addAll(model.subprojects.getSlowSubprojects().map { it.createFunctionalTestsFor(model, eachStage, testConfig) })
+                }
+            }
+            deferredTests
+        }
+    }
+
+    private
+    fun buildBuckets(buildClassTimeJson: File, model: CIBuildModel): Map<TestCoverage, List<BuildTypeBucket>> {
+        val jsonObj = JSON.parseObject(buildClassTimeJson.readText()) as JSONObject
+        val buildProjectClassTimes: BuildProjectToSubprojectTestClassTimes = jsonObj.map { buildProjectToSubprojectTestClassTime ->
+            buildProjectToSubprojectTestClassTime.key to (buildProjectToSubprojectTestClassTime.value as JSONObject).map { subProjectToTestClassTime ->
+                subProjectToTestClassTime.key to (subProjectToTestClassTime.value as JSONArray).map { TestClassTime(it as JSONObject) }
+            }.toMap()
+        }.toMap()
+
+        val result = mutableMapOf<TestCoverage, List<BuildTypeBucket>>()
+        for (stage in model.stages) {
+            for (testCoverage in stage.functionalTests) {
+                when (testCoverage.testType) {
+                    TestType.allVersionsIntegMultiVersion -> {
+                        result[testCoverage] = listOf(AllSubprojectsIntegMultiVersionTest.INSTANCE)
+                    }
+                    in listOf(TestType.allVersionsCrossVersion, TestType.quickFeedbackCrossVersion) -> {
+                        result[testCoverage] = splitBucketsByGradleVersionForBuildProject(6)
+                    }
+                    else -> {
+                        result[testCoverage] = splitBucketsByTestClassesForBuildProject(testCoverage, stage, buildProjectClassTimes)
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    // For quickFeedbackCrossVersion and allVersionsCrossVersion, the buckets are split by Gradle version
+    // By default, split them into [gradle1, gradle2, gradle3, gradle4, gradle5, gradle6]
+    private fun splitBucketsByGradleVersionForBuildProject(maxGradleMajorVersion: Int) = (1..maxGradleMajorVersion).map { GradleVersionXCrossVersionTestBucket(it) }
+
+    private
+    fun splitBucketsByTestClassesForBuildProject(testCoverage: TestCoverage, stage: Stage, buildProjectClassTimes: BuildProjectToSubprojectTestClassTimes): List<BuildTypeBucket> {
+        val validSubprojects = model.subprojects.getSubprojectsFor(testCoverage, stage)
+
+        // Build project not found, don't split into buckets
+        val subProjectToClassTimes: Map<String, List<TestClassTime>> = buildProjectClassTimes[testCoverage.asId(model)] ?: return validSubprojects
+
+        val subProjectTestClassTimes: List<SubprojectTestClassTime> = subProjectToClassTimes
+            .entries
+            .filter { "UNKNOWN" != it.key }
+            .filter { model.subprojects.getSubprojectByName(it.key) != null }
+            .map { SubprojectTestClassTime(model.subprojects.getSubprojectByName(it.key)!!, it.value.filter { it.sourceSet != "test" }) }
+        val expectedBucketSize: Int = subProjectTestClassTimes.sumBy { it.totalTime } / BUCKET_NUMBER
+
+        return split(subProjectTestClassTimes, expectedBucketSize)
+    }
+
+    private
+    fun split(subprojects: List<SubprojectTestClassTime>, expectedBucketSize: Int): List<BuildTypeBucket> {
+        val buckets: List<List<SubprojectTestClassTime>> = split(subprojects, SubprojectTestClassTime::totalTime, expectedBucketSize)
+        val ret = mutableListOf<BuildTypeBucket>()
+        var bucketNumber = 1
+        buckets.forEach { subprojectsInBucket ->
+            if (subprojectsInBucket.size == 1) {
+                // Split large project to potential multiple buckets
+                ret.addAll(subprojectsInBucket[0].split(expectedBucketSize))
+            } else {
+                ret.add(SmallSubprojectBucket("bucket${bucketNumber++}", subprojectsInBucket.map { it.subProject }))
+            }
+        }
+        return ret
+    }
+}
+
+/**
+ * Split a list of object into buckets with expected size.
+ *
+ * For example, we have a list of number [9, 1, 2, 10, 4, 5] and the expected size is 5,
+ * the result buckets will be [[10], [9], [5], [4, 1], [2]]
+ */
+fun <T> split(list: List<T>, function: (T) -> Int, expectedBucketSize: Int): List<List<T>> {
+    val originalList = ArrayList(list)
+    val ret = mutableListOf<List<T>>()
+
+    while (originalList.isNotEmpty()) {
+        val largest = originalList.removeAt(0)
+        val bucket = mutableListOf<T>()
+        var restCapacity = expectedBucketSize - function(largest)
+
+        bucket.add(largest)
+
+        while (true) {
+            // Find next largest object which can fit in resetCapacity
+            val index = originalList.indexOfFirst { function(it) < restCapacity }
+            if (index == -1 || originalList.isEmpty()) {
+                break
+            }
+
+            val nextElementToAddToBucket = originalList.removeAt(index)
+            restCapacity -= function(nextElementToAddToBucket)
+            bucket.add(nextElementToAddToBucket)
+        }
+
+        ret.add(bucket)
+    }
+    return ret
+}
+
+enum class AllSubprojectsIntegMultiVersionTest : BuildTypeBucket {
+    INSTANCE;
+
+    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage) =
+        FunctionalTest(model,
+            testCoverage.asConfigurationId(model, "all"),
+            testCoverage.asName(),
+            "${testCoverage.asName()} for all subprojects",
+            testCoverage,
+            stage,
+            emptyList()
+        )
+}
+
+class GradleVersionXCrossVersionTestBucket(private val gradleMajorVersion: Int) : BuildTypeBucket {
+    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage) =
+        FunctionalTest(model,
+            testCoverage.asConfigurationId(model, "gradle$gradleMajorVersion"),
+            "${testCoverage.asName()} (gradle $gradleMajorVersion)",
+            "${testCoverage.asName()} for gradle $gradleMajorVersion",
+            testCoverage,
+            stage,
+            emptyList(),
+            "-PonlyTestGradleMajorVersion=$gradleMajorVersion"
+        )
+}
+
+class LargeSubprojectSplitBucket(private val subProject: GradleSubproject, private val number: Int, private val include: Boolean, private val classes: List<TestClassTime>) : BuildTypeBucket by subProject {
+    val name = if (number == 1) subProject.name else "${subProject.name}_$number"
+
+    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage): FunctionalTest =
+        FunctionalTest(model,
+            testCoverage.asConfigurationId(model, name),
+            "${testCoverage.asName()} ($name)",
+            "${testCoverage.asName()} for projects $name",
+            testCoverage,
+            stage,
+            subprojects = listOf(subProject.name),
+            extraParameters = "-PrunTestClassesInBucket ${if (include) "-x ${subProject.name}:test" else ""}", // Only run unit test in last bucket
+            preBuildSteps = prepareTestClassesStep(testCoverage.os)
+        )
+
+    private fun prepareTestClassesStep(os: Os): BuildSteps.() -> Unit {
+        val testClasses = classes.map { it.toPropertiesLine() }
+        val action = if (include) "include" else "exclude"
+        val unixScript = """
+mkdir -p build
+rm -rf build/*-test-classes.properties
+cat > build/$action-test-classes.properties << EOL
+${testClasses.joinToString("\n")}
+EOL
+
+echo "Tests to be ${action}d in this build"
+cat build/$action-test-classes.properties
+"""
+
+        val linesWithEcho = testClasses.joinToString("\n") { "echo $it" }
+
+        val windowsScript = """
+mkdir build
+del /f /q build\include-test-classes.properties
+del /f /q build\exclude-test-classes.properties
+(
+$linesWithEcho
+) > build\$action-test-classes.properties
+
+echo "Tests to be ${action}d in this build"
+type build\$action-test-classes.properties
+"""
+
+        return {
+            script {
+                name = "PREPARE_TEST_CLASSES"
+                executionMode = BuildStep.ExecutionMode.ALWAYS
+                scriptContent = if (os == Os.windows) windowsScript else unixScript
+            }
+        }
+    }
+}
+
+class SmallSubprojectBucket(val name: String, private val subprojects: List<GradleSubproject>) : BuildTypeBucket {
+    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage): FunctionalTest =
+        FunctionalTest(model, testCoverage.asConfigurationId(model, name),
+            "${testCoverage.asName()} (${subprojects.joinToString(", ") { it.name }})",
+            "${testCoverage.asName()} for ${subprojects.joinToString(", ") { it.name }}",
+            testCoverage,
+            stage,
+            subprojects.map { it.name }
+        )
+}
+
+class TestClassTime(var testClass: String, val sourceSet: String, var buildTimeMs: Int) {
+    constructor(jsonObject: JSONObject) : this(
+        jsonObject.getString("testClass"),
+        jsonObject.getString("sourceSet"),
+        jsonObject.getIntValue("buildTimeMs")
+    )
+
+    fun toPropertiesLine() = "$testClass=$sourceSet"
+}
+
+class SubprojectTestClassTime(val subProject: GradleSubproject, private val testClassTimes: List<TestClassTime>) {
+    val totalTime: Int = testClassTimes.sumBy { it.buildTimeMs }
+
+    fun split(expectedBuildTimePerBucket: Int): List<BuildTypeBucket> {
+        return if (totalTime < 1.1 * expectedBuildTimePerBucket) {
+            listOf(subProject)
+        } else {
+            val buckets: List<List<TestClassTime>> = split(testClassTimes, TestClassTime::buildTimeMs, expectedBuildTimePerBucket)
+            return if (buckets.size == 1) {
+                listOf(subProject)
+            } else {
+                buckets.mapIndexed { index: Int, classesInBucket: List<TestClassTime> ->
+                    val include = index != buckets.size - 1
+                    val classes = if (include) classesInBucket else buckets.subList(0, buckets.size - 1).flatten()
+                    LargeSubprojectSplitBucket(subProject, index + 1, include, classes)
+                }
+            }
+        }
+    }
+}

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -1,5 +1,6 @@
 package model
 
+import Gradle_Check.model.GradleSubprojectList
 import common.BuildCache
 import common.JvmCategory
 import common.JvmVendor
@@ -14,8 +15,6 @@ import configurations.Gradleception
 import configurations.SanityCheck
 import configurations.SmokeTests
 import jetbrains.buildServer.configs.kotlin.v2018_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2018_2.ErrorConsumer
-import jetbrains.buildServer.configs.kotlin.v2018_2.Validatable
 
 enum class StageNames(override val stageName: String, override val description: String, override val uuid: String) : StageName {
     QUICK_FEEDBACK_LINUX_ONLY("Quick Feedback - Linux Only", "Run checks and functional tests (embedded executer, Linux)", "QuickFeedbackLinuxOnly"),
@@ -83,7 +82,9 @@ data class CIBuildModel(
                 TestCoverage(12, TestType.noDaemon, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(13, TestType.noDaemon, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor),
                 TestCoverage(14, TestType.platform, Os.macos, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
-                TestCoverage(15, TestType.forceRealizeDependencyManagement, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor)),
+                TestCoverage(15, TestType.forceRealizeDependencyManagement, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
+                TestCoverage(33, TestType.allVersionsIntegMultiVersion, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
+                TestCoverage(34, TestType.allVersionsIntegMultiVersion, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor)),
             performanceTests = listOf(
                 PerformanceTestType.slow)),
         Stage(StageNames.HISTORICAL_PERFORMANCE,
@@ -103,7 +104,8 @@ data class CIBuildModel(
             runsIndependent = true,
             disablesBuildCache = true,
             functionalTests = listOf(
-                TestCoverage(26, TestType.quick, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))),
+                TestCoverage(26, TestType.quick, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))
+        ),
         Stage(StageNames.WINDOWS_10_EVALUATION_PLATFORM,
             trigger = Trigger.never,
             runsIndependent = true,
@@ -123,241 +125,124 @@ data class CIBuildModel(
                 TestCoverage(29, TestType.vfsRetention, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(30, TestType.vfsRetention, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor),
                 TestCoverage(31, TestType.vfsRetention, Os.macos, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
-                TestCoverage(32, TestType.vfsRetention, Os.macos, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)))
-        ),
-
-    val subProjects: List<GradleSubproject> = listOf(
-        GradleSubproject("antlr"),
-        GradleSubproject("baseServices"),
-        GradleSubproject("baseServicesGroovy", functionalTests = false),
-        GradleSubproject("bootstrap", unitTests = false, functionalTests = false),
-        GradleSubproject("buildCache"),
-        GradleSubproject("buildCacheHttp", unitTests = false),
-        GradleSubproject("buildCachePackaging", functionalTests = false),
-        GradleSubproject("buildEvents"),
-        GradleSubproject("buildProfile"),
-        GradleSubproject("buildOption", functionalTests = false),
-        GradleSubproject("buildInit"),
-        GradleSubproject("cli", functionalTests = false),
-        GradleSubproject("codeQuality"),
-        GradleSubproject("compositeBuilds"),
-        GradleSubproject("core", crossVersionTests = true),
-        GradleSubproject("coreApi", functionalTests = false),
-        GradleSubproject("dependencyManagement", crossVersionTests = true),
-        GradleSubproject("diagnostics"),
-        GradleSubproject("ear"),
-        GradleSubproject("execution"),
-        GradleSubproject("fileCollections"),
-        GradleSubproject("files", functionalTests = false),
-        GradleSubproject("hashing", functionalTests = false),
-        GradleSubproject("ide", crossVersionTests = true),
-        GradleSubproject("ideNative"),
-        GradleSubproject("idePlay", unitTests = false),
-        GradleSubproject("instantExecution"),
-        GradleSubproject("instantExecutionReport", unitTests = false, functionalTests = false),
-        GradleSubproject("integTest", unitTests = false, crossVersionTests = true),
-        GradleSubproject("internalIntegTesting"),
-        GradleSubproject("internalPerformanceTesting"),
-        GradleSubproject("internalTesting", functionalTests = false),
-        GradleSubproject("ivy", crossVersionTests = true),
-        GradleSubproject("jacoco"),
-        GradleSubproject("javascript"),
-        GradleSubproject("jvmServices", functionalTests = false),
-        GradleSubproject("languageGroovy"),
-        GradleSubproject("languageJava", crossVersionTests = true),
-        GradleSubproject("languageJvm"),
-        GradleSubproject("languageNative"),
-        GradleSubproject("languageScala"),
-        GradleSubproject("launcher"),
-        GradleSubproject("logging"),
-        GradleSubproject("maven", crossVersionTests = true),
-        GradleSubproject("messaging"),
-        GradleSubproject("modelCore"),
-        GradleSubproject("modelGroovy"),
-        GradleSubproject("native"),
-        GradleSubproject("persistentCache"),
-        GradleSubproject("pineapple", unitTests = false, functionalTests = false),
-        GradleSubproject("platformBase"),
-        GradleSubproject("platformJvm"),
-        GradleSubproject("platformNative"),
-        GradleSubproject("platformPlay", containsSlowTests = true),
-        GradleSubproject("pluginDevelopment"),
-        GradleSubproject("pluginUse"),
-        GradleSubproject("plugins"),
-        GradleSubproject("processServices"),
-        GradleSubproject("publish"),
-        GradleSubproject("reporting"),
-        GradleSubproject("resources"),
-        GradleSubproject("resourcesGcs"),
-        GradleSubproject("resourcesHttp"),
-        GradleSubproject("resourcesS3"),
-        GradleSubproject("resourcesSftp"),
-        GradleSubproject("scala"),
-        GradleSubproject("signing"),
-        GradleSubproject("snapshots"),
-        GradleSubproject("samples", unitTests = false, functionalTests = true),
-        GradleSubproject("testKit"),
-        GradleSubproject("testingBase"),
-        GradleSubproject("testingJvm"),
-        GradleSubproject("testingJunitPlatform", unitTests = false, functionalTests = false),
-        GradleSubproject("testingNative"),
-        GradleSubproject("toolingApi", crossVersionTests = true),
-        GradleSubproject("toolingApiBuilders", functionalTests = false),
-        GradleSubproject("toolingNative", unitTests = false, functionalTests = false, crossVersionTests = true),
-        GradleSubproject("versionControl"),
-        GradleSubproject("workers"),
-        GradleSubproject("workerProcesses", unitTests = false, functionalTests = false),
-        GradleSubproject("wrapper", crossVersionTests = true),
-
-        GradleSubproject("soak", unitTests = false, functionalTests = false),
-
-        GradleSubproject("apiMetadata", unitTests = false, functionalTests = false),
-        GradleSubproject("kotlinDsl", unitTests = true, functionalTests = true),
-        GradleSubproject("kotlinDslProviderPlugins", unitTests = true, functionalTests = false),
-        GradleSubproject("kotlinDslToolingModels", unitTests = false, functionalTests = false),
-        GradleSubproject("kotlinDslToolingBuilders", unitTests = true, functionalTests = true, crossVersionTests = true),
-        GradleSubproject("kotlinDslPlugins", unitTests = false, functionalTests = true),
-        GradleSubproject("kotlinDslTestFixtures", unitTests = true, functionalTests = false),
-        GradleSubproject("kotlinDslIntegTests", unitTests = false, functionalTests = true),
-        GradleSubproject("kotlinCompilerEmbeddable", unitTests = false, functionalTests = false),
-
-        GradleSubproject("architectureTest", unitTests = false, functionalTests = false),
-        GradleSubproject("distributionsDependencies", unitTests = false, functionalTests = false),
-        GradleSubproject("buildScanPerformance", unitTests = false, functionalTests = false),
-        GradleSubproject("distributions", unitTests = false, functionalTests = false),
-        GradleSubproject("docs", unitTests = false, functionalTests = false),
-        GradleSubproject("installationBeacon", unitTests = false, functionalTests = false),
-        GradleSubproject("internalAndroidPerformanceTesting", unitTests = false, functionalTests = false),
-        GradleSubproject("performance", unitTests = false, functionalTests = false),
-        GradleSubproject("runtimeApiInfo", unitTests = false, functionalTests = false),
-        GradleSubproject("smokeTest", unitTests = false, functionalTests = false))
-) {
-    val buildTypeBuckets: List<BuildTypeBucket>
-
-    init {
-        val subprojectMap = subProjects.map { it.name to it }.toMap()
-        val buckets = mapOf(
-            "resources" to listOf("resources", "resourcesGcs", "resourcesHttp", "resourcesS3", "resourcesSftp"),
-            "platformBase" to listOf("platformBase", "platformJvm", "platformNative"),
-            "bucket1" to listOf("kotlinDslProviderPlugins", "buildCachePackaging", "native", "snapshots", "internalPerformanceTesting", "internalIntegTesting", "execution", "publish", "ear", "languageJvm"),
-            "bucket2" to listOf("baseServices", "processServices", "messaging", "buildProfile", "modelGroovy"),
-            "bucket3" to listOf("javascript", "fileCollections", "buildCache", "toolingNative", "buildCacheHttp"),
-            "bucket4" to listOf("antlr", "languageGroovy", "reporting", "diagnostics", "versionControl"),
-            "bucket5" to listOf("testingBase", "testingNative", "wrapper", "ideNative"),
-            "bucket7" to listOf("jacoco", "idePlay"),
-            "bucket8" to listOf("signing", "ivy"),
-            "bucket9" to listOf("kotlinDsl", "kotlinDslToolingBuilders"),
-            "bucket10" to listOf("modelCore", "ide"),
-            "bucket11" to listOf("codeQuality", "persistentCache")
+                TestCoverage(32, TestType.vfsRetention, Os.macos, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))
         )
-        val largeSubprojects = mapOf(
-            "integTest" to 3,
-            "core" to 4,
-            "dependencyManagement" to 3,
-            "toolingApi" to 2,
-            "samples" to 2,
-            "launcher" to 2,
-            "languageJava" to 2)
+    ),
+    val subprojects: GradleSubprojectList = GradleSubprojectList(
+        listOf(
+            GradleSubproject("antlr"),
+            GradleSubproject("baseServices"),
+            GradleSubproject("baseServicesGroovy", functionalTests = false),
+            GradleSubproject("bootstrap", unitTests = false, functionalTests = false),
+            GradleSubproject("buildCache"),
+            GradleSubproject("buildCacheHttp", unitTests = false),
+            GradleSubproject("buildCachePackaging", functionalTests = false),
+            GradleSubproject("buildEvents"),
+            GradleSubproject("buildProfile"),
+            GradleSubproject("buildOption", functionalTests = false),
+            GradleSubproject("buildInit"),
+            GradleSubproject("cli", functionalTests = false),
+            GradleSubproject("codeQuality"),
+            GradleSubproject("compositeBuilds"),
+            GradleSubproject("core", crossVersionTests = true),
+            GradleSubproject("coreApi", functionalTests = false),
+            GradleSubproject("dependencyManagement", crossVersionTests = true),
+            GradleSubproject("diagnostics"),
+            GradleSubproject("ear"),
+            GradleSubproject("execution"),
+            GradleSubproject("fileCollections"),
+            GradleSubproject("files", functionalTests = false),
+            GradleSubproject("hashing", functionalTests = false),
+            GradleSubproject("ide", crossVersionTests = true),
+            GradleSubproject("ideNative"),
+            GradleSubproject("idePlay", unitTests = false),
+            GradleSubproject("instantExecution"),
+            GradleSubproject("instantExecutionReport", unitTests = false, functionalTests = false),
+            GradleSubproject("integTest", unitTests = false, crossVersionTests = true),
+            GradleSubproject("internalIntegTesting"),
+            GradleSubproject("internalPerformanceTesting"),
+            GradleSubproject("internalTesting", functionalTests = false),
+            GradleSubproject("ivy", crossVersionTests = true),
+            GradleSubproject("jacoco"),
+            GradleSubproject("javascript"),
+            GradleSubproject("jvmServices", functionalTests = false),
+            GradleSubproject("languageGroovy"),
+            GradleSubproject("languageJava", crossVersionTests = true),
+            GradleSubproject("languageJvm"),
+            GradleSubproject("languageNative"),
+            GradleSubproject("languageScala"),
+            GradleSubproject("launcher"),
+            GradleSubproject("logging"),
+            GradleSubproject("maven", crossVersionTests = true),
+            GradleSubproject("messaging"),
+            GradleSubproject("modelCore"),
+            GradleSubproject("modelGroovy"),
+            GradleSubproject("native"),
+            GradleSubproject("persistentCache"),
+            GradleSubproject("pineapple", unitTests = false, functionalTests = false),
+            GradleSubproject("platformBase"),
+            GradleSubproject("platformJvm"),
+            GradleSubproject("platformNative"),
+            GradleSubproject("platformPlay", containsSlowTests = true),
+            GradleSubproject("pluginDevelopment"),
+            GradleSubproject("pluginUse"),
+            GradleSubproject("plugins"),
+            GradleSubproject("processServices"),
+            GradleSubproject("publish"),
+            GradleSubproject("reporting"),
+            GradleSubproject("resources"),
+            GradleSubproject("resourcesGcs"),
+            GradleSubproject("resourcesHttp"),
+            GradleSubproject("resourcesS3"),
+            GradleSubproject("resourcesSftp"),
+            GradleSubproject("scala"),
+            GradleSubproject("signing"),
+            GradleSubproject("snapshots"),
+            GradleSubproject("samples", unitTests = false, functionalTests = true),
+            GradleSubproject("testKit"),
+            GradleSubproject("testingBase"),
+            GradleSubproject("testingJvm"),
+            GradleSubproject("testingJunitPlatform", unitTests = false, functionalTests = false),
+            GradleSubproject("testingNative"),
+            GradleSubproject("toolingApi", crossVersionTests = true),
+            GradleSubproject("toolingApiBuilders", functionalTests = false),
+            GradleSubproject("toolingNative", unitTests = false, functionalTests = false, crossVersionTests = true),
+            GradleSubproject("versionControl"),
+            GradleSubproject("workers"),
+            GradleSubproject("workerProcesses", unitTests = false, functionalTests = false),
+            GradleSubproject("wrapper", crossVersionTests = true),
 
-        val nonTrivialBuckets = listOf<BuildTypeBucket>(
-            SubprojectBucket(name = "AllUnitTest", subprojects = subProjects.filter { it.hasOnlyUnitTests() })
-        ) + buckets.map { entry ->
-            SubprojectBucket(name = entry.key, subprojects = entry.value.map { subprojectMap.getValue(it) })
-        } + largeSubprojects.map { entry ->
-            SubprojectSplit(subproject = subprojectMap.getValue(entry.key), total = entry.value)
-        }
-        val handledSubprojects = nonTrivialBuckets.flatMap { it.getSubprojectNames() }
-        buildTypeBuckets = nonTrivialBuckets + subProjects.filter { !handledSubprojects.contains(it.name) }
-    }
-}
+            GradleSubproject("soak", unitTests = false, functionalTests = false),
+
+            GradleSubproject("apiMetadata", unitTests = false, functionalTests = false),
+            GradleSubproject("kotlinDsl", unitTests = true, functionalTests = true),
+            GradleSubproject("kotlinDslProviderPlugins", unitTests = true, functionalTests = false),
+            GradleSubproject("kotlinDslToolingModels", unitTests = false, functionalTests = false),
+            GradleSubproject("kotlinDslToolingBuilders", unitTests = true, functionalTests = true, crossVersionTests = true),
+            GradleSubproject("kotlinDslPlugins", unitTests = false, functionalTests = true),
+            GradleSubproject("kotlinDslTestFixtures", unitTests = true, functionalTests = false),
+            GradleSubproject("kotlinDslIntegTests", unitTests = false, functionalTests = true),
+            GradleSubproject("kotlinCompilerEmbeddable", unitTests = false, functionalTests = false),
+
+            GradleSubproject("architectureTest", unitTests = false, functionalTests = false),
+            GradleSubproject("distributionsDependencies", unitTests = false, functionalTests = false),
+            GradleSubproject("buildScanPerformance", unitTests = false, functionalTests = false),
+            GradleSubproject("distributions", unitTests = false, functionalTests = false),
+            GradleSubproject("docs", unitTests = false, functionalTests = false),
+            GradleSubproject("installationBeacon", unitTests = false, functionalTests = false),
+            GradleSubproject("internalAndroidPerformanceTesting", unitTests = false, functionalTests = false),
+            GradleSubproject("performance", unitTests = false, functionalTests = false),
+            GradleSubproject("runtimeApiInfo", unitTests = false, functionalTests = false),
+            GradleSubproject("smokeTest", unitTests = false, functionalTests = false))
+    )
+)
 
 interface BuildTypeBucket {
-    // TODO: Hacky. We should really be running all the subprojects on macOS
-    // But we're restricting this to just a subset of projects for now
-    // since we only have a small pool of macOS agents
-    fun shouldBeSkipped(testCoverage: TestCoverage): Boolean
-
-    fun containsSlowTests(): Boolean
-    fun shouldBeSkippedInStage(stage: Stage): Boolean
-    fun hasTestsOf(testType: TestType): Boolean
-    fun getSubprojectNames(): List<String>
-
-    fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage): List<FunctionalTest>
-}
-
-data class SubprojectSplit(val subproject: GradleSubproject, val total: Int) : BuildTypeBucket by subproject, Validatable {
-    override fun validate(consumer: ErrorConsumer) {
-        if (total <= 1) {
-            consumer.consumeError("Split number must be > 1: ${subproject.name} $total!")
-        }
-    }
-
-    private fun getName(number: Int) = if (number == 1) subproject.name else "${subproject.name}_$number"
-
-    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage) =
-        (1..total).map { createFunctionalTestsFor(model, stage, testCoverage, getName(it), "-PtestSplit=$it/$total") }
-
-    private fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage, name: String, parameter: String): FunctionalTest = FunctionalTest(model,
-        testCoverage.asConfigurationId(model, name),
-        "${testCoverage.asName()} ($name)",
-        "${testCoverage.asName()} for projects $name",
-        testCoverage,
-        stage,
-        listOf(subproject.name),
-        parameter
-    )
-}
-
-data class SubprojectBucket(val name: String, val subprojects: List<GradleSubproject>) : BuildTypeBucket, Validatable {
-    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage): List<FunctionalTest> {
-        val subprojectsForCoverage = subprojects.filter { !it.shouldBeSkipped(testCoverage) }
-        return listOf(
-            FunctionalTest(model, testCoverage.asConfigurationId(model, name),
-                "${testCoverage.asName()} (${subprojectsForCoverage.joinToString(", ") { it.name }})",
-                "${testCoverage.asName()} for ${subprojectsForCoverage.joinToString(", ") { it.name }}",
-                testCoverage,
-                stage,
-                subprojectsForCoverage.map { it.name }
-            )
-        )
-    }
-
-    override fun getSubprojectNames(): List<String> {
-        return subprojects.map { it.name }
-    }
-
-    override fun shouldBeSkippedInStage(stage: Stage) = stage.omitsSlowProjects && subprojects.any { it.containsSlowTests }
-
-    override fun validate(consumer: ErrorConsumer) {
-        if (!hasSameProperties { it.unitTests } ||
-            !hasSameProperties { it.functionalTests } ||
-            !hasSameProperties { it.crossVersionTests }) {
-            consumer.consumeError("All merged subprojects must have same properties: ${subprojects.joinToString(" ") { it.name }}")
-        }
-
-        Os.values().forEach {
-            val intersected = subprojects.intersect(it.ignoredSubprojects)
-            if (intersected.isNotEmpty() && intersected.size != subprojects.size) {
-                consumer.consumeError("Either all subprojects in a bucket are ignored, or none of them are ignored")
-            }
-        }
-    }
-
-    private
-    fun hasSameProperties(predicate: (GradleSubproject) -> Boolean): Boolean {
-        val count = subprojects.count(predicate)
-        return count == 0 || count == subprojects.size
-    }
-
-    override fun shouldBeSkipped(testCoverage: TestCoverage) = subprojects.all { it.shouldBeSkipped(testCoverage) }
-
-    override fun containsSlowTests() = subprojects.any { it.containsSlowTests }
-
-    override fun hasTestsOf(testType: TestType) = subprojects.any { it.hasTestsOf(testType) }
+    fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage): FunctionalTest
 }
 
 data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false) : BuildTypeBucket {
-    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage) = listOf(
+    override fun createFunctionalTestsFor(model: CIBuildModel, stage: Stage, testCoverage: TestCoverage) =
         FunctionalTest(model,
             testCoverage.asConfigurationId(model, name),
             "${testCoverage.asName()} ($name)",
@@ -365,25 +250,13 @@ data class GradleSubproject(val name: String, val unitTests: Boolean = true, val
             testCoverage,
             stage,
             listOf(name)
-        ))
+        )
 
-    override fun getSubprojectNames(): List<String> {
-        return listOf(name)
-    }
-
-    override fun shouldBeSkippedInStage(stage: Stage) = containsSlowTests && stage.omitsSlowProjects
-
-    override fun shouldBeSkipped(testCoverage: TestCoverage) = testCoverage.os.ignoredSubprojects.contains(name)
-
-    override fun containsSlowTests() = containsSlowTests
-
-    override fun hasTestsOf(testType: TestType) = (unitTests && testType.unitTests) || (functionalTests && testType.functionalTests) || (crossVersionTests && testType.crossVersionTests)
+    fun hasTestsOf(testType: TestType) = (unitTests && testType.unitTests) || (functionalTests && testType.functionalTests) || (crossVersionTests && testType.crossVersionTests)
 
     fun asDirectoryName(): String {
         return name.replace(Regex("([A-Z])")) { "-" + it.groups[1]!!.value.toLowerCase() }
     }
-
-    fun hasOnlyUnitTests() = unitTests && !functionalTests && !crossVersionTests
 }
 
 interface StageName {
@@ -408,15 +281,15 @@ data class TestCoverage(val uuid: Int, val testType: TestType, val os: Os, val t
     val testCoveragePrefix
         get() = "${testType.name.capitalize()}_$uuid"
 
-    fun asConfigurationId(model: CIBuildModel, subproject: String = ""): String {
+    fun asConfigurationId(model: CIBuildModel, subProject: String = ""): String {
         val prefix = "${testCoveragePrefix}_"
-        val shortenedSubprojectName = shortenSubprojectName(model.projectPrefix, prefix + subproject)
-        return model.projectPrefix + if (subproject.isNotEmpty()) shortenedSubprojectName else "${prefix}0"
+        val shortenedSubprojectName = shortenSubprojectName(model.projectPrefix, prefix + subProject)
+        return model.projectPrefix + if (subProject.isNotEmpty()) shortenedSubprojectName else "${prefix}0"
     }
 
     private
-    fun shortenSubprojectName(prefix: String, subprojectName: String): String {
-        val shortenedSubprojectName = subprojectName.replace("internal", "i").replace("Testing", "T")
+    fun shortenSubprojectName(prefix: String, subProjectName: String): String {
+        val shortenedSubprojectName = subProjectName.replace("internal", "i").replace("Testing", "T")
         if (shortenedSubprojectName.length + prefix.length <= 80) {
             return shortenedSubprojectName
         }
@@ -436,7 +309,9 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     // Cross version tests select a small set of versions to cover when run as part of this stage
     quickFeedbackCrossVersion(false, false, true),
     // Cross version tests select all versions to cover when run as part of this stage
-    allVersionsCrossVersion(false, true, true, 240),
+    allVersionsCrossVersion(false, false, true, 240),
+    // run integMultiVersionTest with all version to cover
+    allVersionsIntegMultiVersion(false, true, false),
     parallel(false, true, false),
     noDaemon(false, true, false, 240),
     instant(false, true, false),

--- a/.teamcity/Gradle_Check/model/GradleSubprojectList.kt
+++ b/.teamcity/Gradle_Check/model/GradleSubprojectList.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package Gradle_Check.model
+
+import model.GradleSubproject
+import model.Stage
+import model.TestCoverage
+
+data class GradleSubprojectList(val subprojects: List<GradleSubproject>) {
+    private val nameToSubproject = subprojects.map { it.name to it }.toMap()
+    fun getSubprojectsFor(testConfig: TestCoverage, stage: Stage) =
+        subprojects.filterNot { it.containsSlowTests && stage.omitsSlowProjects }
+            .filter { it.hasTestsOf(testConfig.testType) }
+            .filterNot { testConfig.os.ignoredSubprojects.contains(it.name) }
+
+    fun getSubprojectByName(name: String) = nameToSubproject[name]
+    fun getSlowSubprojects() = subprojects.filter { it.containsSlowTests }
+}

--- a/.teamcity/Gradle_Check/projects/RootProject.kt
+++ b/.teamcity/Gradle_Check/projects/RootProject.kt
@@ -1,6 +1,6 @@
 package projects
 
-import configurations.FunctionalTest
+import Gradle_Check.model.GradleBuildBucketProvider
 import configurations.StagePasses
 import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2018_2.ParameterDisplay
@@ -10,7 +10,7 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.projectFeatures.versionedSet
 import model.CIBuildModel
 import model.Stage
 
-class RootProject(model: CIBuildModel) : Project({
+class RootProject(model: CIBuildModel, gradleBuildBucketProvider: GradleBuildBucketProvider) : Project({
     uuid = model.projectPrefix.removeSuffix("_")
     id = AbsoluteId(uuid)
     parentId = AbsoluteId("Gradle")
@@ -33,9 +33,8 @@ class RootProject(model: CIBuildModel) : Project({
     }
 
     var prevStage: Stage? = null
-    val deferredFunctionalTests = mutableListOf<(Stage) -> List<FunctionalTest>>()
     model.stages.forEach { stage ->
-        val stageProject = StageProject(model, stage, uuid, deferredFunctionalTests)
+        val stageProject = StageProject(model, gradleBuildBucketProvider, stage, uuid)
         val stagePasses = StagePasses(model, stage, prevStage, stageProject)
         buildType(stagePasses)
         subProject(stageProject)

--- a/.teamcity/Gradle_Check/settings.kts
+++ b/.teamcity/Gradle_Check/settings.kts
@@ -1,9 +1,11 @@
 package Gradle_Check
 
+import Gradle_Check.model.StatisticBasedGradleBuildBucketProvider
 import jetbrains.buildServer.configs.kotlin.v2018_2.project
 import jetbrains.buildServer.configs.kotlin.v2018_2.version
 import model.CIBuildModel
 import projects.RootProject
+import java.io.File
 
 /*
 The settings script is an entry point for defining a single
@@ -26,4 +28,6 @@ calling the subProjects() method in this project.
 */
 
 version = "2019.1"
-project(RootProject(CIBuildModel(buildScanTags = listOf("Check"))))
+val model = CIBuildModel(buildScanTags = listOf("Check"))
+val gradleBuildBucketProvider = StatisticBasedGradleBuildBucketProvider(model, File("./test-class-data.json"))
+project(RootProject(model,gradleBuildBucketProvider))

--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -71,6 +71,26 @@
                     <format>kotlin</format>
                     <dstDir>target/generated-configs</dstDir>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-jdk8</artifactId>
+                        <version>${kotlin.version}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-reflect</artifactId>
+                        <version>${kotlin.version}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-script-runtime</artifactId>
+                        <version>${kotlin.version}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -94,6 +114,12 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.62</version>
+        </dependency>
+
         <dependency>
             <groupId>org.jetbrains.teamcity</groupId>
             <artifactId>configs-dsl-kotlin</artifactId>

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -1,4 +1,6 @@
 import common.JvmCategory
+import Gradle_Check.model.GradleBuildBucketProvider
+import Gradle_Check.model.StatisticBasedGradleBuildBucketProvider
 import common.JvmVendor
 import common.JvmVersion
 import common.NoBuildCache
@@ -12,7 +14,6 @@ import model.GradleSubproject
 import model.SpecificBuild
 import model.Stage
 import model.StageNames
-import model.SubprojectSplit
 import model.TestCoverage
 import model.TestType
 import model.Trigger
@@ -26,19 +27,18 @@ import projects.StageProject
 import java.io.File
 
 class CIConfigIntegrationTests {
+    private val model = CIBuildModel(buildScanTags = listOf("Check"))
+    private val gradleBuildBucketProvider = StatisticBasedGradleBuildBucketProvider(model, File("./test-class-data.json").absoluteFile)
+    private val rootProject = RootProject(model, gradleBuildBucketProvider)
     @Test
     fun configurationTreeCanBeGenerated() {
-        val model = CIBuildModel()
-        val rootProject = RootProject(model)
         assertEquals(rootProject.subProjects.size, model.stages.size + 1)
         assertEquals(rootProject.buildTypes.size, model.stages.size)
     }
 
     @Test
     fun macBuildsHasEmptyRepoMirrorUrlsParam() {
-        val model = CIBuildModel()
-        val rootProject = RootProject(model)
-        val readyForRelease = rootProject.searchSubproject("Gradle_Check_Stage_ReadyforRelease")
+        val readyForRelease = rootProject.searchBuildProject("Gradle_Check_Stage_ReadyforRelease")
         val macBuilds = readyForRelease.subProjects.filter { it.name.contains("Macos") }.flatMap { (it as FunctionalTestProject).functionalTests }
         assertTrue(macBuilds.isNotEmpty())
         assertTrue(macBuilds.all { it.params.findRawParam("env.REPO_MIRROR_URLS")!!.value == "" })
@@ -46,32 +46,28 @@ class CIConfigIntegrationTests {
 
     @Test
     fun macOSBuildsSubset() {
-        val m = CIBuildModel()
-        val p = RootProject(m)
-        val readyForRelease = p.subProjects.find { it.name.contains(StageNames.READY_FOR_RELEASE.stageName) }!!
+        val readyForRelease = rootProject.subProjects.find { it.name.contains(StageNames.READY_FOR_RELEASE.stageName) }!!
         val macOS = readyForRelease.subProjects.find { it.name.contains("Macos") }!!
 
         macOS.buildTypes.forEach { buildType ->
-            assertFalse(Os.macos.ignoredSubprojects.any { subproject ->
-                buildType.name.endsWith("($subproject)")
+            assertFalse(Os.macos.ignoredSubprojects.any { subProject ->
+                buildType.name.endsWith("($subProject)")
             })
         }
     }
 
     @Test
     fun configurationsHaveDependencies() {
-        val m = CIBuildModel()
-        val p = RootProject(m)
-        val stagePassConfigs = p.buildTypes
+        val stagePassConfigs = rootProject.buildTypes
         stagePassConfigs.forEach {
             val stageNumber = stagePassConfigs.indexOf(it) + 1
             println(it.id)
             it.dependencies.items.forEach {
                 println("--> " + it.buildTypeId)
             }
-            if (stageNumber <= m.stages.size) {
-                val stage = m.stages[stageNumber - 1]
-                val prevStage = if (stageNumber > 1) m.stages[stageNumber - 2] else null
+            if (stageNumber <= model.stages.size) {
+                val stage = model.stages[stageNumber - 1]
+                val prevStage = if (stageNumber > 1) model.stages[stageNumber - 2] else null
                 var functionalTestCount = 0
 
                 if (stage.runsIndependent) {
@@ -79,13 +75,7 @@ class CIConfigIntegrationTests {
                 }
 
                 stage.functionalTests.forEach { testCoverage ->
-                    m.buildTypeBuckets.filter { bucket ->
-                        !bucket.shouldBeSkippedInStage(stage) && !bucket.shouldBeSkipped(testCoverage)
-                    }.forEach { subprojectBucket ->
-                        if (subprojectBucket.hasTestsOf(testCoverage.testType)) {
-                            functionalTestCount += subprojectBucket.createFunctionalTestsFor(m, stage, testCoverage).size
-                        }
-                    }
+                    functionalTestCount += gradleBuildBucketProvider.createFunctionalTestsFor(stage, testCoverage).size
                     if (testCoverage.testType == TestType.soak) {
                         functionalTestCount++
                     }
@@ -100,6 +90,13 @@ class CIConfigIntegrationTests {
                 assertEquals(2, it.dependencies.items.size) // Individual Performance Worker
             }
         }
+    }
+
+    class SubProjectBucketProvider(private val model: CIBuildModel) : GradleBuildBucketProvider {
+        override fun createFunctionalTestsFor(stage: Stage, testConfig: TestCoverage) =
+            model.subprojects.subprojects.map { it.createFunctionalTestsFor(model, stage, testConfig) }
+
+        override fun createDeferredFunctionalTestsFor(stage: Stage) = emptyList<FunctionalTest>()
     }
 
     @Test
@@ -120,94 +117,117 @@ class CIConfigIntegrationTests {
                     omitsSlowProjects = true)
             )
         )
-        val p = RootProject(m)
+        val p = RootProject(m, SubProjectBucketProvider(m))
         printTree(p)
         assertTrue(p.subProjects.size == 1)
     }
 
-    fun Project.searchSubproject(id: String): StageProject = (subProjects.find { it.id!!.value == id } as StageProject)
+    private
+    fun Project.searchBuildProject(id: String): StageProject = (subProjects.find { it.id!!.value == id } as StageProject)
+
+    private
+    val largeSubProjectRegex = """\((\w+(_\d+)?)\)""".toRegex()
+
+    /**
+     * Test Coverage - AllVersionsCrossVersion Java8 Oracle Linux (core_2) -> core_2
+     */
+    private
+    fun FunctionalTest.getSubProjectSplitName() = largeSubProjectRegex.find(this.name)!!.groupValues[1]
+
+    private
+    fun FunctionalTest.getGradleTasks(): String {
+        val runnerStep = this.steps.items.find { it.name == "GRADLE_RUNNER" } as GradleBuildStep
+        return runnerStep.tasks!!
+    }
+
+    private
+    fun FunctionalTest.getGradleParams(): String {
+        val runnerStep = this.steps.items.find { it.name == "GRADLE_RUNNER" } as GradleBuildStep
+        return runnerStep.gradleParams!!
+    }
 
     @Test
     fun canSplitLargeProjects() {
-        val model = CIBuildModel()
-        val rootProject = RootProject(model)
-        val largeSubprojects = model.buildTypeBuckets.filterIsInstance<SubprojectSplit>()
-
-        fun FunctionalTest.isLargeProjectSplit(): Boolean {
-            return largeSubprojects.any { this.name.contains("(${it.subproject.name})") || this.name.contains("(${it.subproject.name}_") }
-        }
-
-        fun find(buildTypeName: String): String {
-            // Test Coverage - AllVersionsCrossVersion Java8 Oracle Linux (core_2) -> core_2
-            return """\((\w+(_\d+)?)\)""".toRegex().find(buildTypeName)!!.groupValues[1]
-        }
-
-        fun assertAllSplitsArePresent(functionalTests: List<FunctionalTest>) {
-            val projectNames = functionalTests.map { find(it.name) }.toSet()
-            val expectedProjectNames = largeSubprojects.flatMap { bucket ->
-                (1..bucket.total).map {
-                    if (it == 1) {
-                        bucket.subproject.name
-                    } else {
-                        "${bucket.subproject.name}_$it"
-                    }
+        fun assertAllSplitsArePresent(subProjectName: String, functionalTests: List<FunctionalTest>) {
+            val splitSubProjectNames = functionalTests.map { it.getSubProjectSplitName() }.toSet()
+            val expectedProjectNames = (1..functionalTests.size).map {
+                if (it == 1) {
+                    subProjectName
+                } else {
+                    "${subProjectName}_$it"
                 }
             }.toSet()
-            assertEquals(expectedProjectNames, projectNames)
+            assertEquals(expectedProjectNames, splitSubProjectNames)
         }
 
-        fun assertCorrectParameters(functionalTests: List<FunctionalTest>) {
-            functionalTests.forEach {
-                // e.g. core_2
-                val projectNameWithSplit = find(it.name)
-                // e.g. core
-                val projectName = projectNameWithSplit.substringBefore('_')
-
-                val numberOfSplits = largeSubprojects.find { it.subproject.name == projectName }!!.total
-                val runnerStep = it.steps.items.find { it.name == "GRADLE_RUNNER" } as GradleBuildStep
-                if (projectNameWithSplit.contains("_")) {
-                    val split = projectNameWithSplit.substringAfter('_')
-                    assertTrue(runnerStep.tasks!!.startsWith("clean $projectName:") && runnerStep.gradleParams!!.contains("-PtestSplit=$split/$numberOfSplits"))
-                } else {
-                    assertTrue(runnerStep.tasks!!.startsWith("clean $projectName:") && runnerStep.gradleParams!!.contains("-PtestSplit=1/$numberOfSplits"))
+        fun assertCorrectParameters(subProjectName: String, functionalTests: List<FunctionalTest>) {
+            functionalTests.forEach { assertTrue(it.getGradleTasks().startsWith("clean $subProjectName")) }
+            if (functionalTests.size == 1) {
+                assertFalse(functionalTests[0].getGradleParams().contains("-PrunTestClassesInBucket"))
+            } else {
+                functionalTests.forEachIndexed { index, it ->
+                    assertTrue(it.getGradleParams().contains("-PrunTestClassesInBucket"))
                 }
             }
         }
 
-        fun assertLargeProjectsAreSplittedCorrectly(id: String) {
-            val functionalTestsWithSplit = rootProject.searchSubproject(id).functionalTests.filter(FunctionalTest::isLargeProjectSplit)
-
-            assertAllSplitsArePresent(functionalTestsWithSplit)
-            assertCorrectParameters(functionalTestsWithSplit)
+        fun assertProjectAreSplitByClassesCorrectly(functionalTests: List<FunctionalTest>) {
+            val functionalTestsWithSplit: Map<String, List<FunctionalTest>> = functionalTests.filter { largeSubProjectRegex.containsMatchIn(it.name) }.groupBy { it.getSubProjectSplitName().substringBefore('_') }
+            functionalTestsWithSplit.forEach {
+                assertAllSplitsArePresent(it.key, it.value)
+                assertCorrectParameters(it.key, it.value)
+            }
         }
 
-        assertLargeProjectsAreSplittedCorrectly("Gradle_Check_Stage_QuickFeedbackLinuxOnly")
-        assertLargeProjectsAreSplittedCorrectly("Gradle_Check_Stage_QuickFeedback")
-        assertLargeProjectsAreSplittedCorrectly("Gradle_Check_Stage_ReadyforMerge")
-        assertLargeProjectsAreSplittedCorrectly("Gradle_Check_Stage_ReadyforNightly")
-        assertLargeProjectsAreSplittedCorrectly("Gradle_Check_Stage_ReadyforRelease")
+        fun assertProjectAreSplitByGradleVersionCorrectly(testType: TestType, functionalTests: List<FunctionalTest>) {
+            (1..6).forEach {
+                assertTrue(functionalTests[it - 1].name.contains("gradle $it"))
+                assertEquals("clean ${testType}Test", functionalTests[it - 1].getGradleTasks())
+                assertTrue(functionalTests[it - 1].getGradleParams().contains("-PonlyTestGradleMajorVersion=$it"))
+            }
+        }
+
+        fun assertMultiVersionIntegrationTest(functionalTests: List<FunctionalTest>) {
+            assertEquals(1, functionalTests.size)
+            assertEquals("clean allVersionsIntegMultiVersionTest", functionalTests[0].getGradleTasks())
+        }
+
+        for (stageProject in rootProject.subProjects.filterIsInstance<StageProject>()) {
+            for (functionalTestProject in stageProject.subProjects.filterIsInstance<FunctionalTestProject>()) {
+                when {
+                    functionalTestProject.name.contains("AllVersionsCrossVersion") -> {
+                        assertProjectAreSplitByGradleVersionCorrectly(TestType.allVersionsCrossVersion, functionalTestProject.functionalTests)
+                    }
+                    functionalTestProject.name.contains("QuickFeedbackCrossVersion") -> {
+                        assertProjectAreSplitByGradleVersionCorrectly(TestType.quickFeedbackCrossVersion, functionalTestProject.functionalTests)
+                    }
+                    functionalTestProject.name.contains("AllVersionsIntegMultiVersion") -> {
+                        assertMultiVersionIntegrationTest(functionalTestProject.functionalTests)
+                    }
+                    else -> {
+                        assertProjectAreSplitByClassesCorrectly(functionalTestProject.functionalTests)
+                    }
+                }
+            }
+        }
     }
 
     @Test
     fun canDeferSlowTestsToLaterStage() {
-        val model = CIBuildModel()
-        val rootProject = RootProject(model)
-        val slowSubprojects = model.subProjects.filter { it.containsSlowTests }.map { it.name }
+        val slowSubProjects = model.subprojects.subprojects.filter { it.containsSlowTests }.map { it.name }
 
-        fun FunctionalTest.isSlow(): Boolean = slowSubprojects.any { name.contains(it) }
-        fun Project.subprojectContainsSlowTests(id: String): Boolean = searchSubproject(id).functionalTests.any(FunctionalTest::isSlow)
+        fun FunctionalTest.isSlow(): Boolean = slowSubProjects.any { name.contains(it) }
+        fun Project.subProjectContainsSlowTests(id: String): Boolean = searchBuildProject(id).functionalTests.any(FunctionalTest::isSlow)
 
-        assertTrue(!rootProject.subprojectContainsSlowTests("Gradle_Check_Stage_QuickFeedbackLinuxOnly"))
-        assertTrue(!rootProject.subprojectContainsSlowTests("Gradle_Check_Stage_QuickFeedback"))
-        assertTrue(!rootProject.subprojectContainsSlowTests("Gradle_Check_Stage_ReadyforMerge"))
-        assertTrue(rootProject.subprojectContainsSlowTests("Gradle_Check_Stage_ReadyforNightly"))
-        assertTrue(rootProject.subprojectContainsSlowTests("Gradle_Check_Stage_ReadyforRelease"))
+        assertTrue(!rootProject.subProjectContainsSlowTests("Gradle_Check_Stage_QuickFeedbackLinuxOnly"))
+        assertTrue(!rootProject.subProjectContainsSlowTests("Gradle_Check_Stage_QuickFeedback"))
+        assertTrue(!rootProject.subProjectContainsSlowTests("Gradle_Check_Stage_ReadyforMerge"))
+        assertTrue(rootProject.subProjectContainsSlowTests("Gradle_Check_Stage_ReadyforNightly"))
+        assertTrue(rootProject.subProjectContainsSlowTests("Gradle_Check_Stage_ReadyforRelease"))
     }
 
     @Test
     fun onlyReadyForNightlyTriggerHasUpdateBranchStatus() {
-        val model = CIBuildModel()
-        val rootProject = RootProject(model)
         val triggerNameToTasks = rootProject.buildTypes.map { it.uuid to ((it as StagePasses).steps.items[0] as GradleBuildStep).tasks }.toMap()
         val readyForNightlyId = toTriggerId("MasterAccept")
         assertEquals("createBuildReceipt updateBranchStatus", triggerNameToTasks[readyForNightlyId])
@@ -219,7 +239,7 @@ class CIConfigIntegrationTests {
 
     @Test
     fun allSubprojectsAreListed() {
-        val knownSubProjectNames = CIBuildModel().subProjects.map { it.asDirectoryName() }
+        val knownSubProjectNames = CIBuildModel().subprojects.subprojects.map { it.asDirectoryName() }
         subProjectFolderList().forEach {
             assertTrue(
                 it.name in knownSubProjectNames,
@@ -236,7 +256,7 @@ class CIConfigIntegrationTests {
 
     @Test
     fun testsAreCorrectlyConfiguredForAllSubProjects() {
-        CIBuildModel().subProjects.filter {
+        CIBuildModel().subprojects.subprojects.filter {
             !listOf(
                 "soak", // soak test
                 "distributions", // build distributions
@@ -253,7 +273,7 @@ class CIConfigIntegrationTests {
 
     @Test
     fun allSubprojectsDefineTheirUnitTestPropertyCorrectly() {
-        val projectsWithUnitTests = CIBuildModel().subProjects.filter { it.unitTests }
+        val projectsWithUnitTests = CIBuildModel().subprojects.subprojects.filter { it.unitTests }
         val projectFoldersWithUnitTests = subProjectFolderList().filter {
             File(it, "src/test").exists() &&
                 it.name != "docs" && // docs:check is part of Sanity Check
@@ -266,8 +286,8 @@ class CIConfigIntegrationTests {
     }
 
     @Test
-    fun allSubprojectsDefineTheirFunctionTestPropertyCorrectly() {
-        val projectsWithFunctionalTests = CIBuildModel().subProjects.filter { it.functionalTests }
+    fun allSubProjectsDefineTheirFunctionTestPropertyCorrectly() {
+        val projectsWithFunctionalTests = CIBuildModel().subprojects.subprojects.filter { it.functionalTests }
         val projectFoldersWithFunctionalTests = subProjectFolderList().filter {
             File(it, "src/integTest").exists() &&
                 it.name != "distributions" && // distributions:integTest is part of Build Distributions
@@ -281,7 +301,7 @@ class CIConfigIntegrationTests {
 
     @Test
     fun allSubprojectsDefineTheirCrossVersionTestPropertyCorrectly() {
-        val projectsWithCrossVersionTests = CIBuildModel().subProjects.filter { it.crossVersionTests }
+        val projectsWithCrossVersionTests = CIBuildModel().subprojects.subprojects.filter { it.crossVersionTests }
         val projectFoldersWithCrossVersionTests = subProjectFolderList().filter { File(it, "src/crossVersionTest").exists() }
         assertFalse(projectFoldersWithCrossVersionTests.isEmpty())
         projectFoldersWithCrossVersionTests.forEach {
@@ -330,7 +350,7 @@ class CIConfigIntegrationTests {
                         TestCoverage(21, TestType.platform, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)))
             )
         )
-        val p = RootProject(m)
+        val p = RootProject(m, SubProjectBucketProvider(m))
         assertTrue(p.subProjects.size == 2)
 
         val buildStepsWithCache = (p.subProjectsOrder[0] as StageProject)
@@ -360,9 +380,9 @@ class CIConfigIntegrationTests {
     }
 
     private fun subProjectFolderList(): List<File> {
-        val subprojectFolders = File("../subprojects").listFiles().filter { it.isDirectory }
-        assertFalse(subprojectFolders.isEmpty())
-        return subprojectFolders
+        val subProjectFolders = File("../subprojects").listFiles().filter { it.isDirectory }
+        assertFalse(subProjectFolders.isEmpty())
+        return subProjectFolders
     }
 
     private fun getSubProjectFolder(subProject: GradleSubproject): File = File("../subprojects/${subProject.asDirectoryName()}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
     gradlebuild.`build-types`
     gradlebuild.`ci-reporting`
     gradlebuild.security
-    id("org.gradle.ci.tag-single-build") version("0.74")
+    id("org.gradle.ci.tag-single-build") version ("0.74")
 }
 
 defaultTasks("assemble")
@@ -123,6 +123,11 @@ buildTypes {
     // Used for cross version tests on CI
     create("allVersionsCrossVersionTest") {
         tasks("allVersionsCrossVersionTests", "integMultiVersionTest")
+        projectProperties("testAllVersions" to true)
+    }
+
+    create("allVersionsIntegMultiVersionTest") {
+        tasks("integMultiVersionTest")
         projectProperties("testAllVersions" to true)
     }
 
@@ -383,12 +388,12 @@ tasks.register<Install>("installAll") {
 tasks.register<UpdateBranchStatus>("updateBranchStatus")
 
 fun distributionImage(named: String) =
-        project(":distributions").property(named) as CopySpec
+    project(":distributions").property(named) as CopySpec
 
 val allIncubationReports = tasks.register<IncubatingApiAggregateReportTask>("allIncubationReports") {
     val allReports = collectAllIncubationReports()
     dependsOn(allReports)
-    reports = allReports.associateBy({ it.title.get()}) { it.textReportFile.asFile.get() }
+    reports = allReports.associateBy({ it.title.get() }) { it.textReportFile.asFile.get() }
 }
 tasks.register<Zip>("allIncubationReportsZip") {
     destinationDir = file("$buildDir/reports/incubation")

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/BuildBucketProvider.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/BuildBucketProvider.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.test.integrationtests
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.*
+import org.gradle.util.GradleVersion
+import java.io.StringReader
+import java.util.Properties
+
+
+interface BuildBucketProvider {
+    fun configureTest(testTask: Test, sourceSet: SourceSet, testType: TestType)
+
+    companion object {
+        private
+        var instance: BuildBucketProvider? = null
+
+        fun getInstance(project: Project): BuildBucketProvider {
+            if (instance == null) {
+                val includeProperties = project.rootProject.buildDir.resolve("include-test-classes.properties")
+                val excludeProperties = project.rootProject.buildDir.resolve("exclude-test-classes.properties")
+                instance = when {
+                    includeProperties.isFile -> {
+                        val content = includeProperties.readText()
+                        println("Tests to be included:\n$content")
+                        IncludeTestClassProvider(readTestClasses(content))
+                    }
+                    excludeProperties.isFile -> {
+                        val content = excludeProperties.readText()
+                        println("Tests to be excluded:\n$content")
+                        ExcludeTestClassProvider(readTestClasses(content))
+                    }
+                    project.stringPropertyOrEmpty("onlyTestGradleMajorVersion").isNotBlank() -> {
+                        CrossVersionBucketProvider(project.stringPropertyOrEmpty("onlyTestGradleMajorVersion"))
+                    }
+                    else -> {
+                        NoOpTestClassProvider()
+                    }
+                }
+            }
+
+            return instance!!
+        }
+
+        private
+        fun readTestClasses(content: String): Map<String, List<String>> {
+            val properties = Properties()
+            val ret = mutableMapOf<String, MutableList<String>>()
+            properties.load(StringReader(content))
+            properties.forEach { key, value ->
+                val list = ret.getOrDefault(value, mutableListOf())
+                list.add(key!!.toString())
+                ret[value!!.toString()] = list
+            }
+            return ret
+        }
+    }
+}
+
+
+class CrossVersionBucketProvider(private val onlyTestGradleMajorVersion: String) : BuildBucketProvider {
+    override fun configureTest(testTask: Test, sourceSet: SourceSet, testType: TestType) {
+        val currentVersionUnderTest = extractTestTaskGradleVersion(testTask.name)
+        currentVersionUnderTest?.apply {
+            testTask.enabled = currentVersionEnabled(currentVersionUnderTest)
+        }
+    }
+
+    private
+    fun currentVersionEnabled(currentVersionUnderTest: String): Boolean {
+        val versionUnderTest = GradleVersion.version(currentVersionUnderTest)
+        // if onlyTestGradleMajorVersion=1, we test Gradle 0.x and Gradle 1.x
+        val testGradleVersion = GradleVersion.version("${if (onlyTestGradleMajorVersion == "1") "0" else onlyTestGradleMajorVersion}.0.0")
+        return testGradleVersion <= versionUnderTest && versionUnderTest <= testGradleVersion.nextMajor
+    }
+
+    private
+    fun extractTestTaskGradleVersion(name: String): String? = "gradle([\\d.]+)CrossVersionTest".toRegex().find(name)?.groupValues?.get(1)
+}
+
+
+class IncludeTestClassProvider(private val includeTestClasses: Map<String, List<String>>) : BuildBucketProvider {
+    override fun configureTest(testTask: Test, sourceSet: SourceSet, testType: TestType) {
+        if (testTask.name == "integMultiVersionTest") {
+            // Run integMultiVersionTest in last split
+            testTask.enabled = false
+        } else {
+            testTask.filter.isFailOnNoMatchingTests = false
+            includeTestClasses[sourceSet.name]?.apply { testTask.filter.includePatterns.addAll(this) }
+        }
+    }
+}
+
+
+class ExcludeTestClassProvider(private val excludeTestClasses: Map<String, List<String>>) : BuildBucketProvider {
+    override fun configureTest(testTask: Test, sourceSet: SourceSet, testType: TestType) {
+        if (testTask.name != "integMultiVersionTest") {
+            testTask.filter.isFailOnNoMatchingTests = false
+            excludeTestClasses[sourceSet.name]?.apply { testTask.filter.excludePatterns.addAll(this) }
+        }
+    }
+}
+
+
+class NoOpTestClassProvider : BuildBucketProvider {
+    override fun configureTest(testTask: Test, sourceSet: SourceSet, testType: TestType) {
+    }
+}

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/CrossVersionTestsPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/CrossVersionTestsPlugin.kt
@@ -15,7 +15,6 @@
  */
 package org.gradle.gradlebuild.test.integrationtests
 
-import com.google.common.collect.MultimapBuilder
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -59,15 +58,11 @@ class CrossVersionTestsPlugin : Plugin<Project> {
 
         val quickTestVersions = releasedVersions.getTestedVersions(true)
         val allTestVersions = releasedVersions.getTestedVersions(false)
-        val testVersionsEnabledInCurrentSplit = getTestVersionsEnabledInCurrentSplit(allTestVersions)
-        if (testVersionsEnabledInCurrentSplit.size != allTestVersions.size) {
-            println("Only enable ${testVersionsEnabledInCurrentSplit.joinToString(", ")} for $name cross version tests")
-        }
+
         allTestVersions.forEach { targetVersion ->
             val crossVersionTest = createTestTask("gradle${targetVersion}CrossVersionTest", "forking", sourceSet, TestType.CROSSVERSION, Action {
                 this.description = "Runs the cross-version tests against Gradle $targetVersion"
                 this.systemProperties["org.gradle.integtest.versions"] = targetVersion
-                enabled = targetVersion in testVersionsEnabledInCurrentSplit
             })
 
             allVersionsCrossVersionTests.configure { dependsOn(crossVersionTest) }
@@ -75,26 +70,5 @@ class CrossVersionTestsPlugin : Plugin<Project> {
                 quickFeedbackCrossVersionTests.configure { dependsOn(crossVersionTest) }
             }
         }
-    }
-
-    // Sample the list, for example, allTestVersions is [1.0, 1.1, 1.2, 1.3, 1.4]
-    // -PtestSplit=1/2 return [1.0, 1,2, 1.4]
-    // -PtestSplit=2/2 return [1.1, 1,3]
-    private
-    fun Project.getTestVersionsEnabledInCurrentSplit(allTestVersions: List<String>): List<String> {
-        val testSplit = project.stringPropertyOrEmpty("testSplit")
-        if (testSplit.isBlank()) {
-            return allTestVersions
-        }
-        val currentSplit = testSplit.split("/")[0].toInt()
-        val numberOfSplits = testSplit.split("/")[1].toInt()
-        val buckets = MultimapBuilder.SetMultimapBuilder
-            .hashKeys()
-            .arrayListValues()
-            .build<Int, String>()
-        for ((index, version) in allTestVersions.withIndex()) {
-            buckets.put(index % numberOfSplits, version)
-        }
-        return buckets[currentSplit - 1]
     }
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -101,9 +101,7 @@ fun Project.insertBuildTypeTasksInto(
         findProject(subproject) != null ->
             forEachBuildTypeTask {
                 val taskPath = "$subproject:$it"
-                val testSplit = stringPropertyOrEmpty("testSplit")
                 when {
-                    isUnitTestWithNonFirstSplit(it, testSplit) -> println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it is a unit test and we're on $testSplit.")
                     tasks.findByPath(taskPath) == null -> println("Skipping task '$taskPath' requested by build type ${buildType.name}, as it does not exist.")
                     else -> insert(taskPath)
                 }
@@ -116,12 +114,6 @@ fun Project.insertBuildTypeTasksInto(
     if (taskList.isEmpty()) {
         taskList.add("help") // do not trigger the default tasks
     }
-}
-
-
-fun isUnitTestWithNonFirstSplit(task: String, testSplit: String): Boolean = when {
-    task != "test" || testSplit.isBlank() -> false
-    else -> testSplit.split("/")[0].toInt() != 1
 }
 
 


### PR DESCRIPTION
### Context

Previously, our TeamCity builds aren't distributed evenly, we want to shorten the feedback time by splitting builds into small buckets. This PR reads the build time data JSON genreated by [ci-health](https://builds.gradle.org/project.html?projectId=Hygiene&):

```
{

"Gradle_Check_Quick_1": {
        "languageNative": [
            {
                "buildTimeMs": 234,
                "testClass": "org.gradle.swiftpm.plugins.SwiftPackageManagerExportPluginTest"
            },
            ...
        ],
        "pluginUse": [
            {
                "buildTimeMs": 92,
                "testClass": "org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolverTest"
            },
            ...
         ]
},

"Gradle_Check_Platform_4": {
...
```

Moreover, looking at [the cross version tests AllVersionsCrossVersionTest](https://builds.gradle.org/project.html?projectId=Gradle_Check_AllVersionsCrossVersion_10&tab=projectOverview&branch_Gradle_Check_AllVersionsCrossVersion_10=master), several large subproject dominates the build time, some tiny subprojects even don't run tests at all.

This PR does:

- For the functional tests, we automatically split buckets to evenly distributed buckets based on the statistics data. The basic rule is:
  - Each build project are split differently based on the test time data of that build project.
  - Large subproject are split into smaller buckets, e.g. `core` -> `[core, core_2, core_3]`. In this case, `core`/`core_2` have a `-PincludeClasses=A,B`/`-PincludeClasses=C,D` parameter and `core_3` has a `-PexcludeClasses=A,B,C,D`.
  - Small subprojects are joined to a single bucket.

- For the cross version tests, we split them by major gradle version, i.e. gradle 1.x cross version test for all subprojects, gradle 2.x cross version test for all subproject, ... etc.

Also, this PR refactors the previous `CIModel` and factors out the `GradleBuildBucketProvider` so it can be easily adjusted in the future (for example, if we don't like buckets and want to use per-subproject infrastructure again).