### PR TITLE
Minor fixes

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
@@ -37,7 +37,7 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
     def "cannot mutate outgoing variants after configuration is resolved"() {
         given:
         buildFile << """
-        
+
         configurations {
             compile {
                 attributes.attribute(usage, 'for compile')
@@ -85,13 +85,13 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
         fails("mutateAfterResolve")
 
         then:
-        failure.assertHasCause "Cannot change attributes of configuration ':compile' after it has been resolved"
+        failure.assertHasCause "Cannot change attributes of dependency configuration ':compile' after it has been resolved"
     }
 
     def "cannot add outgoing variants after configuration is resolved"() {
         given:
         buildFile << """
-        
+
         configurations {
             compile {
                 attributes.attribute(usage, 'for compile')
@@ -139,6 +139,6 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
         fails("mutateAfterResolve")
 
         then:
-        failure.assertHasCause "Cannot create variant 'sources' after configuration ':compile' has been resolved"
+        failure.assertHasCause "Cannot create variant 'sources' after dependency configuration ':compile' has been resolved"
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -127,7 +127,7 @@ project(":b") {
         mavenRepo.module("org.other", "externalA", "1.2").publish()
 
         and:
-        file('settings.gradle') << """rootProject.name='test' 
+        file('settings.gradle') << """rootProject.name='test'
 include 'a', 'b'"""
 
         and:
@@ -616,7 +616,7 @@ project('c') {
         fails("impl:check")
 
         then:
-        failure.assertHasCause "Cannot change dependencies of configuration ':api:conf' after it has been included in dependency resolution"
+        failure.assertHasCause "Cannot change dependencies of dependency configuration ':api:conf' after it has been included in dependency resolution"
     }
 
     @Issue(["GRADLE-3330", "GRADLE-3362"])

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -262,7 +262,7 @@ configurations.conf.incoming.beforeResolve {
         fails "checkDefault"
 
         and:
-        failure.assertHasCause "Cannot change dependencies of configuration ':conf' after it has been included in dependency resolution."
+        failure.assertHasCause "Cannot change dependencies of dependency configuration ':conf' after it has been included in dependency resolution."
     }
 
     @ToBeFixedForInstantExecution

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -207,11 +207,11 @@ configurations.compile.withDependencies {
 
         then:
         fails "mutateResolved"
-        failure.assertHasCause("Cannot change dependencies of configuration ':compile' after it has been resolved.")
+        failure.assertHasCause("Cannot change dependencies of dependency configuration ':compile' after it has been resolved.")
 
         and:
         fails "mutateParent"
-        failure.assertHasCause("Cannot change dependencies of configuration ':conf' after it has been included in dependency resolution.")
+        failure.assertHasCause("Cannot change dependencies of dependency configuration ':conf' after it has been included in dependency resolution.")
     }
 
     void resolvedGraph(@DelegatesTo(ResolveTestFixture.NodeBuilder) Closure closure) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleIntegrationTest.groovy
@@ -50,7 +50,7 @@ class ConfigurationRoleIntegrationTest extends AbstractIntegrationSpec {
         fails 'checkState'
 
         then:
-        failure.assertHasCause("Resolving configuration 'internal' directly is not allowed")
+        failure.assertHasCause("Resolving dependency configuration 'internal' is not allowed as it is defined as 'canBeResolved=false'.\nInstead, a resolvable ('canBeResolved=true') dependency configuration that extends 'internal' should be resolved.")
 
         where:
         role                      | code
@@ -82,7 +82,7 @@ class ConfigurationRoleIntegrationTest extends AbstractIntegrationSpec {
         fails 'checkState'
 
         then:
-        failure.assertHasCause("Resolving configuration 'internal' directly is not allowed")
+        failure.assertHasCause("Resolving dependency configuration 'internal' is not allowed as it is defined as 'canBeResolved=false'.\nInstead, a resolvable ('canBeResolved=true') dependency configuration that extends 'internal' should be resolved.")
 
         where:
         role                      | code
@@ -117,7 +117,7 @@ class ConfigurationRoleIntegrationTest extends AbstractIntegrationSpec {
         fails 'checkState'
 
         then:
-        failure.assertHasCause("Resolving configuration 'internal' directly is not allowed")
+        failure.assertHasCause("Resolving dependency configuration 'internal' is not allowed as it is defined as 'canBeResolved=false'.\nInstead, a resolvable ('canBeResolved=true') dependency configuration that extends 'internal' should be resolved.")
 
         where:
         [method, role] << [

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
@@ -32,7 +32,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
             dependencies { a files("some.jar") }
         """
         when: fails()
-        then: failure.assertHasCause("Cannot change dependencies of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change dependencies of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow adding artifacts to a configuration that has been resolved"() {
@@ -42,7 +42,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
             artifacts { a file("some.jar") }
         """
         when: fails()
-        then: failure.assertHasCause("Cannot change artifacts of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change artifacts of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing excludes on a configuration that has been resolved"() {
@@ -52,7 +52,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
             configurations.a.exclude group: 'someGroup'
         """
         when: fails()
-        then: failure.assertHasCause("Cannot change dependencies of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change dependencies of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing conflict resolution on a configuration that has been resolved"() {
@@ -63,7 +63,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         """
 
         when: fails()
-        then: failure.assertHasCause("Cannot change strategy of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change resolution strategy of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing forced versions on a configuration that has been resolved"() {
@@ -74,7 +74,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         """
 
         when: fails()
-        then: failure.assertHasCause("Cannot change strategy of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change resolution strategy of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing cache policy on a configuration that has been resolved"() {
@@ -86,7 +86,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change strategy of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change resolution strategy of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing resolution rules on a configuration that has been resolved"() {
@@ -98,7 +98,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change strategy of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change resolution strategy of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing substitution rules on a configuration that has been resolved"() {
@@ -110,7 +110,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change strategy of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change resolution strategy of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing component selection rules on a configuration that has been resolved"() {
@@ -122,7 +122,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change strategy of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change resolution strategy of dependency configuration ':a' after it has been resolved")
     }
 
     def "does not allow changing dependencies of a configuration that has been resolved for task dependencies"() {
@@ -195,19 +195,19 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         fails("impl:modifyConfigDuringTaskExecution")
 
         then:
-        failure.assertHasCause("Cannot change dependencies of configuration ':impl:compile' after task dependencies have been resolved")
+        failure.assertHasCause("Cannot change dependencies of dependency configuration ':impl:compile' after task dependencies have been resolved")
 
         when:
         fails("impl:modifyParentConfigDuringTaskExecution")
 
         then:
-        failure.assertHasCause("Cannot change dependencies of configuration ':impl:compile' after it has been included in dependency resolution.")
+        failure.assertHasCause("Cannot change dependencies of dependency configuration ':impl:compile' after it has been included in dependency resolution.")
 
         when:
         fails("impl:modifyDependentConfigDuringTaskExecution")
 
         then:
-        failure.assertHasCause("Cannot change dependencies of configuration ':api:compile' after it has been included in dependency resolution.")
+        failure.assertHasCause("Cannot change dependencies of dependency configuration ':api:compile' after it has been included in dependency resolution.")
     }
 
     def "does not allow changing artifacts of a configuration that has been resolved for task dependencies"() {
@@ -256,18 +256,18 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
         when:
         fails("impl:addArtifactToConfigDuringTaskExecution")
         then:
-        failure.assertHasCause("Cannot change artifacts of configuration ':impl:compile' after task dependencies have been resolved")
+        failure.assertHasCause("Cannot change artifacts of dependency configuration ':impl:compile' after task dependencies have been resolved")
 
         when:
         fails("impl:addArtifactToParentConfigDuringTaskExecution")
 
         then:
-        failure.assertHasCause("Cannot change artifacts of configuration ':impl:compile' after it has been included in dependency resolution.")
+        failure.assertHasCause("Cannot change artifacts of dependency configuration ':impl:compile' after it has been included in dependency resolution.")
 
         when:
         fails("impl:addArtifactToDependentConfigDuringTaskExecution")
         then:
-        failure.assertHasCause("Cannot change artifacts of configuration ':api:compile' after it has been included in dependency resolution.")
+        failure.assertHasCause("Cannot change artifacts of dependency configuration ':api:compile' after it has been included in dependency resolution.")
     }
 
     @Issue("GRADLE-3155")
@@ -285,7 +285,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change dependencies of configuration ':a' after it has been included in dependency resolution.")
+        then: failure.assertHasCause("Cannot change dependencies of dependency configuration ':a' after it has been included in dependency resolution.")
     }
 
     @Issue("GRADLE-3155")
@@ -303,7 +303,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change artifacts of configuration ':a' after it has been included in dependency resolution.")
+        then: failure.assertHasCause("Cannot change artifacts of dependency configuration ':a' after it has been included in dependency resolution.")
     }
 
     @Issue("GRADLE-3155")
@@ -321,7 +321,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change dependencies of configuration ':a' after it has been included in dependency resolution.")
+        then: failure.assertHasCause("Cannot change dependencies of dependency configuration ':a' after it has been included in dependency resolution.")
     }
 
     def "allows changing resolution strategy of a configuration whose child has been resolved"() {
@@ -358,7 +358,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change dependencies of configuration ':a' after it has been included in dependency resolution.")
+        then: failure.assertHasCause("Cannot change dependencies of dependency configuration ':a' after it has been included in dependency resolution.")
     }
 
     @Issue("GRADLE-3155")
@@ -427,7 +427,7 @@ class UnsupportedConfigurationMutationTest extends AbstractIntegrationSpec {
 
 
         when: fails()
-        then: failure.assertHasCause("Cannot change dependencies of configuration ':api:compile' after it has been included in dependency resolution.")
+        then: failure.assertHasCause("Cannot change dependencies of dependency configuration ':api:compile' after it has been included in dependency resolution.")
     }
 
     @Issue("GRADLE-3297")
@@ -470,7 +470,7 @@ task resolveChildFirst {
             configurations.a.attributes { attribute(Attribute.of('foo', String), 'bar') }
         """
         when: fails()
-        then: failure.assertHasCause("Cannot change attributes of configuration ':a' after it has been resolved")
+        then: failure.assertHasCause("Cannot change attributes of dependency configuration ':a' after it has been resolved")
     }
 
     @Unroll
@@ -484,7 +484,7 @@ task resolveChildFirst {
         fails()
 
         then:
-        failure.assertHasCause("Cannot change role of configuration ':a' after it has been resolved")
+        failure.assertHasCause("Cannot change role of dependency configuration ':a' after it has been resolved")
 
         where:
         role                      | code

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1144,16 +1144,16 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         if (resolvedState == ARTIFACTS_RESOLVED) {
             // The public result for the configuration has been calculated.
             // It is an error to change anything that would change the dependencies or artifacts
-            throw new InvalidUserDataException(String.format("Cannot change %s of %s after it has been resolved.", type, getDisplayName()));
+            throw new InvalidUserDataException(String.format("Cannot change %s of dependency %s after it has been resolved.", type, getDisplayName()));
         } else if (resolvedState == GRAPH_RESOLVED) {
             // The task dependencies for the configuration have been calculated using Configuration.getBuildDependencies().
-            throw new InvalidUserDataException(String.format("Cannot change %s of %s after task dependencies have been resolved", type, getDisplayName()));
+            throw new InvalidUserDataException(String.format("Cannot change %s of dependency %s after task dependencies have been resolved", type, getDisplayName()));
         } else if (observedState == GRAPH_RESOLVED || observedState == ARTIFACTS_RESOLVED) {
             // The configuration has been used in a resolution, and it is an error for build logic to change any dependencies,
             // exclude rules or parent configurations (values that will affect the resolved graph).
             if (type != MutationType.STRATEGY) {
                 String extraMessage = insideBeforeResolve ? " Use 'defaultDependencies' instead of 'beforeResolve' to specify default dependencies for a configuration." : "";
-                throw new InvalidUserDataException(String.format("Cannot change %s of %s after it has been included in dependency resolution.%s", type, getDisplayName(), extraMessage));
+                throw new InvalidUserDataException(String.format("Cannot change %s of dependency %s after it has been included in dependency resolution.%s", type, getDisplayName(), extraMessage));
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1295,7 +1295,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     private void assertIsResolvable() {
         if (!canBeResolved) {
-            throw new IllegalStateException("Resolving configuration '" + name + "' directly is not allowed");
+            throw new IllegalStateException("Resolving dependency configuration '" + name + "' is not allowed as it is defined as 'canBeResolved=false'.\nInstead, a resolvable ('canBeResolved=true') dependency configuration that extends '" + name + "' should be resolved.");
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -173,7 +173,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
             }
             capabilities.add(descriptor);
         } else {
-            throw new InvalidUserCodeException("Cannot declare capability '" + notation + "' after " + displayName + " has been resolved");
+            throw new InvalidUserCodeException("Cannot declare capability '" + notation + "' after dependency " + displayName + " has been resolved");
         }
     }
 
@@ -197,7 +197,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
             if (canCreate) {
                 return instantiator.newInstance(DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory);
             } else {
-                throw new InvalidUserCodeException("Cannot create variant '" + name + "' after " + displayName + " has been resolved");
+                throw new InvalidUserCodeException("Cannot create variant '" + name + "' after dependency " + displayName + " has been resolved");
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/MutationValidator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/MutationValidator.java
@@ -24,33 +24,39 @@ public interface MutationValidator {
         /**
          * The mutation of the resolution strategy of the configuration, i.e. caching, resolution rules etc.
          */
-        STRATEGY,
+        STRATEGY("resolution strategy"),
 
         /**
          * The mutation of anything that will affect the resolved dependency graph of this configuration.
          */
-        DEPENDENCIES,
+        DEPENDENCIES("dependencies"),
 
         /**
          * The mutation of the attributes (other than coordinates) of a dependency.
          * Theoretically these should be bundled under {@link MutationType#DEPENDENCIES}, but these mutations are not (yet)
          * prevented on resolved configurations.
          */
-        DEPENDENCY_ATTRIBUTES,
+        DEPENDENCY_ATTRIBUTES("dependency attributes"),
 
         /**
          * The mutation of the artifacts of the configuration.
          */
-        ARTIFACTS,
+        ARTIFACTS("artifacts"),
 
         /**
          * The mutation of the role of the configuration (can be queries, resolved, ...)
          */
-        ROLE;
+        ROLE("role");
+
+        private final String displayName;
+
+        MutationType(String displayName) {
+            this.displayName = displayName;
+        }
 
         @Override
         public String toString() {
-            return name().toLowerCase();
+            return displayName;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributeContainerWithErrorMessage.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/ImmutableAttributeContainerWithErrorMessage.java
@@ -48,7 +48,7 @@ public class ImmutableAttributeContainerWithErrorMessage implements AttributeCon
 
     @Override
     public <T> AttributeContainer attribute(Attribute<T> key, T value) {
-        throw new IllegalArgumentException(String.format("Cannot change attributes of %s after it has been resolved", owner.getDisplayName()));
+        throw new IllegalArgumentException(String.format("Cannot change attributes of dependency %s after it has been resolved", owner.getDisplayName()));
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1348,13 +1348,13 @@ class DefaultConfigurationSpec extends Specification {
         conf.dependencies.add(Mock(Dependency))
         then:
         def exDependency = thrown(InvalidUserDataException);
-        exDependency.message == "Cannot change dependencies of configuration ':conf' after it has been resolved."
+        exDependency.message == "Cannot change dependencies of dependency configuration ':conf' after it has been resolved."
 
         when:
         conf.artifacts.add(Mock(PublishArtifact))
         then:
         def exArtifact = thrown(InvalidUserDataException);
-        exArtifact.message == "Cannot change artifacts of configuration ':conf' after it has been resolved."
+        exArtifact.message == "Cannot change artifacts of dependency configuration ':conf' after it has been resolved."
     }
 
     def "defaultDependencies action does not trigger when config has dependencies"() {
@@ -1549,7 +1549,7 @@ class DefaultConfigurationSpec extends Specification {
 
         then:
         IllegalArgumentException t = thrown()
-        t.message == "Cannot change attributes of configuration ':conf' after it has been resolved"
+        t.message == "Cannot change attributes of dependency configuration ':conf' after it has been resolved"
     }
 
     def "wrapper attribute container behaves similar to the delegatee"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -2148,7 +2148,7 @@ org:leaf3:1.0
         fails "dependencyInsight", "--dependency", "foo", "--configuration", "api"
 
         then:
-        failure.assertHasCause("Resolving configuration 'api' directly is not allowed")
+        failure.assertHasCause("Resolving dependency configuration 'api' is not allowed as it is defined as 'canBeResolved=false'.")
 
         when:
         run "dependencyInsight", "--dependency", "foo", "--configuration", "compile"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
@@ -168,7 +168,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         then:
         !deprecated(alternatives) || output.contains("The $configuration configuration has been deprecated for resolution. This will fail with an error in Gradle 7.0. Please resolve the ${alternatives} configuration instead.")
         !valid(alternatives)      || output.contains("> Task :resolve\n\n")
-        !forbidden(alternatives)  || errorOutput.contains("Resolving configuration '$configuration' directly is not allowed")
+        !forbidden(alternatives)  || errorOutput.contains("Resolving dependency configuration '$configuration' is not allowed as it is defined as 'canBeResolved=false'.\nInstead, a resolvable ('canBeResolved=true') dependency configuration that extends '$configuration' should be resolved.")
 
         where:
         plugin         | configuration                  | alternatives

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -280,7 +280,12 @@ public class GradleModuleMetadataWriter {
         jsonWriter.name("name");
         jsonWriter.value(variant.getName());
         writeAttributes(variant.getAttributes(), jsonWriter);
+        writeAvailableAt(coordinates, targetCoordinates, jsonWriter);
+        writeCapabilities("capabilities", variant.getCapabilities(), jsonWriter);
+        jsonWriter.endObject();
+    }
 
+    private void writeAvailableAt(ModuleVersionIdentifier coordinates, ModuleVersionIdentifier targetCoordinates, JsonWriter jsonWriter) throws IOException {
         jsonWriter.name("available-at");
         jsonWriter.beginObject();
 
@@ -293,8 +298,6 @@ public class GradleModuleMetadataWriter {
         jsonWriter.value(targetCoordinates.getName());
         jsonWriter.name("version");
         jsonWriter.value(targetCoordinates.getVersion());
-        jsonWriter.endObject();
-
         jsonWriter.endObject();
     }
 

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -628,9 +628,17 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def comp2 = Stub(TestComponent)
         def publication2 = publication(comp2, id2)
 
+        def c1 = Stub(Capability) {
+            getGroup() >> 'org.test'
+            getName() >> 'foo'
+            getVersion() >> '1'
+        }
+
+
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
+        v1.capabilities >> [c1]
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
@@ -669,7 +677,14 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         "group": "group",
         "module": "other-1",
         "version": "1"
-      }
+      },
+      "capabilities": [
+        {
+          "group": "org.test",
+          "name": "foo",
+          "version": "1"
+        }
+      ]
     },
     {
       "name": "v2",


### PR DESCRIPTION
* Improved error message for invalid configuration mutation
* Write capabilities in `available-at` variants
* Improved error message for invalid configuration resolution