### PR TITLE
Model compile task destination as directory property

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
@@ -16,6 +16,7 @@
 package org.gradle.api.file;
 
 import org.gradle.api.Describable;
+import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.util.PatternFilterable;
@@ -127,4 +128,19 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @since 4.0
      */
     void setOutputDir(File outputDir);
+
+    /**
+     * Returns the directory property that is, or can be, bound to the task that produces the output.
+     * Use this as part of a classpath or input to another task to ensure that the output is created before it is used.
+     *
+     * Set this property to a output property of a task to connect this source directory set to the output producing (compile) task.
+     *
+     * Note: To define the path of the output folder for a source directory set that is already wired to
+     * a task (e.g. 'java' / `compileJava`) use {@link #setOutputDir(Provider)} or {@link #setOutputDir(File)}.
+     *
+     * @return The output directory property for this set of sources.
+     * @since 6.1
+     */
+    @Incubating
+    DirectoryProperty getOutputDirectoryProperty();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
@@ -18,12 +18,16 @@ package org.gradle.api.file;
 import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.Task;
+import org.gradle.api.model.ReplacedBy;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.model.internal.core.UnmanagedStruct;
 
 import java.io.File;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * <p>A {@code SourceDirectorySet} represents a set of source files composed from a set of source directories, along
@@ -106,11 +110,43 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
     PatternFilterable getFilter();
 
     /**
+     * Configure the directory to assemble the compiled classes into.
+     *
+     * @return The destination directory property for this set of sources.
+     * @since 6.1
+     */
+    @Incubating
+    DirectoryProperty getDestinationDirectory();
+
+    /**
+     * Returns the directory property that is bound to the task that produces the output via {@link #compiledBy(TaskProvider, Function)}.
+     * Use this as part of a classpath or input to another task to ensure that the output is created before it is used.
+     *
+     * Note: To define the path of the output folder use {@link #getDestinationDirectory()}
+     *
+     * @return The output directory property for this set of sources.
+     * @since 6.1
+     */
+    @Incubating
+    Provider<Directory> getClassesDirectory();
+
+    /**
+     * Define the task responsible for processing the source.
+     *
+     * @param taskProvider the task responsible for compiling the sources (.e.g. compileJava)
+     * @param mapping a mapping from the task to the task's output directory (e.g. AbstractCompile::getDestinationDirectory)
+     * @since 6.1
+     */
+    @Incubating
+    <T extends Task> void compiledBy(TaskProvider<T> taskProvider, Function<T, DirectoryProperty> mapping);
+
+    /**
      * Returns the directory to put the output for these sources.
      *
      * @return The output directory for this set of sources.
      * @since 4.0
      */
+    @ReplacedBy("destinationDirectory")
     File getOutputDir();
 
     /**
@@ -119,6 +155,7 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @param provider provides output directory for this source directory set
      * @since 4.0
      */
+    @ReplacedBy("destinationDirectory")
     void setOutputDir(Provider<File> provider);
 
     /**
@@ -127,20 +164,6 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @param outputDir output directory for this source directory set
      * @since 4.0
      */
+    @ReplacedBy("destinationDirectory")
     void setOutputDir(File outputDir);
-
-    /**
-     * Returns the directory property that is, or can be, bound to the task that produces the output.
-     * Use this as part of a classpath or input to another task to ensure that the output is created before it is used.
-     *
-     * Set this property to a output property of a task to connect this source directory set to the output producing (compile) task.
-     *
-     * Note: To define the path of the output folder for a source directory set that is already wired to
-     * a task (e.g. 'java' / `compileJava`) use {@link #setOutputDir(Provider)} or {@link #setOutputDir(File)}.
-     *
-     * @return The output directory property for this set of sources.
-     * @since 6.1
-     */
-    @Incubating
-    DirectoryProperty getOutputDirectoryProperty();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/SourceDirectorySet.java
@@ -146,7 +146,7 @@ public interface SourceDirectorySet extends FileTree, PatternFilterable, Named, 
      * @return The output directory for this set of sources.
      * @since 4.0
      */
-    @ReplacedBy("destinationDirectory")
+    @ReplacedBy("classesDirectory")
     File getOutputDir();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskActionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskActionIntegrationTest.groovy
@@ -86,14 +86,14 @@ class CachedTaskActionIntegrationTest extends AbstractIntegrationSpec implements
             def input = file("input.txt")
 
             task compileA(type: JavaCompile) {
-                destinationDir = file("build/compile-a")
+                destinationDirectory = file("build/compile-a")
                 doLast {
                     file("\$destinationDir/output.txt") << "From compile task A"
                 }
             }
- 
+
             task compileB(type: JavaCompile) {
-                destinationDir = file("build/compile-b")
+                destinationDirectory = file("build/compile-b")
                 doLast {
                     file("\$destinationDir/output.txt") << "From compile task B"
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file;
 import groovy.lang.Closure;
 import org.gradle.api.Buildable;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTreeElement;
@@ -55,7 +56,8 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
     private final PatternSet patterns;
     private final PatternSet filter;
     private final FileCollection dirs;
-    private final Property<File> outputDir;
+    private final Property<File> outputDir;          // the user configurable output directory
+    private final DirectoryProperty outputDirectory; // bound to the compile task output
 
     public DefaultSourceDirectorySet(String name, String displayName, Factory<PatternSet> patternSetFactory, FileCollectionFactory fileCollectionFactory, DirectoryFileTreeFactory directoryFileTreeFactory, ObjectFactory objectFactory) {
         this.name = name;
@@ -66,6 +68,7 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
         this.filter = patternSetFactory.create();
         this.dirs = new FileCollectionAdapter(new SourceDirectories());
         this.outputDir = objectFactory.property(File.class);
+        this.outputDirectory = objectFactory.directoryProperty();
     }
 
     @Override
@@ -175,6 +178,11 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
     @Override
     public void setOutputDir(File outputDir) {
         this.outputDir.set(outputDir);
+    }
+
+    @Override
+    public DirectoryProperty getOutputDirectoryProperty() {
+        return outputDirectory;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
@@ -62,6 +62,8 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
     private final DirectoryProperty destinationDirectory; // the user configurable output directory
     private final DirectoryProperty classesDirectory;     // bound to the compile task output
 
+    private TaskProvider<?> compileTaskProvider;
+
     public DefaultSourceDirectorySet(String name, String displayName, Factory<PatternSet> patternSetFactory, FileCollectionFactory fileCollectionFactory, DirectoryFileTreeFactory directoryFileTreeFactory, ObjectFactory objectFactory) {
         this.name = name;
         this.displayName = displayName;
@@ -195,7 +197,12 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
 
     @Override
     public <T extends Task> void compiledBy(TaskProvider<T> taskProvider, Function<T, DirectoryProperty> mapping) {
-        taskProvider.configure(task -> mapping.apply(task).set(destinationDirectory));
+        this.compileTaskProvider = taskProvider;
+        taskProvider.configure(task -> {
+            if (taskProvider == this.compileTaskProvider) {
+                mapping.apply(task).set(destinationDirectory);
+            }
+        });
         classesDirectory.set(taskProvider.flatMap(mapping::apply));
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/VariantAwareResolutionWithConfigurationAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/VariantAwareResolutionWithConfigurationAttributesIntegrationTest.groovy
@@ -84,7 +84,7 @@ class VariantAwareResolutionWithConfigurationAttributesIntegrationTest extends A
                                 def compileTask = p.tasks.create("compileJava${f.capitalize()}${bt.capitalize()}", JavaCompile) { task ->
                                     def taskName = task.name
                                     task.source(p.tasks.compileJava.source)
-                                    task.destinationDir = project.file("${p.buildDir}/classes/$taskName")
+                                    task.destinationDirectory = project.file("${p.buildDir}/classes/$taskName")
                                     task.classpath = _compileConfig
                                     task.doFirst {
                                        // this is only for assertions in tests

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.file.SourceDirectorySet.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.file.SourceDirectorySet.xml
@@ -34,6 +34,14 @@
                 <td></td>
             </tr>
             <tr>
+                <td>destinationDirectory</td>
+                <td><literal><replaceable>${project.buildDir}</replaceable>/classes/<replaceable>${sourceDirectorySet.name}</replaceable>/<replaceable>${sourceSet.name}</replaceable></literal></td>
+            </tr>
+            <tr>
+                <td>classesDirectory</td>
+                <td><literal><replaceable>${project.buildDir}</replaceable>/classes/<replaceable>${sourceDirectorySet.name}</replaceable>/<replaceable>${sourceSet.name}</replaceable></literal></td>
+            </tr>
+            <tr>
                 <td>outputDir</td>
                 <td><literal><replaceable>${project.buildDir}</replaceable>/classes/<replaceable>${sourceDirectorySet.name}</replaceable>/<replaceable>${sourceSet.name}</replaceable></literal></td>
             </tr>
@@ -55,6 +63,9 @@
             </tr>
             <tr>
                 <td>source</td>
+            </tr>
+            <tr>
+                <td>compiledBy</td>
             </tr>
         </table>
     </section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.AbstractCompile.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.AbstractCompile.xml
@@ -13,8 +13,12 @@
                 <td><literal><replaceable>sourceSet</replaceable>.compileClasspath</literal></td>
             </tr>
             <tr>
+                <td>destinationDirectory</td>
+                <td><literal><replaceable>sourceSet</replaceable>.<replaceable>sourceDirectorySet</replaceable>.destinationDirectory</literal></td>
+            </tr>
+            <tr>
                 <td>destinationDir</td>
-                <td><literal><replaceable>sourceSet</replaceable>.<replaceable>sourceDirectorySet</replaceable>.outputDir</literal></td>
+                <td><literal><replaceable>sourceSet</replaceable>.<replaceable>sourceDirectorySet</replaceable>.destinationDirectory</literal></td>
             </tr>
             <tr>
                 <td>sourceCompatibility</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -76,12 +76,6 @@ tasks.named('compileKotlin') {
 }
 ```
 
-## Features for Gradle tooling providers
-
-### `TestLauncher` can select specific methods
-
-The `TestLauncher` interface in the Tooling API is capable of launching tests by specifying the name of the test classes or methods. If there are multiple test tasks contain those test classes/methods, then all tasks are executed. This is not ideal for IDEs: developers usually want to execute only one test variant at the time. To overcome this, Gradle 6.1 introduces the `withTaskAndTestClasses()` and `withTaskAndTestMethods()` methods.
-
 ## Improvements for plugin authors
 
 ### Finalize property value only when the value is queried

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -51,6 +51,37 @@ Gradle now supports compiling Groovy code with [method parameter names](https://
 
 This was contributed by [Andrew Malyhin](https://github.com/katoquro).
 
+## Defining compilation order between Groovy, Scala and Java sources in the same project
+
+Previously, the relationship between Java, Groovy and Scala compilation was hardcoded with task dependencies.
+Gradle assumed Groovy and Scala compilation always depended on Java compilation.
+That is, `compileGroovy` and `compileScala` would directly depend on `compileJava`.
+
+These task dependencies have been remodelled with [directory properties](userguide/lazy_configuration.html#) that represent the destination folders of the compile tasks.
+Adding such a destination folder to the classpath of another task automatically adds the corresponding task dependencies.
+Removing such a destination folder from the classpath also removes the corresponding task dependency.
+This can be used to remove the above mentioned dependencies and to add different ones.
+This is helpful, for example, when combining Groovy and Kotlin in the same project.
+
+```
+tasks.named('compileGroovy') {
+    // Groovy only needs the declared dependencies
+    // (and not longer the output of compileJava)
+    classpath = sourceSets.main.compileClasspath
+}
+tasks.named('compileKotlin') {
+    // Kotlin also depends on the result of Groovy compilation 
+    // (which automatically makes it depend of compileGroovy)
+    classpath += files(sourceSets.main.groovy.classesDirectory)
+}
+```
+
+## Features for Gradle tooling providers
+
+### `TestLauncher` can select specific methods
+
+The `TestLauncher` interface in the Tooling API is capable of launching tests by specifying the name of the test classes or methods. If there are multiple test tasks contain those test classes/methods, then all tasks are executed. This is not ideal for IDEs: developers usually want to execute only one test variant at the time. To overcome this, Gradle 6.1 introduces the `withTaskAndTestClasses()` and `withTaskAndTestMethods()` methods.
+
 ## Improvements for plugin authors
 
 ### Finalize property value only when the value is queried

--- a/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -513,6 +513,16 @@ This plugin is the exception as it does not apply the Java Plugin.
 
 If you want to leverage the multi language aspect of the JVM, most of what was described here will still apply.
 
-Gradle itself provides <<groovy_plugin.adoc#,Groovy>> and <<scala_plugin.adoc#,Scala>> plugins. Note that these can be further enhanced by combining them with the `java-library` plugin.
+Gradle itself provides <<groovy_plugin.adoc#,Groovy>> and <<scala_plugin.adoc#,Scala>> plugins.
+The plugins automatically apply support for compiling Java code and can be further enhanced by combining them with the `java-library` plugin.
 
-And beyond core Gradle, there are other https://plugins.gradle.org/search?term=jvm[great plugins] for more JVM languages!
+These plugins create a dependency between Groovy/Scala compilation and Java compilation (of source code in tha `java` folder of a source set).
+You can change this default behavior by adjusting the classpath of the involved compile tasks as shown in the following example:
+
+.Changing the classpath of compile tasks
+====
+include::sample[dir="userguide/tutorial/compileTaskClasspath/groovy",files="build.gradle[tags=compile-task-classpath]"]
+include::sample[dir="userguide/tutorial/compileTaskClasspath/kotlin",files="build.gradle.kts[tags=compile-task-classpath]"]
+====
+
+Beyond core Gradle, there are other https://plugins.gradle.org/search?term=jvm[great plugins] for more JVM languages!

--- a/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
@@ -39,6 +39,7 @@ include::sample[dir="groovy/quickstart/kotlin",files="build.gradle.kts[tags=use-
 == Tasks
 
 The Groovy plugin adds the following tasks to the project.
+Information about altering the dependencies to Java compile tasks are found <<building_java_projects.adoc#sec:building_jvm_lang,here>>.
 
 `compileGroovy` — link:{groovyDslPath}/org.gradle.api.tasks.compile.GroovyCompile.html[GroovyCompile]::
 _Depends on_: `compileJava`

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -39,6 +39,7 @@ include::sample[dir="scala/quickstart/kotlin",files="build.gradle.kts[tags=use-p
 == Tasks
 
 The Scala plugin adds the following tasks to the project.
+Information about altering the dependencies to Java compile tasks are found <<building_java_projects.adoc#sec:building_jvm_lang,here>>.
 
 `compileScala` — link:{groovyDslPath}/org.gradle.api.tasks.scala.ScalaCompile.html[ScalaCompile]::
 _Depends on_: `compileJava`

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/compileTaskClasspath.out
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/compileTaskClasspath.out
@@ -1,0 +1,5 @@
+> Task :compileGroovy
+> Task :compileJava
+
+BUILD SUCCESSFUL in 0s
+2 actionable tasks: 2 executed

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/compileTaskClasspath.sample.conf
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/compileTaskClasspath.sample.conf
@@ -1,0 +1,11 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: compileJava
+    expected-output-file: compileTaskClasspath.out
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: compileJava
+    expected-output-file: compileTaskClasspath.out
+}]

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'groovy'
+}
+dependencies {
+    implementation(localGroovy())
+}
+
+// tag::compile-task-classpath[]
+tasks.named('compileGroovy') {
+    // Groovy only needs the declared dependencies
+    // (and not longer the output of compileJava)
+    classpath = sourceSets.main.compileClasspath
+}
+tasks.named('compileJava') {
+    // Java also depends on the result of Groovy compilation
+    // (which automatically makes it depend of compileGroovy)
+    classpath += files(sourceSets.main.groovy.classesDirectory)
+}
+// end::compile-task-classpath[]

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'compileTaskClasspath'

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/src/main/groovy/Groovy.groovy
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/src/main/groovy/Groovy.groovy
@@ -1,0 +1,1 @@
+class Groovy { }

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/src/main/java/Java.java
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/groovy/src/main/java/Java.java
@@ -1,0 +1,1 @@
+public class Java { Groovy groovy = new Groovy(); }

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    groovy
+}
+dependencies {
+    implementation(localGroovy())
+}
+
+// tag::compile-task-classpath[]
+tasks.named<AbstractCompile>("compileGroovy") {
+    // Groovy only needs the declared dependencies
+    // (and not longer the output of compileJava)
+    classpath = sourceSets.main.get().compileClasspath
+}
+tasks.named<AbstractCompile>("compileJava") {
+    // Java also depends on the result of Groovy compilation
+    // (which automatically makes it depend of compileGroovy)
+    classpath += files(sourceSets.main.get().withConvention(GroovySourceSet::class) { groovy }.classesDirectory)
+}
+// end::compile-task-classpath[]

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "compileTaskClasspath"

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/src/main/groovy/Groovy.groovy
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/src/main/groovy/Groovy.groovy
@@ -1,0 +1,1 @@
+class Groovy { }

--- a/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/src/main/java/Java.java
+++ b/subprojects/docs/src/snippets/userguide/tutorial/compileTaskClasspath/kotlin/src/main/java/Java.java
@@ -1,0 +1,1 @@
+public class Java { Groovy groovy = new Groovy(); }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputHistoryLossIntegrationTest.groovy
@@ -157,6 +157,7 @@ class StaleOutputHistoryLossIntegrationTest extends AbstractIntegrationSpec {
         javaProject.redundantClassFileAlternate.assertIsFile()
 
         when:
+        buildFile.text = buildFile.text.replace('compileJava.destinationDir', 'compileJava.destinationDirectory')
         forceDelete(javaProject.redundantSourceFile)
         succeeds JAR_TASK_NAME
 

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
@@ -40,7 +40,7 @@ class GroovyCompileRelocationIntegrationTest extends AbstractProjectRelocationIn
             task compile(type: GroovyCompile) {
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()
-                destinationDir = file("build/classes")
+                destinationDirectory = file("build/classes")
                 source "src/main/groovy"
                 classpath = files()
                 groovyClasspath = files('libs')

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -289,7 +289,7 @@ public class GroovyCompile extends AbstractCompile {
 
         spec.setSourcesRoots(sourceRoots);
         spec.setSourceFiles(stableSourcesAsFileTree);
-        spec.setDestinationDir(getDestinationDir());
+        spec.setDestinationDir(getDestinationDirectory().getAsFile().getOrNull());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(determineGroovyCompileClasspath()));

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -289,7 +289,7 @@ public class GroovyCompile extends AbstractCompile {
 
         spec.setSourcesRoots(sourceRoots);
         spec.setSourceFiles(stableSourcesAsFileTree);
-        spec.setDestinationDir(getDestinationDirectory().getAsFile().getOrNull());
+        spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(determineGroovyCompileClasspath()));

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -36,7 +36,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
 
     def "uses default platform settings when applying java plugin"() {
         buildFile << """
-            apply plugin:"java"
+            apply plugin: "java"
         """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
@@ -138,7 +138,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
             task compile(type: JavaCompile) {
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()
-                destinationDir = file("build/classes")
+                destinationDirectory = file("build/classes")
                 source "src/main/java"
                 classpath = files('${dependencies.join("', '")}')
             }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
@@ -40,7 +40,7 @@ class JavaCompileRelocationIntegrationTest extends AbstractProjectRelocationInte
             task compile(type: JavaCompile) {
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()
-                destinationDir = file("build/classes")
+                destinationDirectory = file("build/classes")
                 source "src/main/java"
                 classpath = files('libs')
             }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskIntegrationTest.groovy
@@ -40,7 +40,7 @@ class JavaCompileTaskIntegrationTest extends AbstractIntegrationSpec {
                 classpath = files()
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()
-                destinationDir = file("build/classes")
+                destinationDirectory = file("build/classes")
                 source "src/main/java"
             }
         """

--- a/subprojects/language-java/src/integTest/resources/org/gradle/javadoc/JavadocIntegrationTest/canCombineLocalOptionWithOtherOptions/build.gradle
+++ b/subprojects/language-java/src/integTest/resources/org/gradle/javadoc/JavadocIntegrationTest/canCombineLocalOptionWithOtherOptions/build.gradle
@@ -18,6 +18,6 @@ javadoc {
         locale = 'de_DE'
         breakIterator = true
         taglets 'LocaleAwareTaglet'
-        tagletPath sourceSets.taglet.java.outputDir
+        tagletPath sourceSets.taglet.java.destinationDirectory.get().asFile
     }
 }

--- a/subprojects/language-java/src/integTest/resources/org/gradle/javadoc/JavadocIntegrationTest/handlesTagsAndTaglets/build.gradle
+++ b/subprojects/language-java/src/integTest/resources/org/gradle/javadoc/JavadocIntegrationTest/handlesTagsAndTaglets/build.gradle
@@ -20,6 +20,6 @@ javadoc {
         tags 'deprecated'
         tags 'customtag:t:"Custom Tag:"'
         taglets 'CustomTaglet'
-        tagletPath sourceSets.taglet.java.outputDir
+        tagletPath sourceSets.taglet.java.destinationDirectory.get().asFile
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -211,7 +211,7 @@ public class JavaCompile extends AbstractCompile {
 
     private DefaultJavaCompileSpec createSpec() {
         final DefaultJavaCompileSpec spec = new DefaultJavaCompileSpecFactory(compileOptions).create();
-        spec.setDestinationDir(getDestinationDir());
+        spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(getClasspath()));

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/plugins/JavaLanguagePlugin.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/plugins/JavaLanguagePlugin.java
@@ -171,7 +171,7 @@ public class JavaLanguagePlugin implements Plugin<Project> {
                 assembly.builtBy(compile);
 
                 compile.setDescription("Compiles " + javaSourceSet + ".");
-                compile.setDestinationDir(conventionalCompilationOutputDirFor(assembly));
+                compile.getDestinationDirectory().set(conventionalCompilationOutputDirFor(assembly));
                 compile.dependsOn(javaSourceSet);
                 compile.setSource(javaSourceSet.getSource());
 

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/plugins/ScalaLanguagePlugin.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/plugins/ScalaLanguagePlugin.java
@@ -146,7 +146,7 @@ public class ScalaLanguagePlugin implements Plugin<Project> {
                     assembly.builtBy(compile);
 
                     compile.setDescription(description);
-                    compile.setDestinationDir(single(assembly.getClassDirectories()));
+                    compile.getDestinationDirectory().set(single(assembly.getClassDirectories()));
 
                     compile.getScalaCompileOptions().getIncrementalOptions().getAnalysisFile().set(
                         compile.getProject().getLayout().getBuildDirectory().file("tmp/scala/compilerAnalysis/" + compile.getName() + ".analysis")

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -117,7 +117,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile {
     protected ScalaJavaJointCompileSpec createSpec() {
         DefaultScalaJavaJointCompileSpec spec = new DefaultScalaJavaJointCompileSpecFactory(compileOptions).create();
         spec.setSourceFiles(getSource().getFiles());
-        spec.setDestinationDir(getDestinationDir());
+        spec.setDestinationDir(getDestinationDirectory().getAsFile().getOrNull());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(getClasspath()));

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -117,7 +117,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile {
     protected ScalaJavaJointCompileSpec createSpec() {
         DefaultScalaJavaJointCompileSpec spec = new DefaultScalaJavaJointCompileSpecFactory(compileOptions).create();
         spec.setSourceFiles(getSource().getFiles());
-        spec.setDestinationDir(getDestinationDirectory().getAsFile().getOrNull());
+        spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
         spec.setWorkingDir(getProject().getProjectDir());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(getClasspath()));

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyJavaJointCompileSourceOrderIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyJavaJointCompileSourceOrderIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.groovy.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
+import spock.lang.Unroll
 
 class GroovyJavaJointCompileSourceOrderIntegrationTest extends AbstractIntegrationSpec {
 
@@ -54,6 +55,36 @@ class GroovyJavaJointCompileSourceOrderIntegrationTest extends AbstractIntegrati
         reversedAgainBytes == originalBytes
     }
 
+    @Unroll
+    def "groovy and java source directory compilation order can be reversed (task configuration #configurationStyle)"() {
+        given:
+        file("src/main/groovy/Groovy.groovy") << "class Groovy { }"
+        file("src/main/java/Java.java") << "public class Java { Groovy groovy = new Groovy(); }"
+        buildFile << """
+            plugins {
+                id 'groovy'
+            }
+            $setup
+            tasks.named('compileGroovy') {
+                classpath = sourceSets.main.compileClasspath
+            }
+            dependencies {
+                implementation localGroovy()
+            }
+        """
+
+        when:
+        succeeds 'compileJava'
+
+        then:
+        result.assertTasksExecutedInOrder(':compileGroovy', ':compileJava')
+
+        where:
+        configurationStyle | setup
+        'lazy'             | "tasks.named('compileJava') { classpath += files(sourceSets.main.groovy.outputDirectory) }"
+        'eager'            | "compileJava { classpath += files(sourceSets.main.groovy.outputDirectory) }"
+    }
+
     private static String buildFileWithSources(String... sourceFiles) {
         """
             configurations {
@@ -66,11 +97,11 @@ class GroovyJavaJointCompileSourceOrderIntegrationTest extends AbstractIntegrati
 
             task compile(type: GroovyCompile) {
                 source ${sourceFiles.collect { "'src/main/groovy/$it'" }.join(", ")}
-                classpath = files(configurations.compile, file("\$buildDir/classes"))
+                classpath = configurations.compile
                 groovyClasspath = configurations.compile
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()
-                destinationDir = file("\$buildDir/classes")
+                destinationDirectory = file("\$buildDir/classes")
             }
         """
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyJavaJointCompileSourceOrderIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyJavaJointCompileSourceOrderIntegrationTest.groovy
@@ -81,8 +81,8 @@ class GroovyJavaJointCompileSourceOrderIntegrationTest extends AbstractIntegrati
 
         where:
         configurationStyle | setup
-        'lazy'             | "tasks.named('compileJava') { classpath += files(sourceSets.main.groovy.outputDirectory) }"
-        'eager'            | "compileJava { classpath += files(sourceSets.main.groovy.outputDirectory) }"
+        'lazy'             | "tasks.named('compileJava') { classpath += files(sourceSets.main.groovy.classesDirectory) }"
+        'eager'            | "compileJava { classpath += files(sourceSets.main.groovy.classesDirectory) }"
     }
 
     private static String buildFileWithSources(String... sourceFiles) {

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/ApiGroovyCompilerIntegrationSpec/canEnableAndDisableAllOptimizations/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/ApiGroovyCompilerIntegrationSpec/canEnableAndDisableAllOptimizations/build.gradle
@@ -7,19 +7,19 @@ repositories {
 task compileWithOptimization(type: GroovyCompile) {
     source = sourceSets.main.groovy
     classpath = configurations.compileClasspath
-    destinationDir = file("$buildDir/classes/optimized")
+    destinationDirectory = file("$buildDir/classes/optimized")
     groovyOptions.optimizationOptions.all = true
 }
 
 task compileWithoutOptimization(type: GroovyCompile) {
     source = sourceSets.main.groovy
     classpath = configurations.compileClasspath
-    destinationDir = file("$buildDir/classes/unoptimized")
+    destinationDirectory = file("$buildDir/classes/unoptimized")
     groovyOptions.optimizationOptions.all = false
 }
 
 task sanityCheck(dependsOn: [compileWithOptimization, compileWithoutOptimization]) {
     doLast {
-        assert fileTree(compileWithOptimization.destinationDir).singleFile.size() != fileTree(compileWithoutOptimization.destinationDir).singleFile.size()
+        assert compileWithOptimization.destinationDirectory.getAsFileTree().singleFile.size() != compileWithoutOptimization.destinationDirectory.getAsFileTree().singleFile.size()
     }
 }

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/ApiGroovyCompilerIntegrationSpec/canEnableAndDisableIntegerOptimization/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/ApiGroovyCompilerIntegrationSpec/canEnableAndDisableIntegerOptimization/build.gradle
@@ -7,19 +7,19 @@ repositories {
 task compileWithOptimization(type: GroovyCompile) {
     source = sourceSets.main.groovy
     classpath = configurations.compileClasspath
-    destinationDir = file("$buildDir/classes/optimized")
+    destinationDirectory = file("$buildDir/classes/optimized")
     groovyOptions.optimizationOptions["int"] = true
 }
 
 task compileWithoutOptimization(type: GroovyCompile) {
     source = sourceSets.main.groovy
     classpath = configurations.compileClasspath
-    destinationDir = file("$buildDir/classes/unoptimized")
+    destinationDirectory = file("$buildDir/classes/unoptimized")
     groovyOptions.optimizationOptions["int"] = false
 }
 
 task sanityCheck(dependsOn: [compileWithOptimization, compileWithoutOptimization]) {
     doLast {
-        assert fileTree(compileWithOptimization.destinationDir).singleFile.size() != fileTree(compileWithoutOptimization.destinationDir).singleFile.size()
+        assert compileWithOptimization.destinationDirectory.getAsFileTree().singleFile.size() != compileWithoutOptimization.destinationDirectory.getAsFileTree().singleFile.size()
     }
 }

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/InvokeDynamicGroovyCompilerSpec/canEnableAndDisableInvokeDynamicOptimization/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/InvokeDynamicGroovyCompilerSpec/canEnableAndDisableInvokeDynamicOptimization/build.gradle
@@ -7,19 +7,19 @@ repositories {
 task compileWithOptimization(type: GroovyCompile) {
     source = sourceSets.main.groovy
     classpath = configurations.compileClasspath
-    destinationDir = file("$buildDir/classes/optimized")
+    destinationDirectory = file("$buildDir/classes/optimized")
     groovyOptions.optimizationOptions.indy = true
 }
 
 task compileWithoutOptimization(type: GroovyCompile) {
     source = sourceSets.main.groovy
     classpath = configurations.compileClasspath
-    destinationDir = file("$buildDir/classes/unoptimized")
+    destinationDirectory = file("$buildDir/classes/unoptimized")
     groovyOptions.optimizationOptions.indy = false
 }
 
 task sanityCheck(dependsOn: [compileWithOptimization, compileWithoutOptimization]) {
     doLast {
-        assert file("$compileWithOptimization.destinationDir/MethodInvocations.class").size() != file("$compileWithoutOptimization.destinationDir/MethodInvocations.class").size()
+        assert file("${compileWithOptimization.destinationDirectory.get()}/MethodInvocations.class").size() != file("${compileWithoutOptimization.destinationDirectory.get()}/MethodInvocations.class").size()
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
@@ -123,12 +123,12 @@ public class DefaultClassDirectoryBinarySpec extends AbstractBuildableComponentS
 
     @Override
     public File getClassesDir() {
-        return sourceSet.getJava().getOutputDir();
+        return sourceSet.getJava().getDestinationDirectory().getAsFile().get();
     }
 
     @Override
     public void setClassesDir(final File classesDir) {
-        sourceSet.getJava().setOutputDir(classesDir);
+        sourceSet.getJava().getDestinationDirectory().set(classesDir);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -31,11 +31,11 @@ import org.gradle.api.internal.tasks.DefaultGroovySourceSet;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.JvmPluginsHelper;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.GroovyRuntime;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.javadoc.Groovydoc;
@@ -110,7 +110,7 @@ public class GroovyBasePlugin implements Plugin<Project> {
                 sourceSet.getAllJava().source(groovySourceSet.getGroovy());
                 sourceSet.getAllSource().source(groovySourceSet.getGroovy());
 
-                final Provider<GroovyCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("groovy"), GroovyCompile.class, new Action<GroovyCompile>() {
+                final TaskProvider<GroovyCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("groovy"), GroovyCompile.class, new Action<GroovyCompile>() {
                     @Override
                     public void execute(final GroovyCompile compile) {
                         JvmPluginsHelper.configureForSourceSet(sourceSet, groovySourceSet.getGroovy(), compile, compile.getOptions(), project);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -114,7 +114,6 @@ public class GroovyBasePlugin implements Plugin<Project> {
                     @Override
                     public void execute(final GroovyCompile compile) {
                         JvmPluginsHelper.configureForSourceSet(sourceSet, groovySourceSet.getGroovy(), compile, compile.getOptions(), project);
-                        compile.dependsOn(sourceSet.getCompileJavaTaskName());
                         compile.setDescription("Compiles the " + sourceSet.getName() + " Groovy source.");
                         compile.setSource(groovySourceSet.getGroovy());
                     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -201,12 +201,12 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                     }
                 });
                 JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, compileTask.getOptions(), target);
-                compileTask.setDestinationDir(target.provider(new Callable<File>() {
+                compileTask.getDestinationDirectory().set(target.getLayout().dir(target.provider(new Callable<File>() {
                     @Override
                     public File call() {
                         return sourceDirectorySet.getOutputDir();
                     }
-                }));
+                })));
             }
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -47,6 +47,7 @@ import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -174,7 +175,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                 definePathsForSourceSet(sourceSet, outputConventionMapping, project);
 
                 createProcessResourcesTask(sourceSet, sourceSet.getResources(), project);
-                Provider<JavaCompile> compileTask = createCompileJavaTask(sourceSet, sourceSet.getJava(), project);
+                TaskProvider<JavaCompile> compileTask = createCompileJavaTask(sourceSet, sourceSet.getJava(), project);
                 createClassesTask(sourceSet, project);
 
                 JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, sourceSet.getJava(), project, compileTask, compileTask.map(new Transformer<CompileOptions, JavaCompile>() {
@@ -187,7 +188,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         });
     }
 
-    private Provider<JavaCompile> createCompileJavaTask(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target) {
+    private TaskProvider<JavaCompile> createCompileJavaTask(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target) {
         return target.getTasks().register(sourceSet.getCompileJavaTaskName(), JavaCompile.class, new Action<JavaCompile>() {
             @Override
             public void execute(JavaCompile compileTask) {
@@ -201,12 +202,6 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                     }
                 });
                 JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, compileTask.getOptions(), target);
-                compileTask.getDestinationDirectory().set(target.getLayout().dir(target.provider(new Callable<File>() {
-                    @Override
-                    public File call() {
-                        return sourceDirectorySet.getOutputDir();
-                    }
-                })));
             }
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -128,7 +128,7 @@ public class JvmPluginsHelper {
         classpath.from(new Callable<Object>() {
             @Override
             public Object call() {
-                return sourceSet.getCompileClasspath().plus(target.files(sourceSet.getJava().getOutputDirectoryProperty()));
+                return sourceSet.getCompileClasspath().plus(target.files(sourceSet.getJava().getClassesDirectory()));
             }
         });
 
@@ -138,12 +138,6 @@ public class JvmPluginsHelper {
                 return classpath;
             }
         });
-        compile.getDestinationDirectory().set(target.getLayout().dir(target.provider(new Callable<File>() {
-            @Override
-            public File call() {
-                return sourceDirectorySet.getOutputDir();
-            }
-        })));
     }
 
     public static void configureAnnotationProcessorPath(final SourceSet sourceSet, SourceDirectorySet sourceDirectorySet, CompileOptions options, final Project target) {
@@ -163,20 +157,15 @@ public class JvmPluginsHelper {
         });
     }
 
-    public static void configureOutputDirectoryForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target, Provider<? extends AbstractCompile> compileTask, Provider<CompileOptions> options) {
+    public static void configureOutputDirectoryForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target, TaskProvider<? extends AbstractCompile> compileTask, Provider<CompileOptions> options) {
         final String sourceSetChildPath = "classes/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
-        sourceDirectorySet.setOutputDir(target.provider(new Callable<File>() {
-            @Override
-            public File call() {
-                return new File(target.getBuildDir(), sourceSetChildPath);
-            }
-        }));
+        sourceDirectorySet.getDestinationDirectory().set(target.getLayout().getBuildDirectory().dir(sourceSetChildPath));
 
         DefaultSourceSetOutput sourceSetOutput = Cast.cast(DefaultSourceSetOutput.class, sourceSet.getOutput());
         sourceSetOutput.addClassesDir(new Callable<File>() {
             @Override
             public File call() {
-                return sourceDirectorySet.getOutputDir();
+                return sourceDirectorySet.getDestinationDirectory().getAsFile().get();
             }
         });
         sourceSetOutput.registerCompileTask(compileTask);
@@ -187,7 +176,7 @@ public class JvmPluginsHelper {
             }
         })).builtBy(compileTask);
 
-        sourceDirectorySet.getOutputDirectoryProperty().set(compileTask.flatMap(AbstractCompile::getDestinationDirectory));
+        sourceDirectorySet.compiledBy(compileTask, AbstractCompile::getDestinationDirectory);
     }
 
     public static void configureClassesDirectoryVariant(SourceSet sourceSet, Project target, String targetConfigName, final String usage) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -128,7 +128,7 @@ public class JvmPluginsHelper {
         classpath.from(new Callable<Object>() {
             @Override
             public Object call() {
-                return sourceSet.getCompileClasspath().plus(target.files(sourceSet.getJava().getOutputDir()));
+                return sourceSet.getCompileClasspath().plus(target.files(sourceSet.getJava().getOutputDirectoryProperty()));
             }
         });
 
@@ -138,12 +138,12 @@ public class JvmPluginsHelper {
                 return classpath;
             }
         });
-        compile.setDestinationDir(target.provider(new Callable<File>() {
+        compile.getDestinationDirectory().set(target.getLayout().dir(target.provider(new Callable<File>() {
             @Override
             public File call() {
                 return sourceDirectorySet.getOutputDir();
             }
-        }));
+        })));
     }
 
     public static void configureAnnotationProcessorPath(final SourceSet sourceSet, SourceDirectorySet sourceDirectorySet, CompileOptions options, final Project target) {
@@ -187,6 +187,7 @@ public class JvmPluginsHelper {
             }
         })).builtBy(compileTask);
 
+        sourceDirectorySet.getOutputDirectoryProperty().set(compileTask.flatMap(AbstractCompile::getDestinationDirectory));
     }
 
     public static void configureClassesDirectoryVariant(SourceSet sourceSet, Project target, String targetConfigName, final String usage) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -159,7 +159,7 @@ public class JvmPluginsHelper {
 
     public static void configureOutputDirectoryForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target, TaskProvider<? extends AbstractCompile> compileTask, Provider<CompileOptions> options) {
         final String sourceSetChildPath = "classes/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
-        sourceDirectorySet.getDestinationDirectory().set(target.getLayout().getBuildDirectory().dir(sourceSetChildPath));
+        sourceDirectorySet.getDestinationDirectory().convention(target.getLayout().getBuildDirectory().dir(sourceSetChildPath));
 
         DefaultSourceSetOutput sourceSetOutput = Cast.cast(DefaultSourceSetOutput.class, sourceSet.getOutput());
         sourceSetOutput.addClassesDir(new Callable<File>() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.api.plugins
 
 import org.gradle.api.reporting.ReportingExtension
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.javadoc.Groovydoc
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
+import static org.hamcrest.core.IsNot.not
 
 class GroovyPluginTest extends AbstractProjectBuilderSpec {
     private final GroovyPlugin groovyPlugin = new GroovyPlugin()
@@ -94,6 +96,34 @@ class GroovyPluginTest extends AbstractProjectBuilderSpec {
         task instanceof GroovyCompile
         task.description == 'Compiles the test Groovy source.'
         dependsOn(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME).matches(task)
+    }
+
+    def "compile dependency to java compilation can be turned off by changing the compile task classpath"() {
+        given:
+        groovyPlugin.apply(project)
+        SourceSet mainSourceSet = project.sourceSets.main
+
+        when:
+        def task = project.tasks['compileGroovy']
+        task.classpath = project.sourceSets.main.compileClasspath
+
+        then:
+        task instanceof GroovyCompile
+        task.classpath.files as List == []
+        not(dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME)).matches(task)
+
+        when:
+        task = project.tasks['compileTestGroovy']
+        task.classpath = project.sourceSets.test.compileClasspath
+
+        then:
+        task instanceof GroovyCompile
+        task.classpath.files as List == [
+            mainSourceSet.java.outputDirectory.get().asFile,
+            mainSourceSet.groovy.outputDirectory.get().asFile,
+            mainSourceSet.output.resourcesDir
+        ]
+        not(dependsOn(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME)).matches(task)
     }
 
     def "dependencies of Java plugin tasks include Groovy compile tasks"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyPluginTest.groovy
@@ -119,8 +119,8 @@ class GroovyPluginTest extends AbstractProjectBuilderSpec {
         then:
         task instanceof GroovyCompile
         task.classpath.files as List == [
-            mainSourceSet.java.outputDirectory.get().asFile,
-            mainSourceSet.groovy.outputDirectory.get().asFile,
+            mainSourceSet.java.destinationDirectory.get().asFile,
+            mainSourceSet.groovy.destinationDirectory.get().asFile,
             mainSourceSet.output.resourcesDir
         ]
         not(dependsOn(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME)).matches(task)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -131,7 +131,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         SourceSet set = project.sourceSets.custom
         set.java.srcDirs == toLinkedSet(project.file('src/custom/java'))
         set.resources.srcDirs == toLinkedSet(project.file('src/custom/resources'))
-        set.java.outputDir == new File(project.buildDir, 'classes/java/custom')
+        set.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/custom'))
         set.output.resourcesDir == new File(project.buildDir, 'resources/custom')
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/custom'))
 
@@ -169,7 +169,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         SourceSet set = project.sourceSets.main
         set.java.srcDirs == toLinkedSet(project.file('src/main/java'))
         set.resources.srcDirs == toLinkedSet(project.file('src/main/resources'))
-        set.java.outputDir == new File(project.buildDir, 'classes/java/main')
+        set.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/main'))
         set.output.resourcesDir == new File(project.buildDir, 'resources/main')
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/main'))
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -250,7 +250,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.resources.srcDirs == toLinkedSet(project.file('src/main/resources'))
         set.compileClasspath.is(project.configurations.compileClasspath)
         set.annotationProcessorPath.is(project.configurations.annotationProcessor)
-        set.java.outputDir == new File(project.buildDir, 'classes/java/main')
+        set.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/main'))
         set.output.resourcesDir == new File(project.buildDir, 'resources/main')
         set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.CLASSES_TASK_NAME ]
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/main'))
@@ -267,7 +267,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.compileClasspath.sourceCollections.contains(project.configurations.testCompileClasspath)
         set.compileClasspath.contains(new File(project.buildDir, 'classes/java/main'))
         set.annotationProcessorPath.is(project.configurations.testAnnotationProcessor)
-        set.java.outputDir == new File(project.buildDir, 'classes/java/test')
+        set.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/test'))
         set.output.resourcesDir == new File(project.buildDir, 'resources/test')
         set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.TEST_CLASSES_TASK_NAME ]
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/test'))
@@ -289,7 +289,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.resources.srcDirs == toLinkedSet(project.file('src/custom/resources'))
         set.compileClasspath.is(project.configurations.customCompileClasspath)
         set.annotationProcessorPath.is(project.configurations.customAnnotationProcessor)
-        set.java.outputDir == new File(project.buildDir, 'classes/java/custom')
+        set.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/custom'))
         set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ 'customClasses' ]
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/custom'))
         set.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ 'compileCustomJava' ]
@@ -322,7 +322,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task.classpath.is(project.sourceSets.main.compileClasspath)
         task.options.annotationProcessorPath.is(project.sourceSets.main.annotationProcessorPath)
         task.options.annotationProcessorGeneratedSourcesDirectory == new File(project.buildDir, 'generated/sources/annotationProcessor/java/main')
-        task.destinationDir == project.sourceSets.main.java.outputDir
+        task.destinationDir == project.sourceSets.main.java.destinationDirectory.get().asFile
         task.source.files == project.sourceSets.main.java.files
 
         when:
@@ -350,7 +350,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task.classpath.is(project.sourceSets.test.compileClasspath)
         task.options.annotationProcessorPath.is(project.sourceSets.test.annotationProcessorPath)
         task.options.annotationProcessorGeneratedSourcesDirectory == new File(project.buildDir, 'generated/sources/annotationProcessor/java/test')
-        task.destinationDir == project.sourceSets.test.java.outputDir
+        task.destinationDir == project.sourceSets.test.java.destinationDirectory.get().asFile
         task.source.files == project.sourceSets.test.java.files
 
         when:
@@ -437,7 +437,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task instanceof org.gradle.api.tasks.testing.Test
         task dependsOn(JavaPlugin.TEST_CLASSES_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME)
         task.classpath == project.sourceSets.test.runtimeClasspath
-        task.testClassesDirs.contains(project.sourceSets.test.java.outputDir)
+        task.testClassesDirs.contains(project.sourceSets.test.java.destinationDirectory.get().asFile)
         task.workingDir == project.projectDir
     }
 
@@ -450,7 +450,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         task.classpath == project.sourceSets.test.runtimeClasspath
-        task.testClassesDirs.contains(project.sourceSets.test.java.outputDir)
+        task.testClassesDirs.contains(project.sourceSets.test.java.destinationDirectory.get().asFile)
         task.workingDir == project.projectDir
         task.reports.junitXml.destination == new File(project.testResultsDir, 'customTest')
         task.reports.html.destination == new File(project.testReportDir, 'customTest')

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/WarPluginTest.groovy
@@ -126,7 +126,7 @@ class WarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def task = project.tasks[WarPlugin.WAR_TASK_NAME]
-        task.classpath.files as List == [project.sourceSets.main.java.outputDir, project.sourceSets.main.output.resourcesDir, compileJar, runtimeJar]
+        task.classpath.files as List == [project.sourceSets.main.java.destinationDirectory.get().asFile, project.sourceSets.main.output.resourcesDir, compileJar, runtimeJar]
     }
 
     def "applies mappings to archive tasks"() {

--- a/subprojects/plugins/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompileTest.groovy
+++ b/subprojects/plugins/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompileTest.groovy
@@ -47,6 +47,7 @@ abstract class AbstractCompileTest extends AbstractConventionTaskTest {
 
         expect:
         compile.getDestinationDir() == null
+        compile.getDestinationDirectory().getOrNull() == null
         compile.getSourceCompatibility() == null
         compile.getTargetCompatibility() == null
         compile.getSource().isEmpty()

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
@@ -66,8 +66,8 @@ class ScalaCompileWithJavaLibraryIntegrationTest extends AbstractIntegrationSpec
 
         where:
         configurationStyle | setup
-        'lazy'             | "tasks.named('compileJava') { classpath += files(sourceSets.main.scala.outputDirectory) }"
-        'eager'            | "compileJava { classpath += files(sourceSets.main.scala.outputDirectory) }"
+        'lazy'             | "tasks.named('compileJava') { classpath += files(sourceSets.main.scala.classesDirectory) }"
+        'eager'            | "compileJava { classpath += files(sourceSets.main.scala.classesDirectory) }"
     }
 
 }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
@@ -38,4 +38,36 @@ class ScalaCompileWithJavaLibraryIntegrationTest extends AbstractIntegrationSpec
         notExecuted(":lib:processResources", ":lib:jar")
     }
 
+    def "scala and java source directory compilation order can be reversed (task configuration #configurationStyle)"() {
+        given:
+        file("src/main/scala/Scala.scala") << "class Scala { }"
+        file("src/main/java/Java.java") << "public class Java { Scala scala = new Scala(); }"
+        buildFile << """
+            plugins {
+                id 'scala'
+            }
+            $setup
+            tasks.named('compileScala') {
+                classpath = sourceSets.main.compileClasspath
+            }
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation("org.scala-lang:scala-library:2.11.12")
+            }
+        """
+
+        when:
+        succeeds 'compileJava'
+
+        then:
+        result.assertTasksExecutedInOrder(':compileScala', ':compileJava')
+
+        where:
+        configurationStyle | setup
+        'lazy'             | "tasks.named('compileJava') { classpath += files(sourceSets.main.scala.outputDirectory) }"
+        'eager'            | "compileJava { classpath += files(sourceSets.main.scala.outputDirectory) }"
+    }
+
 }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
@@ -70,4 +70,37 @@ class ScalaCompileWithJavaLibraryIntegrationTest extends AbstractIntegrationSpec
         'eager'            | "compileJava { classpath += files(sourceSets.main.scala.classesDirectory) }"
     }
 
+    def "scala and java source directory compilation order can be reversed for a custom source set"() {
+        given:
+        file("src/mySources/scala/Scala.scala") << "class Scala { }"
+        file("src/mySources/java/Java.java") << "public class Java { Scala scala = new Scala(); }"
+        buildFile << """
+            plugins {
+                id 'scala'
+            }
+            sourceSets {
+                mySources
+            }
+
+            tasks.named('compileMySourcesJava') {
+                classpath += files(sourceSets.mySources.scala.classesDirectory)
+            }
+            tasks.named('compileMySourcesScala') {
+                classpath = sourceSets.mySources.compileClasspath
+            }
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                mySourcesImplementation("org.scala-lang:scala-library:2.11.12")
+            }
+        """
+
+        when:
+        succeeds 'compileMySourcesJava'
+
+        then:
+        result.assertTasksExecutedInOrder(':compileMySourcesScala', ':compileMySourcesJava')
+    }
+
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -187,7 +187,6 @@ public class ScalaBasePlugin implements Plugin<Project> {
         final TaskProvider<ScalaCompile> scalaCompile = project.getTasks().register(sourceSet.getCompileTaskName("scala"), ScalaCompile.class, new Action<ScalaCompile>() {
             @Override
             public void execute(ScalaCompile scalaCompile) {
-                scalaCompile.dependsOn(sourceSet.getCompileJavaTaskName());
                 JvmPluginsHelper.configureForSourceSet(sourceSet, scalaSourceSet.getScala(), scalaCompile, scalaCompile.getOptions(), project);
                 scalaCompile.setDescription("Compiles the " + scalaSourceSet.getScala() + ".");
                 scalaCompile.setSource(scalaSourceSet.getScala());

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
@@ -83,7 +83,7 @@ class ScalaBasePluginTest {
         assertThat(task, instanceOf(ScalaCompile.class))
         assertThat(task.description, equalTo('Compiles the custom Scala source.'))
         assertThat(task.classpath.files as List, equalTo([
-            customSourceSet.java.outputDir
+            customSourceSet.java.destinationDirectory.get().asFile
         ]))
         assertThat(task.source as List, equalTo(customSourceSet.scala as List))
         assertThat(task, dependsOn('compileCustomJava'))

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
@@ -65,7 +65,7 @@ class ScalaPluginTest {
         assertThat(task, instanceOf(ScalaCompile.class))
         assertThat(task.description, equalTo('Compiles the main Scala source.'))
         assertThat(task.classpath.files as List, equalTo([
-            mainSourceSet.java.outputDir
+            mainSourceSet.java.destinationDirectory.get().asFile
         ]))
         assertThat(task.source as List, equalTo(mainSourceSet.scala  as List))
         assertThat(task, dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME))
@@ -75,10 +75,10 @@ class ScalaPluginTest {
         assertThat(task, instanceOf(ScalaCompile.class))
         assertThat(task.description, equalTo('Compiles the test Scala source.'))
         assertThat(task.classpath.files as List, equalTo([
-            mainSourceSet.java.outputDir,
-            mainSourceSet.scala.outputDir,
+            mainSourceSet.java.destinationDirectory.get().asFile,
+            mainSourceSet.scala.destinationDirectory.get().asFile,
             mainSourceSet.output.resourcesDir,
-            testSourceSet.java.outputDir,
+            testSourceSet.java.destinationDirectory.get().asFile,
         ]))
         assertThat(task.source as List, equalTo(testSourceSet.scala as List))
         assertThat(task, dependsOn(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME, JavaPlugin.CLASSES_TASK_NAME))
@@ -102,8 +102,8 @@ class ScalaPluginTest {
         def testSourceSet = project.sourceSets.test
         assertThat(task, instanceOf(ScalaCompile.class))
         assertThat(task.classpath.files as List, equalTo([
-            mainSourceSet.java.outputDirectory.get().asFile,
-            mainSourceSet.scala.outputDirectory.get().asFile,
+            mainSourceSet.java.destinationDirectory.get().asFile,
+            mainSourceSet.scala.destinationDirectory.get().asFile,
             mainSourceSet.output.resourcesDir
         ]))
         assertThat(task.source as List, equalTo(testSourceSet.scala as List))

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -124,6 +124,52 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
         ].combinations()
     }
 
+    @Unroll
+    @Requires(KOTLIN_SCRIPT)
+    def 'kotlin #kotlinVersion and groovy plugins combined'() {
+        given:
+        buildFile << """
+            buildscript {
+                ext.kotlin_version = '$kotlinVersion'
+                repositories { mavenCentral() }
+                dependencies {
+                    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+                }
+            }
+            apply plugin: 'kotlin'
+            apply plugin: 'groovy'
+
+            repositories {
+                mavenCentral()
+            }
+
+            tasks.named('compileGroovy') {
+                classpath = sourceSets.main.compileClasspath
+            }
+            tasks.named('compileKotlin') {
+                classpath += files(sourceSets.main.groovy.outputDirectory)
+            }
+
+            dependencies {
+                implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+                implementation localGroovy()
+            }
+        """
+        file("src/main/groovy/Groovy.groovy") << "class Groovy { }"
+        file("src/main/kotlin/Kotlin.kt")     << "class Kotlin { val groovy = Groovy() }"
+        file("src/main/java/Java.java")       << "class Java { private Kotlin kotlin = new Kotlin(); }" // dependency to compileJava->compileKotlin is added by Kotlin plugin
+
+        when:
+        def result = build(false, 'compileJava')
+
+        then:
+        result.task(':compileJava').outcome == SUCCESS
+        result.tasks.collect { it.path } == [':compileGroovy', ':compileKotlin', ':compileJava']
+
+        where:
+        kotlinVersion << TestedVersions.kotlin.versions
+    }
+
     private BuildResult build(boolean workers, String... tasks) {
         return runner(tasks + ["--parallel", "-Pkotlin.parallel.tasks.in.project=$workers"] as String[])
             .forwardOutput()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -147,7 +147,7 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
                 classpath = sourceSets.main.compileClasspath
             }
             tasks.named('compileKotlin') {
-                classpath += files(sourceSets.main.groovy.outputDirectory)
+                classpath += files(sourceSets.main.groovy.classesDirectory)
             }
 
             dependencies {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -126,6 +126,7 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
     @Unroll
     @Requires(KOTLIN_SCRIPT)
+    @ToBeFixedForInstantExecution
     def 'kotlin #kotlinVersion and groovy plugins combined'() {
         given:
         buildFile << """


### PR DESCRIPTION
This is following up on this suggestion https://github.com/gradle/gradle/pull/11474#discussion_r351094510 to solve #11333 and in general to improve the modeling of task dependencies here.

With this change, there is no need to explicitly declare `dependsOn` between different compile tasks. 

@big-guy the behavior of `DefaultSourceDirectorySet` wrt. to defining the output directory is a bit tricky. There are two different concerns:

- Define the location which should always be reflect back to the corresponding compile task (current behavior).
- Define the "directory property" that represents the output of the compile task bound to the task itself.

This is a dependency in both directions. I ended up solving this by not deprecating anything in `DefaultSourceDirectorySet` so that `setOuputDir` can still be used to define a different location for the compile task destination. Instead I only added `getDirectoryProperty()` as a place to link the tasks output (and with that the task) to the source directory set.
In `AbstractCompile`, the old methods are deprecated.

TODOs:
- [x] document this in release notes if we go with this solution
- [x] ~decide if option to turn off default behavior #11480 is still needed (I am 50/50 on that). Otherwise document the "classpath reset" as the solution for the Kotlin/Groovy mix.~