### PR TITLE
Increase heap for architecture tests

### DIFF
--- a/subprojects/architecture-test/architecture-test.gradle.kts
+++ b/subprojects/architecture-test/architecture-test.gradle.kts
@@ -1,6 +1,6 @@
 import org.gradle.gradlebuild.ProjectGroups.publicProjects
-import org.gradle.gradlebuild.unittestandcompile.ModuleType
 import org.gradle.gradlebuild.PublicApi
+import org.gradle.gradlebuild.unittestandcompile.ModuleType
 
 plugins {
     `java-library`
@@ -13,7 +13,7 @@ gradlebuildJava {
 dependencies {
     testImplementation(project(":baseServices"))
     testImplementation(project(":modelCore"))
-    
+
     testImplementation(testLibrary("archunit_junit4"))
     testImplementation(library("jsr305"))
     testImplementation(library("guava"))
@@ -24,6 +24,9 @@ dependencies {
 }
 
 tasks.withType<Test> {
+    // Looks like loading all the classes requires more than the default 512M
+    maxHeapSize = "700M"
+
     systemProperty("org.gradle.public.api.includes", PublicApi.includes.joinToString(":"))
     systemProperty("org.gradle.public.api.excludes", PublicApi.excludes.joinToString(":"))
 }


### PR DESCRIPTION
The tests fail on my machine with the default 512M, 600M also doesn't
seem to be enough.