### PR TITLE
Refactor `ModuleSource`

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -56,7 +56,7 @@ public enum CacheLayout {
         .changedTo(71, "5.3-rc-1")
         .changedTo(79, "6.0-rc-1")
         .changedTo(82, "6.0-rc-2")
-        .changedTo(90, "6.1-rc-1")
+        .changedTo(90_453_222, "6.1-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -42,7 +42,8 @@ import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.WrappedComponentResolveMetadata;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.BuildableComponentResolveResult;
 
@@ -103,7 +104,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         return new ModuleDependencyMetadataWrapper(dependencyMetadata);
     }
 
-    private static class ClientModuleComponentResolveMetadata implements ComponentResolveMetadata {
+    private static class ClientModuleComponentResolveMetadata implements WrappedComponentResolveMetadata {
         private final ModuleComponentResolveMetadata delegate;
         private final ModuleComponentArtifactMetadata clientModuleArtifact;
         private final List<ModuleDependencyMetadata> clientModuleDependencies;
@@ -120,18 +121,18 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         }
 
         @Override
-        public ModuleComponentResolveMetadata withSource(ModuleSource source) {
-            return delegate.withSource(source);
-        }
-
-        @Override
         public ModuleVersionIdentifier getModuleVersionId() {
             return delegate.getModuleVersionId();
         }
 
         @Override
-        public ModuleSource getSource() {
-            return delegate.getSource();
+        public ModuleSources getSources() {
+            return delegate.getSources();
+        }
+
+        @Override
+        public ComponentResolveMetadata withSources(ModuleSources sources) {
+            return delegate.withSources(sources);
         }
 
         @Override
@@ -183,6 +184,11 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         @Override
         public ImmutableAttributes getAttributes() {
             return delegate.getAttributes();
+        }
+
+        @Override
+        public ComponentResolveMetadata unwrap() {
+            return delegate;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
@@ -23,7 +23,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -62,8 +62,8 @@ public class BaseModuleComponentRepositoryAccess implements ModuleComponentRepos
     }
 
     @Override
-    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
-        delegate.resolveArtifact(artifact, moduleSource, result);
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+        delegate.resolveArtifact(artifact, moduleSources, result);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -30,7 +30,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -112,8 +112,8 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
         }
 
         @Override
-        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
-            delegate.resolveArtifact(artifact, moduleSource, result);
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+            delegate.resolveArtifact(artifact, moduleSources, result);
             if (result.hasResult()) {
                 ComponentArtifactIdentifier id = artifact.getId();
                 if (isExternalArtifactId(id)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolver.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
@@ -41,9 +41,9 @@ public class ErrorHandlingArtifactResolver implements ArtifactResolver {
     }
 
     @Override
-    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
         try {
-            resolver.resolveArtifact(artifact, moduleSource, result);
+            resolver.resolveArtifact(artifact, moduleSources, result);
         } catch (Exception t) {
             result.failed(new ArtifactResolveException(artifact.getId(), t));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -35,7 +35,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ArtifactNotFoundException;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -175,10 +175,10 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         }
 
         @Override
-        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
             performOperationWithRetries(result,
                     () -> {
-                        delegate.resolveArtifact(artifact, moduleSource, result);
+                        delegate.resolveArtifact(artifact, moduleSources, result);
                         if (result.hasResult()) {
                             ArtifactResolveException failure = result.getFailure();
                             if (!(failure instanceof ArtifactNotFoundException)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/FilteredModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/FilteredModuleComponentRepository.java
@@ -34,7 +34,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -137,8 +137,8 @@ public class FilteredModuleComponentRepository implements ModuleComponentReposit
         }
 
         @Override
-        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
-            delegate.resolveArtifact(artifact, moduleSource, result);
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+            delegate.resolveArtifact(artifact, moduleSources, result);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -24,7 +24,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -95,10 +95,10 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
-            delegate.getLocalAccess().resolveArtifact(artifact, moduleSource, result);
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+            delegate.getLocalAccess().resolveArtifact(artifact, moduleSources, result);
             if(!result.hasResult()) {
-                delegate.getRemoteAccess().resolveArtifact(artifact, moduleSource, result);
+                delegate.getRemoteAccess().resolveArtifact(artifact, moduleSources, result);
             }
         }
 
@@ -131,7 +131,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
@@ -24,7 +24,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -63,7 +63,7 @@ public interface ModuleComponentRepositoryAccess {
     /**
      * Resolves the given artifact. Any failures are packaged up in the result.
      */
-    void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result);
+    void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result);
 
     MetadataFetchingCost estimateMetadataFetchingCost(ModuleComponentIdentifier moduleComponentIdentifier);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
@@ -28,7 +28,7 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -92,7 +92,7 @@ public class NoRepositoriesResolver implements ComponentResolvers, DependencyToC
     }
 
     @Override
-    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
         throw new UnsupportedOperationException();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
@@ -23,11 +23,10 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
-import org.gradle.internal.Transformers;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.OriginArtifactSelector;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
@@ -49,19 +48,18 @@ class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifac
 
     @Override
     public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
-        ModuleComponentRepository sourceRepository = findSourceRepository(component.getSource());
-        ComponentResolveMetadata unpackedComponent = unpackSource(component);
+        ModuleComponentRepository sourceRepository = findSourceRepository(component.getSources());
         // First try to determine the artifacts locally before going remote
-        sourceRepository.getLocalAccess().resolveArtifactsWithType(unpackedComponent, artifactType, result);
+        sourceRepository.getLocalAccess().resolveArtifactsWithType(component, artifactType, result);
         if (!result.hasResult()) {
-            sourceRepository.getRemoteAccess().resolveArtifactsWithType(unpackedComponent, artifactType, result);
+            sourceRepository.getRemoteAccess().resolveArtifactsWithType(component, artifactType, result);
         }
     }
 
     @Nullable
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactTypeRegistry artifactTypeRegistry, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
-        if (component.getSource() == null) {
+        if (component.getSources() == null) {
             // virtual components have no source
             return NO_ARTIFACTS;
         }
@@ -75,13 +73,12 @@ class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifac
                 }
             }
         }
-        ModuleComponentRepository sourceRepository = findSourceRepository(component.getSource());
-        ComponentResolveMetadata unpackedComponent = unpackSource(component);
+        ModuleComponentRepository sourceRepository = findSourceRepository(component.getSources());
         // First try to determine the artifacts locally before going remote
         DefaultBuildableComponentArtifactsResolveResult result = new DefaultBuildableComponentArtifactsResolveResult();
-        sourceRepository.getLocalAccess().resolveArtifacts(unpackedComponent, configuration, result);
+        sourceRepository.getLocalAccess().resolveArtifacts(component, configuration, result);
         if (!result.hasResult()) {
-            sourceRepository.getRemoteAccess().resolveArtifacts(unpackedComponent, configuration, result);
+            sourceRepository.getRemoteAccess().resolveArtifacts(component, configuration, result);
         }
         if (result.hasResult()) {
             return result.getResult().getArtifactsFor(component, configuration, this, sourceRepository.getArtifactCache(), artifactTypeRegistry, exclusions, overriddenAttributes);
@@ -90,34 +87,23 @@ class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifac
     }
 
     @Override
-    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource source, BuildableArtifactResolveResult result) {
-        ModuleComponentRepository sourceRepository = findSourceRepository(source);
-        ModuleSource unpackedSource = unpackSource(source);
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources sources, BuildableArtifactResolveResult result) {
+        ModuleComponentRepository sourceRepository = findSourceRepository(sources);
 
         // First try to resolve the artifacts locally before going remote
-        sourceRepository.getLocalAccess().resolveArtifact(artifact, unpackedSource, result);
+        sourceRepository.getLocalAccess().resolveArtifact(artifact, sources, result);
         if (!result.hasResult()) {
-            sourceRepository.getRemoteAccess().resolveArtifact(artifact, unpackedSource, result);
+            sourceRepository.getRemoteAccess().resolveArtifact(artifact, sources, result);
         }
     }
 
-    private ModuleComponentRepository findSourceRepository(ModuleSource originalSource) {
-        ModuleComponentRepository moduleVersionRepository = repositories.get(repositorySource(originalSource).getRepositoryId());
+    private ModuleComponentRepository findSourceRepository(ModuleSources sources) {
+        RepositoryChainModuleSource repositoryChainModuleSource = sources.getSource(RepositoryChainModuleSource.class).get();
+        ModuleComponentRepository moduleVersionRepository = repositories.get(repositoryChainModuleSource.getRepositoryId());
         if (moduleVersionRepository == null) {
             throw new IllegalStateException("Attempting to resolve artifacts from invalid repository");
         }
         return moduleVersionRepository;
     }
 
-    private RepositoryChainModuleSource repositorySource(ModuleSource original) {
-        return Transformers.cast(RepositoryChainModuleSource.class).transform(original);
-    }
-
-    private ModuleSource unpackSource(ModuleSource original) {
-        return repositorySource(original).getDelegate();
-    }
-
-    private ComponentResolveMetadata unpackSource(ComponentResolveMetadata component) {
-        return component.withSource(repositorySource(component.getSource()).getDelegate());
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleSource.java
@@ -20,21 +20,15 @@ import org.gradle.internal.component.model.ModuleSource;
 public class RepositoryChainModuleSource implements ModuleSource {
     private final String repositoryId;
     private final String repositoryName;
-    private final ModuleSource delegate;
 
-    public RepositoryChainModuleSource(ModuleComponentRepository repository, ModuleSource delegate) {
+    public RepositoryChainModuleSource(ModuleComponentRepository repository) {
         this.repositoryId = repository.getId();
         this.repositoryName = repository.getName();
-        this.delegate = delegate;
     }
 
     @Override
     public String toString() {
-        return "{repo: " + repositoryId + ", source: " + delegate + "}";
-    }
-
-    public ModuleSource getDelegate() {
-        return delegate;
+        return "{repo: " + repositoryId + "}";
     }
 
     public String getRepositoryId() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -43,7 +43,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
@@ -214,8 +214,8 @@ public class ResolveIvyFactory {
         }
 
         @Override
-        public void resolveArtifact(final ComponentArtifactMetadata artifact, final ModuleSource moduleSource, final BuildableArtifactResolveResult result) {
-            delegate.getArtifactResolver().resolveArtifact(artifact, moduleSource, result);
+        public void resolveArtifact(final ComponentArtifactMetadata artifact, final ModuleSources moduleSources, final BuildableArtifactResolveResult result) {
+            delegate.getArtifactResolver().resolveArtifact(artifact, moduleSources, result);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -30,7 +30,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -130,7 +130,7 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
             result.failed(new ArtifactResolveException(artifact.getId(), "No cached version available for offline mode"));
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -26,6 +26,8 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionC
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.model.ImmutableModuleSources;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -86,8 +88,9 @@ public class UserResolverChain implements ComponentResolvers {
     private static class ModuleTransformer implements Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> {
         @Override
         public ModuleComponentResolveMetadata transform(RepositoryChainModuleResolution original) {
-            RepositoryChainModuleSource moduleSource = new RepositoryChainModuleSource(original.repository, original.module.getSource());
-            return original.module.withSource(moduleSource);
+            RepositoryChainModuleSource moduleSource = new RepositoryChainModuleSource(original.repository);
+            ModuleSources originSources = original.module.getSources();
+            return original.module.withSources(ImmutableModuleSources.of(originSources, moduleSource));
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.DefaultResolvedModuleVersion;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.util.BuildCommencedTimeProvider;
 
 import javax.annotation.Nullable;
@@ -27,14 +26,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
-    private final ModuleSources moduleSources;
     private final long ageMillis;
     private final ModuleComponentResolveMetadata metadata;
 
     private volatile Map<Integer, ModuleComponentResolveMetadata> processedMetadataByRules;
 
     DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
-        this.moduleSources = entry.moduleSources;
         this.ageMillis = timeProvider.getCurrentTime() - entry.createTimestamp;
         this.metadata = metadata;
     }
@@ -42,11 +39,6 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
     @Override
     public boolean isMissing() {
         return metadata == null;
-    }
-
-    @Override
-    public ModuleSources getModuleSources() {
-        return moduleSources;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.DefaultResolvedModuleVersion;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.util.BuildCommencedTimeProvider;
 
 import javax.annotation.Nullable;
@@ -27,14 +27,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
-    private final ModuleSource moduleSource;
+    private final ModuleSources moduleSources;
     private final long ageMillis;
     private final ModuleComponentResolveMetadata metadata;
 
     private volatile Map<Integer, ModuleComponentResolveMetadata> processedMetadataByRules;
 
     DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
-        this.moduleSource = entry.moduleSource;
+        this.moduleSources = entry.moduleSources;
         this.ageMillis = timeProvider.getCurrentTime() - entry.createTimestamp;
         this.metadata = metadata;
     }
@@ -45,8 +45,8 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
     }
 
     @Override
-    public ModuleSource getModuleSource() {
-        return moduleSource;
+    public ModuleSources getModuleSources() {
+        return moduleSources;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/MissingModuleCacheEntry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/MissingModuleCacheEntry.java
@@ -18,6 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 class MissingModuleCacheEntry extends ModuleMetadataCacheEntry {
     public MissingModuleCacheEntry(long createTimestamp) {
-        super(TYPE_MISSING, false, createTimestamp, null);
+        super(TYPE_MISSING, false, createTimestamp);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
@@ -19,7 +19,7 @@ import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 
 import javax.annotation.Nullable;
 
@@ -39,7 +39,7 @@ public interface ModuleMetadataCache {
 
         boolean isMissing();
 
-        ModuleSource getModuleSource();
+        ModuleSources getModuleSources();
 
         /**
          * The metadata after being processed by component metadata rules.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
@@ -19,7 +19,6 @@ import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 
 import javax.annotation.Nullable;
 
@@ -38,8 +37,6 @@ public interface ModuleMetadataCache {
         long getAgeMillis();
 
         boolean isMissing();
-
-        ModuleSources getModuleSources();
 
         /**
          * The metadata after being processed by component metadata rules.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCacheEntry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCacheEntry.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 
 class ModuleMetadataCacheEntry {
     static final byte TYPE_MISSING = 0;
@@ -26,13 +26,13 @@ class ModuleMetadataCacheEntry {
     final byte type;
     final boolean isChanging;
     final long createTimestamp;
-    final ModuleSource moduleSource;
+    final ModuleSources moduleSources;
 
-    ModuleMetadataCacheEntry(byte type, boolean isChanging, long createTimestamp, ModuleSource moduleSource) {
+    ModuleMetadataCacheEntry(byte type, boolean isChanging, long createTimestamp, ModuleSources moduleSources) {
         this.type = type;
         this.isChanging = isChanging;
         this.createTimestamp = createTimestamp;
-        this.moduleSource = moduleSource;
+        this.moduleSources = moduleSources;
     }
 
     public static ModuleMetadataCacheEntry forMissingModule(long createTimestamp) {
@@ -40,7 +40,7 @@ class ModuleMetadataCacheEntry {
     }
 
     public static ModuleMetadataCacheEntry forMetaData(ModuleComponentResolveMetadata metaData, long createTimestamp) {
-        return new ModuleMetadataCacheEntry(TYPE_PRESENT, metaData.isChanging(), createTimestamp, metaData.getSource());
+        return new ModuleMetadataCacheEntry(TYPE_PRESENT, metaData.isChanging(), createTimestamp, metaData.getSources());
     }
 
     public boolean isMissing() {
@@ -49,7 +49,7 @@ class ModuleMetadataCacheEntry {
 
     protected ModuleComponentResolveMetadata configure(MutableModuleComponentResolveMetadata input) {
         input.setChanging(isChanging);
-        input.setSource(moduleSource);
+        input.setSources(moduleSources);
         return input.asImmutable();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCacheEntry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCacheEntry.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 
 class ModuleMetadataCacheEntry {
     static final byte TYPE_MISSING = 0;
@@ -26,13 +25,11 @@ class ModuleMetadataCacheEntry {
     final byte type;
     final boolean isChanging;
     final long createTimestamp;
-    final ModuleSources moduleSources;
 
-    ModuleMetadataCacheEntry(byte type, boolean isChanging, long createTimestamp, ModuleSources moduleSources) {
+    ModuleMetadataCacheEntry(byte type, boolean isChanging, long createTimestamp) {
         this.type = type;
         this.isChanging = isChanging;
         this.createTimestamp = createTimestamp;
-        this.moduleSources = moduleSources;
     }
 
     public static ModuleMetadataCacheEntry forMissingModule(long createTimestamp) {
@@ -40,7 +37,7 @@ class ModuleMetadataCacheEntry {
     }
 
     public static ModuleMetadataCacheEntry forMetaData(ModuleComponentResolveMetadata metaData, long createTimestamp) {
-        return new ModuleMetadataCacheEntry(TYPE_PRESENT, metaData.isChanging(), createTimestamp, metaData.getSources());
+        return new ModuleMetadataCacheEntry(TYPE_PRESENT, metaData.isChanging(), createTimestamp);
     }
 
     public boolean isMissing() {
@@ -49,7 +46,6 @@ class ModuleMetadataCacheEntry {
 
     protected ModuleComponentResolveMetadata configure(MutableModuleComponentResolveMetadata input) {
         input.setChanging(isChanging);
-        input.setSources(moduleSources);
         return input.asImmutable();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -60,6 +60,7 @@ import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.MutableModuleSources;
 import org.gradle.internal.hash.HashValue;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -429,6 +430,7 @@ public class ModuleMetadataSerializer {
             metadata.setChanging(decoder.readBoolean());
             metadata.setStatus(decoder.readString());
             metadata.setStatusScheme(readStringList());
+            metadata.setSources(new MutableModuleSources());
         }
 
         private MutableModuleComponentResolveMetadata readMaven(Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -39,7 +39,7 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -133,14 +133,14 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     @Override
     public ArtifactSet resolveArtifacts(final ComponentResolveMetadata component, final ConfigurationMetadata configuration, final ArtifactTypeRegistry artifactTypeRegistry, final ExcludeSpec exclusions, final ImmutableAttributes overriddenAttributes) {
         if (isProjectModule(component.getId())) {
-            return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, overriddenAttributes);
+            return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSources(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, overriddenAttributes);
         } else {
             return null;
         }
     }
 
     @Override
-    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, final BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, final BuildableArtifactResolveResult result) {
         if (isProjectModule(artifact.getComponentId())) {
             final LocalComponentArtifactMetadata projectArtifact = (LocalComponentArtifactMetadata) artifact;
             ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) artifact.getComponentId();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
@@ -25,7 +25,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.resolver.DefaultArtifactSelector;
@@ -115,12 +115,12 @@ public class ComponentResolversChain {
         }
 
         @Override
-        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+        public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
             for (ArtifactResolver resolver : resolvers) {
                 if (result.hasResult()) {
                     return;
                 }
-                resolver.resolveArtifact(artifact, moduleSource, result);
+                resolver.resolveArtifact(artifact, moduleSources, result);
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -36,7 +36,7 @@ import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
@@ -71,27 +71,27 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
         return selectionAttributes;
     }
 
-    public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ExcludeSpec exclusions, Set<? extends VariantResolveMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
+    public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, Set<? extends VariantResolveMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
         if (variants.size() == 1) {
             VariantResolveMetadata variantMetadata = variants.iterator().next();
-            ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
+            ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
         }
         ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builder();
         for (VariantResolveMetadata variant : variants) {
-            ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
+            ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             result.add(resolvedVariant);
         }
         return new MultipleVariantArtifactSet(componentIdentifier, schema, result.build(), selectionAttributes);
     }
 
-    public static ArtifactSet singleVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, DisplayName displayName, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSource moduleSource, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes variantAttributes, ImmutableAttributes selectionAttributes) {
+    public static ArtifactSet singleVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, DisplayName displayName, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes variantAttributes, ImmutableAttributes selectionAttributes) {
         VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(displayName, variantAttributes, ImmutableList.copyOf(artifacts), ImmutableCapabilities.EMPTY);
-        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
+        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
         return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
     }
 
-    private static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ExcludeSpec exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry) {
+    private static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, ModuleVersionIdentifier ownerId, ModuleSources moduleSources, ExcludeSpec exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry) {
         List<? extends ComponentArtifactMetadata> artifacts = variant.getArtifacts();
         ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builder();
 
@@ -106,7 +106,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
 
             ResolvableArtifact resolvedArtifact = allResolvedArtifacts.get(artifact.getId());
             if (resolvedArtifact == null) {
-                Factory<File> artifactSource = new LazyArtifactSource(artifact, moduleSource, artifactResolver);
+                Factory<File> artifactSource = new LazyArtifactSource(artifact, moduleSources, artifactResolver);
                 resolvedArtifact = new DefaultResolvedArtifact(ownerId, artifactName, artifact.getId(), context -> context.add(artifact.getBuildDependencies()), artifactSource);
                 allResolvedArtifacts.put(artifact.getId(), resolvedArtifact);
             }
@@ -169,19 +169,19 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
 
     private static class LazyArtifactSource implements Factory<File> {
         private final ArtifactResolver artifactResolver;
-        private final ModuleSource moduleSource;
+        private final ModuleSources moduleSources;
         private final ComponentArtifactMetadata artifact;
 
-        private LazyArtifactSource(ComponentArtifactMetadata artifact, ModuleSource moduleSource, ArtifactResolver artifactResolver) {
+        private LazyArtifactSource(ComponentArtifactMetadata artifact, ModuleSources moduleSources, ArtifactResolver artifactResolver) {
             this.artifact = artifact;
             this.artifactResolver = artifactResolver;
-            this.moduleSource = moduleSource;
+            this.moduleSources = moduleSources;
         }
 
         @Override
         public File create() {
             DefaultBuildableArtifactResolveResult result = new DefaultBuildableArtifactResolveResult();
-            artifactResolver.resolveArtifact(artifact, moduleSource, result);
+            artifactResolver.resolveArtifact(artifact, moduleSources, result);
             return result.getResult();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -36,7 +36,6 @@ import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
-import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentResolveResult;
@@ -104,11 +103,9 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
 
     @Override
     public String getRepositoryName() {
-        ModuleSource moduleSource = metadata.getSource();
-        if (moduleSource instanceof RepositoryChainModuleSource) {
-            return ((RepositoryChainModuleSource) moduleSource).getRepositoryName();
-        }
-        return null;
+        return metadata.getSources().withSource(RepositoryChainModuleSource.class, source -> source
+            .map(RepositoryChainModuleSource::getRepositoryName)
+            .orElse(null));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -36,7 +36,7 @@ import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.hash.HashValue;
 
 import javax.annotation.Nullable;
@@ -71,18 +71,13 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
     }
 
     @Override
-    public ModuleSource getSource() {
+    public ModuleSources getSources() {
         return null;
     }
 
     @Override
     public AttributesSchemaInternal getAttributesSchema() {
         return null;
-    }
-
-    @Override
-    public ModuleComponentResolveMetadata withSource(ModuleSource source) {
-        return this;
     }
 
     @Override
@@ -152,6 +147,11 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
     @Override
     public MutableModuleComponentResolveMetadata asMutable() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ModuleComponentResolveMetadata withSources(ModuleSources sources) {
+        return this;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -184,7 +184,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
 
         for (ComponentArtifactMetadata artifactMetaData : artifactSetResolveResult.getResult()) {
             BuildableArtifactResolveResult resolveResult = new DefaultBuildableArtifactResolveResult();
-            artifactResolver.resolveArtifact(artifactMetaData, component.getSource(), resolveResult);
+            artifactResolver.resolveArtifact(artifactMetaData, component.getSources(), resolveResult);
             if (resolveResult.getFailure() != null) {
                 artifacts.addArtifact(new DefaultUnresolvedArtifactResult(artifactMetaData.getId(), type, resolveResult.getFailure()));
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DefaultExternalResourceArtifactResolver.java
@@ -19,7 +19,6 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactIdent
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.UrlBackedArtifactMetadata;
 import org.gradle.internal.component.model.ModuleDescriptorArtifactMetadata;
-import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceRepository;
@@ -52,11 +51,6 @@ class DefaultExternalResourceArtifactResolver implements ExternalResourceArtifac
         this.artifactPatterns = artifactPatterns;
         this.fileStore = fileStore;
         this.resourceAccessor = resourceAccessor;
-    }
-
-    @Override
-    public ModuleSource getSource() {
-        return null;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceArtifactResolver.java
@@ -16,15 +16,12 @@
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
-import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 
 import javax.annotation.Nullable;
 
 public interface ExternalResourceArtifactResolver {
-    ModuleSource getSource();
-
     @Nullable
     LocallyAvailableExternalResource resolveArtifact(ModuleComponentArtifactMetadata artifact, ResourceAwareResolveResult result);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -53,7 +53,6 @@ import org.gradle.internal.component.model.DefaultModuleDescriptorArtifactMetada
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleDescriptorArtifactMetadata;
 import org.gradle.internal.component.model.ModuleSources;
-import org.gradle.internal.component.model.MutableModuleSources;
 import org.gradle.internal.component.model.WrappedComponentResolveMetadata;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.hash.HashValue;
@@ -249,7 +248,6 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         for (MetadataSource<?> source : metadataSources.sources()) {
             MutableModuleComponentResolveMetadata value = source.create(name, componentResolvers, moduleVersionIdentifier, prescribedMetaData, artifactResolver, result);
             if (value != null) {
-                value.setSources(MutableModuleSources.of(artifactResolver.getSource()));
                 result.resolved(value.asImmutable());
                 return;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
@@ -75,7 +75,7 @@ public class ExternalResourceResolverDescriptorParseContext implements Descripto
 
         BuildableArtifactResolveResult artifactResolveResult = new DefaultBuildableArtifactResolveResult();
         ComponentArtifactMetadata artifactMetaData = moduleArtifactsResolveResult.getResult().iterator().next();
-        artifactResolver.resolveArtifact(artifactMetaData, moduleVersionResolveResult.getMetadata().getSource(), artifactResolveResult);
+        artifactResolver.resolveArtifact(artifactMetaData, moduleVersionResolveResult.getMetadata().getSources(), artifactResolveResult);
         return artifactResolveResult.getResult();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -37,7 +37,8 @@ import org.gradle.internal.component.external.model.maven.MutableMavenModuleReso
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.MutableModuleSources;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -132,17 +133,18 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     }
 
     private void resolveUniqueSnapshotDependency(MavenUniqueSnapshotComponentIdentifier module, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult result, MavenUniqueSnapshotModuleSource snapshotSource) {
-        resolveStaticDependency(module, prescribedMetaData, result, createArtifactResolver(snapshotSource));
+        resolveStaticDependency(module, prescribedMetaData, result, createArtifactResolver(MutableModuleSources.of(snapshotSource)));
     }
 
     @Override
-    protected ExternalResourceArtifactResolver createArtifactResolver(ModuleSource moduleSource) {
-
-        if (moduleSource instanceof MavenUniqueSnapshotModuleSource) {
-            return new MavenUniqueSnapshotExternalResourceArtifactResolver(super.createArtifactResolver(moduleSource), (MavenUniqueSnapshotModuleSource) moduleSource);
-        }
-
-        return super.createArtifactResolver(moduleSource);
+    protected ExternalResourceArtifactResolver createArtifactResolver(final ModuleSources moduleSources) {
+        return moduleSources.withSource(MavenUniqueSnapshotModuleSource.class, source -> {
+            if (source.isPresent()) {
+                return new MavenUniqueSnapshotExternalResourceArtifactResolver(super.createArtifactResolver(moduleSources), source.get());
+            } else {
+                return super.createArtifactResolver(moduleSources);
+            }
+        });
     }
 
     public void addArtifactLocation(URI baseUri) {
@@ -255,7 +257,7 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
             } else {
                 ModuleComponentArtifactMetadata artifactMetaData = module.artifact(module.getPackaging(), module.getPackaging(), null);
 
-                if (createArtifactResolver(module.getSource()).artifactExists(artifactMetaData, new DefaultResourceAwareResolveResult())) {
+                if (createArtifactResolver(module.getSources()).artifactExists(artifactMetaData, new DefaultResourceAwareResolveResult())) {
                     result.resolved(new FixedComponentArtifacts(ImmutableSet.of(artifactMetaData)));
                 } else {
                     ModuleComponentArtifactMetadata artifact = module.artifact("jar", "jar", null);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotExternalResourceArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenUniqueSnapshotExternalResourceArtifactResolver.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.UrlBackedArtifactMetadata;
-import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 
@@ -29,11 +28,6 @@ class MavenUniqueSnapshotExternalResourceArtifactResolver implements ExternalRes
     public MavenUniqueSnapshotExternalResourceArtifactResolver(ExternalResourceArtifactResolver delegate, MavenUniqueSnapshotModuleSource snapshot) {
         this.delegate = delegate;
         this.snapshot = snapshot;
-    }
-
-    @Override
-    public ModuleSource getSource() {
-        return snapshot;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -27,9 +27,8 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 
-import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -61,8 +60,8 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
     /**
      * Creates a copy of the given metadata
      */
-    protected AbstractLazyModuleComponentResolveMetadata(AbstractLazyModuleComponentResolveMetadata metadata, @Nullable ModuleSource source) {
-        super(metadata, source);
+    protected AbstractLazyModuleComponentResolveMetadata(AbstractLazyModuleComponentResolveMetadata metadata, ModuleSources sources) {
+        super(metadata, sources);
         this.configurationDefinitions = metadata.configurationDefinitions;
         variantMetadataRules = metadata.variantMetadataRules;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -28,8 +28,9 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.ImmutableModuleSources;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.hash.HashValue;
 
 import javax.annotation.Nullable;
@@ -42,8 +43,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final boolean changing;
     private final boolean missing;
     private final List<String> statusScheme;
-    @Nullable
-    private final ModuleSource moduleSource;
+    private final ImmutableModuleSources moduleSources;
     private final ImmutableList<? extends ComponentVariant> variants;
     private final HashValue originalContentHash;
     private final ImmutableAttributes attributes;
@@ -56,7 +56,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         changing = metadata.isChanging();
         missing = metadata.isMissing();
         statusScheme = metadata.getStatusScheme();
-        moduleSource = metadata.getSource();
+        moduleSources = ImmutableModuleSources.of(metadata.getSources());
         attributesFactory = metadata.getAttributesFactory();
         schema = metadata.getAttributesSchema();
         originalContentHash = metadata.getContentHash();
@@ -71,7 +71,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         changing = metadata.isChanging();
         missing = metadata.isMissing();
         statusScheme = metadata.getStatusScheme();
-        moduleSource = metadata.getSource();
+        moduleSources = ImmutableModuleSources.of(metadata.getSources());
         attributesFactory = metadata.getAttributesFactory();
         schema = metadata.getAttributesSchema();
         originalContentHash = metadata.getOriginalContentHash();
@@ -86,7 +86,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         changing = metadata.changing;
         missing = metadata.missing;
         statusScheme = metadata.statusScheme;
-        moduleSource = metadata.moduleSource;
+        moduleSources = metadata.moduleSources;
         attributesFactory = metadata.attributesFactory;
         schema = metadata.schema;
         originalContentHash = metadata.originalContentHash;
@@ -95,7 +95,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         platformOwners = metadata.platformOwners;
     }
 
-    public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ModuleSource source) {
+    public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ModuleSources sources) {
         this.componentIdentifier = metadata.componentIdentifier;
         this.moduleVersionIdentifier = metadata.moduleVersionIdentifier;
         changing = metadata.changing;
@@ -107,7 +107,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         attributes = metadata.attributes;
         variants = metadata.variants;
         platformOwners = metadata.platformOwners;
-        moduleSource = source;
+        moduleSources = ImmutableModuleSources.of(sources);
     }
 
     private static ImmutableAttributes extractAttributes(AbstractMutableModuleComponentResolveMetadata metadata) {
@@ -145,8 +145,8 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     @Override
-    public ModuleSource getSource() {
-        return moduleSource;
+    public ModuleSources getSources() {
+        return moduleSources;
     }
 
     @Override
@@ -214,7 +214,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             && Objects.equal(moduleVersionIdentifier, that.moduleVersionIdentifier)
             && Objects.equal(componentIdentifier, that.componentIdentifier)
             && Objects.equal(statusScheme, that.statusScheme)
-            && Objects.equal(moduleSource, that.moduleSource)
+            && Objects.equal(moduleSources, that.moduleSources)
             && Objects.equal(attributes, that.attributes)
             && Objects.equal(variants, that.variants)
             && Objects.equal(originalContentHash, that.originalContentHash);
@@ -228,7 +228,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             changing,
             missing,
             statusScheme,
-            moduleSource,
+            moduleSources,
             attributes,
             variants,
             originalContentHash);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -40,7 +40,8 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.MutableModuleSources;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.hash.HashValue;
@@ -64,7 +65,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     private boolean changing;
     private boolean missing;
     private List<String> statusScheme = DEFAULT_STATUS_SCHEME;
-    private ModuleSource moduleSource;
+    private MutableModuleSources moduleSources;
     private HashValue contentHash = EMPTY_CONTENT;
     private /*Mutable*/AttributeContainerInternal componentLevelAttributes;
     private final AttributesSchemaInternal schema;
@@ -82,6 +83,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         this.componentLevelAttributes = defaultAttributes(attributesFactory);
         this.schema = schema;
         this.variantMetadataRules = new VariantMetadataRules(attributesFactory, moduleVersionId);
+        this.moduleSources = new MutableModuleSources();
     }
 
     protected AbstractMutableModuleComponentResolveMetadata(ModuleComponentResolveMetadata metadata) {
@@ -90,12 +92,12 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         this.changing = metadata.isChanging();
         this.missing = metadata.isMissing();
         this.statusScheme = metadata.getStatusScheme();
-        this.moduleSource = metadata.getSource();
+        this.moduleSources = MutableModuleSources.of(metadata.getSources());
         this.contentHash = metadata.getOriginalContentHash();
         this.variants = metadata.getVariants();
         this.attributesFactory = metadata.getAttributesFactory();
         this.schema = metadata.getAttributesSchema();
-        this.componentLevelAttributes = attributesFactory.mutable((AttributeContainerInternal) metadata.getAttributes());
+        this.componentLevelAttributes = attributesFactory.mutable(metadata.getAttributes());
         this.variantMetadataRules = new VariantMetadataRules(attributesFactory, moduleVersionId);
         this.variantMetadataRules.setVariantDerivationStrategy(metadata.getVariantMetadataRules().getVariantDerivationStrategy());
     }
@@ -175,13 +177,13 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     }
 
     @Override
-    public ModuleSource getSource() {
-        return moduleSource;
+    public MutableModuleSources getSources() {
+        return moduleSources;
     }
 
     @Override
-    public void setSource(ModuleSource source) {
-        this.moduleSource = source;
+    public void setSources(ModuleSources sources) {
+        this.moduleSources = MutableModuleSources.of(sources);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -28,7 +28,7 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import javax.annotation.Nullable;
@@ -55,8 +55,8 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         this.configurations = metadata.configurations;
     }
 
-    public AbstractRealisedModuleComponentResolveMetadata(AbstractRealisedModuleComponentResolveMetadata metadata, ModuleSource source) {
-        super(metadata, source);
+    public AbstractRealisedModuleComponentResolveMetadata(AbstractRealisedModuleComponentResolveMetadata metadata, ModuleSources sources) {
+        super(metadata, sources);
         this.configurations = metadata.configurations;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
@@ -49,6 +49,6 @@ public class FixedComponentArtifacts implements ComponentArtifacts {
 
     @Override
     public ArtifactSet getArtifactsFor(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
-        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), configuration.asDescribable(), artifacts, component.getSource(), exclusions, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, configuration.getAttributes(), overriddenAttributes);
+        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), configuration.asDescribable(), artifacts, component.getSources(), exclusions, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, configuration.getAttributes(), overriddenAttributes);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MetadataSourcedComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MetadataSourcedComponentArtifacts.java
@@ -36,6 +36,6 @@ import java.util.Map;
 public class MetadataSourcedComponentArtifacts implements ComponentArtifacts {
     @Override
     public ArtifactSet getArtifactsFor(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
-        return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes);
+        return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSources(), exclusions, configuration.getVariants(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
@@ -19,7 +19,9 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ImmutableModuleSources;
 import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.hash.HashValue;
 
 import javax.annotation.Nullable;
@@ -37,17 +39,23 @@ public interface ModuleComponentResolveMetadata extends ComponentResolveMetadata
     ModuleComponentIdentifier getId();
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    ModuleComponentResolveMetadata withSource(ModuleSource source);
-
-    /**
      * Creates a mutable copy of this metadata.
      *
      * Note that this method can be expensive. Often it is more efficient to use a more specialised mutation method such as {@link #withSource(ModuleSource)} rather than this method.
      */
     MutableModuleComponentResolveMetadata asMutable();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ModuleComponentResolveMetadata withSources(ModuleSources sources);
+
+    default ModuleComponentResolveMetadata withExtraSource(ModuleSource source) {
+        return withSources(
+            ImmutableModuleSources.of(getSources(), source)
+        );
+    }
 
     /**
      * Creates an artifact for this module. Does not mutate this metadata.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -20,7 +20,8 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.MutableModuleSources;
 import org.gradle.internal.hash.HashValue;
 
 import javax.annotation.Nullable;
@@ -66,8 +67,9 @@ public interface MutableModuleComponentResolveMetadata {
     List<String> getStatusScheme();
     void setStatusScheme(List<String> statusScheme);
 
-    ModuleSource getSource();
-    void setSource(ModuleSource source);
+    MutableModuleSources getSources();
+
+    void setSources(ModuleSources moduleSources);
 
     MutableComponentVariant addVariant(MutableComponentVariant variant);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
@@ -32,7 +32,7 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactMetad
 import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ExcludeMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.util.CollectionUtils;
 
 import java.util.IdentityHashMap;
@@ -64,8 +64,8 @@ public class DefaultIvyModuleResolveMetadata extends AbstractLazyModuleComponent
         this.extraAttributes = metadata.getExtraAttributes();
     }
 
-    private DefaultIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata metadata, ModuleSource source) {
-        super(metadata, source);
+    private DefaultIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata metadata, ModuleSources sources) {
+        super(metadata, sources);
         this.configurationDefinitions = metadata.configurationDefinitions;
         this.branch = metadata.branch;
         this.artifactDefinitions = metadata.artifactDefinitions;
@@ -77,7 +77,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractLazyModuleComponent
     }
 
     private DefaultIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata metadata, List<IvyDependencyDescriptor> dependencies) {
-        super(metadata, metadata.getSource());
+        super(metadata, metadata.getSources());
         this.configurationDefinitions = metadata.configurationDefinitions;
         this.branch = metadata.branch;
         this.artifactDefinitions = metadata.artifactDefinitions;
@@ -103,13 +103,13 @@ public class DefaultIvyModuleResolveMetadata extends AbstractLazyModuleComponent
     }
 
     @Override
-    public DefaultIvyModuleResolveMetadata withSource(ModuleSource source) {
-        return new DefaultIvyModuleResolveMetadata(this, source);
+    public MutableIvyModuleResolveMetadata asMutable() {
+        return new DefaultMutableIvyModuleResolveMetadata(this);
     }
 
     @Override
-    public MutableIvyModuleResolveMetadata asMutable() {
-        return new DefaultMutableIvyModuleResolveMetadata(this);
+    public DefaultIvyModuleResolveMetadata withSources(ModuleSources sources) {
+        return new DefaultIvyModuleResolveMetadata(this, sources);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyModuleResolveMetadata.java
@@ -22,7 +22,6 @@ import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.Exclude;
-import org.gradle.internal.component.model.ModuleSource;
 
 import javax.annotation.Nullable;
 
@@ -35,12 +34,6 @@ public interface IvyModuleResolveMetadata extends ModuleComponentResolveMetadata
      */
     @Override
     MutableIvyModuleResolveMetadata asMutable();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    IvyModuleResolveMetadata withSource(ModuleSource source);
 
     /***
      * Returns the branch attribute for the module.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
@@ -45,7 +45,7 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 
 import javax.annotation.Nullable;
 import java.util.IdentityHashMap;
@@ -158,15 +158,15 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
         this.metadata = metadata.metadata;
     }
 
-    private RealisedIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata metadata, ModuleSource source) {
-        super(metadata, source);
+    private RealisedIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata metadata, ModuleSources sources) {
+        super(metadata, sources);
         this.configurationDefinitions = metadata.configurationDefinitions;
         this.branch = metadata.branch;
         this.artifactDefinitions = metadata.artifactDefinitions;
         this.dependencies = metadata.dependencies;
         this.excludes = metadata.excludes;
         this.extraAttributes = metadata.extraAttributes;
-        this.metadata = metadata.metadata.withSource(source);
+        this.metadata = metadata.metadata;
     }
 
     RealisedIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata metadata,
@@ -224,8 +224,8 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
     }
 
     @Override
-    public IvyModuleResolveMetadata withSource(ModuleSource source) {
-        return new RealisedIvyModuleResolveMetadata(this, source);
+    public RealisedIvyModuleResolveMetadata withSources(ModuleSources sources) {
+        return new RealisedIvyModuleResolveMetadata(this, sources);
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -38,7 +38,7 @@ import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -79,8 +79,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
         dependencies = metadata.getDependencies();
     }
 
-    private DefaultMavenModuleResolveMetadata(DefaultMavenModuleResolveMetadata metadata, ModuleSource source) {
-        super(metadata, source);
+    private DefaultMavenModuleResolveMetadata(DefaultMavenModuleResolveMetadata metadata, ModuleSources sources) {
+        super(metadata, sources);
         this.objectInstantiator = metadata.objectInstantiator;
         this.mavenImmutableAttributesFactory = metadata.mavenImmutableAttributesFactory;
         packaging = metadata.packaging;
@@ -204,13 +204,13 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     }
 
     @Override
-    public DefaultMavenModuleResolveMetadata withSource(ModuleSource source) {
-        return new DefaultMavenModuleResolveMetadata(this, source);
+    public MutableMavenModuleResolveMetadata asMutable() {
+        return new DefaultMutableMavenModuleResolveMetadata(this, objectInstantiator);
     }
 
     @Override
-    public MutableMavenModuleResolveMetadata asMutable() {
-        return new DefaultMutableMavenModuleResolveMetadata(this, objectInstantiator);
+    public DefaultMavenModuleResolveMetadata withSources(ModuleSources sources) {
+        return new DefaultMavenModuleResolveMetadata(this, sources);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenModuleResolveMetadata.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.external.model.maven;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSource;
 
 /**
  * Meta-data for a component resolved from a Maven repository.
@@ -29,12 +28,6 @@ public interface MavenModuleResolveMetadata extends ModuleComponentResolveMetada
      */
     @Override
     MutableMavenModuleResolveMetadata asMutable();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    MavenModuleResolveMetadata withSource(ModuleSource source);
 
     String getPackaging();
     boolean isRelocated();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -45,7 +45,7 @@ import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -237,8 +237,8 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         this.derivedVariants = ImmutableList.copyOf(derivedVariants);
     }
 
-    private RealisedMavenModuleResolveMetadata(RealisedMavenModuleResolveMetadata metadata, ModuleSource source) {
-        super(metadata, source);
+    private RealisedMavenModuleResolveMetadata(RealisedMavenModuleResolveMetadata metadata, ModuleSources sources) {
+        super(metadata, sources);
         this.objectInstantiator = metadata.objectInstantiator;
         packaging = metadata.packaging;
         relocated = metadata.relocated;
@@ -257,8 +257,8 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
     }
 
     @Override
-    public RealisedMavenModuleResolveMetadata withSource(ModuleSource source) {
-        return new RealisedMavenModuleResolveMetadata(this, source);
+    public RealisedMavenModuleResolveMetadata withSources(ModuleSources sources) {
+        return new RealisedMavenModuleResolveMetadata(this, sources);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -46,9 +46,10 @@ import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.ImmutableModuleSources;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.HashMap;
@@ -64,6 +65,8 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     private final ModuleVersionIdentifier moduleVersionId;
     private final String status;
     private final AttributesSchemaInternal attributesSchema;
+    private final ModuleSources moduleSources = ImmutableModuleSources.of();
+
     private Optional<ImmutableList<? extends ConfigurationMetadata>> consumableConfigurations;
 
     public DefaultLocalComponentMetadata(ModuleVersionIdentifier moduleVersionId, ComponentIdentifier componentId, String status, AttributesSchemaInternal attributesSchema) {
@@ -183,12 +186,12 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
-    public ModuleSource getSource() {
-        return null;
+    public ModuleSources getSources() {
+        return moduleSources;
     }
 
     @Override
-    public ComponentResolveMetadata withSource(ModuleSource source) {
+    public ComponentResolveMetadata withSources(ModuleSources source) {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -52,19 +52,19 @@ public interface ComponentResolveMetadata extends HasAttributes {
     ModuleVersionIdentifier getModuleVersionId();
 
     /**
-     * Returns the source (eg location) for this component.
+     * @return the sources information for this component.
      */
-    ModuleSource getSource();
+    ModuleSources getSources();
+
+    /**
+     * Creates a copy of this meta-data with the given sources.
+     */
+    ComponentResolveMetadata withSources(ModuleSources sources);
 
     /**
      * Returns the schema used by this component.
      */
     AttributesSchemaInternal getAttributesSchema();
-
-    /**
-     * Creates a copy of this meta-data with the given source.
-     */
-    ComponentResolveMetadata withSource(ModuleSource source);
 
     /**
      * Returns the names of all of the legacy configurations for this component. May be empty, in which case the component should provide at least one variant via {@link #getVariantsForGraphTraversal()}.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ImmutableModuleSources.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ImmutableModuleSources.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+import com.google.common.collect.Lists;
+import org.gradle.internal.Cast;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class ImmutableModuleSources implements ModuleSources {
+    private static final ImmutableModuleSources EMPTY = new ImmutableModuleSources(null, null);
+
+    private final ImmutableModuleSources previous;
+    private final ModuleSource value;
+    private final int hashCode;
+    private final int size;
+
+    public static ImmutableModuleSources of() {
+        return EMPTY;
+    }
+
+    public static ImmutableModuleSources of(ModuleSource... sources) {
+        ImmutableModuleSources cur = EMPTY;
+        for (ModuleSource source : sources) {
+            cur = new ImmutableModuleSources(cur, source);
+        }
+        return cur;
+    }
+
+    private ImmutableModuleSources(ImmutableModuleSources previous, ModuleSource value) {
+        if (previous != null && value == null) {
+            throw new AssertionError("value must not be null");
+        }
+        this.previous = previous;
+        this.value = value;
+        this.hashCode = 31 * (previous == null ? 0 : previous.hashCode) + (value == null ? 0 : value.hashCode());
+        this.size = previous == null ? 0 : 1 + previous.size;
+    }
+
+    public static ImmutableModuleSources of(ModuleSources sources, ModuleSource source) {
+        if (sources instanceof ImmutableModuleSources) {
+            return new ImmutableModuleSources((ImmutableModuleSources) sources, source);
+        }
+        List<ModuleSource> all = Lists.newArrayList();
+        sources.withSources(all::add);
+        all.add(source);
+        return of(all.toArray(new ModuleSource[0]));
+    }
+
+    public static ImmutableModuleSources of(ModuleSources sources) {
+        if (sources instanceof ImmutableModuleSources) {
+            return (ImmutableModuleSources) sources;
+        }
+        return ((MutableModuleSources) sources).asImmutable();
+    }
+
+    @Override
+    public <T extends ModuleSource> Optional<T> getSource(Class<T> sourceType) {
+        if (previous == null) {
+            return Optional.empty();
+        }
+        if (sourceType.isAssignableFrom(value.getClass())) {
+            T src = Cast.uncheckedCast(value);
+            return Optional.of(src);
+        }
+        return previous.getSource(sourceType);
+    }
+
+    @Override
+    public void withSources(Consumer<ModuleSource> consumer) {
+        ImmutableModuleSources cur = this;
+        while (cur.value != null) {
+            consumer.accept(cur.value);
+            cur = cur.previous;
+        }
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ImmutableModuleSources that = (ImmutableModuleSources) o;
+
+        if (previous != null ? !previous.equals(that.previous) : that.previous != null) {
+            return false;
+        }
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ModuleSources.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ModuleSources.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public interface ModuleSources {
+    <T extends ModuleSource> Optional<T> getSource(Class<T> sourceType);
+
+    void withSources(Consumer<ModuleSource> consumer);
+
+    default <T extends ModuleSource, R> R withSource(Class<T> sourceType, Function<Optional<T>, R> action) {
+        return action.apply(getSource(sourceType));
+    }
+
+    int size();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MutableModuleSources.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MutableModuleSources.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+import com.google.common.collect.Lists;
+import org.gradle.internal.Cast;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class MutableModuleSources implements ModuleSources {
+    private List<ModuleSource> moduleSources;
+
+    public static MutableModuleSources of(@Nullable ModuleSource source) {
+        MutableModuleSources sources = new MutableModuleSources();
+        if (source != null) {
+            sources.add(source);
+        }
+        return sources;
+    }
+
+    public static MutableModuleSources of(ModuleSources sources) {
+        if (sources instanceof MutableModuleSources) {
+            return (MutableModuleSources) sources;
+        }
+        MutableModuleSources mutableModuleSources = new MutableModuleSources();
+        if (sources == null) {
+            return mutableModuleSources;
+        }
+        sources.withSources(mutableModuleSources::add);
+        return mutableModuleSources;
+    }
+
+    @Override
+    public <T extends ModuleSource> Optional<T> getSource(Class<T> sourceType) {
+        if (moduleSources == null) {
+            return Optional.empty();
+        }
+        return Cast.uncheckedCast(moduleSources.stream()
+            .filter(src -> sourceType.isAssignableFrom(src.getClass()))
+            .findFirst());
+    }
+
+    @Override
+    public void withSources(Consumer<ModuleSource> consumer) {
+        if (moduleSources != null) {
+            moduleSources.forEach(consumer);
+        }
+    }
+
+    @Override
+    public int size() {
+        return moduleSources == null ? 0 : moduleSources.size();
+    }
+
+    public void add(ModuleSource source) {
+        assert source != null;
+        maybeCreateStore();
+        moduleSources.add(source);
+    }
+
+    private void maybeCreateStore() {
+        if (moduleSources == null) {
+            moduleSources = Lists.newArrayListWithExpectedSize(2);
+        }
+    }
+
+    ImmutableModuleSources asImmutable() {
+        if (moduleSources == null) {
+            return ImmutableModuleSources.of();
+        }
+        return ImmutableModuleSources.of(moduleSources.toArray(new ModuleSource[0]));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MutableModuleSources that = (MutableModuleSources) o;
+
+        return moduleSources != null ? moduleSources.equals(that.moduleSources) : that.moduleSources == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return moduleSources != null ? moduleSources.hashCode() : 0;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/WrappedComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/WrappedComponentResolveMetadata.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+public interface WrappedComponentResolveMetadata extends ComponentResolveMetadata {
+    // TODO: Remove when we get rid of client module resolve metadata
+    ComponentResolveMetadata unwrap();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ArtifactResolver.java
@@ -18,7 +18,7 @@ package org.gradle.internal.resolve.resolver;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 
@@ -31,5 +31,5 @@ public interface ArtifactResolver {
     /**
      * Resolves the given artifact. Any failures are packaged up in the result.
      */
-    void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result);
+    void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -72,6 +72,6 @@ public class DefaultArtifactSelector implements ArtifactSelector {
 
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes) {
-        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), Describables.of(component.getId()), artifacts, component.getSource(), EXCLUDE_NONE, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getAttributes(), overriddenAttributes);
+        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), Describables.of(component.getId()), artifacts, component.getSources(), EXCLUDE_NONE, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, component.getAttributes(), overriddenAttributes);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 90
+        expectedVersion = 90453222
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
@@ -37,7 +37,7 @@ import org.gradle.internal.component.model.ComponentArtifacts
 import org.gradle.internal.component.model.ComponentOverrideMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.ConfigurationMetadata
-import org.gradle.internal.component.model.ModuleSource
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactSetResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableComponentArtifactsResolveResult
@@ -88,7 +88,7 @@ class CachingModuleComponentRepositoryTest extends Specification {
         ArtifactAtRepositoryKey atRepositoryKey = new ArtifactAtRepositoryKey("repo-id", artifactId)
 
         when:
-        repo.remoteAccess.resolveArtifact(artifact, moduleSource, result)
+        repo.remoteAccess.resolveArtifact(artifact, ImmutableModuleSources.of(moduleSource), result)
 
         then:
         1 * artifactAtRepositoryCache.store(atRepositoryKey, file, descriptorHash)
@@ -129,8 +129,6 @@ class CachingModuleComponentRepositoryTest extends Specification {
 
     def "does not use cache when artifacts for type can be determined locally"() {
         def component = Mock(ComponentResolveMetadata)
-        def source = Mock(ModuleSource)
-        def cachingSource = new CachingModuleComponentRepository.CachingModuleSource(BigInteger.ONE, false, source)
         def artifactType = ArtifactType.JAVADOC
         def result = new DefaultBuildableArtifactSetResolveResult()
 
@@ -138,8 +136,6 @@ class CachingModuleComponentRepositoryTest extends Specification {
         repo.localAccess.resolveArtifactsWithType(component, artifactType, result)
 
         then:
-        1 * component.getSource() >> cachingSource
-        1 * component.withSource(source) >> component
         realLocalAccess.resolveArtifactsWithType(component, artifactType, result) >> {
             result.resolved([Mock(ComponentArtifactMetadata)])
         }
@@ -149,16 +145,12 @@ class CachingModuleComponentRepositoryTest extends Specification {
     def "does not use cache when component artifacts can be determined locally"() {
         def component = Mock(ComponentResolveMetadata)
         def variant = Mock(ConfigurationMetadata)
-        def source = Mock(ModuleSource)
-        def cachingSource = new CachingModuleComponentRepository.CachingModuleSource(BigInteger.ONE, false, source)
         def result = new DefaultBuildableComponentArtifactsResolveResult()
 
         when:
         repo.localAccess.resolveArtifacts(component, variant, result)
 
         then:
-        1 * component.getSource() >> cachingSource
-        1 * component.withSource(source) >> component
         realLocalAccess.resolveArtifacts(component, variant, result) >> {
             result.resolved(Stub(ComponentArtifacts))
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolverTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.component.ArtifactType
 import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.internal.resolve.ArtifactResolveException
 import org.gradle.internal.resolve.resolver.ArtifactResolver
@@ -39,15 +40,15 @@ class ErrorHandlingArtifactResolverTest extends Specification {
         def componentArtifact = Stub(ComponentArtifactMetadata) {
             getId() >> componentArtifactId
         }
-        def moduleSource = Mock(ModuleSource)
+        def moduleSources = ImmutableModuleSources.of(Mock(ModuleSource))
         def artifactResolveResult = Mock(BuildableArtifactResolveResult)
         def failure = new RuntimeException("foo")
 
         when:
-        delegate.resolveArtifact(componentArtifact, moduleSource, artifactResolveResult) >> { throw failure }
+        delegate.resolveArtifact(componentArtifact, moduleSources, artifactResolveResult) >> { throw failure }
 
         and:
-        artifactResolver.resolveArtifact(componentArtifact, moduleSource, artifactResolveResult)
+        artifactResolver.resolveArtifact(componentArtifact, moduleSources, artifactResolveResult)
 
         then:
         1 * artifactResolveResult.failed(_ as ArtifactResolveException) >> { ArtifactResolveException e ->

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.ComponentOverrideMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.ConfigurationMetadata
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.internal.resolve.ArtifactResolveException
 import org.gradle.internal.resolve.ModuleVersionResolveException
@@ -235,20 +236,20 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         given:
         def artifact = Mock(ComponentArtifactMetadata)
         def artifactId = Mock(ComponentArtifactIdentifier)
-        def moduleSource = Mock(ModuleSource)
+        def moduleSources = ImmutableModuleSources.of(Mock(ModuleSource))
         def result = Mock(BuildableArtifactResolveResult)
         artifact.getId() >> artifactId
 
         when: 'repo is not blacklisted'
         repositoryBlacklister.isBlacklisted(REPOSITORY_ID) >> false
-        access.resolveArtifact(artifact, moduleSource, result)
+        access.resolveArtifact(artifact, moduleSources, result)
 
         then: 'work is delegated'
-        1 * delegate.resolveArtifact(artifact, moduleSource, result)
+        1 * delegate.resolveArtifact(artifact, moduleSources, result)
 
         when: 'exception is thrown in resolution'
-        effectiveRetries * delegate.resolveArtifact(artifact, moduleSource, result) >> { throw exception }
-        access.resolveArtifact(artifact, moduleSource, result)
+        effectiveRetries * delegate.resolveArtifact(artifact, moduleSources, result) >> { throw exception }
+        access.resolveArtifact(artifact, moduleSources, result)
 
         then: 'resolution fails and repo is blacklisted'
         1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, { hasCause(it, exception) })
@@ -256,7 +257,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
 
         when: 'repo is already blacklisted'
         repositoryBlacklister.isBlacklisted(REPOSITORY_ID) >> true
-        access.resolveArtifact(artifact, moduleSource, result)
+        access.resolveArtifact(artifact, moduleSources, result)
 
         then: 'resolution fails directly'
         1 * result.failed(_ as ArtifactResolveException)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolverTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.ComponentArtifacts
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.ConfigurationMetadata
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult
 import spock.lang.Specification
@@ -44,7 +45,7 @@ class RepositoryChainArtifactResolverTest extends Specification {
         getRemoteAccess() >> remoteAccess2
         getId() >> "repo2"
     }
-    def repo2Source = new RepositoryChainModuleSource(repo2, originalSource)
+    def repo2Source = new RepositoryChainModuleSource(repo2)
 
     final RepositoryChainArtifactResolver resolver = new RepositoryChainArtifactResolver()
 
@@ -67,8 +68,7 @@ class RepositoryChainArtifactResolverTest extends Specification {
         result == artifactSet
 
         and:
-        _ * component.getSource() >> repo2Source
-        1 * component.withSource(originalSource) >> component
+        _ * component.getSources() >> ImmutableModuleSources.of(repo2Source)
         1 * repo2.artifactCache >> [:]
         1 * repo2.getLocalAccess() >> localAccess2
         1 * localAccess2.resolveArtifacts(component, configuration, _) >> {
@@ -92,8 +92,7 @@ class RepositoryChainArtifactResolverTest extends Specification {
         result == artifactSet
 
         and:
-        _ * component.getSource() >> repo2Source
-        1 * component.withSource(originalSource) >> component
+        _ * component.getSources() >> ImmutableModuleSources.of(repo2Source)
         1 * repo2.artifactCache >> [:]
         1 * repo2.getLocalAccess() >> localAccess2
         1 * localAccess2.resolveArtifacts(component, configuration, _)
@@ -108,12 +107,13 @@ class RepositoryChainArtifactResolverTest extends Specification {
     def "locates artifact with local access in repository defined by module source"() {
         def artifactFile = Mock(File)
         def artifact = Mock(ComponentArtifactMetadata)
+        def moduleSources = ImmutableModuleSources.of(repo2Source)
         when:
-        resolver.resolveArtifact(artifact, repo2Source, result)
+        resolver.resolveArtifact(artifact, moduleSources, result)
 
         then:
         1 * repo2.getLocalAccess() >> localAccess2
-        1 * localAccess2.resolveArtifact(artifact, originalSource, result) >> {
+        1 * localAccess2.resolveArtifact(artifact, moduleSources, result) >> {
             it[2].resolved(artifactFile)
         }
         0 * _._
@@ -125,14 +125,15 @@ class RepositoryChainArtifactResolverTest extends Specification {
     def "locates artifact with remote access in repository defined by module source"() {
         def artifactFile = Mock(File)
         def artifact = Mock(ComponentArtifactMetadata)
+        def moduleSources = ImmutableModuleSources.of(repo2Source)
         when:
-        resolver.resolveArtifact(artifact, repo2Source, result)
+        resolver.resolveArtifact(artifact, moduleSources, result)
 
         then:
         1 * repo2.getLocalAccess() >> localAccess2
-        1 * localAccess2.resolveArtifact(artifact, originalSource, result)
+        1 * localAccess2.resolveArtifact(artifact, moduleSources, result)
         1 * repo2.getRemoteAccess() >> remoteAccess2
-        1 * remoteAccess2.resolveArtifact(artifact, originalSource, result) >> {
+        1 * remoteAccess2.resolveArtifact(artifact, moduleSources, result) >> {
             it[2].resolved(artifactFile)
         }
         0 * _._

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.MutableModuleMeta
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
 import org.gradle.internal.component.model.ComponentOverrideMetadata
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.internal.resolve.ArtifactResolveException
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult
@@ -66,7 +67,7 @@ class ExternalResourceResolverTest extends Specification {
 
     def reportsNotFoundArtifactResolveResult() {
         when:
-        resolver.remoteAccess.resolveArtifact(artifact, moduleSource, artifactResult)
+        resolver.remoteAccess.resolveArtifact(artifact, ImmutableModuleSources.of(moduleSource), artifactResult)
 
         then:
         1 * artifactResolver.resolveArtifact(artifact, _) >> null
@@ -77,7 +78,7 @@ class ExternalResourceResolverTest extends Specification {
 
     def reportsFailedArtifactResolveResult() {
         when:
-        resolver.remoteAccess.resolveArtifact(artifact, moduleSource, artifactResult)
+        resolver.remoteAccess.resolveArtifact(artifact, ImmutableModuleSources.of(moduleSource), artifactResult)
 
         then:
         1 * artifactResolver.resolveArtifact(artifact, _) >> {
@@ -93,7 +94,7 @@ class ExternalResourceResolverTest extends Specification {
 
     def reportsResolvedArtifactResolveResult() {
         when:
-        resolver.remoteAccess.resolveArtifact(artifact, moduleSource, artifactResult)
+        resolver.remoteAccess.resolveArtifact(artifact, ImmutableModuleSources.of(moduleSource), artifactResult)
 
         then:
         1 * artifactResolver.resolveArtifact(artifact, _) >> Stub(LocallyAvailableExternalResource) {
@@ -109,7 +110,7 @@ class ExternalResourceResolverTest extends Specification {
         artifactIsTimestampedSnapshotVersion()
 
         when:
-        resolver.remoteAccess.resolveArtifact(artifact, moduleSource, artifactResult)
+        resolver.remoteAccess.resolveArtifact(artifact, ImmutableModuleSources.of(moduleSource), artifactResult)
 
         then:
         1 * artifactResolver.resolveArtifact(artifact, _) >> Stub(LocallyAvailableExternalResource) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadataTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
-import org.gradle.internal.component.model.ModuleSource
 import spock.lang.Specification
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
@@ -51,25 +50,6 @@ abstract class AbstractLazyModuleComponentResolveMetadataTest extends Specificat
     def "returns null for unknown configuration"() {
         expect:
         metadata.getConfiguration("conf") == null
-    }
-
-    def "can make a copy with different source"() {
-        given:
-        configuration("compile")
-        def source = Stub(ModuleSource)
-
-        def metadata = getMetadata()
-        // Prime the configuration
-        metadata.getConfiguration("compile")
-
-        when:
-        def copy = metadata.withSource(source)
-
-        then:
-        copy.source == source
-        copy.configurationNames == metadata.configurationNames
-        copy.getConfiguration("compile").is(metadata.getConfiguration("compile"))
-        copy.dependencies.is(metadata.dependencies)
     }
 
     def configuration(String name, List<String> extendsFrom = []) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -17,7 +17,6 @@
 
 package org.gradle.internal.component.external.model
 
-
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
@@ -33,7 +32,6 @@ import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
-import org.gradle.internal.component.model.ModuleSource
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Unroll
@@ -102,25 +100,6 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         then:
         runtimeArtifacts.size() == compileArtifacts.size()
         defaultArtifacts.size() == runtimeArtifacts.size()
-    }
-
-    def "copy with different source"() {
-        given:
-        def source = Stub(ModuleSource)
-        def mutable = mavenMetadataFactory.create(id, [])
-        mutable.packaging = "other"
-        mutable.relocated = true
-        mutable.snapshotTimestamp = "123"
-        def metadata = mutable.asImmutable()
-
-        when:
-        def copy = metadata.withSource(source)
-
-        then:
-        copy.source == source
-        copy.packaging == "other"
-        copy.relocated
-        copy.snapshotTimestamp == "123"
     }
 
     def "recognises pom packaging"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
@@ -27,7 +27,9 @@ import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.component.model.DependencyMetadata
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.component.model.ModuleSource
+import org.gradle.internal.component.model.MutableModuleSources
 import org.gradle.internal.hash.HashValue
 
 class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleComponentResolveMetadataTest {
@@ -57,7 +59,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
 
         and:
         metadata.contentHash == AbstractMutableModuleComponentResolveMetadata.EMPTY_CONTENT
-        metadata.source == null
+        metadata.sources == new MutableModuleSources()
         metadata.artifactDefinitions.size() == 2
         metadata.excludes.empty
 
@@ -65,7 +67,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         def immutable = metadata.asImmutable()
         immutable != metadata
         immutable.id == id
-        immutable.source == null
+        immutable.sources == ImmutableModuleSources.of()
         immutable.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         immutable.branch == null
         immutable.excludes.empty
@@ -84,7 +86,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         def copy = immutable.asMutable()
         copy != metadata
         copy.id == id
-        copy.source == null
+        copy.sources == new MutableModuleSources()
         copy.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         copy.branch == null
         copy.artifactDefinitions.size() == 2
@@ -110,14 +112,14 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
     def "can override values from descriptor"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
-        def source = Stub(ModuleSource)
+        def sources = ImmutableModuleSources.of(Mock(ModuleSource))
         def contentHash = new HashValue("123")
         def excludes = [new DefaultExclude(DefaultModuleIdentifier.newId("group", "name"))]
 
         when:
         def metadata = ivyMetadataFactory.create(id, [], [], [], excludes)
         metadata.id = newId
-        metadata.source = source
+        metadata.sources = sources
         metadata.status = "3"
         metadata.branch = "release"
         metadata.changing = true
@@ -128,7 +130,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         then:
         metadata.id == newId
         metadata.moduleVersionId == DefaultModuleVersionIdentifier.newId(newId)
-        metadata.source == source
+        metadata.sources == MutableModuleSources.of(sources)
         metadata.changing
         metadata.missing
         metadata.status == "3"
@@ -141,7 +143,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         immutable != metadata
         immutable.id == newId
         immutable.moduleVersionId == DefaultModuleVersionIdentifier.newId(newId)
-        immutable.source == source
+        immutable.sources == sources
         immutable.status == "3"
         immutable.branch == "release"
         immutable.changing
@@ -154,7 +156,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         copy != metadata
         copy.id == newId
         copy.moduleVersionId == DefaultModuleVersionIdentifier.newId(newId)
-        copy.source == source
+        copy.sources == MutableModuleSources.of(sources)
         copy.status == "3"
         copy.branch == "release"
         copy.changing
@@ -167,61 +169,61 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
     def "making changes to copy does not affect original"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
-        def source = Stub(ModuleSource)
+        def sources = ImmutableModuleSources.of(Stub(ModuleSource))
 
         when:
         def metadata = ivyMetadataFactory.create(id, [], [], [], [])
         def immutable = metadata.asImmutable()
         def copy = immutable.asMutable()
         copy.id = newId
-        copy.source = source
+        copy.sources = sources
         copy.statusScheme = ["2", "3"]
         def immutableCopy = copy.asImmutable()
 
         then:
         metadata.id == id
-        metadata.source == null
+        metadata.sources == new MutableModuleSources()
         metadata.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
 
         immutable.id == id
-        immutable.source == null
+        immutable.sources == ImmutableModuleSources.of()
         immutable.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
 
         copy.id == newId
-        copy.source == source
+        copy.sources == MutableModuleSources.of(sources)
         copy.statusScheme == ["2", "3"]
 
         immutableCopy.id == newId
-        immutableCopy.source == source
+        immutableCopy.sources == sources
         immutableCopy.statusScheme == ["2", "3"]
     }
 
     def "making changes to original does not affect copy"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
-        def source = Stub(ModuleSource)
+        def sources = ImmutableModuleSources.of(Stub(ModuleSource))
 
         when:
         def metadata = ivyMetadataFactory.create(id, [], [], [], [])
         def immutable = metadata.asImmutable()
 
         metadata.id = newId
-        metadata.source = source
+        metadata.sources = sources
         metadata.statusScheme = ["1", "2"]
 
         def immutableCopy = metadata.asImmutable()
 
         then:
         metadata.id == newId
-        metadata.source == source
+        metadata.sources == MutableModuleSources.of(sources)
         metadata.statusScheme == ["1", "2"]
 
         immutable.id == id
-        immutable.source == null
+        immutable.sources == ImmutableModuleSources.of()
         immutable.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
 
         immutableCopy.id == newId
-        immutableCopy.source == source
+        immutableCopy.sources == sources
         immutableCopy.statusScheme == ["1", "2"]
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -26,7 +26,9 @@ import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModul
 import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.DependencyMetadata
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.component.model.ModuleSource
+import org.gradle.internal.component.model.MutableModuleSources
 import org.gradle.internal.hash.HashValue
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
@@ -88,7 +90,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         metadata.status == "integration"
 
         and:
-        metadata.source == null
+        metadata.sources == new MutableModuleSources()
         metadata.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         metadata.snapshotTimestamp == null
         metadata.packaging == "jar"
@@ -98,7 +100,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         def immutable = metadata.asImmutable()
         immutable != metadata
         immutable.id == id
-        immutable.source == null
+        immutable.sources == ImmutableModuleSources.of()
         immutable.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         immutable.snapshotTimestamp == null
         immutable.packaging == "jar"
@@ -112,7 +114,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         def copy = immutable.asMutable()
         copy != metadata
         copy.id == id
-        copy.source == null
+        copy.sources == new MutableModuleSources()
         copy.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         copy.snapshotTimestamp == null
         copy.packaging == "jar"
@@ -129,14 +131,14 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     def "can override values from descriptor"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
-        def source = Stub(ModuleSource)
+        def sources = ImmutableModuleSources.of(Stub(ModuleSource))
         def contentHash = new HashValue("123")
 
         def metadata = mavenMetadataFactory.create(id, [])
 
         when:
         metadata.id = newId
-        metadata.source = source
+        metadata.sources = sources
         metadata.status = "3"
         metadata.changing = true
         metadata.statusScheme = ["1", "2", "3"]
@@ -148,7 +150,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         then:
         metadata.id == newId
         metadata.moduleVersionId == DefaultModuleVersionIdentifier.newId(newId)
-        metadata.source == source
+        metadata.sources == MutableModuleSources.of(sources)
         metadata.changing
         metadata.status == "3"
         metadata.statusScheme == ["1", "2", "3"]
@@ -161,7 +163,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         immutable != metadata
         immutable.id == newId
         immutable.moduleVersionId == DefaultModuleVersionIdentifier.newId(newId)
-        immutable.source == source
+        immutable.sources == sources
         immutable.status == "3"
         immutable.changing
         immutable.statusScheme == ["1", "2", "3"]
@@ -174,7 +176,7 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         copy != metadata
         copy.id == newId
         copy.moduleVersionId == DefaultModuleVersionIdentifier.newId(newId)
-        copy.source == source
+        copy.sources == MutableModuleSources.of(sources)
         copy.status == "3"
         copy.changing
         copy.statusScheme == ["1", "2", "3"]
@@ -187,14 +189,14 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     def "making changes to copy does not affect original"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
-        def source = Stub(ModuleSource)
+        def sources = ImmutableModuleSources.of(Stub(ModuleSource))
         def metadata = mavenMetadataFactory.create(id, [])
 
         when:
         def immutable = metadata.asImmutable()
         def copy = immutable.asMutable()
         copy.id = newId
-        copy.source = source
+        copy.sources = MutableModuleSources.of(sources)
         copy.changing = true
         copy.status = "3"
         copy.statusScheme = ["2", "3"]
@@ -205,28 +207,28 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
 
         then:
         metadata.id == id
-        metadata.source == null
+        metadata.sources == new MutableModuleSources()
         metadata.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         metadata.snapshotTimestamp == null
         metadata.packaging == "jar"
         !metadata.relocated
 
         immutable.id == id
-        immutable.source == null
+        immutable.sources == ImmutableModuleSources.of()
         immutable.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         immutable.snapshotTimestamp == null
         immutable.packaging == "jar"
         !immutable.relocated
 
         copy.id == newId
-        copy.source == source
+        copy.sources == MutableModuleSources.of(sources)
         copy.statusScheme == ["2", "3"]
         copy.snapshotTimestamp == "123"
         copy.packaging == "pom"
         copy.relocated
 
         immutableCopy.id == newId
-        immutableCopy.source == source
+        immutableCopy.sources == sources
         immutableCopy.statusScheme == ["2", "3"]
         immutableCopy.snapshotTimestamp == "123"
         immutableCopy.packaging == "pom"
@@ -236,14 +238,14 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
     def "making changes to original does not affect copy"() {
         def id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "version")
         def newId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "module"), "1.2")
-        def source = Stub(ModuleSource)
+        def sources = ImmutableModuleSources.of(Stub(ModuleSource))
         def metadata = mavenMetadataFactory.create(id, [])
 
         when:
         def immutable = metadata.asImmutable()
 
         metadata.id = newId
-        metadata.source = source
+        metadata.sources = MutableModuleSources.of(sources)
         metadata.statusScheme = ["1", "2"]
         metadata.snapshotTimestamp = "123"
         metadata.packaging = "pom"
@@ -253,21 +255,21 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
 
         then:
         metadata.id == newId
-        metadata.source == source
+        metadata.sources == MutableModuleSources.of(sources)
         metadata.statusScheme == ["1", "2"]
         metadata.snapshotTimestamp == "123"
         metadata.packaging == "pom"
         metadata.relocated
 
         immutable.id == id
-        immutable.source == null
+        immutable.sources == ImmutableModuleSources.of()
         immutable.statusScheme == ComponentResolveMetadata.DEFAULT_STATUS_SCHEME
         immutable.snapshotTimestamp == null
         immutable.packaging == "jar"
         !immutable.relocated
 
         immutableCopy.id == newId
-        immutableCopy.source == source
+        immutableCopy.sources == sources
         immutableCopy.statusScheme == ["1", "2"]
         immutableCopy.snapshotTimestamp == "123"
         immutableCopy.packaging == "pom"

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
@@ -39,7 +39,7 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -222,7 +222,7 @@ public class LocalLibraryDependencyResolver implements DependencyToComponentIdRe
     }
 
     @Override
-    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
         if (isLibrary(artifact.getComponentId())) {
             if (artifact instanceof PublishArtifactLocalArtifactMetadata) {
                 result.resolved(((PublishArtifactLocalArtifactMetadata) artifact).getFile());

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/internal/resolve/JvmLocalLibraryDependencyResolverTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/internal/resolve/JvmLocalLibraryDependencyResolverTest.groovy
@@ -39,7 +39,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.ConfigurationMetadata
 import org.gradle.internal.component.model.DependencyMetadata
-import org.gradle.internal.component.model.ModuleSource
+import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactSetResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult
@@ -179,7 +179,7 @@ class JvmLocalLibraryDependencyResolverTest extends Specification {
         artifact.componentId >> Mock(LibraryBinaryIdentifier)
 
         when:
-        resolver.resolveArtifact(artifact, Mock(ModuleSource), result)
+        resolver.resolveArtifact(artifact, ImmutableModuleSources.of(), result)
 
         then:
         result.hasResult()
@@ -192,7 +192,7 @@ class JvmLocalLibraryDependencyResolverTest extends Specification {
         artifact.componentId >> Mock(ModuleComponentIdentifier)
 
         when:
-        resolver.resolveArtifact(artifact, Mock(ModuleSource), result)
+        resolver.resolveArtifact(artifact, ImmutableModuleSources.of(), result)
 
         then:
         !result.hasResult()

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
@@ -42,7 +42,7 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -190,6 +190,6 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
     }
 
     @Override
-    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
     }
 }


### PR DESCRIPTION
### Context

The `ModuleSource` concept was a bit messy. It was designed in order
to be able to store the origin of an artifact. Over time, it evolved
into storing more information, like snapshot timestamps, repositories
or content hash.

The code was convoluted because each part of the code was expecting
some kind of module source, but because of delegation, it wasn't
really possible to add/mix more sources.

This commit refactors this concept into a `ModuleSources` concept
which allows storing more information about a module source, in
a safe and consistent manner. No more wrapping/unwrapping, and each
code requiring a specific type of module source can query for it.
