### PR TITLE
Disable concurrency tests on mac agents

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -173,7 +173,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
         // Simplistic approach at detecting MSBuild by assuming Windows imply MSBuild is present
         WINDOWS.fulfilled
     }),
-    SUPPORTS_TARGETING_JAVA6({!JDK12_OR_LATER.fulfilled})
+    SUPPORTS_TARGETING_JAVA6({ !JDK12_OR_LATER.fulfilled }),
+    // Currently mac agents are not that strong so we avoid running high-concurrency tests on them
+    HIGH_PERFORMANCE(NOT_MAC_OS_X)
 
     /**
      * A predicate for testing whether the precondition is fulfilled.
@@ -182,6 +184,10 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
 
     TestPrecondition(Closure predicate) {
         this.predicate = predicate
+    }
+
+    TestPrecondition(TestPrecondition aliasOf) {
+        this.predicate = aliasOf.predicate
     }
 
     /**

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsConcurrencyIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsConcurrencyIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.Plugin
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
-@Requires(TestPrecondition.JDK8_OR_LATER)
+@Requires([TestPrecondition.JDK8_OR_LATER, TestPrecondition.HIGH_PERFORMANCE])
 class GradleImplDepsConcurrencyIntegrationTest extends BaseGradleImplDepsIntegrationTest {
 
     private static final int CONCURRENT_BUILDS_PROJECT_COUNT = 4


### PR DESCRIPTION
To avoid potential timeouts.