### PR TITLE
Update test error code for Win10

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
@@ -254,7 +254,7 @@ class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
                 // We expect AttachConsole to fail with a particular error if the
                 // provided pid is not attached to a console
                 if (!AttachConsole(pid)) {
-                    if (GetLastError() == ERROR_GEN_FAILURE) {
+                    if (GetLastError() == ERROR_GEN_FAILURE || GetLastError() == ERROR_INVALID_HANDLE) {
                         printf("none\\n");
                         exit(0);
                     } else {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/ProcessCrashHandlingIntegrationTest.groovy
@@ -253,6 +253,9 @@ class ProcessCrashHandlingIntegrationTest extends DaemonIntegrationSpec {
 
                 // We expect AttachConsole to fail with a particular error if the
                 // provided pid is not attached to a console
+                // when pid is not attached to console, GetLastError(pid) returns:
+                // ERROR_GEN_FAILURE on Win7
+                // ERROR_INVALID_HANDLE on Win10
                 if (!AttachConsole(pid)) {
                     if (GetLastError() == ERROR_GEN_FAILURE || GetLastError() == ERROR_INVALID_HANDLE) {
                         printf("none\\n");


### PR DESCRIPTION
### Context
Update an integration test to be compatible with Windows10.
`AttachConsole` Windows API method returns `ERROR_INVALID_HANDLE` when the given PID is not attached to the console as per https://docs.microsoft.com/en-us/windows/console/attachconsole