### PR TITLE
Move cache creation for DefaultCachedClasspathTransformer into factory

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
@@ -117,4 +117,9 @@ public class JavaMethod<T, R> {
     public Class<?>[] getParameterTypes(){
         return method.getParameterTypes();
     }
+
+    @Override
+    public String toString() {
+        return method.toString();
+    }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/ReflectionBasedServiceMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/ReflectionBasedServiceMethod.java
@@ -36,4 +36,9 @@ class ReflectionBasedServiceMethod extends AbstractServiceMethod {
             throw UncheckedException.throwAsUncheckedException(e);
         }
     }
+
+    @Override
+    public String toString() {
+        return javaMethod.toString();
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -262,8 +262,8 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         given:
         requireOwnGradleUserHomeDir() // messes with caches
         def oldCacheDirs = [
-            userHomeCacheDir.createDir("${DefaultClasspathTransformerCache.CACHE_NAME}-1"),
-            userHomeCacheDir.createDir("${DefaultClasspathTransformerCache.CACHE_NAME}-2")
+            userHomeCacheDir.createDir("${DefaultClasspathTransformerCacheFactory.CACHE_NAME}-1"),
+            userHomeCacheDir.createDir("${DefaultClasspathTransformerCacheFactory.CACHE_NAME}-2")
         ]
         gcFile.createFile().lastModified = daysAgo(2)
 
@@ -291,7 +291,7 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
     }
 
     TestFile getCacheDir() {
-        return userHomeCacheDir.file(DefaultClasspathTransformerCache.CACHE_KEY)
+        return userHomeCacheDir.file(DefaultClasspathTransformerCacheFactory.CACHE_KEY)
     }
 
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathTransformerCacheFactory.java
@@ -16,12 +16,13 @@
 
 package org.gradle.internal.classpath;
 
+import org.gradle.cache.CacheRepository;
 import org.gradle.cache.PersistentCache;
 import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.resource.local.FileAccessTracker;
 
-public interface ClasspathTransformerCache extends CachedJarFileStore {
-    PersistentCache getCache();
+public interface ClasspathTransformerCacheFactory extends CachedJarFileStore {
+    PersistentCache createCache(CacheRepository cacheRepository, FileAccessTimeJournal fileAccessTimeJournal);
 
     FileAccessTracker createFileAccessTracker(FileAccessTimeJournal fileAccessTimeJournal);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -53,7 +53,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
     private final UsedGradleVersions usedGradleVersions;
 
     public DefaultClasspathTransformerCacheFactory(CacheScopeMapping cacheScopeMapping, UsedGradleVersions usedGradleVersions) {
-        this.cacheDir = cacheScopeMapping.getBaseDirectory(null, CACHE_KEY, VersionStrategy.CachePerVersion);
+        this.cacheDir = cacheScopeMapping.getBaseDirectory(null, CACHE_KEY, VersionStrategy.SharedCache);
         this.usedGradleVersions = usedGradleVersions;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -21,17 +21,18 @@ import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
+import org.gradle.cache.internal.CacheScopeMapping;
 import org.gradle.cache.internal.CacheVersionMapping;
 import org.gradle.cache.internal.CompositeCleanupAction;
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup;
 import org.gradle.cache.internal.SingleDepthFilesFinder;
 import org.gradle.cache.internal.UnusedVersionsCacheCleanup;
 import org.gradle.cache.internal.UsedGradleVersions;
+import org.gradle.cache.internal.VersionStrategy;
 import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.resource.local.SingleDepthFileAccessTracker;
 
-import java.io.Closeable;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +41,7 @@ import static org.gradle.cache.internal.CacheVersionMapping.introducedIn;
 import static org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
-public class DefaultClasspathTransformerCache implements ClasspathTransformerCache, Closeable {
+public class DefaultClasspathTransformerCacheFactory implements ClasspathTransformerCacheFactory {
     private static final CacheVersionMapping CACHE_VERSION_MAPPING = introducedIn("3.1-rc-1").incrementedIn("3.2-rc-1").incrementedIn("3.5-rc-1").build();
     @VisibleForTesting
     static final String CACHE_NAME = "jars";
@@ -48,15 +49,18 @@ public class DefaultClasspathTransformerCache implements ClasspathTransformerCac
     static final String CACHE_KEY = CACHE_NAME + "-" + CACHE_VERSION_MAPPING.getLatestVersion();
     private static final int FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP = 1;
 
-    private final PersistentCache cache;
+    private final File cacheDir;
+    private final UsedGradleVersions usedGradleVersions;
 
-    public DefaultClasspathTransformerCache(
-        CacheRepository cacheRepository,
-        FileAccessTimeJournal fileAccessTimeJournal,
-        UsedGradleVersions usedGradleVersions
-    ) {
-        this.cache = cacheRepository
-            .cache(CACHE_KEY)
+    public DefaultClasspathTransformerCacheFactory(CacheScopeMapping cacheScopeMapping, UsedGradleVersions usedGradleVersions) {
+        this.cacheDir = cacheScopeMapping.getBaseDirectory(null, CACHE_KEY, VersionStrategy.CachePerVersion);
+        this.usedGradleVersions = usedGradleVersions;
+    }
+
+    @Override
+    public PersistentCache createCache(CacheRepository cacheRepository, FileAccessTimeJournal fileAccessTimeJournal) {
+        return cacheRepository
+            .cache(cacheDir)
             .withDisplayName(CACHE_NAME)
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
             .withLockOptions(mode(FileLockManager.LockMode.None))
@@ -68,22 +72,12 @@ public class DefaultClasspathTransformerCache implements ClasspathTransformerCac
     }
 
     @Override
-    public PersistentCache getCache() {
-        return cache;
-    }
-
-    @Override
     public FileAccessTracker createFileAccessTracker(FileAccessTimeJournal fileAccessTimeJournal) {
-        return new SingleDepthFileAccessTracker(fileAccessTimeJournal, cache.getBaseDir(), FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP);
+        return new SingleDepthFileAccessTracker(fileAccessTimeJournal, cacheDir, FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP);
     }
 
     @Override
     public List<File> getFileStoreRoots() {
-        return Collections.singletonList(cache.getBaseDir());
-    }
-
-    @Override
-    public void close() {
-        cache.close();
+        return Collections.singletonList(cacheDir);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -48,9 +48,9 @@ import org.gradle.internal.classloader.DefaultHashingClassLoaderFactory;
 import org.gradle.internal.classloader.HashingClassLoaderFactory;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.classpath.CachedJarFileStore;
-import org.gradle.internal.classpath.ClasspathTransformerCache;
+import org.gradle.internal.classpath.ClasspathTransformerCacheFactory;
 import org.gradle.internal.classpath.DefaultCachedClasspathTransformer;
-import org.gradle.internal.classpath.DefaultClasspathTransformerCache;
+import org.gradle.internal.classpath.DefaultClasspathTransformerCacheFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
@@ -134,14 +134,12 @@ public class GradleUserHomeScopeServices {
         return cache;
     }
 
-    ClasspathTransformerCache createClasspathTransformerCache(
-        CacheRepository cacheRepository,
-        FileAccessTimeJournal fileAccessTimeJournal,
+    ClasspathTransformerCacheFactory createClasspathTransformerCache(
+        CacheScopeMapping cacheScopeMapping,
         UsedGradleVersions usedGradleVersions
     ) {
-        return new DefaultClasspathTransformerCache(
-            cacheRepository,
-            fileAccessTimeJournal,
+        return new DefaultClasspathTransformerCacheFactory(
+            cacheScopeMapping,
             usedGradleVersions
         );
     }
@@ -151,13 +149,15 @@ public class GradleUserHomeScopeServices {
     }
 
     CachedClasspathTransformer createCachedClasspathTransformer(
-        ClasspathTransformerCache classpathTransformerCache,
+        CacheRepository cacheRepository,
+        ClasspathTransformerCacheFactory classpathTransformerCacheFactory,
         FileHasher fileHasher,
         FileAccessTimeJournal fileAccessTimeJournal,
         WellKnownFileLocations wellKnownFileLocations
     ) {
         return new DefaultCachedClasspathTransformer(
-            classpathTransformerCache,
+            cacheRepository,
+            classpathTransformerCacheFactory,
             fileAccessTimeJournal,
             new JarCache(fileHasher),
             wellKnownFileLocations

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -56,7 +56,7 @@ class DefaultCachedClasspathTransformerTest extends Specification {
     def fileAccessTimeJournal = Mock(FileAccessTimeJournal)
     def usedGradleVersions = Stub(UsedGradleVersions)
 
-    def classpathTransformerCache = new DefaultClasspathTransformerCache(cacheRepository, fileAccessTimeJournal, usedGradleVersions)
+    def classpathTransformerCache = new DefaultClasspathTransformerCacheFactory(cacheRepository, fileAccessTimeJournal, usedGradleVersions)
     def wellKnownFileLocations = new DefaultWellKnownFileLocations([classpathTransformerCache, jarFileStore])
 
     @Subject


### PR DESCRIPTION
This is to avoid creating services for it when not needed.
