### PR TITLE
Fail fast when MSBuild installation can't be found

### DIFF
--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/fixtures/MSBuildVersionLocator.java
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/fixtures/MSBuildVersionLocator.java
@@ -54,7 +54,7 @@ public class MSBuildVersionLocator {
         TestFile msbuild;
         if (!location.isEmpty()) {
             msbuild = new TestFile(location).file("MSBuild/" + vsVersion.getMajor() + ".0/Bin/MSBuild.exe");
-        } else if (vsVersion.getMajor() == 11){
+        } else if (vsVersion.getMajor() == 11) {
             msbuild = new TestFile("C:/Windows/Microsoft.Net/Framework/v4.0.30319/MSBuild.exe");
         } else {
             msbuild = new TestFile("C:/program files (x86)/MSBuild/" + vsVersion.getMajor() + ".0/Bin/MSBuild.exe");
@@ -63,7 +63,12 @@ public class MSBuildVersionLocator {
         // There is some value to the other ways to locate MSBuild (aka matching the MSBuild installation with the VS installation), this is a last chance to try and locate a usable MSBuild installation which will just try to get the latest available MSBuild. We can refine this later.
         if (!msbuild.exists()) {
             vsWhereOutput = new TestFile(vswhere).exec("-latest", "-requires", "Microsoft.Component.MSBuild", "-find", "MSBuild\\**\\Bin\\MSBuild.exe");
-            msbuild = new TestFile(vsWhereOutput.getOut().trim());
+            location = vsWhereOutput.getOut().trim();
+            if (location.isEmpty()) {
+                throw new IllegalStateException(String.format("Could not determine the location of MSBuild %s: %s", vsVersion.getMajor(), vsWhereOutput.getError()));
+            }
+
+            msbuild = new TestFile(location);
         }
 
         if (!msbuild.exists()) {


### PR DESCRIPTION
### Context
Previously, the build failed late when MSBuild can't be determined,
which makes the error message very confusing. This commit makes
the build fail fast in this case.

When `vsWhere.exe` returns empty string, the empty string was used to construct a `TestFile("")`, which is the current working directory. That's why we got https://builds.gradle.org/viewLog.html?buildId=29017960&buildTypeId=Gradle_Check_AllVersionsCrossVersion_11_bucket5  failure.