### PR TITLE
Let instant execution support serializable beans with only a `writeObject` method

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -593,16 +593,13 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
                 import org.gradle.api.*;
                 import org.gradle.api.tasks.*;
+                import java.util.function.Supplier;
 
                 public class LambdaTask extends DefaultTask {
 
-                    public interface SerializableSupplier<T> extends java.io.Serializable {
-                        T get();
-                    }
-
-                    private SerializableSupplier<Integer> supplier;
-
-                    public void setSupplier(SerializableSupplier<Integer> supplier) {
+                    private Supplier<Integer> supplier;
+                    
+                    public <T extends Supplier<Integer> & java.io.Serializable> void setSupplier(T supplier) {
                         this.supplier = supplier;
                     }
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -420,6 +420,12 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         when:
         instantRun "ok"
 
+        then: "bean is serialized before task runs"
+        outputContains("bean.value = 42")
+
+        when:
+        instantRun "ok"
+
         then:
         outputContains("bean.value = 42")
     }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -623,13 +623,16 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
                 import org.gradle.api.*;
                 import org.gradle.api.tasks.*;
-                import java.util.function.Supplier;
 
                 public class LambdaTask extends DefaultTask {
 
-                    private Supplier<Integer> supplier;
-                    
-                    public <T extends Supplier<Integer> & java.io.Serializable> void setSupplier(T supplier) {
+                    public interface SerializableSupplier<T> extends java.io.Serializable {
+                        T get();
+                    }
+
+                    private SerializableSupplier<Integer> supplier;
+
+                    public void setSupplier(SerializableSupplier<Integer> supplier) {
                         this.supplier = supplier;
                     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Combinators.kt
@@ -342,3 +342,30 @@ fun <E : Enum<E>> WriteContext.writeEnum(value: E) {
 
 inline fun <reified E : Enum<E>> ReadContext.readEnum(): E =
     readSmallInt().let { ordinal -> enumValues<E>()[ordinal] }
+
+
+fun WriteContext.writeShort(value: Short) {
+    BaseSerializerFactory.SHORT_SERIALIZER.write(this, value)
+}
+
+
+fun ReadContext.readShort(): Short =
+    BaseSerializerFactory.SHORT_SERIALIZER.read(this)
+
+
+fun WriteContext.writeFloat(value: Float) {
+    BaseSerializerFactory.FLOAT_SERIALIZER.write(this, value)
+}
+
+
+fun ReadContext.readFloat(): Float =
+    BaseSerializerFactory.FLOAT_SERIALIZER.read(this)
+
+
+fun WriteContext.writeDouble(value: Double) {
+    BaseSerializerFactory.DOUBLE_SERIALIZER.write(this, value)
+}
+
+
+fun ReadContext.readDouble(): Double =
+    BaseSerializerFactory.DOUBLE_SERIALIZER.read(this)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValueCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/BrokenValueCodec.kt
@@ -22,6 +22,7 @@ import org.gradle.instantexecution.serialization.WriteContext
 
 
 object BrokenValueCodec : Codec<BrokenValue> {
+
     override suspend fun WriteContext.encode(value: BrokenValue) {
         maybeEncode(value.failure.cause)
         writeNullableString(value.failure.message)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/SerializableWriteObjectCodec.kt
@@ -24,8 +24,14 @@ import org.gradle.instantexecution.serialization.WriteContext
 import org.gradle.instantexecution.serialization.beans.BeanStateReader
 import org.gradle.instantexecution.serialization.decodePreservingIdentity
 import org.gradle.instantexecution.serialization.encodePreservingIdentityOf
+import org.gradle.instantexecution.serialization.readDouble
+import org.gradle.instantexecution.serialization.readFloat
+import org.gradle.instantexecution.serialization.readShort
 import org.gradle.instantexecution.serialization.withBeanTrace
 import org.gradle.instantexecution.serialization.withImmediateMode
+import org.gradle.instantexecution.serialization.writeDouble
+import org.gradle.instantexecution.serialization.writeFloat
+import org.gradle.instantexecution.serialization.writeShort
 
 import java.io.InputStream
 import java.io.ObjectInputStream
@@ -175,8 +181,20 @@ class RecordingObjectOutputStream(
         writeBoolean(`val`)
     }
 
+    override fun writeShort(`val`: Int) = record {
+        this.writeShort(`val`.toShort())
+    }
+
     override fun writeLong(`val`: Long) = record {
         writeLong(`val`)
+    }
+
+    override fun writeFloat(`val`: Float) = record {
+        this.writeFloat(`val`)
+    }
+
+    override fun writeDouble(`val`: Double) = record {
+        this.writeDouble(`val`)
     }
 
     override fun useProtocolVersion(version: Int) = Unit
@@ -195,13 +213,7 @@ class RecordingObjectOutputStream(
 
     override fun writeUnshared(obj: Any?) = TODO("writeUnshared")
 
-    override fun writeShort(`val`: Int) = TODO("writeShort")
-
     override fun writeBytes(str: String) = TODO("writeBytes")
-
-    override fun writeDouble(`val`: Double) = TODO("writeDouble")
-
-    override fun writeFloat(`val`: Float) = TODO("writeFloat")
 }
 
 
@@ -243,7 +255,13 @@ class ObjectInputStreamAdapter(
 
     override fun readChar(): Char = readContext.readInt().toChar()
 
+    override fun readShort(): Short = readContext.readShort()
+
     override fun readLong(): Long = readContext.readLong()
+
+    override fun readFloat(): Float = readContext.readFloat()
+
+    override fun readDouble(): Double = readContext.readDouble()
 
     override fun readBoolean(): Boolean = readContext.readBoolean()
 
@@ -272,17 +290,11 @@ class ObjectInputStreamAdapter(
 
     override fun readFully(buf: ByteArray, off: Int, len: Int) = TODO("readFully")
 
-    override fun readDouble(): Double = TODO("readDouble")
-
     override fun readUnshared(): Any = TODO("readUnshared")
-
-    override fun readShort(): Short = TODO("readShort")
 
     override fun readUnsignedShort(): Int = TODO("readUnsignedShort")
 
     override fun readUnsignedByte(): Int = TODO("readUnsignedByte")
-
-    override fun readFloat(): Float = TODO("readFloat")
 
     override fun readFields(): GetField = TODO("readFields")
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -133,6 +133,14 @@ class UserTypesCodecTest {
     }
 
     @Test
+    fun `can handle Serializable with only writeObject`() {
+        assertThat(
+            roundtrip(SerializableWriteObjectOnlyBean()).value,
+            equalTo<Any>("42")
+        )
+    }
+
+    @Test
     fun `preserves identity of Serializable objects`() {
         val writeReplaceBean = SerializableWriteReplaceBean()
         val writeObjectBean = SerializableWriteObjectBean(Pair(writeReplaceBean, writeReplaceBean))
@@ -183,6 +191,15 @@ class UserTypesCodecTest {
         class Memento {
             @Suppress("unused")
             fun readResolve() = SerializableWriteReplaceBean("42")
+        }
+    }
+
+    class SerializableWriteObjectOnlyBean(var value: Any? = null) : Serializable {
+
+        private
+        fun writeObject(objectOutputStream: ObjectOutputStream) {
+            value = "42"
+            objectOutputStream.defaultWriteObject()
         }
     }
 

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -93,6 +93,11 @@ class UserTypesCodecTest {
         )
 
         assertThat(
+            decodedSerializable.transientShort,
+            equalTo(SerializableWriteObjectBean.EXPECTED_SHORT)
+        )
+
+        assertThat(
             decodedSerializable.transientInt,
             equalTo(SerializableWriteObjectBean.EXPECTED_INT)
         )
@@ -100,6 +105,16 @@ class UserTypesCodecTest {
         assertThat(
             decodedSerializable.transientString,
             equalTo(SerializableWriteObjectBean.EXPECTED_STRING)
+        )
+
+        assertThat(
+            decodedSerializable.transientFloat,
+            equalTo(SerializableWriteObjectBean.EXPECTED_FLOAT)
+        )
+
+        assertThat(
+            decodedSerializable.transientDouble,
+            equalTo(SerializableWriteObjectBean.EXPECTED_DOUBLE)
         )
 
         assertThat(
@@ -175,10 +190,19 @@ class UserTypesCodecTest {
 
         companion object {
 
+            const val EXPECTED_SHORT: Short = Short.MAX_VALUE
+
             const val EXPECTED_INT: Int = 42
 
             const val EXPECTED_STRING: String = "42"
+
+            const val EXPECTED_FLOAT: Float = 1.618f
+
+            const val EXPECTED_DOUBLE: Double = Math.PI
         }
+
+        @Transient
+        var transientShort: Short? = null
 
         @Transient
         var transientInt: Int? = null
@@ -186,20 +210,32 @@ class UserTypesCodecTest {
         @Transient
         var transientString: String? = null
 
+        @Transient
+        var transientFloat: Float? = null
+
+        @Transient
+        var transientDouble: Double? = null
+
         private
         fun writeObject(objectOutputStream: ObjectOutputStream) {
             objectOutputStream.run {
                 defaultWriteObject()
+                writeShort(EXPECTED_SHORT.toInt())
                 writeInt(EXPECTED_INT)
                 writeUTF(EXPECTED_STRING)
+                writeFloat(EXPECTED_FLOAT)
+                writeDouble(EXPECTED_DOUBLE)
             }
         }
 
         private
         fun readObject(objectInputStream: ObjectInputStream) {
             objectInputStream.defaultReadObject()
+            transientShort = objectInputStream.readShort()
             transientInt = objectInputStream.readInt()
             transientString = objectInputStream.readUTF()
+            transientFloat = objectInputStream.readFloat()
+            transientDouble = objectInputStream.readDouble()
         }
     }
 


### PR DESCRIPTION
Also, add support for Short, Float and Double to the `ObjectInputStream` and `ObjectOutputStream` implementations.