### PR TITLE
Mention `application` plugin

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -23,7 +23,7 @@ You can find a comprehensive introduction and overview to the Java Plugin in the
 ====
 As indicated above, this plugin adds basic building blocks for working with JVM projects.
 Its feature set has been superseded by other plugins, offering more features based on your project type.
-Instead of applying it directly to your project, you should look into the `java-library` or `java-application` plugins or one of the supported alternative JVM language.
+Instead of applying it directly to your project, you should look into the `java-library` or `application` plugins or one of the supported alternative JVM language.
 ====
 
 [[sec:java_usage]]


### PR DESCRIPTION
The `java-application` plugin doesn't exists.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
