### PR TITLE
Fix cycle in 'buildNeeded' and 'buildDependents' tasks

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjects.java
@@ -46,9 +46,11 @@ class TasksFromDependentProjects extends AbstractTaskDependency {
         Project thisProject = context.getTask().getProject();
         Set<Task> tasksWithName = thisProject.getRootProject().getTasksByName(taskName, true);
         for (Task nextTask : tasksWithName) {
-            boolean isDependency = checker.isDependent(thisProject, configurationName, nextTask.getProject());
-            if (isDependency) {
-                context.add(nextTask);
+            if (context.getTask() != nextTask) {
+                boolean isDependency = checker.isDependent(thisProject, configurationName, nextTask.getProject());
+                if (isDependency) {
+                    context.add(nextTask);
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
@@ -47,7 +47,7 @@ class TasksFromProjectDependencies extends AbstractTaskDependency {
             projectAccessListener.beforeResolvingProjectDependency((ProjectInternal) projectDependency.getDependencyProject());
 
             Task nextTask = projectDependency.getDependencyProject().getTasks().findByName(taskName);
-            if (nextTask != null) {
+            if (nextTask != null && context.getTask() != nextTask) {
                 context.add(nextTask);
             }
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjectsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromDependentProjectsTest.groovy
@@ -46,8 +46,7 @@ class TasksFromDependentProjectsTest extends AbstractProjectBuilderSpec {
         when: dep.visitDependencies(context)
 
         then:
-        1 * context.getTask() >> child1.tasks["buildDependents"]
-        1 * checker.isDependent(child1, "testRuntime", child1) >> false
+        4 * context.getTask() >> child1.tasks["buildDependents"]
         1 * checker.isDependent(child1, "testRuntime", child2) >> false
         1 * checker.isDependent(child1, "testRuntime", child3) >> true
         1 * context.add(child3.tasks["buildDependents"])

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
@@ -47,6 +47,7 @@ class TasksFromProjectDependenciesTest extends AbstractProjectBuilderSpec {
 
         then:
         1 * context.add(project1.tasks["buildNeeded"])
+        1 * context.getTask()
         0 * context._
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -469,10 +469,77 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         appProject.pluginManager.apply(JavaPlugin)
 
         appProject.dependencies {
-            compile middleProject
+            implementation middleProject
         }
         middleProject.dependencies {
-            compile commonProject
+            implementation commonProject
+        }
+
+        and:
+        def task = middleProject.tasks['buildNeeded']
+
+        then:
+        task.taskDependencies.getDependencies(task)*.path as Set == [':middle:build', ':common:buildNeeded'] as Set
+
+        when:
+        task = middleProject.tasks['buildDependents']
+
+        then:
+        task.taskDependencies.getDependencies(task)*.path as Set == [':middle:build', ':app:buildDependents'] as Set
+    }
+
+    def buildOtherProjectsWithCyclicDependencies() {
+        given:
+        def commonProject = TestUtil.createChildProject(project, "common")
+        def middleProject = TestUtil.createChildProject(project, "middle")
+        def appProject = TestUtil.createChildProject(project, "app")
+
+        when:
+        project.pluginManager.apply(JavaPlugin)
+        commonProject.pluginManager.apply(JavaPlugin)
+        commonProject.group = "group"
+        commonProject.extensions.configure(JavaPluginExtension) {
+            it.registerFeature("other") {
+                it.usingSourceSet(commonProject.sourceSets.main)
+            }
+        }
+        middleProject.pluginManager.apply(JavaPlugin)
+        middleProject.group = "group"
+        middleProject.extensions.configure(JavaPluginExtension) {
+            it.registerFeature("other") {
+                it.usingSourceSet(middleProject.sourceSets.main)
+            }
+        }
+        appProject.pluginManager.apply(JavaPlugin)
+        appProject.group = "group"
+        appProject.extensions.configure(JavaPluginExtension) {
+            it.registerFeature("other") {
+                it.usingSourceSet(appProject.sourceSets.main)
+            }
+        }
+
+        appProject.dependencies {
+            implementation middleProject
+            implementation(appProject) {
+                capabilities {
+                    requireCapability("group:appProject-other")
+                }
+            }
+        }
+        middleProject.dependencies {
+            implementation commonProject
+            implementation(middleProject) {
+                capabilities {
+                    requireCapability("group:middleProject-other")
+                }
+            }
+        }
+        commonProject.dependencies {
+            implementation(commonProject) {
+                capabilities {
+                    requireCapability("group:commonProject-other")
+                }
+            }
         }
 
         and:


### PR DESCRIPTION
With the introduction of capabilities, it is possible that a project
depends on another variant of itself. This is the case, for example,
if you apply the 'java-test-fixtures' plugin.
The issue was that in these cases the 'buildNeeded' / 'buildDependents'
tasks would add a dependency to themselves. This is fixed by checking
that the task about to be added as dependency is not the same task for
which the dependencies are calculated.

Fixes #10410