### PR TITLE
Add maxFailures property to PMD (resolves #11557)

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -88,6 +88,39 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
     }
 
     @ToBeFixedForInstantExecution
+    void "can set max failures"() {
+        badCode()
+        buildFile << """
+            pmd {
+                maxFailures = 2
+            }
+        """
+
+        expect:
+        succeeds("check")
+        file("build/reports/pmd/main.xml").assertContents(not(containsClass("org.gradle.Class1")))
+        file("build/reports/pmd/test.xml").assertContents(containsClass("org.gradle.Class1Test"))
+        output.contains("2 PMD rule violations were found. See the report at:")
+    }
+
+    @ToBeFixedForInstantExecution
+    void "does not ignore more than max failures"() {
+        badCode()
+        buildFile << """
+            pmd {
+                maxFailures = 1
+            }
+        """
+
+        expect:
+        fails("check")
+        failure.assertHasDescription("Execution failed for task ':pmdTest'.")
+        failure.assertThatCause(containsString("2 PMD rule violations were found. See the report at:"))
+        file("build/reports/pmd/main.xml").assertContents(not(containsClass("org.gradle.Class1")))
+        file("build/reports/pmd/test.xml").assertContents(containsClass("org.gradle.Class1Test"))
+    }
+
+    @ToBeFixedForInstantExecution
     void "can configure priority level threshold"() {
         badCode()
         buildFile << """

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -71,12 +71,14 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     private int rulePriority;
     private boolean consoleOutput;
     private FileCollection classpath;
+    private Property<Integer> maxFailures;
     private Property<Boolean> incrementalAnalysis;
 
     public Pmd() {
         ObjectFactory objects = getObjectFactory();
         reports = objects.newInstance(PmdReportsImpl.class, this);
         this.incrementalAnalysis = objects.property(Boolean.class);
+        this.maxFailures = objects.property(Integer.class);
     }
 
     @Inject
@@ -290,6 +292,21 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     }
 
     /**
+     * The maximum number of failures to allow before stopping the build.
+     *
+     * Defaults to 0, which will stop the build on any failure.  Values 0 and
+     * above are valid.  If <pre>ignoreFailures</pre> is set, this is ignored
+     * and the build will continue (infinite failures allowed).
+     *
+     * @since 6.4
+     */
+    @Input
+    @Incubating
+    public Property<Integer> getMaxFailures() {
+        return maxFailures;
+    }
+
+    /**
      * Specifies the rule priority threshold.
      *
      * @since 2.8
@@ -308,7 +325,6 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     public void setRulePriority(int intValue) {
         validate(intValue);
         rulePriority = intValue;
-
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -41,12 +41,14 @@ public class PmdExtension extends CodeQualityExtension {
     private TextResource ruleSetConfig;
     private ConfigurableFileCollection ruleSetFiles;
     private boolean consoleOutput;
+    private Property<Integer> maxFailures;
     private Property<Boolean> incrementalAnalysis;
 
     public PmdExtension(Project project) {
         this.project = project;
         // TODO: Enable this by default when toolVersion >= 6.0.0 if it's stable enough.
         this.incrementalAnalysis = project.getObjects().property(Boolean.class).convention(false);
+        this.maxFailures = project.getObjects().property(Integer.class).convention(0);
     }
 
     /**
@@ -99,6 +101,18 @@ public class PmdExtension extends CodeQualityExtension {
      */
     public void setTargetJdk(TargetJdk targetJdk) {
         this.targetJdk = targetJdk;
+    }
+
+    /**
+     * The maximum number of failures to allow before stopping the build.
+     *
+     * If <pre>ignoreFailures</pre> is set, this is ignored and no limit is enforced.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    public Property<Integer> getMaxFailures() {
+        return maxFailures;
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -102,6 +102,7 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         taskMapping.map("ruleSetConfig", () ->  extension.getRuleSetConfig());
         taskMapping.map("ruleSetFiles", () ->  extension.getRuleSetFiles());
         taskMapping.map("ignoreFailures", () -> extension.isIgnoreFailures());
+        taskMapping.map("maxFailures", () -> extension.getMaxFailures());
         taskMapping.map("rulePriority", () ->  extension.getRulePriority());
         taskMapping.map("consoleOutput", () ->  extension.isConsoleOutput());
         taskMapping.map("targetJdk", () ->  extension.getTargetJdk());

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
@@ -43,6 +43,7 @@ abstract class PmdInvoker {
         def consoleOutput = pmdTask.consoleOutput
         def stdOutIsAttachedToTerminal = consoleOutput ? pmdTask.stdOutIsAttachedToTerminal() : false
         def ignoreFailures = pmdTask.ignoreFailures
+        def maxFailures = pmdTask.maxFailures.get()
         def logger = pmdTask.logger
         def incrementalAnalysis = pmdTask.incrementalAnalysis.get()
         def incrementalCacheFile = pmdTask.incrementalCacheFile
@@ -98,6 +99,10 @@ abstract class PmdInvoker {
                         }
                     }
 
+                    if (maxFailures < 0) {
+                        throw new GradleException("Invalid maxFailures $maxFailures. Valid range is >= 0.")
+                    }
+
                     ant.taskdef(name: 'pmd', classname: 'net.sourceforge.pmd.ant.PMDTask')
                     ant.pmd(antPmdArgs) {
                         source.addToAntBuilder(ant, 'fileset', FileCollection.AntType.FileSet)
@@ -140,7 +145,7 @@ abstract class PmdInvoker {
                             def reportUrl = new ConsoleRenderer().asClickableFileUrl(report.destination)
                             message += " See the report at: $reportUrl"
                         }
-                        if (ignoreFailures) {
+                        if (ignoreFailures || ((failureCount as Integer) <= maxFailures)) {
                             logger.warn(message)
                         } else {
                             throw new GradleException(message)

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -53,6 +53,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         extension.ruleSetFiles.empty
         extension.reportsDir == project.file("build/reports/pmd")
         !extension.ignoreFailures
+        extension.maxFailures.get() == 0
         extension.rulePriority == 5
     }
 
@@ -106,6 +107,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert reports.xml.destination == project.file("build/reports/pmd/${sourceSet.name}.xml")
             assert reports.html.destination == project.file("build/reports/pmd/${sourceSet.name}.html")
             assert ignoreFailures == false
+            assert maxFailures.get() == 0
             assert rulePriority == 5
             assert incrementalAnalysis.get() == false
         }
@@ -124,6 +126,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.reports.xml.destination == project.file("build/reports/pmd/custom.xml")
         task.reports.html.destination == project.file("build/reports/pmd/custom.html")
         task.ignoreFailures == false
+        task.maxFailures.get() == 0
         task.rulePriority == 5
         task.incrementalAnalysis.get() == false
     }
@@ -155,6 +158,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             ruleSetFiles = project.getLayout().files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
+            maxFailures = 17
             rulePriority = 3
         }
 
@@ -179,6 +183,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert reports.xml.destination == project.file("pmd-reports/${sourceSet.name}.xml")
             assert reports.html.destination == project.file("pmd-reports/${sourceSet.name}.html")
             assert ignoreFailures == true
+            assert maxFailures.get() == 17
             assert rulePriority == 3
         }
     }
@@ -191,6 +196,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             ruleSetFiles = project.getLayout().files("my-ruleset.xml")
             reportsDir = project.file("pmd-reports")
             ignoreFailures = true
+            maxFailures = 5
             rulePriority = 3
         }
 
@@ -205,6 +211,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.reports.html.destination == project.file("pmd-reports/custom.html")
         task.outputs.files.files == task.reports.enabled*.destination as Set
         task.ignoreFailures == true
+        task.maxFailures.get() == 5
         task.rulePriority == 3
     }
 

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
@@ -29,6 +29,10 @@
                 <td><literal>project.pmd.ignoreFailures</literal></td>
             </tr>
             <tr>
+                <td>maxFailures</td>
+                <td><literal>project.pmd.maxFailures</literal></td>
+            </tr>
+            <tr>
                 <td>rulePriority</td>
                 <td><literal>project.pmd.rulePriority</literal></td>
             </tr>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
@@ -37,6 +37,10 @@
                 <td><literal>false</literal></td>
             </tr>
             <tr>
+                <td>maxFailures</td>
+                <td><literal>0</literal></td>
+            </tr>
+            <tr>
                 <td>rulePriority</td>
                 <td><literal>5</literal></td>
             </tr>


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #11557

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
As described in #11557, when introducing static analysis to a new project it's beneficial to initially set a cap and then ratchet the allowed number of failures to keep the code from getting worse.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
