### PR TITLE
Fix https://github.com/gradle/gradle/issues/11490

### DIFF
--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/BaseForkOptions.java
@@ -15,13 +15,15 @@
  */
 package org.gradle.api.tasks.compile;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Fork options for compilation. Only take effect if {@code fork}
@@ -34,7 +36,7 @@ public class BaseForkOptions extends AbstractOptions {
 
     private String memoryMaximumSize;
 
-    private List<String> jvmArgs = Lists.newArrayList();
+    private List<String> jvmArgs = new ArrayList<>();
 
     /**
      * Returns the initial heap size for the compiler process.
@@ -83,10 +85,15 @@ public class BaseForkOptions extends AbstractOptions {
 
     /**
      * Sets any additional JVM arguments for the compiler process.
-     * Defaults to the empty list.
+     * Defaults to the empty list. Empty or null arguments are filtered out because they cause
+     * JVM Launch to fail.
      */
     public void setJvmArgs(@Nullable List<String> jvmArgs) {
-        this.jvmArgs = jvmArgs;
+        this.jvmArgs = jvmArgs == null ? null : jvmArgs.stream()
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(string -> !string.isEmpty())
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/subprojects/language-jvm/src/test/groovy/org/gradle/api/tasks/compile/BaseForkOptionsTest.groovy
+++ b/subprojects/language-jvm/src/test/groovy/org/gradle/api/tasks/compile/BaseForkOptionsTest.groovy
@@ -19,24 +19,24 @@ package org.gradle.api.tasks.compile
 import spock.lang.Specification
 
 public class BaseForkOptionsTest extends Specification {
-    def "JVM options are filtered properly even with bad input"() {
+    def 'JVM options are filtered properly even with bad input'() {
 	    def options = new BaseForkOptions()
 
-        options.jvmArgs = ["","",""]
+        options.jvmArgs = ['', '', '']
 
         expect:
         options.jvmArgs.isEmpty()
     }
 
-    def "JVM options are preserved if they're not bad"() {
+    def 'JVM options are preserved if they are not bad'() {
         def options = new BaseForkOptions()
 
-        options.jvmArgs = ["x", "", "y"]
+        options.jvmArgs = ['x', '', 'y']
 
         expect:
         options.jvmArgs.size() == 2
-        options.jvmArgs[0] == "x"
-        options.jvmArgs[1] == "y"
+        options.jvmArgs[0] == 'x'
+        options.jvmArgs[1] == 'y'
     }
 }
 

--- a/subprojects/language-jvm/src/test/groovy/org/gradle/api/tasks/compile/BaseForkOptionsTest.groovy
+++ b/subprojects/language-jvm/src/test/groovy/org/gradle/api/tasks/compile/BaseForkOptionsTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.tasks.compile
+
+
+import spock.lang.Specification
+
+public class BaseForkOptionsTest extends Specification {
+    def "JVM options are filtered properly even with bad input"() {
+	    def options = new BaseForkOptions()
+
+        options.jvmArgs = ["","",""]
+
+        expect:
+        options.jvmArgs.isEmpty()
+    }
+
+    def "JVM options are preserved if they're not bad"() {
+        def options = new BaseForkOptions()
+
+        options.jvmArgs = ["x", "", "y"]
+
+        expect:
+        options.jvmArgs.size() == 2
+        options.jvmArgs[0] == "x"
+        options.jvmArgs[1] == "y"
+    }
+}
+


### PR DESCRIPTION
<!--- The issue this PR addresses -->
https://github.com/gradle/gradle/issues/11490

### Context
<!--- Why do you believe many users will benefit from this change? -->
Users will not receive errors when they inadvertently pass empty or null values as part of the jvmArgs. Instead, the valid arguments will be used.
<!--- Link to relevant issues or forum discussions here -->
https://github.com/gradle/gradle/issues/4689 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
