### PR TITLE
Explicitly model dependencies between source directory sets

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
@@ -16,12 +16,16 @@
 package org.gradle.api.file;
 
 import org.gradle.api.Describable;
+import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.model.internal.core.UnmanagedStruct;
 
+import javax.annotation.Nullable;
 import java.io.File;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -127,4 +131,34 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @since 4.0
      */
     void setOutputDir(File outputDir);
+
+    /**
+     * Define dependencies between source directories of one source set.
+     *
+     * @return the mutable list of source directory sets this set depends on
+     * @since 6.1
+     */
+    @Incubating
+    List<SourceDirectorySet> getCompilationOrderDependencies();
+
+    /**
+     * Get the task responsible for processing the sources from this set if available.
+     *
+     * @return the task compiling sources from this set
+     * @since 6.1
+     */
+    @Incubating
+    @Nullable
+    Provider<? extends Task> getCompileTask();
+
+    /**
+     * Register the task responsible for processing the sources from this set.
+     * This is helpful to let plugins know how the sources are processed so that they can respect
+     * the compilation order defined through {@link #getCompilationOrderDependencies()}.
+     *
+     * @param compileTask the task compiling sources from this set
+     * @since 6.1
+     */
+    @Incubating
+    void setCompileTask(@Nullable Provider<? extends Task> compileTask);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file;
 import groovy.lang.Closure;
 import org.gradle.api.Buildable;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTreeElement;
@@ -38,6 +39,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -47,7 +49,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class DefaultSourceDirectorySet extends CompositeFileTree implements SourceDirectorySet {
-    private final List<Object> source = new ArrayList<Object>();
+    private final List<Object> source = new ArrayList<>();
     private final String name;
     private final String displayName;
     private final FileCollectionFactory fileCollectionFactory;
@@ -56,6 +58,9 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
     private final PatternSet filter;
     private final FileCollection dirs;
     private final Property<File> outputDir;
+    private final List<SourceDirectorySet> dependencies = new ArrayList<>();
+
+    private Provider<? extends Task> compileTask = null;
 
     public DefaultSourceDirectorySet(String name, String displayName, Factory<PatternSet> patternSetFactory, FileCollectionFactory fileCollectionFactory, DirectoryFileTreeFactory directoryFileTreeFactory, ObjectFactory objectFactory) {
         this.name = name;
@@ -175,6 +180,22 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
     @Override
     public void setOutputDir(File outputDir) {
         this.outputDir.set(outputDir);
+    }
+
+    @Override
+    public List<SourceDirectorySet> getCompilationOrderDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    @Nullable
+    public Provider<? extends Task> getCompileTask() {
+        return compileTask;
+    }
+
+    @Override
+    public void setCompileTask(@Nullable Provider<? extends Task> compileTask) {
+        this.compileTask = compileTask;
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -98,6 +98,7 @@ public class GroovyBasePlugin implements Plugin<Project> {
             @Override
             public void execute(final SourceSet sourceSet) {
                 final DefaultGroovySourceSet groovySourceSet = new DefaultGroovySourceSet("groovy", ((DefaultSourceSet) sourceSet).getDisplayName(), objectFactory);
+                groovySourceSet.getGroovy().getCompilationOrderDependencies().add(sourceSet.getJava());
                 new DslObject(sourceSet).getConvention().getPlugins().put("groovy", groovySourceSet);
 
                 groovySourceSet.getGroovy().srcDir("src/" + sourceSet.getName() + "/groovy");
@@ -114,7 +115,6 @@ public class GroovyBasePlugin implements Plugin<Project> {
                     @Override
                     public void execute(final GroovyCompile compile) {
                         JvmPluginsHelper.configureForSourceSet(sourceSet, groovySourceSet.getGroovy(), compile, compile.getOptions(), project);
-                        compile.dependsOn(sourceSet.getCompileJavaTaskName());
                         compile.setDescription("Compiles the " + sourceSet.getName() + " Groovy source.");
                         compile.setSource(groovySourceSet.getGroovy());
                     }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -152,6 +152,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
                 String displayName = (String) InvokerHelper.invokeMethod(sourceSet, "getDisplayName", null);
                 Convention sourceSetConvention = (Convention) InvokerHelper.getProperty(sourceSet, "convention");
                 DefaultScalaSourceSet scalaSourceSet = new DefaultScalaSourceSet(displayName, objectFactory);
+                scalaSourceSet.getScala().getCompilationOrderDependencies().add(sourceSet.getJava());
                 sourceSetConvention.getPlugins().put("scala", scalaSourceSet);
 
                 final SourceDirectorySet scalaDirectorySet = scalaSourceSet.getScala();
@@ -187,7 +188,6 @@ public class ScalaBasePlugin implements Plugin<Project> {
         final TaskProvider<ScalaCompile> scalaCompile = project.getTasks().register(sourceSet.getCompileTaskName("scala"), ScalaCompile.class, new Action<ScalaCompile>() {
             @Override
             public void execute(ScalaCompile scalaCompile) {
-                scalaCompile.dependsOn(sourceSet.getCompileJavaTaskName());
                 JvmPluginsHelper.configureForSourceSet(sourceSet, scalaSourceSet.getScala(), scalaCompile, scalaCompile.getOptions(), project);
                 scalaCompile.setDescription("Compiles the " + scalaSourceSet.getScala() + ".");
                 scalaCompile.setSource(scalaSourceSet.getScala());


### PR DESCRIPTION
This is an attempt to model the dependencies between _source directory sets_ (e.g. `main/java` and `main/groovy`) of **one** source set - https://github.com/gradle/gradle/issues/11333.
The main motivation is to make this model configurable in the build, so that the (currently hard coded) dependencies can be removed or altered. 
The change would not automatically wire up everything for "new" _source directory sets_  added by other plugins or in the build. But they allow to expose the information to do the wiring.

@big-guy @melix would be great to have some feedback.
1. Do you think this approach works in general?
2. Maybe the APIs could be a bit smarter or more aligned to where we are going with "task dependencies" etc. Please suggest improvements/alternatives.

I did not add any new tests yet. Will wait until we decided if the direction is ok. But CI shows that a change like this does not break anything.
I tested this manually and you can now do things like this:

```
sourceSets {
    main {
        groovy {
            // in this project, the main groovy sources do not depend on the main Java sources
            compilationOrderDependencies.clear()
        }
    }
}
```