### PR TITLE
Add lenient version of ComponentMetadataDetails.addVariant()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 
@@ -104,6 +105,20 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      * @since 6.0
      */
     void addVariant(String name, String base, Action<? super VariantMetadata> action);
+
+    /**
+     * This is the lenient version of {@link #addVariant(String, String, Action)}.
+     * The only difference is that this will do nothing (instead of throwing an error), if the 'base' variant does not exist for a component.
+     * This is particularly useful for rules that are applied to {@link org.gradle.api.artifacts.dsl.ComponentMetadataHandler#all(Class)} components.
+     *
+     * @param name a name for the variant
+     * @param base name of the variant (pom or Gradle module metadata) or configuration (ivy.xml metadata) from which the new variant will be initialized
+     * @param action the action to populate the variant
+     *
+     * @since 6.1
+     */
+    @Incubating
+    void maybeAddVariant(String name, String base, Action<? super VariantMetadata> action);
 
     /**
      * Declares that this component belongs to a virtual platform, which should be

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -40,8 +40,6 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                 MissingJdk8VariantRule(String base) {
                     this.base = base
                 }
-                @javax.inject.Inject
-                ObjectFactory getObjects() { }
                 void execute(ComponentMetadataContext context) {
                     context.details.addVariant('jdk8Runtime', base) {
                         attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8) }
@@ -53,8 +51,6 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                 }
             }
             class MissingJdk8VariantRuleWithoutBase implements ComponentMetadataRule {
-                @javax.inject.Inject
-                ObjectFactory getObjects() { }
                 void execute(ComponentMetadataContext context) {
                     context.details.addVariant('jdk8Runtime') {
                         attributes { attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8) }
@@ -75,8 +71,6 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                     this.type = type
                     this.url = url
                 }
-                @javax.inject.Inject
-                ObjectFactory getObjects() { }
                 void execute(ComponentMetadataContext context) {
                     context.details.withVariant('runtime') {
                         withFiles {
@@ -88,6 +82,35 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                         }
                     }
                 }
+            }
+
+            class DirectMetadataAccessVariantRule implements ComponentMetadataRule {
+                @javax.inject.Inject
+                ObjectFactory getObjects() { }
+
+                void execute(ComponentMetadataContext context) {
+                    def id = context.details.id
+                    context.details.maybeAddVariant("apiElementsWithMetadata", "api") {
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "all-files"))
+                        }
+                        withFiles {
+                            addFile("\${id.name}-\${id.version}.pom")
+                            addFile("\${id.name}-\${id.version}.module")
+                        }
+                    }
+                    context.details.maybeAddVariant("compileWithMetadata", "compile") {
+                        attributes {
+                            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "all-files"))
+                        }
+                        withFiles {
+                            addFile("\${id.name}-\${id.version}.pom")
+                        }
+                    }
+                }
+
             }
         """
     }
@@ -110,7 +133,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
             dependencies {
                 conf 'org.test:moduleA:1.0'
                 components {
-                    withModule('org.test:moduleA', MissingJdk8VariantRule) { params('runtime') } 
+                    withModule('org.test:moduleA', MissingJdk8VariantRule) { params('runtime') }
                 }
             }
         """
@@ -198,7 +221,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
             dependencies {
                 conf 'org.test:moduleA:1.0'
                 components {
-                    withModule('org.test:moduleA', MissingJdk8VariantRule) { params('this-does-not-exist') } 
+                    withModule('org.test:moduleA', MissingJdk8VariantRule) { params('this-does-not-exist') }
                 }
             }
         """
@@ -212,6 +235,63 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         def baseType = useMaven() || gradleMetadataPublished ? 'Variant' : 'Configuration'
         fails 'checkDep'
         failure.assertHasCause "$baseType 'this-does-not-exist' not defined in module org.test:moduleA:1.0"
+    }
+
+    @RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    )
+    def "can add variants containing metadata as artifacts using lenient rules"() {
+        given:
+        repository {
+            'org.test:moduleA:1.0' {
+                dependsOn 'org.test:moduleB:1.0'
+            }
+            'org.test:moduleB:1.0'()
+        }
+
+        when:
+        buildFile << """
+            configurations.conf {
+                attributes { attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "all-files")) }
+            }
+            dependencies {
+                conf 'org.test:moduleA:1.0'
+                components {
+                    all(DirectMetadataAccessVariantRule)
+                }
+            }
+        """
+        repositoryInteractions {
+            'org.test:moduleA:1.0' {
+                expectResolve()
+            }
+            'org.test:moduleB:1.0' {
+                expectResolve()
+            }
+        }
+
+        then:
+        succeeds 'checkDep'
+        def allFilesVariant = gradleMetadataPublished ? 'apiElementsWithMetadata' : 'compileWithMetadata'
+        def hasModuleFile = gradleMetadataPublished
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org.test:moduleA:1.0') {
+                    variant(allFilesVariant, ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar',
+                                            'org.gradle.category': 'documentation', 'org.gradle.docstype': 'all-files'])
+                    artifact(group: 'org.test', name: 'moduleA', version: '1.0', type: 'jar')
+                    artifact(group: 'org.test', name: 'moduleA', version: '1.0', type: 'pom')
+                    if (hasModuleFile) { artifact(group: 'org.test', name: 'moduleA', version: '1.0', type: 'module') }
+                    module('org.test:moduleB:1.0') {
+                        variant(allFilesVariant, ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar',
+                                                'org.gradle.category': 'documentation', 'org.gradle.docstype': 'all-files'])
+                        artifact(group: 'org.test', name: 'moduleB', version: '1.0', type: 'jar')
+                        artifact(group: 'org.test', name: 'moduleB', version: '1.0', type: 'pom')
+                        if (hasModuleFile) { artifact(group: 'org.test', name: 'moduleB', version: '1.0', type: 'module') }
+                    }
+                }
+            }
+        }
     }
 
     def "file can be added to existing variant"() {
@@ -377,7 +457,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
 
                 void execute(ComponentMetadataContext context) {
                     context.details.addVariant('runtimeElements', 'default') { // the way it is published, the ivy 'default' configuration is the runtime variant
-                        attributes { 
+                        attributes {
                             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
                             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
                             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
@@ -385,7 +465,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
                         }
                     }
                     context.details.addVariant('apiElements', 'compile') {
-                        attributes { 
+                        attributes {
                             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
                             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
                             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -359,6 +359,11 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         }
 
         @Override
+        public void maybeAddVariant(String name, String base, Action<? super VariantMetadata> action) {
+
+        }
+
+        @Override
         public void belongsTo(Object notation) {
 
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -112,7 +112,13 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
 
     @Override
     public void addVariant(String name, String base, Action<? super VariantMetadata> action) {
-        metadata.getVariantMetadataRules().addVariant(name, base);
+        metadata.getVariantMetadataRules().addVariant(name, base, false);
+        withVariant(name, action);
+    }
+
+    @Override
+    public void maybeAddVariant(String name, String base, Action<? super VariantMetadata> action) {
+        metadata.getVariantMetadataRules().addVariant(name, base, true);
         withVariant(name, action);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -111,24 +111,26 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
         if (variants.isPresent()) {
             builder.addAll(variants.get());
         }
-        for (Map.Entry<String, String> variantName : variantMetadataRules.getAdditionalVariants().entrySet()) {
-            String baseName = variantName.getValue();
+        for (AdditionalVariant additionalVariant : variantMetadataRules.getAdditionalVariants()) {
+            String baseName = additionalVariant.getBase();
             ConfigurationMetadata base = null;
             if (baseName != null) {
                 if (variants.isPresent()) {
                     base = variantsByName.get(baseName);
-                    if (!(base instanceof ModuleConfigurationMetadata)) {
+                    if (!additionalVariant.isLenient() && !(base instanceof ModuleConfigurationMetadata)) {
                         throw new InvalidUserDataException("Variant '" + baseName + "' not defined in module " + getId().getDisplayName());
                     }
                 } else {
                     base = getConfiguration(baseName);
-                    if (!(base instanceof ModuleConfigurationMetadata)) {
+                    if (!additionalVariant.isLenient() && !(base instanceof ModuleConfigurationMetadata)) {
                         throw new InvalidUserDataException("Configuration '" + baseName + "' not defined in module " + getId().getDisplayName());
                     }
                 }
             }
-            ConfigurationMetadata configurationMetadata = new LazyRuleAwareWithBaseConfigurationMetadata(variantName.getKey(), (ModuleConfigurationMetadata) base, getId(), getAttributes(), variantMetadataRules);
-            builder.add(configurationMetadata);
+            if (baseName == null || base instanceof ModuleConfigurationMetadata) {
+                ConfigurationMetadata configurationMetadata = new LazyRuleAwareWithBaseConfigurationMetadata(additionalVariant.getName(), (ModuleConfigurationMetadata) base, getId(), getAttributes(), variantMetadataRules);
+                builder.add(configurationMetadata);
+            }
         }
         return Optional.of(builder.build());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AdditionalVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AdditionalVariant.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import javax.annotation.Nullable;
+
+public class AdditionalVariant {
+    private final String name;
+    private final String base;
+    private final boolean lenient;
+
+    public AdditionalVariant(String name) {
+        this(name, null, false);
+    }
+
+    public AdditionalVariant(String name, @Nullable String base, boolean lenient) {
+        this.name = name;
+        this.base = base;
+        this.lenient = lenient;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getBase() {
+        return base;
+    }
+
+    public boolean isLenient() {
+        return lenient;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -17,7 +17,6 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.MutableVariantFilesMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -45,7 +44,6 @@ import org.gradle.internal.typeconversion.NotationParser;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class VariantMetadataRules {
     private final ImmutableAttributesFactory attributesFactory;
@@ -55,7 +53,7 @@ public class VariantMetadataRules {
     private VariantFilesRules variantFilesRules;
     private VariantDerivationStrategy variantDerivationStrategy = new NoOpDerivationStrategy();
     private final ModuleVersionIdentifier moduleVersionId;
-    private Map<String, String> additionalVariants = Maps.newHashMap();
+    private List<AdditionalVariant> additionalVariants = Lists.newArrayList();
 
     public VariantMetadataRules(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier moduleVersionId) {
         this.attributesFactory = attributesFactory;
@@ -148,14 +146,14 @@ public class VariantMetadataRules {
     }
 
     public void addVariant(String name) {
-        additionalVariants.put(name, null);
+        additionalVariants.add(new AdditionalVariant(name));
     }
 
-    public void addVariant(String name, String basedOn) {
-        additionalVariants.put(name, basedOn);
+    public void addVariant(String name, String basedOn, boolean lenient) {
+        additionalVariants.add(new AdditionalVariant(name, basedOn, lenient));
     }
 
-    public Map<String, String> getAdditionalVariants() {
+    public List<AdditionalVariant> getAdditionalVariants() {
         return additionalVariants;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -145,7 +145,7 @@ class VariantFilesMetadataRulesTest extends Specification {
     @Unroll
     def "new variant can be added to #metadataType metadata"() {
         when:
-        metadata.getVariantMetadataRules().addVariant("new-variant", "runtime")
+        metadata.getVariantMetadataRules().addVariant("new-variant", "runtime", false)
         def immutableMetadata = metadata.asImmutable()
         def variants = immutableMetadata.variantsForGraphTraversal.get()
         def baseVariant = variants.find { it.name == 'runtime' }
@@ -198,7 +198,7 @@ class VariantFilesMetadataRulesTest extends Specification {
         def rule = Mock(Action)
 
         when:
-        metadata.variantMetadataRules.addVariant('new-variant', 'runtime')
+        metadata.variantMetadataRules.addVariant('new-variant', 'runtime', false)
         metadata.variantMetadataRules.addVariantFilesAction(new VariantMetadataRules.VariantAction<MutableVariantFilesMetadata>({ true }, rule))
         def newVariant =  metadata.asImmutable().variantsForGraphTraversal.get().find { it.name == 'new-variant' }
 
@@ -228,7 +228,7 @@ class VariantFilesMetadataRulesTest extends Specification {
     @Unroll
     def "throws error for non-existing base in #metadataType metadata"() {
         when:
-        metadata.getVariantMetadataRules().addVariant("new-variant", "not-exist")
+        metadata.getVariantMetadataRules().addVariant("new-variant", "not-exist", false)
         def immutableMetadata = metadata.asImmutable()
         immutableMetadata.variantsForGraphTraversal.get()
 
@@ -241,6 +241,30 @@ class VariantFilesMetadataRulesTest extends Specification {
         "maven"      | mavenComponentMetadata('dep')  | 'Variant'
         "ivy"        | ivyComponentMetadata('dep')    | 'Configuration'
         "gradle"     | gradleComponentMetadata('dep') | 'Variant'
+    }
+
+    @Unroll
+    def "does not add a variant for non-existing base in #metadataType metadata if lenient"() {
+        given:
+        def rule = Mock(Action)
+
+        when:
+        metadata.getVariantMetadataRules().addVariant("new-variant", "not-exist", true)
+        metadata.variantMetadataRules.addVariantFilesAction(new VariantMetadataRules.VariantAction<MutableVariantFilesMetadata>({ true }, rule))
+        def immutableMetadata = metadata.asImmutable()
+        def variants = immutableMetadata.variantsForGraphTraversal.get()
+
+        then:
+        0 * rule.execute(_)
+        variants.size() == initialVariantCount
+        !variants.any { it.name == 'new-variant' }
+        !variants.any { it.name == 'not-exist' }
+
+        where:
+        metadataType | metadata                       | initialVariantCount
+        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
+        "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
     }
 
     @Unroll


### PR DESCRIPTION
This adds `ComponentMetadataDetails.maybeAddVariant(name, base)`, which is not doing anything if 'base' does not exist (instead of failing).

This came up because there are some use cases where writing a generic rule for all components, typically applied with `components { all<Rule>() }`, makes sense. Then you can end up with situations where some components do not have a certain variant. E.g.:

- Treat metadata files as artifacts by deriving from the "runtime" or "api" variant (these are named differently in 'module' and pom 'metadata').
- Grep additional documentation (like javadoc or samples) transitively by deriving from the "runtime" or "api" variant. In this case this would also be combined with a lenient artifact view to not fail if one of the components does not offer the javadoc/sample jar.

This is most likely sufficient to solve https://github.com/gradle/gradle/issues/11449.