### PR TITLE
Fix bug of DefaultFileHierarchySet on Windows

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
@@ -167,8 +167,13 @@ public class DefaultFileHierarchySet {
                 }
             }
             String commonPrefix = prefix.substring(0, prefixLen);
-            Node newThis = new Node(prefix.substring(prefixLen + 1), children);
-            Node sibling = new Node(path.substring(prefixLen + 1));
+
+            // On windows the common prefix can be 0
+            // For example, new Node("C:").plus("D:")
+            int newChildrenStartIndex = (prefixLen == 0) ? 0 : prefixLen + 1;
+
+            Node newThis = new Node(prefix.substring(newChildrenStartIndex), children);
+            Node sibling = new Node(path.substring(newChildrenStartIndex));
             return new Node(commonPrefix, ImmutableList.of(newThis, sibling));
         }
 
@@ -182,6 +187,10 @@ public class DefaultFileHierarchySet {
          * which does not check for negative indices or integer overflow.
          */
         boolean isChildOfOrThis(String filePath, int offset) {
+            if (prefix.isEmpty()) {
+                return true;
+            }
+
             int pathLength = filePath.length();
             int prefixLength = prefix.length();
             int endOfThisSegment = prefixLength + offset;
@@ -204,7 +213,7 @@ public class DefaultFileHierarchySet {
                 return true;
             }
 
-            int startNextSegment = offset + prefix.length() + 1;
+            int startNextSegment = prefix.isEmpty() ? offset : offset + prefix.length() + 1;
             for (Node child : children) {
                 if (child.contains(filePath, startNextSegment)) {
                     return true;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
@@ -132,7 +132,7 @@ public class DefaultFileHierarchySet {
         Node plus(String path) {
             int maxPos = Math.min(prefix.length(), path.length());
             int prefixLen = sizeOfCommonPrefix(path, 0);
-            if (prefixLen == maxPos && prefixLen != 0) {
+            if (prefixLen == maxPos) {
                 if (prefix.length() == path.length()) {
                     // Path == prefix
                     if (children.isEmpty()) {
@@ -145,7 +145,7 @@ public class DefaultFileHierarchySet {
                     if (children.isEmpty()) {
                         return this;
                     }
-                    int startNextSegment = prefix.length() + 1;
+                    int startNextSegment = (prefixLen == 0) ? 0 : prefixLen + 1;
                     List<Node> merged = new ArrayList<Node>(children.size() + 1);
                     boolean matched = false;
                     for (Node child : children) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/file/DefaultFileHierarchySet.java
@@ -132,7 +132,7 @@ public class DefaultFileHierarchySet {
         Node plus(String path) {
             int maxPos = Math.min(prefix.length(), path.length());
             int prefixLen = sizeOfCommonPrefix(path, 0);
-            if (prefixLen == maxPos) {
+            if (prefixLen == maxPos && prefixLen != 0) {
                 if (prefix.length() == path.length()) {
                     // Path == prefix
                     if (children.isEmpty()) {
@@ -168,8 +168,6 @@ public class DefaultFileHierarchySet {
             }
             String commonPrefix = prefix.substring(0, prefixLen);
 
-            // On windows the common prefix can be 0
-            // For example, new Node("C:").plus("D:")
             int newChildrenStartIndex = (prefixLen == 0) ? 0 : prefixLen + 1;
 
             Node newThis = new Node(prefix.substring(newChildrenStartIndex), children);

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/file/DefaultFileHierarchySetTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/file/DefaultFileHierarchySetTest.groovy
@@ -46,6 +46,7 @@ class DefaultFileHierarchySetTest extends Specification {
         !set.contains(tmpDir.file("any"))
     }
 
+
     def "creates from collection containing single file"() {
         def dir = tmpDir.createDir("dir")
 
@@ -134,18 +135,24 @@ class DefaultFileHierarchySetTest extends Specification {
         DefaultFileHierarchySet.of(pathList.collect { new File(it) }).contains(target) == result
 
         where:
-        pathList                  | target               | result
-        ['/var', '/home']         | '/usr'               | false
-        ['/var', '/home']         | '/var'               | true
-        ['/var', '/home']         | '/home'              | true
-        ['/var', '/home', '/usr'] | '/home'              | true
-        ['/var', '/home', '/usr'] | '/usr'               | true
-        ['/var', '/home', '/usr'] | '/bin'               | false
-        ['/var/log', '/home/my']  | '/var/log'           | true
-        ['/var/log', '/home/my']  | '/home/my/documents' | true
-        ['/var', '/var/log']      | '/var/log/kern.log'  | true
-        ['/var', '/var/log']      | '/var/other'         | true
-        ['/var', '/var/log']      | '/home'              | false
+        pathList                       | target               | result
+        ['/var', '/home']              | '/usr'               | false
+        ['/var/log', '/var/home', '/'] | '/usr'               | true
+        ['/', '/home']                 | '/'                  | true
+        ['/home', '/']                 | '/'                  | true
+        ['/home', '/']                 | '/home'              | true
+        ['/', '/home']                 | '/home'              | true
+        ['/', '/']                     | '/'                  | true
+        ['/var', '/home']              | '/var'               | true
+        ['/var', '/home']              | '/home'              | true
+        ['/var', '/home', '/usr']      | '/home'              | true
+        ['/var', '/home', '/usr']      | '/usr'               | true
+        ['/var', '/home', '/usr']      | '/bin'               | false
+        ['/var/log', '/home/my']       | '/var/log'           | true
+        ['/var/log', '/home/my']       | '/home/my/documents' | true
+        ['/var', '/var/log']           | '/var/log/kern.log'  | true
+        ['/var', '/var/log']           | '/var/other'         | true
+        ['/var', '/var/log']           | '/home'              | false
     }
 
     def "can add dir to empty set"() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/file/DefaultFileHierarchySetTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/file/DefaultFileHierarchySetTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Issue
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class DefaultFileHierarchySetTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
@@ -101,6 +102,25 @@ class DefaultFileHierarchySetTest extends Specification {
         expect:
         def set = DefaultFileHierarchySet.of(Arrays.asList(File.listRoots()))
         set.contains(tmpDir.file("any"))
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    @Unroll
+    def 'can handle more root dirs'() {
+        expect:
+        DefaultFileHierarchySet.of([new File(path1), new File(path2)]).contains(target) == result
+
+        where:
+        path1      | path2      | target            | result
+        'C:\\'     | 'D:\\'     | 'C:\\'            | true
+        'C:\\'     | 'D:\\'     | 'D:\\'            | true
+        'C:\\'     | 'D:\\'     | 'C:\\any'         | true
+        'C:\\'     | 'D:\\'     | 'D:\\any'         | true
+        'C:\\'     | 'D:\\'     | 'E:\\any'         | false
+        'C:\\'     | 'C:\\any'  | 'C:\\any\\thing'  | true
+        'C:\\'     | 'C:\\any'  | 'E:\\any\\thing'  | false
+        'C:\\any1' | 'D:\\any2' | 'C:\\any1\\thing' | true
+        'C:\\any1' | 'D:\\any2' | 'D:\\any2\\thing' | true
     }
 
     def "can add dir to empty set"() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/11508

### Context

Previously `DefaultFileHierarchySet` doesn't handle windows root directory `C:\`/`D:\` correctly, which results in test failures on windows agents with more than one disk.

This PR fixes this corner case.