### PR TITLE
Add separate experimental project without cache

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -94,17 +94,7 @@ data class CIBuildModel(
                 TestCoverage(16, TestType.quick, Os.linux, JvmCategory.EXPERIMENTAL_VERSION.version, vendor = JvmCategory.EXPERIMENTAL_VERSION.vendor),
                 TestCoverage(17, TestType.quick, Os.windows, JvmCategory.EXPERIMENTAL_VERSION.version, vendor = JvmCategory.EXPERIMENTAL_VERSION.vendor),
                 TestCoverage(18, TestType.platform, Os.linux, JvmCategory.EXPERIMENTAL_VERSION.version, vendor = JvmCategory.EXPERIMENTAL_VERSION.vendor),
-                TestCoverage(19, TestType.platform, Os.windows, JvmCategory.EXPERIMENTAL_VERSION.version, vendor = JvmCategory.EXPERIMENTAL_VERSION.vendor))),
-        Stage(StageNames.WINDOWS_10_EVALUATION_QUICK,
-            trigger = Trigger.never,
-            runsIndependent = true,
-            functionalTests = listOf(
-                TestCoverage(20, TestType.quick, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))),
-        Stage(StageNames.WINDOWS_10_EVALUATION_PLATFORM,
-            trigger = Trigger.never,
-            runsIndependent = true,
-            functionalTests = listOf(
-                TestCoverage(21, TestType.platform, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)))
+                TestCoverage(19, TestType.platform, Os.windows, JvmCategory.EXPERIMENTAL_VERSION.version, vendor = JvmCategory.EXPERIMENTAL_VERSION.vendor)))
     ),
 
     val subProjects: List<GradleSubproject> = listOf(

--- a/.teamcity/Gradle_Experimental/settings.kts
+++ b/.teamcity/Gradle_Experimental/settings.kts
@@ -1,0 +1,53 @@
+package Gradle_Experimental
+
+import common.JvmCategory
+import common.NoBuildCache
+import common.Os
+import jetbrains.buildServer.configs.kotlin.v2018_2.project
+import jetbrains.buildServer.configs.kotlin.v2018_2.version
+import model.CIBuildModel
+import model.Stage
+import model.StageNames
+import model.TestCoverage
+import model.TestType
+import model.Trigger
+import projects.RootProject
+
+/*
+The settings script is an entry point for defining a single
+TeamCity project. TeamCity looks for the 'settings.kts' file in a
+project directory and runs it if it's found, so the script name
+shouldn't be changed and its package should be the same as the
+project's external id.
+
+The script should contain a single call to the project() function
+with a Project instance or an init function as an argument, you
+can also specify both of them to refine the specified Project in
+the init function.
+
+VcsRoots, BuildTypes, and Templates of this project must be
+registered inside project using the vcsRoot(), buildType(), and
+template() methods respectively.
+
+Subprojects can be defined either in their own settings.kts or by
+calling the subProjects() method in this project.
+*/
+
+version = "2019.1"
+project(RootProject(CIBuildModel(
+    buildScanTags = listOf("Check"),
+    projectPrefix = "Gradle_Experimental_NoBuildCache",
+    parentBuildCache = NoBuildCache,
+    childBuildCache = NoBuildCache,
+    stages = listOf(
+        Stage(StageNames.WINDOWS_10_EVALUATION_QUICK,
+            trigger = Trigger.never,
+            runsIndependent = true,
+            functionalTests = listOf(
+                TestCoverage(20, TestType.quick, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))),
+        Stage(StageNames.WINDOWS_10_EVALUATION_PLATFORM,
+            trigger = Trigger.never,
+            runsIndependent = true,
+            functionalTests = listOf(
+                TestCoverage(21, TestType.platform, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)))
+    ))))

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -215,9 +215,7 @@ class CIConfigIntegrationTests {
             "Gradle_Check_Stage_MasterAccept_Trigger" to "createBuildReceipt updateBranchStatus",
             "Gradle_Check_Stage_ReleaseAccept_Trigger" to "createBuildReceipt",
             "Gradle_Check_Stage_HistoricalPerformance_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_Experimental_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_ExperimentalWindows10quick_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_ExperimentalWindows10platform_Trigger" to "createBuildReceipt"),
+            "Gradle_Check_Stage_Experimental_Trigger" to "createBuildReceipt"),
             triggerNameToTasks)
     }
 


### PR DESCRIPTION
At the moment build cache is configured per TC project and not per stage.
This change creates a separate project with experimental Windows10 build stages that has the build cache disabled.
When Windows10 agents are ready to replace Windows7, the experimental project should be removed.

Perhaps it also makes sense to have a ticket to refactor the CI model and allow to toggle build cache per stage and not per project.