### PR TITLE
Ignore changing modules for dependency verification

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -52,6 +52,31 @@ class DependencyVerificationIntegrityCheckIntegTest extends AbstractDependencyVe
         "sha512" | "734fce768f0e1a3aec423cb4804e5cdf343fd317418a5da1adc825256805c5cad9026a3e927ae43ecc12d378ce8f45cc3e16ade9114c9a147fda3958d357a85b"
     }
 
+    def "doesn't try to verify checksums for changing dependencies"() {
+        createMetadataFile {
+            // empty
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0-SNAPSHOT")
+        uncheckedModule("org", "bar")
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0-SNAPSHOT"
+                api("org:bar:1.0") {
+                   changing = true
+                }
+            }
+        """
+
+        when:
+        run ":compileJava"
+
+        then:
+        noExceptionThrown()
+    }
+
     @Unroll
     @ToBeFixedForInstantExecution
     def "fails verifying the file but not resolution itself if verification metadata fails for #kind"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -321,6 +321,29 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         }
     }
 
+    def "doesn't generate checksums for changing dependencies"() {
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0-SNAPSHOT")
+        uncheckedModule("org", "bar")
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0-SNAPSHOT"
+                api("org:bar:1.0") {
+                   changing = true
+                }
+            }
+        """
+
+        when:
+        writeVerificationMetadata()
+        run ":help"
+
+        then:
+        hasModules([])
+    }
+
     @ToBeFixedForInstantExecution
     def "writes checksums of plugins using plugins block"() {
         given:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -116,11 +116,18 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
             delegate.resolveArtifact(artifact, moduleSource, result);
             if (result.hasResult()) {
                 ComponentArtifactIdentifier id = artifact.getId();
-                if (isExternalArtifactId(id)) {
+                if (isExternalArtifactId(id) && isNotChanging(moduleSource)) {
                     ModuleComponentArtifactIdentifier mcai = (ModuleComponentArtifactIdentifier) id;
                     operation.onArtifact(mcai, result.getResult());
                 }
             }
+        }
+
+        private boolean isNotChanging(ModuleSource moduleSource) {
+            if (moduleSource instanceof CachingModuleComponentRepository.CachingModuleSource) {
+                return !((CachingModuleComponentRepository.CachingModuleSource) moduleSource).isChangingModule();
+            }
+            return true;
         }
 
         private boolean isExternalArtifactId(ComponentArtifactIdentifier id) {


### PR DESCRIPTION
### Context

It doesn't make sense to check changing versions or write metadata for changing versions. This commit fixes it.

