### PR TITLE
Improvements to the metrics collector API

### DIFF
--- a/subprojects/build-events/build-events.gradle.kts
+++ b/subprojects/build-events/build-events.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(library("jsr305"))
     implementation(library("guava"))
 
+    testImplementation(project(":internalTesting"))
     testImplementation(project(":modelCore"))
 
     integTestImplementation(project(":internalTesting"))

--- a/subprojects/build-events/build-events.gradle.kts
+++ b/subprojects/build-events/build-events.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":coreApi"))
     implementation(project(":core"))
+    implementation(project(":modelCore"))
     implementation(project(":toolingApi"))
 
     implementation(library("jsr305"))
@@ -38,6 +39,9 @@ dependencies {
 
     integTestImplementation(project(":internalTesting"))
     integTestImplementation(project(":internalIntegTesting"))
+    integTestImplementation(project(":logging")) {
+        because("This isn't declared as part of integtesting's API, but should be as logging's classes are in fact visible on the API")
+    }
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))
     integTestRuntimeOnly(project(":toolingApiBuilders")) {

--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -134,8 +134,8 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
             import ${BuildEventsListenerRegistry.name}
 
             def registry = project.services.get(BuildEventsListenerRegistry)
-            registry.subscribe(gradle.sharedServices.registerIfAbsent('broken', BrokenListener) { })
-            registry.subscribe(gradle.sharedServices.registerIfAbsent('listener', LoggingListener) { })
+            registry.onTaskCompletion(gradle.sharedServices.registerIfAbsent('broken', BrokenListener) { })
+            registry.onTaskCompletion(gradle.sharedServices.registerIfAbsent('listener', LoggingListener) { })
 
             task a 
             task b { dependsOn a }
@@ -175,8 +175,8 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
             import ${BuildEventsListenerRegistry.name}
 
             def registry = project.services.get(BuildEventsListenerRegistry)
-            registry.subscribe(gradle.sharedServices.registerIfAbsent('broken', BrokenListener) { })
-            registry.subscribe(gradle.sharedServices.registerIfAbsent('listener', LoggingListener) { })
+            registry.onTaskCompletion(gradle.sharedServices.registerIfAbsent('broken', BrokenListener) { })
+            registry.onTaskCompletion(gradle.sharedServices.registerIfAbsent('listener', LoggingListener) { })
 
             task a 
             task b { dependsOn a }
@@ -301,7 +301,7 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
 
                 void apply(Project project) {
                     def listener = project.gradle.sharedServices.registerIfAbsent("listener", LoggingListener) { }
-                    listenerRegistry.subscribe(listener)
+                    listenerRegistry.onTaskCompletion(listener)
                 }
             }
         """

--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsParallelIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsParallelIntegrationTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.build.event
+
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
+import org.gradle.tooling.events.task.TaskFinishEvent
+import org.junit.Rule
+
+class BuildEventsParallelIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+
+    def setup() {
+        server.start()
+    }
+
+    def "event handling does not block other work"() {
+        buildFile << """
+            import ${BuildEventsListenerRegistry.name}
+            import ${OperationCompletionListener.name}
+            import ${FinishEvent.name}
+            import ${TaskFinishEvent.name}
+            import ${BuildServiceParameters.name}
+
+            interface Params extends BuildServiceParameters {
+                Property<String> getPrefix()
+            }
+
+            abstract class BlockingListener implements OperationCompletionListener, BuildService<Params> {
+                @Override
+                void onFinish(FinishEvent event) {
+                    if (event instanceof TaskFinishEvent) {
+                        ${server.callFromBuildUsingExpression("parameters.prefix.get() + event.descriptor.taskPath")}
+                    } else {
+                        throw new IllegalArgumentException()
+                    }
+                }
+            }
+            
+            def registry = project.services.get(BuildEventsListenerRegistry)
+            registry.subscribe(gradle.sharedServices.registerIfAbsent('listener1', BlockingListener) {
+                parameters.prefix = "handle1_"
+            })
+            registry.subscribe(gradle.sharedServices.registerIfAbsent('listener2', BlockingListener) {
+                parameters.prefix = "handle2_"
+            })
+
+            task a { }
+            task b { 
+                dependsOn a
+                doFirst {
+                    ${server.callFromBuild("run_:b")}
+                }
+            } 
+        """
+
+        server.expectConcurrent("run_:b", "handle1_:a", "handle2_:a")
+        server.expectConcurrent("handle1_:b", "handle2_:b")
+
+        when:
+        run("b")
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsParallelIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsParallelIntegrationTest.groovy
@@ -56,10 +56,10 @@ class BuildEventsParallelIntegrationTest extends AbstractIntegrationSpec {
             }
             
             def registry = project.services.get(BuildEventsListenerRegistry)
-            registry.subscribe(gradle.sharedServices.registerIfAbsent('listener1', BlockingListener) {
+            registry.onTaskCompletion(gradle.sharedServices.registerIfAbsent('listener1', BlockingListener) {
                 parameters.prefix = "handle1_"
             })
-            registry.subscribe(gradle.sharedServices.registerIfAbsent('listener2', BlockingListener) {
+            registry.onTaskCompletion(gradle.sharedServices.registerIfAbsent('listener2', BlockingListener) {
                 parameters.prefix = "handle2_"
             })
 

--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/InternalBuildOperationEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/InternalBuildOperationEventsIntegrationTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.build.event
+
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.InstantExecutionRunner
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.BuildOperationListener
+import org.gradle.internal.operations.OperationFinishEvent
+import org.gradle.internal.operations.OperationIdentifier
+import org.gradle.internal.operations.OperationProgressEvent
+import org.gradle.internal.operations.OperationStartEvent
+import org.junit.runner.RunWith
+
+@RunWith(InstantExecutionRunner)
+class InternalBuildOperationEventsIntegrationTest extends AbstractIntegrationSpec {
+    def "init script can inject listener via use internal API to subscribe to build operation events"() {
+        def initScript = file("init.gradle") << """
+            import ${BuildEventsListenerRegistry.name}
+            import ${BuildOperationListener.name}
+            import ${BuildOperationDescriptor.name}
+            import ${OperationStartEvent.name}
+            import ${OperationFinishEvent.name}
+            import ${OperationProgressEvent.name}
+            import ${OperationIdentifier.name}
+            import ${ExecuteTaskBuildOperationType.name}
+            import ${BuildServiceParameters.name}
+
+            abstract class LoggingListener implements BuildOperationListener, BuildService<BuildServiceParameters.None> {
+                void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+                    throw new RuntimeException()
+                }
+                void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
+                    throw new RuntimeException()
+                }
+                void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+                    if (buildOperation.details instanceof ExecuteTaskBuildOperationType.Details) {
+                        println("EVENT: " + buildOperation.details)
+                    }
+                }
+            }
+
+            def listener = gradle.sharedServices.registerIfAbsent("listener", LoggingListener) { } 
+
+            def registry = services.get(BuildEventsListenerRegistry)
+            registry.onOperationCompletion(listener)
+        """
+
+        buildFile << """
+            task a
+            task b
+        """
+        executer.beforeExecute {
+            usingInitScript(initScript)
+        }
+
+        when:
+        run("a")
+
+        then:
+        output.count("EVENT:") == 1
+
+        when:
+        run("a")
+
+        then:
+        output.count("EVENT:") == 1
+
+        when:
+        run("a", "b")
+
+        then:
+        output.count("EVENT:") == 2
+
+        when:
+        run("a", "b")
+
+        then:
+        output.count("EVENT:") == 2
+    }
+}

--- a/subprojects/build-events/src/main/java/org/gradle/build/event/BuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/build/event/BuildEventsListenerRegistry.java
@@ -21,7 +21,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.tooling.events.OperationCompletionListener;
 
 /**
- * Allows a plugin to receive information about the operations that run as part of the current build.
+ * Allows a plugin to receive information about the operations that run within a build.
  *
  * <p>An instance of this registry can be injected into tasks, plugins and other objects by annotating a public constructor or property getter method with {@code javax.inject.Inject}.</p>
  *
@@ -30,7 +30,14 @@ import org.gradle.tooling.events.OperationCompletionListener;
 @Incubating
 public interface BuildEventsListenerRegistry {
     /**
-     * Subscribes the given listener to operation finish events, if not already subscribed. The listener receives events as each operation completes.
+     * Subscribes the given listener to the finish events for tasks, if not already subscribed. The listener receives events as each task completes.
+     *
+     * <p>The events are delivered to the listener one at a time, so the implementation does not need to be thread-safe. Also, events are delivered to the listener concurrently with
+     * task execution and other work, so event handling does not block task execution. This means that a task finish event is delivered to the listener some time "soon" after the task
+     * has completed. The events contain timestamps to allow you collect timing information.
+     * </p>
+     *
+     * @param listener The listener to receive events. This must be a {@link org.gradle.api.services.BuildService} instance, see {@link org.gradle.api.services.BuildServiceRegistry}.
      */
-    void subscribe(Provider<? extends OperationCompletionListener> listener);
+    void onTaskCompletion(Provider<? extends OperationCompletionListener> listener);
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
@@ -18,9 +18,17 @@ package org.gradle.internal.build.event;
 
 import org.gradle.api.provider.Provider;
 import org.gradle.build.event.BuildEventsListenerRegistry;
+import org.gradle.internal.operations.BuildOperationListener;
 
 import java.util.List;
 
 public interface BuildEventListenerRegistryInternal extends BuildEventsListenerRegistry {
+    /**
+     * Subscribes the given listener to build operation completion events. Note that no start events are forwarded to the listener.
+     */
+    void onOperationCompletion(Provider<? extends BuildOperationListener> provider);
+
+    void subscribe(Provider<?> provider);
+
     List<Provider<?>> getSubscriptions();
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -17,14 +17,16 @@
 package org.gradle.internal.build.event;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.internal.GradleInternal;
+import org.gradle.BuildAdapter;
+import org.gradle.BuildResult;
 import org.gradle.api.provider.Provider;
 import org.gradle.build.event.BuildEventsListenerRegistry;
 import org.gradle.initialization.BuildEventConsumer;
-import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.event.types.DefaultTaskFinishedProgressEvent;
 import org.gradle.internal.concurrent.CompositeStoppable;
+import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.BuildOperationListenerManager;
@@ -45,6 +47,10 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRegistry, BuildEventListenerRegistryInternal {
     private final List<BuildEventListenerFactory> factories;
@@ -52,11 +58,14 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     private final BuildOperationListenerManager buildOperationListenerManager;
     private final Map<Provider<?>, ForwardingBuildEventConsumer> subscriptions = new LinkedHashMap<>();
     private final List<Object> listeners = new ArrayList<>();
+    private final ExecutorFactory executorFactory;
 
-    public DefaultBuildEventsListenerRegistry(List<BuildEventListenerFactory> factories, ListenerManager listenerManager, BuildOperationListenerManager buildOperationListenerManager) {
+    public DefaultBuildEventsListenerRegistry(List<BuildEventListenerFactory> factories, ListenerManager listenerManager,
+                                              BuildOperationListenerManager buildOperationListenerManager, ExecutorFactory executorFactory) {
         this.factories = factories;
         this.listenerManager = listenerManager;
         this.buildOperationListenerManager = buildOperationListenerManager;
+        this.executorFactory = executorFactory;
         listenerManager.addListener(new ListenerCleanup());
     }
 
@@ -73,7 +82,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         // TODO - deliver events asynchronously
         // TODO - reuse the listeners
 
-        ForwardingBuildEventConsumer consumer = new ForwardingBuildEventConsumer(listenerProvider);
+        ForwardingBuildEventConsumer consumer = new ForwardingBuildEventConsumer(listenerProvider, executorFactory);
         subscriptions.put(listenerProvider, consumer);
 
         BuildEventSubscriptions eventSubscriptions = new BuildEventSubscriptions(Collections.singleton(OperationType.TASK));
@@ -90,51 +99,73 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     }
 
     private static class ForwardingBuildEventConsumer implements BuildEventConsumer, Closeable {
+        private static final Object END = new Object();
         private final Provider<? extends OperationCompletionListener> listenerProvider;
-        private Exception failure;
+        private final ManagedExecutor executor;
+        private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
+        private final AtomicReference<Exception> failure = new AtomicReference<>();
 
-        public ForwardingBuildEventConsumer(Provider<? extends OperationCompletionListener> listenerProvider) {
+        public ForwardingBuildEventConsumer(Provider<? extends OperationCompletionListener> listenerProvider, ExecutorFactory executorFactory) {
             this.listenerProvider = listenerProvider;
+            this.executor = executorFactory.create("build event listener");
+            executor.submit(this::run);
+        }
+
+        private void run() {
+            while (true) {
+                Object next;
+                try {
+                    next = events.take();
+                } catch (InterruptedException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+                if (next == END) {
+                    return;
+                }
+                // TODO - reuse adapters from tooling api client
+                InternalProgressEvent event = (InternalProgressEvent) next;
+                if (event instanceof DefaultTaskFinishedProgressEvent) {
+                    DefaultTaskFinishedProgressEvent providerEvent = (DefaultTaskFinishedProgressEvent) event;
+                    InternalTaskDescriptor providerDescriptor = providerEvent.getDescriptor();
+                    InternalTaskResult providerResult = providerEvent.getResult();
+                    DefaultTaskOperationDescriptor descriptor = new DefaultTaskOperationDescriptor(providerDescriptor, null, providerDescriptor.getTaskPath());
+                    TaskOperationResult result = BuildProgressListenerAdapter.toTaskResult(providerResult);
+                    DefaultTaskFinishEvent finishEvent = new DefaultTaskFinishEvent(event.getEventTime(), event.getDisplayName(), descriptor, result);
+                    try {
+                        listenerProvider.get().onFinish(finishEvent);
+                    } catch (Exception e) {
+                        failure.set(e);
+                        break;
+                    }
+                }
+            }
+            // A failure has happened. Drain the queue and complete without waiting. There should no more messages added to the queue
+            // as the dispatch method will see the failure
+            events.clear();
         }
 
         @Override
         public void dispatch(Object message) {
-            if (failure != null) {
-                return;
+            if (failure.get() == null) {
+                events.add(message);
             }
-
-            // TODO - reuse adapters from tooling api client
-            InternalProgressEvent event = (InternalProgressEvent) message;
-            if (event instanceof DefaultTaskFinishedProgressEvent) {
-                DefaultTaskFinishedProgressEvent providerEvent = (DefaultTaskFinishedProgressEvent) event;
-                InternalTaskDescriptor providerDescriptor = providerEvent.getDescriptor();
-                InternalTaskResult providerResult = providerEvent.getResult();
-                DefaultTaskOperationDescriptor descriptor = new DefaultTaskOperationDescriptor(providerDescriptor, null, providerDescriptor.getTaskPath());
-                TaskOperationResult result = BuildProgressListenerAdapter.toTaskResult(providerResult);
-                DefaultTaskFinishEvent finishEvent = new DefaultTaskFinishEvent(event.getEventTime(), event.getDisplayName(), descriptor, result);
-                try {
-                    listenerProvider.get().onFinish(finishEvent);
-                } catch (Exception e) {
-                    failure = e;
-                }
-            }
+            // else, the handler thread is no longer handling messages so discard it
         }
 
         @Override
         public void close() {
+            events.add(END);
+            executor.stop(60, TimeUnit.SECONDS);
+            Exception failure = this.failure.get();
             if (failure != null) {
                 throw UncheckedException.throwAsUncheckedException(failure);
             }
         }
     }
 
-    private class ListenerCleanup implements RootBuildLifecycleListener {
+    private class ListenerCleanup extends BuildAdapter {
         @Override
-        public void afterStart(GradleInternal gradle) {
-        }
-
-        @Override
-        public void beforeComplete(GradleInternal gradle) {
+        public void buildFinished(BuildResult result) {
             // TODO - maybe make this registry a build scoped service
             try {
                 for (Object listener : listeners) {

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -22,7 +22,9 @@ import org.gradle.api.provider.Provider;
 import org.gradle.build.event.BuildEventsListenerRegistry;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.initialization.RootBuildLifecycleListener;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.event.types.DefaultTaskFinishedProgressEvent;
+import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.BuildOperationListenerManager;
@@ -37,17 +39,18 @@ import org.gradle.tooling.internal.protocol.events.InternalTaskDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalTaskResult;
 import org.gradle.util.CollectionUtils;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRegistry, BuildEventListenerRegistryInternal {
     private final List<BuildEventListenerFactory> factories;
     private final ListenerManager listenerManager;
     private final BuildOperationListenerManager buildOperationListenerManager;
-    private final Set<Provider<?>> subscriptions = new LinkedHashSet<>();
+    private final Map<Provider<?>, ForwardingBuildEventConsumer> subscriptions = new LinkedHashMap<>();
     private final List<Object> listeners = new ArrayList<>();
 
     public DefaultBuildEventsListenerRegistry(List<BuildEventListenerFactory> factories, ListenerManager listenerManager, BuildOperationListenerManager buildOperationListenerManager) {
@@ -59,19 +62,20 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
 
     @Override
     public List<Provider<?>> getSubscriptions() {
-        return ImmutableList.copyOf(subscriptions);
+        return ImmutableList.copyOf(subscriptions.keySet());
     }
 
     @Override
     public void subscribe(Provider<? extends OperationCompletionListener> listenerProvider) {
-        if (!subscriptions.add(listenerProvider)) {
+        if (subscriptions.containsKey(listenerProvider)) {
             return;
         }
-
         // TODO - deliver events asynchronously
         // TODO - reuse the listeners
 
         ForwardingBuildEventConsumer consumer = new ForwardingBuildEventConsumer(listenerProvider);
+        subscriptions.put(listenerProvider, consumer);
+
         BuildEventSubscriptions eventSubscriptions = new BuildEventSubscriptions(Collections.singleton(OperationType.TASK));
         for (BuildEventListenerFactory registration : factories) {
             Iterable<Object> listeners = registration.createListeners(eventSubscriptions, consumer);
@@ -85,8 +89,9 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         }
     }
 
-    private static class ForwardingBuildEventConsumer implements BuildEventConsumer {
+    private static class ForwardingBuildEventConsumer implements BuildEventConsumer, Closeable {
         private final Provider<? extends OperationCompletionListener> listenerProvider;
+        private Exception failure;
 
         public ForwardingBuildEventConsumer(Provider<? extends OperationCompletionListener> listenerProvider) {
             this.listenerProvider = listenerProvider;
@@ -94,15 +99,31 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
 
         @Override
         public void dispatch(Object message) {
+            if (failure != null) {
+                return;
+            }
+
             // TODO - reuse adapters from tooling api client
             InternalProgressEvent event = (InternalProgressEvent) message;
             if (event instanceof DefaultTaskFinishedProgressEvent) {
-                DefaultTaskFinishedProgressEvent finishEvent = (DefaultTaskFinishedProgressEvent) event;
-                InternalTaskDescriptor providerDescriptor = finishEvent.getDescriptor();
-                InternalTaskResult providerResult = finishEvent.getResult();
+                DefaultTaskFinishedProgressEvent providerEvent = (DefaultTaskFinishedProgressEvent) event;
+                InternalTaskDescriptor providerDescriptor = providerEvent.getDescriptor();
+                InternalTaskResult providerResult = providerEvent.getResult();
                 DefaultTaskOperationDescriptor descriptor = new DefaultTaskOperationDescriptor(providerDescriptor, null, providerDescriptor.getTaskPath());
                 TaskOperationResult result = BuildProgressListenerAdapter.toTaskResult(providerResult);
-                listenerProvider.get().onFinish(new DefaultTaskFinishEvent(event.getEventTime(), event.getDisplayName(), descriptor, result));
+                DefaultTaskFinishEvent finishEvent = new DefaultTaskFinishEvent(event.getEventTime(), event.getDisplayName(), descriptor, result);
+                try {
+                    listenerProvider.get().onFinish(finishEvent);
+                } catch (Exception e) {
+                    failure = e;
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            if (failure != null) {
+                throw UncheckedException.throwAsUncheckedException(failure);
             }
         }
     }
@@ -115,14 +136,18 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         @Override
         public void beforeComplete(GradleInternal gradle) {
             // TODO - maybe make this registry a build scoped service
-            for (Object listener : listeners) {
-                listenerManager.removeListener(listener);
-                if (listener instanceof BuildOperationListener) {
-                    buildOperationListenerManager.removeListener((BuildOperationListener) listener);
+            try {
+                for (Object listener : listeners) {
+                    listenerManager.removeListener(listener);
+                    if (listener instanceof BuildOperationListener) {
+                        buildOperationListenerManager.removeListener((BuildOperationListener) listener);
+                    }
                 }
+                CompositeStoppable.stoppable(subscriptions.values()).stop();
+            } finally {
+                listeners.clear();
+                subscriptions.clear();
             }
-            listeners.clear();
-            subscriptions.clear();
         }
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceRegistry.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/services/BuildServiceRegistry.java
@@ -37,7 +37,7 @@ public interface BuildServiceRegistry {
     NamedDomainObjectSet<BuildServiceRegistration<?, ?>> getRegistrations();
 
     /**
-     * Registers a service, if a service with the given name is not already registered. The service is not created until required.
+     * Registers a service, if a service with the given name is not already registered. The service is not created until required, when the returned {@link Provider} is queried.
      *
      * @param name A name to use to identify the service.
      * @param implementationType The service implementation type. Instances of the service are created as for {@link org.gradle.api.model.ObjectFactory#newInstance(Class, Object...)}.

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/concurrent/TestManagedExecutor.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/concurrent/TestManagedExecutor.groovy
@@ -72,7 +72,7 @@ class TestManagedExecutor extends AbstractExecutorService implements ManagedExec
     }
 
     void stop(int timeoutValue, TimeUnit timeoutUnits) throws IllegalStateException {
-        throw new UnsupportedOperationException()
+        stop()
     }
 
     void shutdown() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -553,7 +553,7 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
         }
     }
 
-    private static TaskOperationResult toTaskResult(InternalTaskResult result) {
+    public static TaskOperationResult toTaskResult(InternalTaskResult result) {
         if (result instanceof InternalTaskSuccessResult) {
             InternalTaskSuccessResult successResult = (InternalTaskSuccessResult) result;
             if (result instanceof InternalJavaCompileTaskOperationResult) {


### PR DESCRIPTION

### Context

Some improvements to the metrics collector APIs added in #11475:

- Include the correct task result in the finish events delivered to listeners.
- Deliver events to listeners in parallel with other work, so that event handling does not block task execution or other scheduled work, or other listeners.
- Tweak the API to explicitly constrain it to task execution events for now.

Also, add an internal method to allow build logic to subscribe to build operation completion events. This is intended to be used by gradle-profiler as a more reliable way to collect these events, and which takes advantage of the benefits of the new infrastructure (eg supported with instant execution, parallel event handling, lifecycling, etc). At some point, we might enrich the tooling API events and gradle-profiler can use the public API instead of this internal method.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
