### PR TITLE
Run smoke tests with instant execution

### DIFF
--- a/.teamcity/Gradle_Check/configurations/SmokeTests.kt
+++ b/.teamcity/Gradle_Check/configurations/SmokeTests.kt
@@ -5,10 +5,10 @@ import jetbrains.buildServer.configs.kotlin.v2018_2.AbsoluteId
 import model.CIBuildModel
 import model.Stage
 
-class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory) : BaseGradleBuildType(model, stage = stage, init = {
-    uuid = "${model.projectPrefix}SmokeTests${testJava.version.name.capitalize()}"
+class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task: String = "smokeTest") : BaseGradleBuildType(model, stage = stage, init = {
+    uuid = "${model.projectPrefix}${task.capitalize()}s${testJava.version.name.capitalize()}"
     id = AbsoluteId(uuid)
-    name = "Smoke Tests with 3rd Party Plugins - ${testJava.version.name.capitalize()} Linux"
+    name = "Smoke Tests with 3rd Party Plugins ($task) - ${testJava.version.name.capitalize()} Linux"
     description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"
 
     params {
@@ -23,7 +23,7 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory) : Bas
     applyTestDefaults(
         model,
         this,
-        "smokeTest:smokeTest",
+        ":smokeTest:$task",
         notQuick = true,
         extraParameters = buildScanTag("SmokeTests") + " -PtestJavaHome=%linux.${testJava.version.name}.${testJava.vendor.name}.64bit%"
     )

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -56,7 +56,9 @@ data class CIBuildModel(
                 SpecificBuild.BuildDistributions,
                 SpecificBuild.Gradleception,
                 SpecificBuild.SmokeTestsMinJavaVersion,
-                SpecificBuild.SmokeTestsMaxJavaVersion
+                SpecificBuild.SmokeTestsMaxJavaVersion,
+                SpecificBuild.InstantSmokeTestsMinJavaVersion,
+                SpecificBuild.InstantSmokeTestsMaxJavaVersion
             ),
             functionalTests = listOf(
                 TestCoverage(3, TestType.platform, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
@@ -483,6 +485,16 @@ enum class SpecificBuild {
     SmokeTestsMaxJavaVersion {
         override fun create(model: CIBuildModel, stage: Stage): BuildType {
             return SmokeTests(model, stage, JvmCategory.MAX_VERSION)
+        }
+    },
+    InstantSmokeTestsMinJavaVersion {
+        override fun create(model: CIBuildModel, stage: Stage): BuildType {
+            return SmokeTests(model, stage, JvmCategory.MIN_VERSION, "instantSmokeTest")
+        }
+    },
+    InstantSmokeTestsMaxJavaVersion {
+        override fun create(model: CIBuildModel, stage: Stage): BuildType {
+            return SmokeTests(model, stage, JvmCategory.MAX_VERSION, "instantSmokeTest")
         }
     },
     DependenciesCheck {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InstantExecutionGradleExecuter.groovy
@@ -23,6 +23,13 @@ import org.gradle.util.GradleVersion
 
 class InstantExecutionGradleExecuter extends DaemonGradleExecuter {
 
+    static final List<String> INSTANT_EXECUTION_ARGS = [
+        "-D${SystemProperties.isEnabled}=true",
+        "-D${SystemProperties.isQuiet}=true",
+        "-D${SystemProperties.maxProblems}=0",
+        "-D${SystemProperties.failOnProblems}=true"
+    ].collect { it.toString() }
+
     InstantExecutionGradleExecuter(
         GradleDistribution distribution,
         TestDirectoryProvider testDirectoryProvider,
@@ -34,11 +41,6 @@ class InstantExecutionGradleExecuter extends DaemonGradleExecuter {
 
     @Override
     protected List<String> getAllArgs() {
-        return super.getAllArgs() + [
-            "-D${SystemProperties.isEnabled}=true",
-            "-D${SystemProperties.isQuiet}=true",
-            "-D${SystemProperties.maxProblems}=0",
-            "-D${SystemProperties.failOnProblems}=true"
-        ].collect { it.toString() }
+        return super.getAllArgs() + INSTANT_EXECUTION_ARGS
     }
 }

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     smokeTestImplementation(project(":internalIntegTesting"))
     smokeTestImplementation(project(":launcher"))
     smokeTestImplementation(project(":persistentCache"))
+    smokeTestImplementation(project(":jvmServices"))
     smokeTestImplementation(library("commons_io"))
     smokeTestImplementation(library("jgit"))
     smokeTestImplementation(library("gradleProfiler")) {
@@ -72,15 +73,25 @@ dependencies {
     testImplementation(testFixtures(project(":versionControl")))
 }
 
-tasks.register<SmokeTest>("smokeTest") {
+fun SmokeTest.configureForSmokeTest() {
     group = "Verification"
-    description = "Runs Smoke tests"
     testClassesDirs = smokeTest.output.classesDirs
     classpath = smokeTest.runtimeClasspath
     maxParallelForks = 1 // those tests are pretty expensive, we shouldn"t execute them concurrently
     gradleInstallationForTest.gradleGeneratedApiJarCacheDir.set(
         defaultGradleGeneratedApiJarCacheDirProvider()
     )
+}
+
+tasks.register<SmokeTest>("smokeTest") {
+    description = "Runs Smoke tests"
+    configureForSmokeTest()
+}
+
+tasks.register<SmokeTest>("instantSmokeTest") {
+    description = "Runs Smoke tests with instant execution"
+    configureForSmokeTest()
+    systemProperty("org.gradle.integtest.executer", "instant")
 }
 
 plugins.withType<IdeaPlugin>().configureEach {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.smoketests
 import org.apache.commons.io.FileUtils
 import org.gradle.cache.internal.DefaultGeneratedGradleJarCache
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.executer.InstantExecutionGradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
 import org.gradle.test.fixtures.file.TestFile
@@ -174,11 +176,15 @@ abstract class AbstractSmokeTest extends Specification {
     }
 
     private static List<String> buildContextParameters() {
+        List<String> parameters = []
+        if (GradleContextualExecuter.isInstant()) {
+            parameters += InstantExecutionGradleExecuter.INSTANT_EXECUTION_ARGS
+        }
         def generatedApiJarCacheDir = IntegrationTestBuildContext.INSTANCE.gradleGeneratedApiJarCacheDir
         if (generatedApiJarCacheDir == null) {
-            return []
+            return parameters
         }
-        return ["-D${DefaultGeneratedGradleJarCache.BASE_DIR_OVERRIDE_PROPERTY}=${generatedApiJarCacheDir.absolutePath}" as String]
+        return parameters + ["-D${DefaultGeneratedGradleJarCache.BASE_DIR_OVERRIDE_PROPERTY}=${generatedApiJarCacheDir.absolutePath}" as String]
     }
 
     private static List<String> outputParameters() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.VersionNumber
@@ -39,6 +40,7 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "android application plugin #pluginVersion"(String pluginVersion) {
         given:
 
@@ -105,6 +107,7 @@ class AndroidPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "android library plugin #pluginVersion"(String pluginVersion) {
         given:
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.internal.scan.config.fixtures.GradleEnterprisePluginSettingsFixture
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
@@ -44,6 +45,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
         homeDir = temporaryFolder.createDir("test-kit-home")
     }
 
+    @ToBeFixedForInstantExecution
     def "check deprecation warnings produced by building Santa Tracker"() {
         def checkoutDir = temporaryFolder.createDir ("checkout")
         setupCopyOfSantaTracker(checkoutDir)
@@ -70,6 +72,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
         )
     }
 
+    @ToBeFixedForInstantExecution
     def "can cache Santa Tracker Android application"() {
         def originalDir = temporaryFolder.createDir ("original")
         def relocatedDir = temporaryFolder.createDir("relocated")
@@ -84,6 +87,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
         verify(relocatedResult, EXPECTED_RESULTS)
     }
 
+    @ToBeFixedForInstantExecution
     def "incremental Java compilation works for Santa Tracker"() {
         def checkoutDir = temporaryFolder.createDir ("checkout")
         setupCopyOfSantaTracker(checkoutDir)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
@@ -16,13 +16,14 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 
-@Requires(TestPrecondition.JDK9_OR_LATER)
+@Requires(value = TestPrecondition.JDK9_OR_LATER, adhoc = { !GradleContextualExecuter.isInstant() })
 class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
 
     def "can build gradle with instant execution enabled"() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinCachingSmokeTest.groovy
@@ -17,10 +17,12 @@
 package org.gradle.smoketests
 
 import org.eclipse.jgit.api.Git
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 
 class KotlinCachingSmokeTest extends AbstractSmokeTest {
 
+    @ToBeFixedForInstantExecution
     def "can cache Spek framework build"() {
         def testRepoUri = "https://github.com/gradle/kotlin-relocation-test"
         def testRepoBranch = "gradle-6.0"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.Requires
@@ -27,6 +28,7 @@ import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def 'kotlin #version plugin, workers=#workers'() {
         given:
         useSample("kotlin-example")
@@ -50,6 +52,7 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def 'kotlin #kotlinPluginVersion android #androidPluginVersion plugins, workers=#workers'() {
         given:
         AndroidHome.assertIsSet()
@@ -95,6 +98,7 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
     @Unroll
     @Requires(KOTLIN_SCRIPT)
+    @ToBeFixedForInstantExecution
     def 'kotlin js #version plugin, workers=#workers'() {
         given:
         useSample("kotlin-js-sample")

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -49,6 +50,7 @@ class NebulaPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Issue('https://plugins.gradle.org/plugin/nebula.plugin-plugin')
+    @ToBeFixedForInstantExecution
     def 'nebula plugin plugin'() {
         when:
         buildFile << """
@@ -73,6 +75,7 @@ class NebulaPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Issue('https://plugins.gradle.org/plugin/nebula.lint')
+    @ToBeFixedForInstantExecution
     def 'nebula lint plugin'() {
         given:
         buildFile << """
@@ -129,6 +132,7 @@ testCompile('junit:junit:4.7')""")
 
     @Issue("gradle/gradle#3798")
     @Unroll
+    @ToBeFixedForInstantExecution
     def "nebula dependency lock plugin version #version binary compatibility"() {
         when:
         buildFile << """
@@ -136,13 +140,13 @@ testCompile('junit:junit:4.7')""")
                 id 'java-library'
                 id 'nebula.dependency-lock' version '$version'
             }
-            
+
             ${jcenterRepository()}
-            
+
             dependencies {
                 api 'org.apache.commons:commons-math3:3.6.1'
             }
-            
+
             task resolve {
                 doFirst {
                     configurations.compileClasspath.each { println it.name }
@@ -193,6 +197,7 @@ testCompile('junit:junit:4.7')""")
 
     @Issue('https://plugins.gradle.org/plugin/nebula.resolution-rules')
     @Requires(TestPrecondition.JDK11_OR_EARLIER)
+    @ToBeFixedForInstantExecution
     def 'nebula resolution rules plugin'() {
         when:
         file('rules.json') << """
@@ -213,12 +218,12 @@ testCompile('junit:junit:4.7')""")
                 id 'java-library'
                 id 'nebula.resolution-rules' version '${TestedVersions.nebulaResolutionRules}'
             }
-            
-            ${jcenterRepository()}                        
+
+            ${jcenterRepository()}
 
             dependencies {
                 resolutionRules files('rules.json')
-                
+
                 // Need a non-empty configuration to trigger the plugin
                 api 'org.apache.commons:commons-math3:3.6.1'
             }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -25,6 +26,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class PlayPluginSmokeTest extends AbstractSmokeTest {
 
     @Requires(TestPrecondition.JDK11_OR_EARLIER)
+    @ToBeFixedForInstantExecution
     def 'build basic Play project'() {
         given:
         useSample("play-example")
@@ -32,13 +34,13 @@ class PlayPluginSmokeTest extends AbstractSmokeTest {
             plugins {
                 id 'org.gradle.playframework' version '${TestedVersions.playframework}'
             }
-            
+
             repositories {
                 ${jcenterRepository()}
                 ${RepoScriptBlockUtil.lightbendMavenRepositoryDefinition()}
                 ${RepoScriptBlockUtil.lightbendIvyRepositoryDefinition()}
             }
-            
+
             dependencies {
                 implementation "com.typesafe.play:play-guice_2.12:2.6.15"
                 implementation 'commons-lang:commons-lang:2.6'

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.ports.ReleasingPortAllocator
@@ -34,6 +35,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
 
     @Unroll
     @Issue('https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow')
+    @ToBeFixedForInstantExecution
     def 'shadow plugin #version'() {
         given:
         buildFile << """
@@ -171,6 +173,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Issue('https://plugins.gradle.org/plugin/io.spring.dependency-management')
+    @ToBeFixedForInstantExecution
     def 'spring dependency management plugin'() {
         given:
         buildFile << """
@@ -357,6 +360,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
 
     @Issue('https://plugins.gradle.org/plugin/com.github.spotbugs')
     @Requires(TestPrecondition.JDK11_OR_EARLIER)
+    @ToBeFixedForInstantExecution
     def 'spotbugs plugin'() {
         given:
         buildFile << """
@@ -438,6 +442,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
     }
 
     @Issue("https://plugins.gradle.org/plugin/com.google.protobuf")
+    @ToBeFixedForInstantExecution
     def "protobuf plugin"() {
         given:
         buildFile << """


### PR DESCRIPTION
This PR introduces a `:smokeTest:instantSmokeTest` task that runs smoke tests with instant execution enabled.
