### PR TITLE
Add a service for checksum computation

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/ChecksumService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/ChecksumService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.resource.local;
-
-import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.resource.Resource;
+package org.gradle.internal.hash;
 
 import java.io.File;
 
-/**
- * Represents a file backed local resource.
- */
-public interface LocallyAvailableResource extends Resource {
+public interface ChecksumService {
+    HashCode md5(File file);
 
-    File getFile();
+    HashCode sha1(File file);
 
-    HashCode getSha1();
+    HashCode sha256(File file);
 
-    long getLastModified();
+    HashCode sha512(File file);
 
-    long getContentLength();
+    HashCode hash(File src, String algorithm);
 }

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.resource.local.DefaultPathKeyFileStore
 import org.gradle.internal.resource.local.FileAccessTracker
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
@@ -33,7 +34,7 @@ import spock.lang.Specification
 class DirectoryBuildCacheServiceTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
     def cacheDir = temporaryFolder.createDir("cache")
-    def fileStore = new DefaultPathKeyFileStore(cacheDir)
+    def fileStore = new DefaultPathKeyFileStore(TestUtil.checksumService, cacheDir)
     def persistentCache = Mock(PersistentCache) {
         getBaseDir() >> cacheDir
         withFileLock(_) >> { Runnable r -> r.run() }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingFileHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CachingFileHasher.java
@@ -39,15 +39,19 @@ public class CachingFileHasher implements FileHasher {
     private final StringInterner stringInterner;
     private final FileTimeStampInspector timestampInspector;
 
-    public CachingFileHasher(FileHasher delegate, CrossBuildFileHashCache store, StringInterner stringInterner, FileTimeStampInspector timestampInspector, String cacheName, FileSystem fileSystem) {
+    public CachingFileHasher(FileHasher delegate, CrossBuildFileHashCache store, StringInterner stringInterner, FileTimeStampInspector timestampInspector, String cacheName, FileSystem fileSystem, int inMemorySize) {
         this.delegate = delegate;
         this.fileSystem = fileSystem;
         this.cache = store.createCache(
             PersistentIndexedCacheParameters.of(cacheName, new InterningStringSerializer(stringInterner), new FileInfoSerializer()),
-            400000,
+            inMemorySize,
             true);
         this.stringInterner = stringInterner;
         this.timestampInspector = timestampInspector;
+    }
+
+    public CachingFileHasher(FileHasher delegate, CrossBuildFileHashCache store, StringInterner stringInterner, FileTimeStampInspector timestampInspector, String cacheName, FileSystem fileSystem) {
+        this(delegate, store, stringInterner, timestampInspector, cacheName, fileSystem, 400000);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
@@ -31,28 +31,47 @@ import java.io.File;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 public class CrossBuildFileHashCache implements Closeable {
-    public static final String FILE_HASHES_CACHE_KEY = "fileHashes";
 
     private final PersistentCache cache;
     private final InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory;
 
-    public CrossBuildFileHashCache(@Nullable File cacheDir, CacheRepository repository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
+    public CrossBuildFileHashCache(@Nullable File cacheDir, CacheRepository repository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, Kind cacheKind) {
         this.inMemoryCacheDecoratorFactory = inMemoryCacheDecoratorFactory;
-        CacheBuilder cacheBuilder = cacheDir != null ? repository.cache(cacheDir) : repository.cache(FILE_HASHES_CACHE_KEY);
+        CacheBuilder cacheBuilder = cacheDir != null ? repository.cache(cacheDir) : repository.cache(cacheKind.cacheId);
         cache = cacheBuilder
-            .withDisplayName("file hash cache")
+            .withDisplayName(cacheKind.description)
             .withLockOptions(mode(FileLockManager.LockMode.None)) // Lock on demand
             .open();
     }
 
     public <K, V> PersistentIndexedCache<K, V> createCache(PersistentIndexedCacheParameters<K, V> parameters, int maxEntriesToKeepInMemory, boolean cacheInMemoryForShortLivedProcesses) {
         return cache.createCache(parameters
-                .withCacheDecorator(inMemoryCacheDecoratorFactory.decorator(maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses))
+            .withCacheDecorator(inMemoryCacheDecoratorFactory.decorator(maxEntriesToKeepInMemory, cacheInMemoryForShortLivedProcesses))
         );
     }
 
     @Override
     public void close() {
         cache.close();
+    }
+
+    public enum Kind {
+        FILE_HASHES("fileHashes", "file hash cache"),
+        CHECKSUMS("checksums", "checksums cache");
+        private final String cacheId;
+        private final String description;
+
+        Kind(String cacheId, String description) {
+            this.cacheId = cacheId;
+            this.description = description;
+        }
+
+        public String getCacheId() {
+            return cacheId;
+        }
+
+        public String getDescription() {
+            return description;
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
+import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache;
 import org.gradle.api.specs.Spec;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.file.Deleter;
@@ -36,9 +37,8 @@ import java.io.IOException;
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
 
-import static org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache.FILE_HASHES_CACHE_KEY;
-
 public class VersionSpecificCacheCleanupAction implements DirectoryCleanupAction {
+    private final static String FILE_HASHES_CACHE_KEY =  CrossBuildFileHashCache.Kind.FILE_HASHES.getCacheId();
 
     @VisibleForTesting static final String MARKER_FILE_PATH = FILE_HASHES_CACHE_KEY + "/" + FILE_HASHES_CACHE_KEY + ".lock";
     private static final Logger LOGGER = LoggerFactory.getLogger(VersionSpecificCacheCleanupAction.class);

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
@@ -24,6 +24,7 @@ import org.gradle.caching.internal.controller.RootBuildCacheControllerRef;
 import org.gradle.caching.local.DirectoryBuildCache;
 import org.gradle.caching.local.internal.DirectoryBuildCacheFileStoreFactory;
 import org.gradle.caching.local.internal.DirectoryBuildCacheServiceFactory;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.local.DefaultPathKeyFileStore;
 import org.gradle.internal.resource.local.PathKeyFileStore;
@@ -58,11 +59,11 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
                 return instantiator.newInstance(DefaultBuildCacheConfiguration.class, instantiator, allBuildCacheServiceFactories);
             }
 
-            DirectoryBuildCacheFileStoreFactory createDirectoryBuildCacheFileStoreFactory() {
+            DirectoryBuildCacheFileStoreFactory createDirectoryBuildCacheFileStoreFactory(ChecksumService checksumService) {
                 return new DirectoryBuildCacheFileStoreFactory() {
                     @Override
                     public PathKeyFileStore createFileStore(File baseDir) {
-                        return new DefaultPathKeyFileStore(baseDir);
+                        return new DefaultPathKeyFileStore(checksumService, baseDir);
                     }
                 };
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/hash/ChecksumHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/hash/ChecksumHasher.java
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
+package org.gradle.internal.hash;
 
 import com.google.common.io.Files;
 import org.gradle.api.UncheckedIOException;
-import org.gradle.internal.hash.FileHasher;
-import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.HashFunction;
 
 import java.io.File;
 import java.io.IOException;

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultPathKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/DefaultPathKeyFileStore.java
@@ -24,6 +24,7 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.file.collections.SingleIncludePatternFileTree;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.RelativePathUtil;
 
@@ -50,6 +51,8 @@ import static org.gradle.internal.FileUtils.hasExtension;
 @NonNullApi
 public class DefaultPathKeyFileStore implements PathKeyFileStore {
 
+    private final ChecksumService checksumService;
+
     /*
         When writing a file into the filestore a marker file with this suffix is written alongside,
         then removed after the write. This is used to detect partially written files (due to a serious crash)
@@ -59,7 +62,8 @@ public class DefaultPathKeyFileStore implements PathKeyFileStore {
 
     private File baseDir;
 
-    public DefaultPathKeyFileStore(File baseDir) {
+    public DefaultPathKeyFileStore(ChecksumService checksumService, File baseDir) {
+        this.checksumService = checksumService;
         this.baseDir = baseDir;
     }
 
@@ -191,14 +195,14 @@ public class DefaultPathKeyFileStore implements PathKeyFileStore {
     }
 
     protected LocallyAvailableResource entryAt(final String path) {
-        return new DefaultLocallyAvailableResource(getFile(path));
+        return new DefaultLocallyAvailableResource(getFile(path), checksumService);
     }
 
     @Override
     public LocallyAvailableResource get(String... path) {
         final File file = getFileWhileCleaningInProgress(path);
         if (file.exists()) {
-            return new DefaultLocallyAvailableResource(getFile(path));
+            return new DefaultLocallyAvailableResource(getFile(path), checksumService);
         } else {
             return null;
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStore.java
@@ -19,7 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Namer;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.internal.file.FileAccessTimeJournal;
-import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.hash.ChecksumService;
 
 import java.io.File;
 import java.util.Set;
@@ -37,14 +37,16 @@ public class GroupedAndNamedUniqueFileStore<K> implements FileStore<K>, FileStor
     private final Namer<K> namer;
     private final FileAccessTracker checksumDirAccessTracker;
     private final File baseDir;
+    private final ChecksumService checksumService;
 
-    public GroupedAndNamedUniqueFileStore(File baseDir, TemporaryFileProvider temporaryFileProvider, FileAccessTimeJournal fileAccessTimeJournal, Grouper<K> grouper, Namer<K> namer) {
-        this.delegate = new UniquePathKeyFileStore(baseDir);
+    public GroupedAndNamedUniqueFileStore(File baseDir, TemporaryFileProvider temporaryFileProvider, FileAccessTimeJournal fileAccessTimeJournal, Grouper<K> grouper, Namer<K> namer, ChecksumService checksumService) {
+        this.delegate = new UniquePathKeyFileStore(checksumService, baseDir);
         this.temporaryFileProvider = temporaryFileProvider;
         this.grouper = grouper;
         this.namer = namer;
         this.checksumDirAccessTracker = new SingleDepthFileAccessTracker(fileAccessTimeJournal, baseDir, grouper.getNumberOfGroupingDirs() + NUMBER_OF_CHECKSUM_DIRS);
         this.baseDir = baseDir;
+        this.checksumService = checksumService;
     }
 
     @Override
@@ -65,11 +67,25 @@ public class GroupedAndNamedUniqueFileStore<K> implements FileStore<K>, FileStor
         String group = grouper.determineGroup(key);
         String name = namer.determineName(key);
 
-        return group + "/" + checksumPart + "/" + name;
+        return group + "/" + stripLeadingZeros(checksumPart) + "/" + name;
+    }
+
+    // We do this for backwards compatibility: older Gradle versions
+    // used to store files in the binary cache with a checksum which removes
+    // the leading zeros
+    private String stripLeadingZeros(String checksumPart) {
+        if (checksumPart.charAt(0) == '0') {
+            int i = 1;
+            while (checksumPart.charAt(i) == '0') {
+                i++;
+            }
+            return checksumPart.substring(i);
+        }
+        return checksumPart;
     }
 
     private String getChecksum(File contentFile) {
-        return HashUtil.createHash(contentFile, "SHA1").asHexString();
+        return checksumService.sha1(contentFile).toString();
     }
 
     private File getTempFile() {

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/PathNormalisingKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/PathNormalisingKeyFileStore.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.resource.local;
 
 import org.gradle.api.Action;
+import org.gradle.internal.hash.ChecksumService;
 
 import java.io.File;
 import java.util.Set;
@@ -25,8 +26,8 @@ public class PathNormalisingKeyFileStore implements FileStore<String>, FileStore
 
     private final DefaultPathKeyFileStore delegate;
 
-    public PathNormalisingKeyFileStore(File baseDir) {
-        this.delegate = new DefaultPathKeyFileStore(baseDir);
+    public PathNormalisingKeyFileStore(File baseDir, ChecksumService checksumService) {
+        this.delegate = new DefaultPathKeyFileStore(checksumService, baseDir);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/resource/local/UniquePathKeyFileStore.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/resource/local/UniquePathKeyFileStore.java
@@ -19,6 +19,7 @@ package org.gradle.internal.resource.local;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Action;
 import org.gradle.api.NonNullApi;
+import org.gradle.internal.hash.ChecksumService;
 
 import java.io.File;
 
@@ -30,8 +31,8 @@ import java.io.File;
 @NonNullApi
 public class UniquePathKeyFileStore extends DefaultPathKeyFileStore {
 
-    public UniquePathKeyFileStore(File baseDir) {
-        super(baseDir);
+    public UniquePathKeyFileStore(ChecksumService checksumService, File baseDir) {
+        super(checksumService, baseDir);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -153,7 +153,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
         registration.addProvider(new Object() {
 
             CrossBuildFileHashCache createCrossBuildFileHashCache(CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
-                return new CrossBuildFileHashCache(null, cacheRepository, inMemoryCacheDecoratorFactory);
+                return new CrossBuildFileHashCache(null, cacheRepository, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.FILE_HASHES);
             }
 
             FileHasher createCachingFileHasher(StringInterner stringInterner, CrossBuildFileHashCache fileStore, FileSystem fileSystem, GlobalScopeFileTimeStampInspector fileTimeStampInspector, StreamHasher streamHasher) {
@@ -256,7 +256,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
         registration.addProvider(new Object() {
             CrossBuildFileHashCache createCrossBuildFileHashCache(ProjectCacheDir projectCacheDir, CacheScopeMapping cacheScopeMapping, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
                 File cacheDir = cacheScopeMapping.getBaseDirectory(projectCacheDir.getDir(), "fileHashes", VersionStrategy.CachePerVersion);
-                return new CrossBuildFileHashCache(cacheDir, cacheRepository, inMemoryCacheDecoratorFactory);
+                return new CrossBuildFileHashCache(cacheDir, cacheRepository, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.FILE_HASHES);
             }
 
             FileHasher createFileHasher(FileHasher globalHasher, CrossBuildFileHashCache cacheAccess, StringInterner stringInterner, FileSystem fileSystem, BuildScopeFileTimeStampInspector fileTimeStampInspector, StreamHasher streamHasher, WellKnownFileLocations wellKnownFileLocations) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/DefaultPathKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/DefaultPathKeyFileStoreTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.resource.local
 import org.gradle.api.Action
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
@@ -33,7 +34,7 @@ class DefaultPathKeyFileStoreTest extends Specification {
 
     def setup() {
         fsBase = dir.file("fs")
-        store = new DefaultPathKeyFileStore(fsBase)
+        store = new DefaultPathKeyFileStore(TestUtil.checksumService, fsBase)
     }
 
     def "can move file to filestore"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStoreTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.internal.file.FileAccessTimeJournal
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
@@ -43,7 +44,7 @@ class GroupedAndNamedUniqueFileStoreTest extends Specification {
         }
     }
 
-    @Subject GroupedAndNamedUniqueFileStore<String> fileStore = new GroupedAndNamedUniqueFileStore<String>(baseDir, temporaryFileProvider, fileAccessTimeJournal, grouper, { key -> key })
+    @Subject GroupedAndNamedUniqueFileStore<String> fileStore = new GroupedAndNamedUniqueFileStore<String>(baseDir, temporaryFileProvider, fileAccessTimeJournal, grouper, { key -> key }, TestUtil.checksumService)
 
     def "marks files accessed when they are added to store"() {
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/PathNormalisingKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/PathNormalisingKeyFileStoreTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.internal.resource.local
 import org.gradle.api.Action
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
@@ -34,7 +35,7 @@ class PathNormalisingKeyFileStoreTest extends Specification {
 
     def setup() {
         fsBase = dir.createDir("fs")
-        store = new PathNormalisingKeyFileStore(fsBase)
+        store = new PathNormalisingKeyFileStore(fsBase, TestUtil.checksumService)
     }
 
     def "can move to filestore"() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/UniquePathKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/UniquePathKeyFileStoreTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.local
 
 import org.gradle.api.Action
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
@@ -31,7 +32,7 @@ class UniquePathKeyFileStoreTest extends Specification {
     UniquePathKeyFileStore uniquePathKeyFileStore
 
     def setup() {
-        uniquePathKeyFileStore = new UniquePathKeyFileStore(temporaryFolder.createDir("fsbase"))
+        uniquePathKeyFileStore = new UniquePathKeyFileStore(TestUtil.checksumService, temporaryFolder.createDir("fsbase"))
     }
 
     def "add executes action if file does not exist"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachedDependencyResolutionIntegrationTest.groovy
@@ -16,13 +16,14 @@
 
 package org.gradle.integtests.resolve.caching
 
+import org.apache.commons.lang.StringUtils
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.internal.hash.HashUtil
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.test.fixtures.server.http.IvyHttpModule
 import org.gradle.test.fixtures.server.http.HttpServer
+import org.gradle.test.fixtures.server.http.IvyHttpModule
 import spock.lang.Issue
-
 /**
  * We are using Ivy here, but the strategy is the same for any kind of repository.
  */
@@ -227,19 +228,21 @@ task retrieve(type: Sync) {
     @ToBeFixedForInstantExecution
     def "no leading zeros in sha1 checksums supported"() {
         given:
+        def sha1 = new File("${module.jarFile.absolutePath}.sha1")
         server.etags = null
         server.sendLastModified = false
-        byte[] jarBytes = [0, 0, 0, 5]
+        byte[] jarBytes = [0, 0, 0, 5] // this should produce leading zeros
         module.jarFile.bytes = jarBytes
+        sha1.text = StringUtils.leftPad(HashUtil.sha1(jarBytes).asHexString(), 40, '0')
         initialResolve()
         expect:
         headThenSha1Requests()
-        trimLeadingZerosFromSHA1()
+        trimLeadingZerosFromSHA1(sha1)
         unchangedResolve()
     }
 
-    def trimLeadingZerosFromSHA1() {
+    def trimLeadingZerosFromSHA1(File sha1) {
         //remove leading zeros from sha1 checksum
-        new File("${module.jarFile.absolutePath}.sha1").text = "e14c6ef59816760e2c9b5a57157e8ac9de4012"
+        sha1.text = sha1.text.replaceAll("^0+", "")
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -702,7 +702,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             artifact("parent-1.0.pom") {
                 declaresChecksums(
                     sha1: "dcf91b67fc14846f8234ef8e9cac922721cabf80",
-                    sha512: "1d797bd76f86414d7d7184522663bc7a28faaf19310caf5458a156dded879a914bd5c151ccc3553a9f65c4e58a85e8ec917692d517f770aaf7debacbf0fcbaf"
+                    sha512: "01d797bd76f86414d7d7184522663bc7a28faaf19310caf5458a156dded879a914bd5c151ccc3553a9f65c4e58a85e8ec917692d517f770aaf7debacbf0fcbaf"
                 )
             }
         }
@@ -734,7 +734,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             }
             artifact("foo-1.0.module") {
                 declaresChecksums(
-                    sha1: "a1a9a2fa2769295b6cef64520662a9a9135e3bb",
+                    sha1: "0a1a9a2fa2769295b6cef64520662a9a9135e3bb",
                     sha512: "7505ecc6796dd6d0a90a7e422d25c50a7c4b85b21b71ecb43dfca431bb3c3d2f696634c839a315333c96662f92987a9c58719748f6a2017fa5a89913870db60b"
                 )
             }
@@ -786,7 +786,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             artifact("parent-1.0.pom") {
                 declaresChecksums(
                     sha1: "dcf91b67fc14846f8234ef8e9cac922721cabf80",
-                    sha512: "1d797bd76f86414d7d7184522663bc7a28faaf19310caf5458a156dded879a914bd5c151ccc3553a9f65c4e58a85e8ec917692d517f770aaf7debacbf0fcbaf"
+                    sha512: "01d797bd76f86414d7d7184522663bc7a28faaf19310caf5458a156dded879a914bd5c151ccc3553a9f65c4e58a85e8ec917692d517f770aaf7debacbf0fcbaf"
                 )
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -58,6 +58,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
@@ -447,7 +448,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                           ObjectFactory objectFactory,
                                                           CollectionCallbackActionDecorator callbackDecorator,
                                                           NamedObjectInstantiator instantiator,
-                                                          DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory) {
+                                                          DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
+                                                          ChecksumService checksumService) {
             return new DefaultBaseRepositoryFactory(
                 localMavenRepositoryLocator,
                 fileResolver,
@@ -468,7 +470,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 isolatableFactory,
                 objectFactory,
                 callbackDecorator,
-                urlArtifactRepositoryFactory
+                urlArtifactRepositoryFactory,
+                checksumService
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -39,6 +39,9 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.cache.internal.CacheScopeMapping;
+import org.gradle.cache.internal.VersionStrategy;
+import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DefaultChecksumService;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
@@ -139,6 +142,7 @@ import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.BuildCommencedTimeProvider;
 import org.gradle.util.internal.SimpleMapInterner;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -453,8 +457,10 @@ class DependencyManagementBuildScopeServices {
         return new ComponentMetadataSupplierRuleExecutor(cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, suppliedComponentMetadataSerializer);
     }
 
-    ChecksumService createchecksumService(StringInterner stringInterner, CrossBuildFileHashCache fileStore, FileSystem fileSystem, GlobalScopeFileTimeStampInspector fileTimeStampInspector) {
-        return new DefaultChecksumService(stringInterner, fileStore, fileSystem, fileTimeStampInspector);
+    ChecksumService createchecksumService(StringInterner stringInterner, CacheScopeMapping cacheScopeMapping, ProjectCacheDir projectCacheDir, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, FileSystem fileSystem, GlobalScopeFileTimeStampInspector fileTimeStampInspector) {
+        File cacheDir = cacheScopeMapping.getBaseDirectory(projectCacheDir.getDir(), "checksums", VersionStrategy.SharedCache);
+        CrossBuildFileHashCache crossBuildCache = new CrossBuildFileHashCache(cacheDir, cacheRepository, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.CHECKSUMS);
+        return new DefaultChecksumService(stringInterner, crossBuildCache, fileSystem, fileTimeStampInspector);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -39,11 +39,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.cache.internal.CacheScopeMapping;
-import org.gradle.cache.internal.VersionStrategy;
-import org.gradle.initialization.layout.ProjectCacheDir;
-import org.gradle.internal.hash.ChecksumService;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DefaultChecksumService;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.InMemoryModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer;
@@ -86,9 +81,6 @@ import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceA
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.cache.StringInterner;
-import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache;
-import org.gradle.api.internal.changedetection.state.GlobalScopeFileTimeStampInspector;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
@@ -116,10 +108,10 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactMetad
 import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
 import org.gradle.internal.component.model.PersistentModuleSource;
 import org.gradle.internal.file.FileAccessTimeJournal;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
-import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
@@ -142,7 +134,6 @@ import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.BuildCommencedTimeProvider;
 import org.gradle.util.internal.SimpleMapInterner;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -455,12 +446,6 @@ class DependencyManagementBuildScopeServices {
                                                                                       final BuildCommencedTimeProvider timeProvider,
                                                                                       SuppliedComponentMetadataSerializer suppliedComponentMetadataSerializer) {
         return new ComponentMetadataSupplierRuleExecutor(cacheRepository, cacheDecoratorFactory, snapshotter, timeProvider, suppliedComponentMetadataSerializer);
-    }
-
-    ChecksumService createchecksumService(StringInterner stringInterner, CacheScopeMapping cacheScopeMapping, ProjectCacheDir projectCacheDir, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, FileSystem fileSystem, GlobalScopeFileTimeStampInspector fileTimeStampInspector) {
-        File cacheDir = cacheScopeMapping.getBaseDirectory(projectCacheDir.getDir(), "checksums", VersionStrategy.SharedCache);
-        CrossBuildFileHashCache crossBuildCache = new CrossBuildFileHashCache(cacheDir, cacheRepository, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.CHECKSUMS);
-        return new DefaultChecksumService(stringInterner, crossBuildCache, fileSystem, fileTimeStampInspector);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -56,7 +56,7 @@ public enum CacheLayout {
         .changedTo(71, "5.3-rc-1")
         .changedTo(79, "6.0-rc-1")
         .changedTo(82, "6.0-rc-2")
-        .changedTo(93_000_002, "6.1-rc-1")
+        .changedTo(93, "6.1-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -56,7 +56,7 @@ public enum CacheLayout {
         .changedTo(71, "5.3-rc-1")
         .changedTo(79, "6.0-rc-1")
         .changedTo(82, "6.0-rc-2")
-        .changedTo(92, "6.1-rc-1")
+        .changedTo(93_000_002, "6.1-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -47,6 +47,7 @@ import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.MutableModuleSources;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.resolve.ArtifactNotFoundException;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
@@ -60,7 +61,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.math.BigInteger;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -266,7 +266,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
             CachedArtifacts cachedModuleArtifacts = moduleArtifactsCache.getCachedArtifacts(delegate, component.getId(), contextId);
             ModuleSources sources = component.getSources();
             ModuleDescriptorHashModuleSource cachingModuleSource = findCachingModuleSource(sources);
-            BigInteger moduleDescriptorHash = cachingModuleSource.getDescriptorHash();
+            HashCode moduleDescriptorHash = cachingModuleSource.getDescriptorHash();
 
             if (cachedModuleArtifacts != null) {
                 if (!cachePolicy.mustRefreshModuleArtifacts(component.getModuleVersionId(), null, cachedModuleArtifacts.getAgeMillis(),
@@ -322,7 +322,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         private void resolveArtifactFromCache(ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
             CachedArtifact cached = moduleArtifactCache.lookup(artifactCacheKey(artifact.getId()));
             ModuleDescriptorHashModuleSource moduleSource = findCachingModuleSource(moduleSources);
-            final BigInteger descriptorHash = moduleSource.getDescriptorHash();
+            final HashCode descriptorHash = moduleSource.getDescriptorHash();
             if (cached != null) {
                 long age = timeProvider.getCurrentTime() - cached.getCachedAt();
                 final boolean isChangingModule = moduleSource.isChangingModule();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleDescriptorHashCodec.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleDescriptorHashCodec.java
@@ -16,11 +16,11 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.internal.component.model.PersistentModuleSource;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 
 import java.io.IOException;
-import java.math.BigInteger;
 
 public class ModuleDescriptorHashCodec implements PersistentModuleSource.Codec<ModuleDescriptorHashModuleSource> {
     @Override
@@ -32,7 +32,7 @@ public class ModuleDescriptorHashCodec implements PersistentModuleSource.Codec<M
     @Override
     public ModuleDescriptorHashModuleSource decode(Decoder decoder) throws IOException {
         return new ModuleDescriptorHashModuleSource(
-            new BigInteger(decoder.readBinary()),
+            HashCode.fromBytes(decoder.readBinary()),
             decoder.readBoolean()
         );
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleDescriptorHashModuleSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleDescriptorHashModuleSource.java
@@ -16,15 +16,14 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.internal.component.model.PersistentModuleSource;
-
-import java.math.BigInteger;
+import org.gradle.internal.hash.HashCode;
 
 public class ModuleDescriptorHashModuleSource implements PersistentModuleSource {
     public static final int CODEC_ID = 2;
-    private final BigInteger descriptorHash;
+    private final HashCode descriptorHash;
     private final boolean changingModule;
 
-    public ModuleDescriptorHashModuleSource(BigInteger descriptorHash, boolean changingModule) {
+    public ModuleDescriptorHashModuleSource(HashCode descriptorHash, boolean changingModule) {
         this.descriptorHash = descriptorHash;
         this.changingModule = changingModule;
     }
@@ -34,7 +33,7 @@ public class ModuleDescriptorHashModuleSource implements PersistentModuleSource 
         return "{descriptor: " + descriptorHash + ", changing: " + changingModule + "}";
     }
 
-    public BigInteger getDescriptorHash() {
+    public HashCode getDescriptorHash() {
         return descriptorHash;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.StartParameter;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ChecksumVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.WriteDependencyVerificationFile;
@@ -73,17 +74,17 @@ public class StartParameterResolutionOverride {
         return original;
     }
 
-    public DependencyVerificationOverride dependencyVerificationOverride(BuildOperationExecutor buildOperationExecutor) {
+    public DependencyVerificationOverride dependencyVerificationOverride(BuildOperationExecutor buildOperationExecutor, ChecksumService checksumService) {
         File currentDir = startParameter.getCurrentDir();
         List<String> checksums = startParameter.getWriteDependencyVerifications();
         if (!checksums.isEmpty()) {
             SingleMessageLogger.incubatingFeatureUsed("Dependency verification");
-            return new WriteDependencyVerificationFile(currentDir, buildOperationExecutor, checksums);
+            return new WriteDependencyVerificationFile(currentDir, buildOperationExecutor, checksums, checksumService);
         } else {
             File verificationsFile = DependencyVerificationOverride.dependencyVerificationsFile(currentDir);
             if (verificationsFile.exists()) {
                 SingleMessageLogger.incubatingFeatureUsed("Dependency verification");
-                return new ChecksumVerificationOverride(buildOperationExecutor, verificationsFile);
+                return new ChecksumVerificationOverride(buildOperationExecutor, verificationsFile, checksumService);
             }
         }
         return DependencyVerificationOverride.NO_VERIFICATION;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumHasher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumHasher.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
+
+import com.google.common.io.Files;
+import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.hash.FileHasher;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.HashFunction;
+
+import java.io.File;
+import java.io.IOException;
+
+class ChecksumHasher implements FileHasher {
+
+    private final HashFunction hashFunction;
+
+    public ChecksumHasher(HashFunction hashFunction) {
+        this.hashFunction = hashFunction;
+    }
+
+    @Override
+    public HashCode hash(File file) {
+        try {
+            return hashFunction.hashBytes(Files.toByteArray(file));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public HashCode hash(File file, long length, long lastModified) {
+        return hash(file);
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumVerificationOverride.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.verification.DependencyVerifier;
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlReader;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.operations.BuildOperationExecutor;
 
@@ -45,9 +46,11 @@ public class ChecksumVerificationOverride implements DependencyVerificationOverr
     private final DependencyVerifier verifier;
     private final Map<ModuleComponentArtifactIdentifier, DependencyVerifier.VerificationFailure> failures = Maps.newLinkedHashMapWithExpectedSize(2);
     private final BuildOperationExecutor buildOperationExecutor;
+    private final ChecksumService checksumService;
 
-    public ChecksumVerificationOverride(BuildOperationExecutor buildOperationExecutor, File verificationsFile) {
+    public ChecksumVerificationOverride(BuildOperationExecutor buildOperationExecutor, File verificationsFile, ChecksumService checksumService) {
         this.buildOperationExecutor = buildOperationExecutor;
+        this.checksumService = checksumService;
         try {
             this.verifier = DependencyVerificationsXmlReader.readFromXml(
                 new FileInputStream(verificationsFile)
@@ -59,7 +62,7 @@ public class ChecksumVerificationOverride implements DependencyVerificationOverr
 
     @Override
     public void onArtifact(ModuleComponentArtifactIdentifier artifact, File path) {
-        verifier.verify(buildOperationExecutor, artifact, path, f -> {
+        verifier.verify(buildOperationExecutor, checksumService, artifact, path, f -> {
             synchronized (failures) {
                 failures.put(artifact, f);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DefaultChecksumService.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DefaultChecksumService.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
+
+import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.api.internal.changedetection.state.CachingFileHasher;
+import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache;
+import org.gradle.api.internal.changedetection.state.GlobalScopeFileTimeStampInspector;
+import org.gradle.internal.hash.ChecksumService;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.HashFunction;
+import org.gradle.internal.hash.Hashing;
+import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+
+import java.io.File;
+
+public class DefaultChecksumService implements ChecksumService {
+    private final CachingFileHasher md5;
+    private final CachingFileHasher sha1;
+    private final CachingFileHasher sha256;
+    private final CachingFileHasher sha512;
+
+    public DefaultChecksumService(StringInterner stringInterner, CrossBuildFileHashCache fileStore, FileSystem fileSystem, GlobalScopeFileTimeStampInspector fileTimeStampInspector) {
+        md5 = createCache(stringInterner, fileStore, fileSystem, fileTimeStampInspector, "md5", Hashing.md5());
+        sha1 = createCache(stringInterner, fileStore, fileSystem, fileTimeStampInspector, "sha1", Hashing.sha1());
+        sha256 = createCache(stringInterner, fileStore, fileSystem, fileTimeStampInspector, "sha256", Hashing.sha256());
+        sha512 = createCache(stringInterner, fileStore, fileSystem, fileTimeStampInspector, "sha512", Hashing.sha512());
+    }
+
+    private CachingFileHasher createCache(StringInterner stringInterner, CrossBuildFileHashCache fileStore, FileSystem fileSystem, GlobalScopeFileTimeStampInspector fileTimeStampInspector, String name, HashFunction hashFunction) {
+        CachingFileHasher hasher = new CachingFileHasher(new ChecksumHasher(hashFunction), fileStore, stringInterner, fileTimeStampInspector, name + "-checksums", fileSystem, 1000);
+        fileTimeStampInspector.attach(hasher);
+        return hasher;
+    }
+
+    @Override
+    public HashCode md5(File file) {
+        return doHash(file, md5);
+    }
+
+    @Override
+    public HashCode sha1(File file) {
+        return doHash(file, sha1);
+    }
+
+    @Override
+    public HashCode sha256(File file) {
+        return doHash(file, sha256);
+    }
+
+    @Override
+    public HashCode sha512(File file) {
+        return doHash(file, sha512);
+    }
+
+    @Override
+    public HashCode hash(File src, String algorithm) {
+        switch (algorithm.toLowerCase()) {
+            case "md5":
+                return md5(src);
+            case "sha1":
+            case "sha-1":
+                return sha1(src);
+            case "sha256":
+            case "sha-256":
+                return sha256(src);
+            case "sha512":
+            case "sha-512":
+                return sha512(src);
+        }
+        throw new UnsupportedOperationException("Cannot hash with algorith " + algorithm);
+    }
+
+    private HashCode doHash(File file, CachingFileHasher hasher) {
+        return hasher.hash(file);
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -95,7 +95,6 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
     }
 
     private VirtualComponentIdentifier readModuleIdentifier(Decoder decoder) throws IOException {
-        decoder.readBoolean();
         String group = decoder.readString();
         String module = decoder.readString();
         String version = decoder.readString();
@@ -128,7 +127,6 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
     }
 
     private void writeComponentIdentifier(Encoder encoder, ModuleComponentIdentifier platformOwner) throws IOException {
-        encoder.writeBoolean(true);
         encoder.writeString(platformOwner.getGroup());
         encoder.writeString(platformOwner.getModule());
         encoder.writeString(platformOwner.getVersion());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/PersistentModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/PersistentModuleMetadataCache.java
@@ -29,6 +29,7 @@ import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.resource.local.DefaultPathKeyFileStore;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
@@ -49,9 +50,10 @@ public class PersistentModuleMetadataCache extends AbstractModuleMetadataCache {
                                          MavenMutableModuleMetadataFactory mavenMetadataFactory,
                                          IvyMutableModuleMetadataFactory ivyMetadataFactory,
                                          Interner<String> stringInterner,
-                                         ModuleSourcesSerializer moduleSourcesSerializer) {
+                                         ModuleSourcesSerializer moduleSourcesSerializer,
+                                         ChecksumService checksumService) {
         super(timeProvider);
-        moduleMetadataStore = new ModuleMetadataStore(new DefaultPathKeyFileStore(artifactCacheMetadata.getMetaDataStoreDirectory()), new ModuleMetadataSerializer(attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory, moduleSourcesSerializer), moduleIdentifierFactory, stringInterner);
+        moduleMetadataStore = new ModuleMetadataStore(new DefaultPathKeyFileStore(checksumService, artifactCacheMetadata.getMetaDataStoreDirectory()), new ModuleMetadataSerializer(attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory, moduleSourcesSerializer), moduleIdentifierFactory, stringInterner);
         this.artifactCacheLockingManager = artifactCacheLockingManager;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/AbstractArtifactsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/AbstractArtifactsCache.java
@@ -19,9 +19,9 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.util.BuildCommencedTimeProvider;
 
-import java.math.BigInteger;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -34,7 +34,7 @@ public abstract class AbstractArtifactsCache implements ModuleArtifactsCache {
     }
 
     @Override
-    public CachedArtifacts cacheArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context, BigInteger descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts) {
+    public CachedArtifacts cacheArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts) {
         ArtifactsAtRepositoryKey key = new ArtifactsAtRepositoryKey(repository.getId(), componentId, context);
         ModuleArtifactsCacheEntry entry = new ModuleArtifactsCacheEntry(ImmutableSet.copyOf(artifacts), timeProvider.getCurrentTime(), descriptorHash);
         store(key, entry);
@@ -59,10 +59,10 @@ public abstract class AbstractArtifactsCache implements ModuleArtifactsCache {
 
     protected static class ModuleArtifactsCacheEntry {
         protected final Set<ComponentArtifactMetadata> artifacts;
-        protected final BigInteger moduleDescriptorHash;
+        protected final HashCode moduleDescriptorHash;
         protected final long createTimestamp;
 
-        ModuleArtifactsCacheEntry(Set<? extends ComponentArtifactMetadata> artifacts, long createTimestamp, BigInteger moduleDescriptorHash) {
+        ModuleArtifactsCacheEntry(Set<? extends ComponentArtifactMetadata> artifacts, long createTimestamp, HashCode moduleDescriptorHash) {
             this.artifacts = new LinkedHashSet<ComponentArtifactMetadata>(artifacts);
             this.createTimestamp = createTimestamp;
             this.moduleDescriptorHash = moduleDescriptorHash;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/CachedArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/CachedArtifact.java
@@ -16,13 +16,13 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.resource.cached.CachedItem;
 
-import java.math.BigInteger;
 import java.util.List;
 
 public interface CachedArtifact extends CachedItem {
-    BigInteger getDescriptorHash();
+    HashCode getDescriptorHash();
 
     List<String> attemptedLocations();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/CachedArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/CachedArtifacts.java
@@ -16,14 +16,14 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.hash.HashCode;
 
-import java.math.BigInteger;
 import java.util.Set;
 
 public interface CachedArtifacts {
     Set<ComponentArtifactMetadata> getArtifacts();
 
-    BigInteger getDescriptorHash();
+    HashCode getDescriptorHash();
 
     long getAgeMillis();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultCachedArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultCachedArtifact.java
@@ -16,26 +16,27 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
+import org.gradle.internal.hash.HashCode;
+
 import java.io.File;
 import java.io.Serializable;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 
 public class DefaultCachedArtifact implements CachedArtifact, Serializable {
     private final File cachedFile;
     private final long cachedAt;
-    private final BigInteger descriptorHash;
+    private final HashCode descriptorHash;
     private final List<String> attemptedLocations;
 
-    public DefaultCachedArtifact(File cachedFile, long cachedAt, BigInteger descriptorHash) {
+    public DefaultCachedArtifact(File cachedFile, long cachedAt, HashCode descriptorHash) {
         this.cachedFile = cachedFile;
         this.cachedAt = cachedAt;
         this.descriptorHash = descriptorHash;
         this.attemptedLocations = Collections.emptyList();
     }
 
-    public DefaultCachedArtifact(List<String> attemptedLocations, long cachedAt, BigInteger descriptorHash) {
+    public DefaultCachedArtifact(List<String> attemptedLocations, long cachedAt, HashCode descriptorHash) {
         this.attemptedLocations = attemptedLocations;
         this.cachedAt = cachedAt;
         this.cachedFile = null;
@@ -58,7 +59,7 @@ public class DefaultCachedArtifact implements CachedArtifact, Serializable {
     }
 
     @Override
-    public BigInteger getDescriptorHash() {
+    public HashCode getDescriptorHash() {
         return descriptorHash;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultCachedArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultCachedArtifacts.java
@@ -16,16 +16,16 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.hash.HashCode;
 
-import java.math.BigInteger;
 import java.util.Set;
 
 class DefaultCachedArtifacts implements CachedArtifacts {
     private final Set<ComponentArtifactMetadata> artifacts;
-    private final BigInteger descriptorHash;
+    private final HashCode descriptorHash;
     private final long ageMillis;
 
-    DefaultCachedArtifacts(Set<ComponentArtifactMetadata> artifacts, BigInteger descriptorHash, long ageMillis) {
+    DefaultCachedArtifacts(Set<ComponentArtifactMetadata> artifacts, HashCode descriptorHash, long ageMillis) {
         this.ageMillis = ageMillis;
         this.artifacts = artifacts;
         this.descriptorHash = descriptorHash;
@@ -37,7 +37,7 @@ class DefaultCachedArtifacts implements CachedArtifacts {
     }
 
     @Override
-    public BigInteger getDescriptorHash() {
+    public HashCode getDescriptorHash() {
         return descriptorHash;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCache.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.metadata.ComponentArtifactIdentifierSer
 import org.gradle.api.internal.artifacts.metadata.ModuleComponentFileArtifactIdentifierSerializer;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.resource.cached.AbstractCachedIndex;
 import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.serialize.Decoder;
@@ -33,7 +34,6 @@ import org.gradle.util.BuildCommencedTimeProvider;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,22 +55,22 @@ public class DefaultModuleArtifactCache extends AbstractCachedIndex<ArtifactAtRe
     }
 
     @Override
-    public void store(final ArtifactAtRepositoryKey key, final File artifactFile, BigInteger moduleDescriptorHash) {
+    public void store(final ArtifactAtRepositoryKey key, final File artifactFile, HashCode moduleDescriptorHash) {
         assertArtifactFileNotNull(artifactFile);
         assertKeyNotNull(key);
         storeInternal(key, createEntry(artifactFile, moduleDescriptorHash));
     }
 
-    private DefaultCachedArtifact createEntry(File artifactFile, BigInteger moduleDescriptorHash) {
+    private DefaultCachedArtifact createEntry(File artifactFile, HashCode moduleDescriptorHash) {
         return new DefaultCachedArtifact(artifactFile, timeProvider.getCurrentTime(), moduleDescriptorHash);
     }
 
     @Override
-    public void storeMissing(ArtifactAtRepositoryKey key, List<String> attemptedLocations, BigInteger descriptorHash) {
+    public void storeMissing(ArtifactAtRepositoryKey key, List<String> attemptedLocations, HashCode descriptorHash) {
         storeInternal(key, createMissingEntry(attemptedLocations, descriptorHash));
     }
 
-    private CachedArtifact createMissingEntry(List<String> attemptedLocations, BigInteger descriptorHash) {
+    private CachedArtifact createMissingEntry(List<String> attemptedLocations, HashCode descriptorHash) {
         return new DefaultCachedArtifact(attemptedLocations, timeProvider.getCurrentTime(), descriptorHash);
     }
 
@@ -149,7 +149,7 @@ public class DefaultModuleArtifactCache extends AbstractCachedIndex<ArtifactAtRe
             boolean isMissing = decoder.readBoolean();
             long createTimestamp = decoder.readLong();
             byte[] encodedHash = decoder.readBinary();
-            BigInteger hash = new BigInteger(encodedHash);
+            HashCode hash = HashCode.fromBytes(encodedHash);
             if (!isMissing) {
                 return new DefaultCachedArtifact(denormalizeAndResolveFilePath(decoder.readString()), createTimestamp, hash);
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactsCache.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.artifacts.metadata.ComponentArtifactMetadataSerializer;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -29,7 +30,6 @@ import org.gradle.internal.serialize.Serializer;
 import org.gradle.internal.serialize.SetSerializer;
 import org.gradle.util.BuildCommencedTimeProvider;
 
-import java.math.BigInteger;
 import java.util.Set;
 
 public class DefaultModuleArtifactsCache extends AbstractArtifactsCache {
@@ -112,7 +112,7 @@ public class DefaultModuleArtifactsCache extends AbstractArtifactsCache {
         public ModuleArtifactsCacheEntry read(Decoder decoder) throws Exception {
             long createTimestamp = decoder.readLong();
             byte[] encodedHash = decoder.readBinary();
-            BigInteger hash = new BigInteger(encodedHash);
+            HashCode hash = HashCode.fromBytes(encodedHash);
             Set<ComponentArtifactMetadata> artifacts = artifactsSerializer.read(decoder);
             return new ModuleArtifactsCacheEntry(artifacts, createTimestamp, hash);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/InMemoryModuleArtifactCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/InMemoryModuleArtifactCache.java
@@ -16,11 +16,11 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
 import com.google.common.collect.Maps;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.util.BuildCommencedTimeProvider;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +40,7 @@ public class InMemoryModuleArtifactCache implements ModuleArtifactCache {
     }
 
     @Override
-    public void store(ArtifactAtRepositoryKey key, File artifactFile, BigInteger moduleDescriptorHash) {
+    public void store(ArtifactAtRepositoryKey key, File artifactFile, HashCode moduleDescriptorHash) {
         inMemoryCache.put(key, new DefaultCachedArtifact(artifactFile, timeProvider.getCurrentTime(), moduleDescriptorHash));
         if (delegate != null) {
             delegate.store(key, artifactFile, moduleDescriptorHash);
@@ -48,7 +48,7 @@ public class InMemoryModuleArtifactCache implements ModuleArtifactCache {
     }
 
     @Override
-    public void storeMissing(ArtifactAtRepositoryKey key, List<String> attemptedLocations, BigInteger descriptorHash) {
+    public void storeMissing(ArtifactAtRepositoryKey key, List<String> attemptedLocations, HashCode descriptorHash) {
         inMemoryCache.put(key, new DefaultCachedArtifact(attemptedLocations, timeProvider.getCurrentTime(), descriptorHash));
         if (delegate != null) {
             delegate.storeMissing(key, attemptedLocations, descriptorHash);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactCache.java
@@ -16,11 +16,11 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.resource.cached.CachedExternalResource;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.math.BigInteger;
 import java.util.List;
 
 public interface ModuleArtifactCache {
@@ -28,20 +28,18 @@ public interface ModuleArtifactCache {
      * Adds a resolution to the index.
      *
      * The incoming file is expected to be in the persistent local. This method will not move/copy the file there. <p>
-     *
-     * @param key The key to cache this resolution under in the index. Cannot be null.
+     *  @param key The key to cache this resolution under in the index. Cannot be null.
      * @param artifactFile The artifact file in the persistent file store. Cannot be null
      * @param moduleDescriptorHash The checksum (SHA1) of the related moduledescriptor.
      */
-    void store(ArtifactAtRepositoryKey key, File artifactFile, BigInteger moduleDescriptorHash);
+    void store(ArtifactAtRepositoryKey key, File artifactFile, HashCode moduleDescriptorHash);
 
     /**
      * Record that the artifact with the given key was missing.
-     *
-     * @param key The key to cache this resolution under in the index.
+     *  @param key The key to cache this resolution under in the index.
      * @param descriptorHash The SHA1 hash of the related moduleDescriptor
      */
-    void storeMissing(ArtifactAtRepositoryKey key, List<String> attemptedLocations, BigInteger descriptorHash);
+    void storeMissing(ArtifactAtRepositoryKey key, List<String> attemptedLocations, HashCode descriptorHash);
 
     /**
      * Lookup a cached resolution.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactsCache.java
@@ -18,12 +18,12 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.hash.HashCode;
 
-import java.math.BigInteger;
 import java.util.Collection;
 
 public interface ModuleArtifactsCache {
-    CachedArtifacts cacheArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context, BigInteger descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts);
+    CachedArtifacts cacheArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts);
 
     CachedArtifacts getCachedArtifacts(ModuleComponentRepository delegate, ComponentIdentifier componentId, String context);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
@@ -77,6 +78,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     private final ObjectFactory objectFactory;
     private final CollectionCallbackActionDecorator callbackActionDecorator;
     private final DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory;
+    private final ChecksumService checksumService;
 
     public DefaultBaseRepositoryFactory(LocalMavenRepositoryLocator localMavenRepositoryLocator,
                                         FileResolver fileResolver,
@@ -97,7 +99,8 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
                                         IsolatableFactory isolatableFactory,
                                         ObjectFactory objectFactory,
                                         CollectionCallbackActionDecorator callbackActionDecorator,
-                                        DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory) {
+                                        DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
+                                        ChecksumService checksumService) {
         this.localMavenRepositoryLocator = localMavenRepositoryLocator;
         this.fileResolver = fileResolver;
         this.fileCollectionFactory = fileCollectionFactory;
@@ -119,11 +122,12 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
         this.objectFactory = objectFactory;
         this.callbackActionDecorator = callbackActionDecorator;
         this.urlArtifactRepositoryFactory = urlArtifactRepositoryFactory;
+        this.checksumService = checksumService;
     }
 
     @Override
     public FlatDirectoryArtifactRepository createFlatDirRepository() {
-        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, ivyMetadataFactory, instantiatorFactory, objectFactory);
+        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactFileStore, moduleIdentifierFactory, ivyMetadataFactory, instantiatorFactory, objectFactory, checksumService);
     }
 
     @Override
@@ -141,7 +145,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     @Override
     public MavenArtifactRepository createMavenLocalRepository() {
-        MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory);
+        MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService);
         File localMavenRepository = localMavenRepositoryLocator.getLocalMavenRepository();
         mavenRepository.setUrl(localMavenRepository);
         return mavenRepository;
@@ -170,16 +174,16 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     @Override
     public IvyArtifactRepository createIvyRepository() {
-        return instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, externalResourcesFileStore, createAuthenticationContainer(), ivyContextManager, moduleIdentifierFactory, instantiatorFactory, fileResourceRepository, metadataParser, ivyMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory);
+        return instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, externalResourcesFileStore, createAuthenticationContainer(), ivyContextManager, moduleIdentifierFactory, instantiatorFactory, fileResourceRepository, metadataParser, ivyMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService);
     }
 
     @Override
     public MavenArtifactRepository createMavenRepository() {
-        return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory);
+        return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService);
     }
 
     public MavenArtifactRepository createMavenRepository(Transformer<String, MavenArtifactRepository> describer) {
-        return instantiator.newInstance(DefaultMavenArtifactRepository.class, describer, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory);
+        return instantiator.newInstance(DefaultMavenArtifactRepository.class, describer, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService);
     }
 
     protected AuthenticationContainer createAuthenticationContainer() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
@@ -38,6 +38,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ImplicitInputRecorder;
@@ -65,6 +66,7 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final IvyMutableModuleMetadataFactory metadataFactory;
     private final InstantiatorFactory instantiatorFactory;
+    private final ChecksumService checksumService;
 
     public DefaultFlatDirArtifactRepository(FileCollectionFactory fileCollectionFactory,
                                             RepositoryTransportFactory transportFactory,
@@ -73,7 +75,8 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
                                             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                             IvyMutableModuleMetadataFactory metadataFactory,
                                             InstantiatorFactory instantiatorFactory,
-                                            ObjectFactory objectFactory) {
+                                            ObjectFactory objectFactory,
+                                            ChecksumService checksumService) {
         super(objectFactory);
         this.fileCollectionFactory = fileCollectionFactory;
         this.transportFactory = transportFactory;
@@ -82,6 +85,7 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
         this.moduleIdentifierFactory = moduleIdentifierFactory;
         this.metadataFactory = metadataFactory;
         this.instantiatorFactory = instantiatorFactory;
+        this.checksumService = checksumService;
     }
 
     @Override
@@ -153,7 +157,7 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
 
         RepositoryTransport transport = transportFactory.createFileTransport(getName());
         Instantiator injector = createInjectorForMetadataSuppliers(transport, instantiatorFactory, null, null);
-        IvyResolver resolver = new IvyResolver(getName(), transport, locallyAvailableResourceFinder, false, artifactFileStore, moduleIdentifierFactory, null, null, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE, injector);
+        IvyResolver resolver = new IvyResolver(getName(), transport, locallyAvailableResourceFinder, false, artifactFileStore, moduleIdentifierFactory, null, null, createMetadataSources(), IvyMetadataArtifactProvider.INSTANCE, injector, checksumService);
         for (File root : dirs) {
             resolver.addArtifactLocation(root.toURI(), "/[artifact]-[revision](-[classifier]).[ext]");
             resolver.addArtifactLocation(root.toURI(), "/[artifact](-[classifier]).[ext]");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories;
 
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenLocalPomMetadataSource;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
@@ -47,6 +48,7 @@ import java.net.URI;
 
 public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRepository implements MavenArtifactRepository {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenResolver.class);
+    private final ChecksumService checksumService;
 
     public DefaultMavenLocalArtifactRepository(FileResolver fileResolver, RepositoryTransportFactory transportFactory,
                                                LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder, InstantiatorFactory instantiatorFactory,
@@ -58,8 +60,10 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
                                                MavenMutableModuleMetadataFactory metadataFactory,
                                                IsolatableFactory isolatableFactory,
                                                ObjectFactory objectFactory,
-                                               DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory) {
-        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, authenticationContainer, null, fileResourceRepository, metadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory);
+                                               DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
+                                               ChecksumService checksumService) {
+        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, authenticationContainer, null, fileResourceRepository, metadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService);
+        this.checksumService = checksumService;
     }
 
     @Override
@@ -79,7 +83,7 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
             MavenMetadataArtifactProvider.INSTANCE,
             mavenMetadataLoader,
             null,
-            null, injector);
+            null, injector, checksumService);
         for (URI repoUrl : getArtifactUrls()) {
             resolver.addArtifactLocation(repoUrl);
         }
@@ -88,7 +92,7 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
 
     @Override
     protected DefaultMavenPomMetadataSource createPomMetadataSource(MavenMetadataLoader mavenMetadataLoader, FileResourceRepository fileResourceRepository) {
-        return new MavenLocalPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader);
+        return new MavenLocalPomMetadataSource(MavenMetadataArtifactProvider.INSTANCE, getPomParser(), fileResourceRepository, getMetadataValidationServices(), mavenMetadataLoader, checksumService);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
@@ -30,7 +30,8 @@ import org.gradle.internal.component.external.model.MutableModuleComponentResolv
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
@@ -38,12 +39,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.math.BigInteger;
 import java.util.List;
 
 public class DefaultArtifactMetadataSource extends AbstractMetadataSource<MutableModuleComponentResolveMetadata> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExternalResourceResolver.class);
-    private static final BigInteger MISSING = HashUtil.createHash("", "MD5").asBigInteger();
+    private static final HashCode MISSING = Hashing.md5().hashString("");
     private final MutableModuleMetadataFactory<? extends MutableModuleComponentResolveMetadata> mutableModuleMetadataFactory;
     private final String artifactType;
     private final String artifactExtension;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMetadataFileSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMetadataFileSource.java
@@ -16,9 +16,9 @@
 package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
-import java.math.BigInteger;
 
 /**
  * This module source stores information about the original
@@ -27,9 +27,9 @@ import java.math.BigInteger;
 public class DefaultMetadataFileSource implements MetadataFileSource {
     private final ModuleComponentArtifactIdentifier artifactId;
     private final File artifactFile;
-    private final BigInteger sha1;
+    private final HashCode sha1;
 
-    public DefaultMetadataFileSource(ModuleComponentArtifactIdentifier artifactId, File artifactFile, BigInteger sha1) {
+    public DefaultMetadataFileSource(ModuleComponentArtifactIdentifier artifactId, File artifactFile, HashCode sha1) {
         this.artifactId = artifactId;
         this.artifactFile = artifactFile;
         this.sha1 = sha1;
@@ -46,7 +46,7 @@ public class DefaultMetadataFileSource implements MetadataFileSource {
     }
 
     @Override
-    public BigInteger getSha1() {
+    public HashCode getSha1() {
         return sha1;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMetadataFileSourceCodec.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMetadataFileSourceCodec.java
@@ -22,12 +22,12 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentIdenti
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier;
 import org.gradle.internal.component.model.PersistentModuleSource;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigInteger;
 
 /**
  * A codec for {@link MetadataFileSource}. This codec is particular because of the persistent cache
@@ -63,18 +63,19 @@ public class DefaultMetadataFileSourceCodec implements PersistentModuleSource.Co
         String module = decoder.readString();
         String version = decoder.readString();
         String name = decoder.readString();
-        BigInteger sha1 = new BigInteger(decoder.readBinary());
+        byte[] sha1 = decoder.readBinary();
         DefaultMetadataFileSource source = createSource(sha1, group, module, version, name);
         return source;
     }
 
-    private DefaultMetadataFileSource createSource(BigInteger sha1, String group, String module, String version, String name) {
+    private DefaultMetadataFileSource createSource(byte[] sha1, String group, String module, String version, String name) {
         ModuleComponentArtifactIdentifier artifactId = createArtifactId(group, module, version, name);
-        File metadataFile = fileStore.whereIs(artifactId, sha1.toString(16));
+        HashCode hashCode = HashCode.fromBytes(sha1);
+        File metadataFile = fileStore.whereIs(artifactId, hashCode.toString());
         return new DefaultMetadataFileSource(
             artifactId,
             metadataFile,
-            sha1);
+            hashCode);
     }
 
     private ModuleComponentFileArtifactIdentifier createArtifactId(String group, String module, String version, String name) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenLocalPomMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenLocalPomMetadataSource.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
 import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
 import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
@@ -34,8 +35,8 @@ import static org.gradle.api.internal.artifacts.repositories.metadata.DefaultArt
 public class MavenLocalPomMetadataSource extends DefaultMavenPomMetadataSource {
 
     @Inject
-    public MavenLocalPomMetadataSource(MetadataArtifactProvider metadataArtifactProvider, MetaDataParser<MutableMavenModuleResolveMetadata> pomParser, FileResourceRepository fileResourceRepository, MavenMetadataValidator validator, MavenMetadataLoader mavenMetadataLoader) {
-        super(metadataArtifactProvider, pomParser, fileResourceRepository, validator, mavenMetadataLoader);
+    public MavenLocalPomMetadataSource(MetadataArtifactProvider metadataArtifactProvider, MetaDataParser<MutableMavenModuleResolveMetadata> pomParser, FileResourceRepository fileResourceRepository, MavenMetadataValidator validator, MavenMetadataLoader mavenMetadataLoader, ChecksumService checksumService) {
+        super(metadataArtifactProvider, pomParser, fileResourceRepository, validator, mavenMetadataLoader, checksumService);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MetadataFileSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MetadataFileSource.java
@@ -17,9 +17,9 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.model.PersistentModuleSource;
+import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
-import java.math.BigInteger;
 
 /**
  * This module source stores information about the metadata file
@@ -37,7 +37,7 @@ public interface MetadataFileSource extends PersistentModuleSource {
 
     ModuleComponentArtifactIdentifier getArtifactId();
 
-    BigInteger getSha1();
+    HashCode getSha1();
 
     @Override
     default int getCodecId() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -54,8 +54,8 @@ import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleDescriptorArtifactMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.WrappedComponentResolveMetadata;
-import org.gradle.internal.hash.HashUtil;
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.ChecksumService;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.reflect.Instantiator;
@@ -110,6 +110,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
     private final InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory;
     private final InstantiatingAction<ComponentMetadataListerDetails> providedVersionLister;
     private final Instantiator injector;
+    private final ChecksumService checksumService;
 
     private String id;
     private ExternalResourceArtifactResolver cachedArtifactResolver;
@@ -124,7 +125,8 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
                                        MetadataArtifactProvider metadataArtifactProvider,
                                        @Nullable InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory,
                                        @Nullable InstantiatingAction<ComponentMetadataListerDetails> providedVersionLister,
-                                       Instantiator injector) {
+                                       Instantiator injector,
+                                       ChecksumService checksumService) {
         this.name = name;
         this.local = local;
         this.cachingResourceAccessor = cachingResourceAccessor;
@@ -136,6 +138,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         this.componentMetadataSupplierFactory = componentMetadataSupplierFactory;
         this.providedVersionLister = providedVersionLister;
         this.injector = injector;
+        this.checksumService = checksumService;
     }
 
     @Override
@@ -340,8 +343,8 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
     }
 
     private byte[] createChecksumFile(File src, String algorithm, int checksumLength) {
-        HashValue hash = HashUtil.createHash(src, algorithm);
-        String formattedHashString = hash.asZeroPaddedHexString(checksumLength);
+        HashCode hash = checksumService.hash(src, algorithm);
+        String formattedHashString = hash.toString();
         try {
             return formattedHashString.getBytes("US-ASCII");
         } catch (UnsupportedEncodingException e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DescriptorParseContext;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMetadataFileSource;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
@@ -27,7 +28,6 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
 import org.gradle.internal.component.model.MutableModuleSources;
-import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
@@ -52,10 +52,12 @@ public class ExternalResourceResolverDescriptorParseContext implements Descripto
     private final ComponentResolvers mainResolvers;
     private final FileResourceRepository fileResourceRepository;
     private final MutableModuleSources sources = new MutableModuleSources();
+    private final ChecksumService checksumService;
 
-    public ExternalResourceResolverDescriptorParseContext(ComponentResolvers mainResolvers, FileResourceRepository fileResourceRepository) {
+    public ExternalResourceResolverDescriptorParseContext(ComponentResolvers mainResolvers, FileResourceRepository fileResourceRepository, ChecksumService checksumService) {
         this.mainResolvers = mainResolvers;
         this.fileResourceRepository = fileResourceRepository;
+        this.checksumService = checksumService;
     }
 
     @Override
@@ -85,7 +87,7 @@ public class ExternalResourceResolverDescriptorParseContext implements Descripto
         LocallyAvailableExternalResource resource = fileResourceRepository.resource(file);
         ComponentArtifactIdentifier id = artifactMetaData.getId();
         if (id instanceof ModuleComponentArtifactIdentifier) {
-            sources.add(new DefaultMetadataFileSource((ModuleComponentArtifactIdentifier) id, file, HashUtil.sha1(file).asBigInteger()));
+            sources.add(new DefaultMetadataFileSource((ModuleComponentArtifactIdentifier) id, file, checksumService.sha1(file)));
         }
         return resource;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -29,6 +29,7 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactIdent
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
@@ -56,7 +57,7 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
                        @Nullable InstantiatingAction<ComponentMetadataListerDetails> componentMetadataVersionListerFactory,
                        ImmutableMetadataSources repositoryContentFilter,
                        MetadataArtifactProvider metadataArtifactProvider,
-                       Instantiator injector) {
+                       Instantiator injector, ChecksumService checksumService) {
         super(
             name,
             transport.isLocal(),
@@ -68,8 +69,8 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
             metadataArtifactProvider,
             componentMetadataSupplierFactory,
             componentMetadataVersionListerFactory,
-            injector
-        );
+            injector,
+            checksumService);
         this.dynamicResolve = dynamicResolve;
         this.localRepositoryAccess = new IvyLocalRepositoryAccess();
         this.remoteRepositoryAccess = new IvyRemoteRepositoryAccess();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -39,6 +39,7 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.MutableModuleSources;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
@@ -76,7 +77,8 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
                          MavenMetadataLoader mavenMetadataLoader,
                          @Nullable InstantiatingAction<ComponentMetadataSupplierDetails> componentMetadataSupplierFactory,
                          @Nullable InstantiatingAction<ComponentMetadataListerDetails> versionListerFactory,
-                         Instantiator injector) {
+                         Instantiator injector,
+                         ChecksumService checksumService) {
         super(name, transport.isLocal(),
             transport.getRepository(),
             transport.getResourceAccessor(),
@@ -86,7 +88,8 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
             metadataArtifactProvider,
             componentMetadataSupplierFactory,
             versionListerFactory,
-            injector);
+            injector,
+            checksumService);
         this.mavenMetaDataLoader = mavenMetadataLoader;
         this.root = rootUri;
         updatePatterns();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.authentication.Authentication;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.authentication.AuthenticationInternal;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resource.ExternalResourceName;
@@ -57,6 +58,7 @@ public class RepositoryTransportFactory {
     private final StartParameterResolutionOverride startParameterResolutionOverride;
     private final ProducerGuard<ExternalResourceName> producerGuard;
     private final FileResourceRepository fileRepository;
+    private final ChecksumService checksumService;
 
     public RepositoryTransportFactory(Collection<ResourceConnectorFactory> resourceConnectorFactory,
                                       ProgressLoggerFactory progressLoggerFactory,
@@ -67,7 +69,8 @@ public class RepositoryTransportFactory {
                                       BuildOperationExecutor buildOperationExecutor,
                                       StartParameterResolutionOverride startParameterResolutionOverride,
                                       ProducerGuard<ExternalResourceName> producerGuard,
-                                      FileResourceRepository fileRepository) {
+                                      FileResourceRepository fileRepository,
+                                      ChecksumService checksumService) {
         this.progressLoggerFactory = progressLoggerFactory;
         this.temporaryFileProvider = temporaryFileProvider;
         this.cachedExternalResourceIndex = cachedExternalResourceIndex;
@@ -77,6 +80,7 @@ public class RepositoryTransportFactory {
         this.startParameterResolutionOverride = startParameterResolutionOverride;
         this.producerGuard = producerGuard;
         this.fileRepository = fileRepository;
+        this.checksumService = checksumService;
 
         for (ResourceConnectorFactory connectorFactory : resourceConnectorFactory) {
             register(connectorFactory);
@@ -96,7 +100,7 @@ public class RepositoryTransportFactory {
     }
 
     public RepositoryTransport createFileTransport(String name) {
-        return new FileTransport(name, fileRepository, cachedExternalResourceIndex, temporaryFileProvider, timeProvider, artifactCacheLockingManager, producerGuard);
+        return new FileTransport(name, fileRepository, cachedExternalResourceIndex, temporaryFileProvider, timeProvider, artifactCacheLockingManager, producerGuard, checksumService);
     }
 
     public RepositoryTransport createTransport(String scheme, String name, Collection<Authentication> authentications, HttpRedirectVerifier redirectVerifier) {
@@ -126,7 +130,7 @@ public class RepositoryTransportFactory {
         ExternalResourceCachePolicy cachePolicy = new DefaultExternalResourceCachePolicy();
         cachePolicy = startParameterResolutionOverride.overrideExternalResourceCachePolicy(cachePolicy);
 
-        return new ResourceConnectorRepositoryTransport(name, progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, artifactCacheLockingManager, resourceConnector, buildOperationExecutor, cachePolicy, producerGuard, fileRepository);
+        return new ResourceConnectorRepositoryTransport(name, progressLoggerFactory, temporaryFileProvider, cachedExternalResourceIndex, timeProvider, artifactCacheLockingManager, resourceConnector, buildOperationExecutor, cachePolicy, producerGuard, fileRepository, checksumService);
     }
 
     private void validateSchemes(Set<String> schemes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/ivy/ArtifactIdentifierFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/filestore/ivy/ArtifactIdentifierFileStore.java
@@ -20,6 +20,7 @@ import org.gradle.api.Namer;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.file.FileAccessTimeJournal;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.resource.local.GroupedAndNamedUniqueFileStore;
 
 import java.io.File;
@@ -48,7 +49,7 @@ public class ArtifactIdentifierFileStore extends GroupedAndNamedUniqueFileStore<
         }
     };
 
-    public ArtifactIdentifierFileStore(File baseDir, TemporaryFileProvider temporaryFileProvider, FileAccessTimeJournal fileAccessTimeJournal) {
-        super(baseDir, temporaryFileProvider, fileAccessTimeJournal, GROUPER, NAMER);
+    public ArtifactIdentifierFileStore(File baseDir, TemporaryFileProvider temporaryFileProvider, FileAccessTimeJournal fileAccessTimeJournal, ChecksumService checksumService) {
+        super(baseDir, temporaryFileProvider, fileAccessTimeJournal, GROUPER, NAMER, checksumService);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutor.java
@@ -38,7 +38,7 @@ public class ComponentMetadataRuleExecutor extends CrossBuildCachingRuleExecutor
             @Override
             public Serializable transform(ModuleComponentResolveMetadata moduleMetadata) {
                 return moduleMetadata.getSources().withSource(ModuleDescriptorHashModuleSource.class, source -> {
-                    return source.map(metadataFileSource -> metadataFileSource.getDescriptorHash().toString(16))
+                    return source.map(metadataFileSource -> metadataFileSource.getDescriptorHash().toString())
                         .orElseThrow(() -> new RuntimeException("Cannot find original content hash"));
                 });
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndex.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndex.java
@@ -18,7 +18,7 @@ package org.gradle.internal.resource.cached;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.resource.local.FileAccessTracker;
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
@@ -100,9 +100,9 @@ public class DefaultCachedExternalResourceIndex<K extends Serializable> extends 
                 String contentType = decoder.readNullableString();
                 long contentLength = decoder.readSmallLong();
                 String etag = decoder.readNullableString();
-                HashValue sha1 = null;
+                HashCode sha1 = null;
                 if (decoder.readBoolean()) {
-                    sha1 = HashValue.parse(decoder.readString());
+                    sha1 = HashCode.fromString(decoder.readString());
                 }
                 metaData = new DefaultExternalResourceMetaData(uri, lastModified, contentLength, contentType, etag, sha1);
             }
@@ -129,7 +129,7 @@ public class DefaultCachedExternalResourceIndex<K extends Serializable> extends 
                 encoder.writeNullableString(metaData.getEtag());
                 encoder.writeBoolean(metaData.getSha1() != null);
                 if (metaData.getSha1() != null) {
-                    encoder.writeString(metaData.getSha1().asHexString());
+                    encoder.writeString(metaData.getSha1().toString());
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ExternalResourceFileStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ExternalResourceFileStore.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Namer;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.internal.file.FileAccessTimeJournal;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.resource.local.GroupedAndNamedUniqueFileStore;
 
 import java.io.File;
@@ -47,7 +48,7 @@ public class ExternalResourceFileStore extends GroupedAndNamedUniqueFileStore<St
         }
     };
 
-    public ExternalResourceFileStore(File baseDir, TemporaryFileProvider tmpProvider, FileAccessTimeJournal fileAccessTimeJournal) {
-        super(baseDir, tmpProvider, fileAccessTimeJournal, GROUPER, NAMER);
+    public ExternalResourceFileStore(File baseDir, TemporaryFileProvider tmpProvider, FileAccessTimeJournal fileAccessTimeJournal, ChecksumService checksumService) {
+        super(baseDir, tmpProvider, fileAccessTimeJournal, GROUPER, NAMER, checksumService);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/local/ivy/PatternBasedLocallyAvailableResourceFinder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/local/ivy/PatternBasedLocallyAvailableResourceFinder.java
@@ -20,6 +20,7 @@ import org.gradle.api.file.EmptyFileVisitor;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.resource.local.AbstractLocallyAvailableResourceFinder;
 import org.gradle.api.internal.file.collections.MinimalFileTree;
 import org.gradle.api.internal.file.collections.SingleIncludePatternFileTree;
@@ -31,8 +32,8 @@ import java.util.List;
 
 public class PatternBasedLocallyAvailableResourceFinder extends AbstractLocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> {
 
-    public PatternBasedLocallyAvailableResourceFinder(File baseDir, ResourcePattern pattern) {
-        super(createProducer(baseDir, pattern));
+    public PatternBasedLocallyAvailableResourceFinder(File baseDir, ResourcePattern pattern, ChecksumService checksumService) {
+        super(createProducer(baseDir, pattern), checksumService);
     }
 
     private static Transformer<Factory<List<File>>, ModuleComponentArtifactMetadata> createProducer(final File baseDir, final ResourcePattern pattern) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/ResourceConnectorRepositoryTransport.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.cache.internal.ProducerGuard;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resource.ExternalResourceName;
@@ -47,12 +48,13 @@ public class ResourceConnectorRepositoryTransport extends AbstractRepositoryTran
                                                 BuildOperationExecutor buildOperationExecutor,
                                                 ExternalResourceCachePolicy cachePolicy,
                                                 ProducerGuard<ExternalResourceName> producerGuard,
-                                                FileResourceRepository fileResourceRepository) {
+                                                FileResourceRepository fileResourceRepository,
+                                                ChecksumService checksumService) {
         super(name);
         ProgressLoggingExternalResourceUploader loggingUploader = new ProgressLoggingExternalResourceUploader(connector, progressLoggerFactory);
         ProgressLoggingExternalResourceAccessor loggingAccessor = new ProgressLoggingExternalResourceAccessor(connector, progressLoggerFactory);
         repository = new DefaultExternalResourceRepository(name, connector, connector, connector, loggingAccessor, loggingUploader, buildOperationExecutor);
-        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, fileResourceRepository);
+        resourceAccessor = new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, fileResourceRepository, checksumService);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transport/file/FileTransport.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultEx
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.cache.internal.ProducerGuard;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.ExternalResourceRepository;
 import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
@@ -38,11 +39,11 @@ public class FileTransport extends AbstractRepositoryTransport {
     private final FileResourceRepository repository;
     private final FileCacheAwareExternalResourceAccessor resourceAccessor;
 
-    public FileTransport(String name, FileResourceRepository repository, CachedExternalResourceIndex<String> cachedExternalResourceIndex, TemporaryFileProvider temporaryFileProvider, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ProducerGuard<ExternalResourceName> producerGuard) {
+    public FileTransport(String name, FileResourceRepository repository, CachedExternalResourceIndex<String> cachedExternalResourceIndex, TemporaryFileProvider temporaryFileProvider, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ProducerGuard<ExternalResourceName> producerGuard, ChecksumService checksumService) {
         super(name);
         this.repository = repository;
         ExternalResourceCachePolicy cachePolicy = new DefaultExternalResourceCachePolicy();
-        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, repository));
+        resourceAccessor = new FileCacheAwareExternalResourceAccessor(new DefaultCacheAwareExternalResourceAccessor(repository, cachedExternalResourceIndex, timeProvider, temporaryFileProvider, artifactCacheLockingManager, cachePolicy, producerGuard, repository, checksumService));
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 92
+        expectedVersion = 93_000_002
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 93_000_002
+        expectedVersion = 93
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataCache
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCaches
@@ -38,6 +37,7 @@ import org.gradle.internal.component.model.ComponentOverrideMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.ConfigurationMetadata
 import org.gradle.internal.component.model.ImmutableModuleSources
+import org.gradle.internal.hash.Hashing
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableArtifactSetResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableComponentArtifactsResolveResult
@@ -61,7 +61,6 @@ class CachingModuleComponentRepositoryTest extends Specification {
     def artifactAtRepositoryCache = Mock(ModuleArtifactCache)
     def cachePolicy = Stub(CachePolicy)
     def metadataProcessor = Stub(ComponentMetadataProcessor)
-    def moduleIdentifierFactory = Mock(ImmutableModuleIdentifierFactory)
     def caches = new ModuleRepositoryCaches(moduleResolutionCache, moduleDescriptorCache, moduleArtifactsCache, artifactAtRepositoryCache)
     def repo = new CachingModuleComponentRepository(realRepo, caches,
         cachePolicy, new BuildCommencedTimeProvider(), metadataProcessor)
@@ -80,7 +79,7 @@ class CachingModuleComponentRepositoryTest extends Specification {
             getFailure() >> null
         }
 
-        def descriptorHash = 1234G
+        def descriptorHash = Hashing.sha1().hashString("Hello")
         def moduleSource = Stub(ModuleDescriptorHashModuleSource) {
             getDescriptorHash() >> descriptorHash
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyResolverIdentifierTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.local.FileStore
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
 import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import java.lang.reflect.Field
@@ -75,7 +76,7 @@ class DependencyResolverIdentifierTest extends Specification {
     static class TestResolver extends ExternalResourceResolver {
 
         protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder locallyAvailableResourceFinder, FileStore artifactFileStore, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
-            super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, metadataSources, metadataArtifactProvider, null, null, null)
+            super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, metadataSources, metadataArtifactProvider, null, null, null, TestUtil.checksumService)
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
@@ -50,6 +50,7 @@ import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
 import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.BuildCommencedTimeProvider
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -78,7 +79,7 @@ class ResolveIvyFactoryTest extends Specification {
         cacheProvider = new ModuleRepositoryCacheProvider(caches, caches)
         startParameterResolutionOverride = Mock(StartParameterResolutionOverride) {
             _ * overrideModuleVersionRepository(_) >> { ModuleComponentRepository repository -> repository }
-            _ * dependencyVerificationOverride(_) >> DependencyVerificationOverride.NO_VERIFICATION
+            _ * dependencyVerificationOverride(_, _) >> DependencyVerificationOverride.NO_VERIFICATION
         }
         buildCommencedTimeProvider = Mock(BuildCommencedTimeProvider)
         moduleIdentifierFactory = Mock(ImmutableModuleIdentifierFactory)
@@ -88,7 +89,7 @@ class ResolveIvyFactoryTest extends Specification {
         instantiatorFactory = Mock()
         buildOperationExecutor = Mock()
 
-        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor), buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, instantiatorFactory)
+        resolveIvyFactory = new ResolveIvyFactory(cacheProvider, startParameterResolutionOverride, startParameterResolutionOverride.dependencyVerificationOverride(buildOperationExecutor, TestUtil.checksumService), buildCommencedTimeProvider, versionComparator, moduleIdentifierFactory, repositoryBlacklister, versionParser, instantiatorFactory)
     }
 
     def "returns an empty resolver when no repositories are configured" () {
@@ -150,7 +151,8 @@ class ResolveIvyFactoryTest extends Specification {
                 metadataArtifactProvider,
                 componentMetadataSupplierFactory,
                 versionListerFactory,
-                Mock(Instantiator)
+                Mock(Instantiator),
+                TestUtil.checksumService
             ]
         ) {
             appendId(_) >> { }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager
 import org.gradle.cache.PersistentIndexedCache
 import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
+import org.gradle.internal.hash.HashCode
 import org.gradle.internal.resource.local.FileAccessTracker
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
@@ -51,7 +52,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         def key = new ArtifactAtRepositoryKey("RepoID", Stub(ModuleComponentArtifactIdentifier))
 
         when:
-        index.store(key, null, 0)
+        index.store(key, null, HashCode.fromInt(0))
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -60,7 +61,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
 
     def "artifact key must be provided"() {
         when:
-        index.store(null, Stub(File), 0)
+        index.store(null, Stub(File), HashCode.fromInt(0))
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -74,14 +75,14 @@ class DefaultModuleArtifactCacheTest extends Specification {
         def testFile = folder.createFile("aTestFile")
 
         when:
-        index.store(key, testFile, BigInteger.TEN)
+        index.store(key, testFile, HashCode.fromInt(10))
 
         then:
         1 * cacheLockingManager.useCache(_) >> { Runnable action -> action.run() }
         1 * timeProvider.currentTime >> 123
         1 * persistentIndexedCache.put(key, _) >> { k, v ->
             assert v.cachedAt == 123
-            assert v.descriptorHash == BigInteger.TEN
+            assert v.descriptorHash == HashCode.fromInt(10)
             assert v.cachedFile == testFile
         }
     }
@@ -138,7 +139,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         then:
         2 * cachedArtifact.isMissing() >> false
         1 * cachedArtifact.cachedAt >> 42L
-        1 * cachedArtifact.getDescriptorHash() >> BigInteger.valueOf(42L)
+        1 * cachedArtifact.getDescriptorHash() >> HashCode.fromInt(42)
         1 * cachedArtifact.getCachedFile() >> commonRootPath.resolve("file.txt").toFile()
 
         1 * encoder.writeString("file.txt")
@@ -156,7 +157,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         then:
         1 * decoder.readBoolean() >> false
         1 * decoder.readLong() >> 42L
-        1 * decoder.readBinary() >> BigInteger.valueOf(42L).toByteArray()
+        1 * decoder.readBinary() >> HashCode.fromInt(42).toByteArray()
         1 * decoder.readString() >> fileName
 
         cachedArtifact.getCachedFile() == commonRootPath.resolve(fileName).toFile()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -65,7 +65,8 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
         artifactIdentifierFileStore, externalResourceFileStore, pomParser, metadataParser, authenticationSchemeRegistry, ivyContextManager, moduleIdentifierFactory,
         TestUtil.instantiatorFactory(), Mock(FileResourceRepository), mavenMetadataFactory, ivyMetadataFactory, SnapshotTestUtil.valueSnapshotter() as IsolatableFactory, Mock(ObjectFactory),
         CollectionCallbackActionDecorator.NOOP,
-        urlArtifactRepositoryFactory
+        urlArtifactRepositoryFactory,
+        TestUtil.checksumService
     )
 
     def testCreateFlatDirResolver() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactMetad
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultFlatDirArtifactRepositoryTest extends Specification {
@@ -42,7 +43,7 @@ class DefaultFlatDirArtifactRepositoryTest extends Specification {
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
-    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, moduleIdentifierFactory, metadataFactory, Mock(InstantiatorFactory), Mock(ObjectFactory))
+    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, moduleIdentifierFactory, metadataFactory, Mock(InstantiatorFactory), Mock(ObjectFactory), TestUtil.checksumService)
 
     def "creates a repository with multiple root directories"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -60,7 +60,12 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     final DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory = new DefaultUrlArtifactRepository.Factory(fileResolver, new DocumentationRegistry())
 
-    final DefaultIvyArtifactRepository repository = instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, metadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory), urlArtifactRepositoryFactory)
+    final DefaultIvyArtifactRepository repository = instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder,
+        artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager,
+        moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser,
+        metadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory), urlArtifactRepositoryFactory,
+        TestUtil.checksumService
+    )
 
     def "default values"() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.ComponentMetadataVersionLister
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -53,12 +52,14 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final MetaDataParser pomParser = Stub()
     final GradleModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
-    final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
     final DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory = new DefaultUrlArtifactRepository.Factory(resolver, new DocumentationRegistry())
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
-        resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(), artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, externalResourceFileStore, Mock(FileResourceRepository), mavenMetadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory), urlArtifactRepositoryFactory)
+        resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(),
+        artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, externalResourceFileStore,
+        Mock(FileResourceRepository), mavenMetadataFactory, SnapshotTestUtil.valueSnapshotter(),
+        Mock(ObjectFactory), urlArtifactRepositoryFactory, TestUtil.checksumService)
 
     def "creates local repository"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -68,7 +68,8 @@ class DefaultMavenLocalRepositoryTest extends Specification {
             mavenMetadataFactory,
             (IsolatableFactory) SnapshotTestUtil.valueSnapshotter(),
             objectFactory,
-            urlArtifactRepositoryFactory
+            urlArtifactRepositoryFactory,
+            TestUtil.checksumService
         )
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolverTest.groovy
@@ -172,7 +172,7 @@ class IvyResolverTest extends Specification {
                     metadataArtifactProvider,
                     null,
                     fileResourceRepository,
-                    moduleIdentifierFactory
+                    TestUtil.checksumService
                 ))
             }
             appendId(_) >> { args ->
@@ -185,16 +185,17 @@ class IvyResolverTest extends Specification {
         def lister = new InstantiatingAction<ComponentMetadataListerDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
 
         new IvyResolver(
-            "repo",
-            transport,
-            Stub(LocallyAvailableResourceFinder),
-            false,
-            Stub(FileStore),
-            moduleIdentifierFactory,
-            supplier,
-            lister,
-            metadataSources,
-            metadataArtifactProvider, Mock(Instantiator)).with {
+                "repo",
+                transport,
+                Stub(LocallyAvailableResourceFinder),
+                false,
+                Stub(FileStore),
+                moduleIdentifierFactory,
+                supplier,
+                lister,
+                metadataSources,
+                metadataArtifactProvider, Mock(Instantiator),
+                TestUtil.checksumService).with {
             if (ivyPattern) {
                 it.addDescriptorLocation(URI.create(""), ivyPattern)
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolverTest.groovy
@@ -149,6 +149,6 @@ class MavenResolverTest extends Specification {
         def supplier = new InstantiatingAction<ComponentMetadataSupplierDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
         def lister = new InstantiatingAction<ComponentMetadataListerDetails>(DefaultConfigurableRules.of(Stub(ConfigurableRule)), TestUtil.instantiatorFactory().inject(), Stub(InstantiatingAction.ExceptionHandler))
 
-        new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), metadataSources, metadataArtifactProvider, Stub(MavenMetadataLoader), supplier, lister, Mock(Instantiator))
+        new MavenResolver("repo", new URI("http://localhost"), Stub(RepositoryTransport), Stub(LocallyAvailableResourceFinder), Stub(FileStore), metadataSources, metadataArtifactProvider, Stub(MavenMetadataLoader), supplier, lister, Mock(Instantiator), TestUtil.checksumService)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
@@ -33,12 +33,13 @@ import org.gradle.internal.resource.ExternalResourceRepository;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.resource.transfer.CacheAwareExternalResourceAccessor;
+import org.gradle.util.TestUtil;
 
 public class TestResolver extends ExternalResourceResolver<ModuleComponentResolveMetadata> {
     ExternalResourceArtifactResolver artifactResolver;
 
     protected TestResolver(String name, boolean local, ExternalResourceRepository repository, CacheAwareExternalResourceAccessor cachingResourceAccessor, LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder, FileStore<ModuleComponentArtifactIdentifier> artifactFileStore, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ImmutableMetadataSources metadataSources, MetadataArtifactProvider metadataArtifactProvider) {
-        super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, metadataSources, metadataArtifactProvider, null, null, null);
+        super(name, local, repository, cachingResourceAccessor, locallyAvailableResourceFinder, artifactFileStore, metadataSources, metadataArtifactProvider, null, null, null, TestUtil.getChecksumService());
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.resource.connector.ResourceConnectorFactory
 import org.gradle.internal.resource.local.FileResourceRepository
 import org.gradle.internal.resource.transport.ResourceConnectorRepositoryTransport
 import org.gradle.internal.verifier.HttpRedirectVerifier
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -45,7 +46,7 @@ class RepositoryTransportFactoryTest extends Specification {
         connectorFactory2.getSupportedAuthentication() >> ([] as Set)
         List<ResourceConnectorFactory> resourceConnectorFactories = Lists.newArrayList(connectorFactory1, connectorFactory2)
         StartParameterResolutionOverride override = new StartParameterResolutionOverride(new StartParameter())
-        repositoryTransportFactory = new RepositoryTransportFactory(resourceConnectorFactories, null, null, null, null, null, null, override, producerGuard, Mock(FileResourceRepository))
+        repositoryTransportFactory = new RepositoryTransportFactory(resourceConnectorFactories, null, null, null, null, null, null, override, producerGuard, Mock(FileResourceRepository), TestUtil.checksumService)
     }
 
     RepositoryTransport createTransport(String scheme, String name, Collection<Authentication> authentications) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashModuleSource
-import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleSourcesSerializer
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheDecorator
 import org.gradle.cache.CacheRepository
@@ -41,7 +40,6 @@ import org.gradle.internal.action.InstantiatingAction
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.MutableModuleSources
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.HashValue
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.service.DefaultServiceRegistry
@@ -74,7 +72,6 @@ class ComponentMetadataRuleExecutorTest extends Specification {
     CachePolicy cachePolicy
 
     ModuleComponentResolveMetadata result
-    ModuleSourcesSerializer modulesSourceSerializer = new ModuleSourcesSerializer([:])
 
     def setup() {
         def cacheBuilder
@@ -104,10 +101,7 @@ class ComponentMetadataRuleExecutorTest extends Specification {
     @Unroll("Cache expiry check refresh = #mustRefresh - #scenario - #ruleClass")
     def "expires entry when cache policy tells us to"() {
         def id = DefaultModuleVersionIdentifier.newId('org', 'foo', '1.0')
-        def hashValue = Mock(HashValue) {
-            asHexString() >> "42"
-            asBigInteger() >> 42G
-        }
+        def hashValue = HashCode.fromInt(42)
         def key = Mock(ModuleComponentResolveMetadata)
         def inputsSnapshot = new StringValueSnapshot("1")
         def hasher = Hashing.newHasher()
@@ -127,7 +121,7 @@ class ComponentMetadataRuleExecutorTest extends Specification {
         }
         def reexecute = mustRefresh || expired
         def moduleSources = new MutableModuleSources()
-        moduleSources.add(new ModuleDescriptorHashModuleSource(hashValue.asBigInteger(), false))
+        moduleSources.add(new ModuleDescriptorHashModuleSource(hashValue, false))
 
         when:
         withRule(ruleClass, ruleServices)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.resource.cached
 
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManagerStub
-import org.gradle.internal.hash.HashValue
+import org.gradle.internal.hash.HashCode
 import org.gradle.internal.resource.local.FileAccessTracker
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData
 import org.gradle.internal.serialize.BaseSerializerFactory
@@ -70,7 +70,7 @@ class DefaultArtifactResolutionCacheTest extends Specification {
 
         where:
         lastModified | contentType | etag   | sha1
-        new Date()   | "something" | "etag" | new HashValue("1234")
+        new Date()   | "something" | "etag" | HashCode.fromInt(123456)
         null         | null        | null   | null
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/local/CompositeLocallyAvailableResourceFinderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/local/CompositeLocallyAvailableResourceFinderTest.groovy
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.resource.local
 
+import org.gradle.internal.hash.Hashing
 import spock.lang.Specification
-import org.gradle.internal.hash.HashUtil
 
 class CompositeLocallyAvailableResourceFinderTest extends Specification {
-    
+
     def "interrogates composites in turn as needed"() {
         given:
         def f1 = Mock(LocallyAvailableResourceFinder)
@@ -29,7 +29,7 @@ class CompositeLocallyAvailableResourceFinderTest extends Specification {
         def c2 = Mock(LocallyAvailableResourceCandidates)
         def f3 = Mock(LocallyAvailableResourceFinder)
         def c3 = Mock(LocallyAvailableResourceCandidates)
-        def hash = HashUtil.sha1("abc".bytes)
+        def hash = Hashing.sha1().hashString("abc")
 
         def composite = new CompositeLocallyAvailableResourceFinder<String>([f1, f2, f3])
         def criterion = "abc"

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -38,6 +38,10 @@ public class Hashing {
 
     private static final HashFunction SHA1 = MessageDigestHashFunction.of("SHA-1");
 
+    private static final HashFunction SHA256 = MessageDigestHashFunction.of("SHA-256");
+
+    private static final HashFunction SHA512 = MessageDigestHashFunction.of("SHA-512");
+
     private static final HashFunction DEFAULT = MD5;
 
     /**
@@ -118,6 +122,20 @@ public class Hashing {
      */
     public static HashFunction sha1() {
         return SHA1;
+    }
+
+    /**
+     * SHA-256 hashing function.
+     */
+    public static HashFunction sha256() {
+        return SHA256;
+    }
+
+    /**
+     * SHA-512 hashing function.
+     */
+    public static HashFunction sha512() {
+        return SHA512;
     }
 
     private static abstract class MessageDigestHashFunction implements HashFunction {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -46,6 +47,7 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Cast;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 
 import javax.inject.Inject;
@@ -68,6 +70,7 @@ public class GenerateModuleMetadata extends DefaultTask {
     private final Property<Publication> publication;
     private final ListProperty<Publication> publications;
     private final RegularFileProperty outputFile;
+    private final ChecksumService checksumService;
 
     public GenerateModuleMetadata() {
         ObjectFactory objectFactory = getProject().getObjects();
@@ -77,6 +80,8 @@ public class GenerateModuleMetadata extends DefaultTask {
         // TODO - should be incremental
         getOutputs().upToDateWhen(Specs.<Task>satisfyNone());
         mustHaveAttachedComponent();
+        // injected here in order to avoid exposing in public API
+        checksumService = ((ProjectInternal)getProject()).getServices().get(ChecksumService.class);
     }
 
     private void mustHaveAttachedComponent() {
@@ -165,7 +170,7 @@ public class GenerateModuleMetadata extends DefaultTask {
         try {
             Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "utf8"));
             try {
-                new GradleModuleMetadataWriter(getBuildInvocationScopeId(), getProjectDependencyPublicationResolver()).generateTo(publication, publications, writer);
+                new GradleModuleMetadataWriter(getBuildInvocationScopeId(), getProjectDependencyPublicationResolver(), checksumService).generateTo(publication, publications, writer);
             } finally {
                 writer.close();
             }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -69,7 +69,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     def buildId = UniqueId.generate()
     def id = DefaultModuleVersionIdentifier.newId("group", "module", "1.2")
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
-    def generator = new GradleModuleMetadataWriter(new BuildInvocationScopeId(buildId), projectDependencyResolver)
+    def generator = new GradleModuleMetadataWriter(new BuildInvocationScopeId(buildId), projectDependencyResolver, TestUtil.checksumService)
 
     def "fails to write file for component with no variants"() {
         def writer = new StringWriter()

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResponseResource.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResponseResource.java
@@ -17,7 +17,7 @@ package org.gradle.internal.resource.transport.http;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.utils.DateUtils;
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
 import org.gradle.internal.resource.transfer.ExternalResourceReadResponse;
@@ -120,17 +120,17 @@ public class HttpResponseResource implements ExternalResourceReadResponse {
         return response.getHeader(HttpHeaders.ETAG);
     }
 
-    private static HashValue getSha1(HttpClientResponse response, String etag) {
+    private static HashCode getSha1(HttpClientResponse response, String etag) {
         String sha1Header = response.getHeader("X-Checksum-Sha1");
         if (sha1Header != null) {
-            return new HashValue(sha1Header);
+            return HashCode.fromString(sha1Header);
         }
 
         // Nexus uses sha1 etags, with a constant prefix
         // e.g {SHA1{b8ad5573a5e9eba7d48ed77a48ad098e3ec2590b}}
         if (etag != null && etag.startsWith("{SHA1{")) {
             String hash = etag.substring(6, etag.length() - 2);
-            return new HashValue(hash);
+            return HashCode.fromString(hash);
         }
 
         return null;

--- a/subprojects/resources/resources.gradle.kts
+++ b/subprojects/resources/resources.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(project(":snapshots"))
 
     testImplementation(testFixtures(project(":core")))
-    
+
     integTestImplementation(project(":internalIntegTesting"))
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/AbstractLocallyAvailableResource.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/AbstractLocallyAvailableResource.java
@@ -15,19 +15,21 @@
  */
 package org.gradle.internal.resource.local;
 
-import org.gradle.internal.hash.HashUtil;
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.Factory;
+import org.gradle.internal.hash.HashCode;
 
 public abstract class AbstractLocallyAvailableResource implements LocallyAvailableResource {
+    private Factory<HashCode> factory;
     // Calculated on demand
-    private HashValue sha1;
+    private HashCode sha1;
     private Long contentLength;
     private Long lastModified;
 
-    protected AbstractLocallyAvailableResource() {
+    protected AbstractLocallyAvailableResource(Factory<HashCode> factory) {
+        this.factory = factory;
     }
 
-    protected AbstractLocallyAvailableResource(HashValue sha1) {
+    protected AbstractLocallyAvailableResource(HashCode sha1) {
         this.sha1 = sha1;
     }
 
@@ -42,9 +44,9 @@ public abstract class AbstractLocallyAvailableResource implements LocallyAvailab
     }
 
     @Override
-    public HashValue getSha1() {
+    public HashCode getSha1() {
         if (sha1 == null) {
-            this.sha1 = HashUtil.sha1(getFile());
+            sha1 = factory.create();
         }
         return sha1;
     }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/AbstractLocallyAvailableResourceFinder.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/AbstractLocallyAvailableResourceFinder.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.local;
 
 import org.gradle.api.Transformer;
 import org.gradle.internal.Factory;
+import org.gradle.internal.hash.ChecksumService;
 
 import java.io.File;
 import java.util.List;
@@ -25,14 +26,19 @@ import java.util.List;
 public class AbstractLocallyAvailableResourceFinder<C> implements LocallyAvailableResourceFinder<C> {
 
     private final Transformer<Factory<List<File>>, C> producer;
+    private final ChecksumService checksumService;
 
-    public AbstractLocallyAvailableResourceFinder(Transformer<Factory<List<File>>, C> producer) {
+    public AbstractLocallyAvailableResourceFinder(Transformer<Factory<List<File>>, C> producer, ChecksumService checksumService) {
         this.producer = producer;
+        this.checksumService = checksumService;
     }
 
     @Override
     public LocallyAvailableResourceCandidates findCandidates(C criterion) {
-        return new LazyLocallyAvailableResourceCandidates(producer.transform(criterion));
+        return new LazyLocallyAvailableResourceCandidates(producer.transform(criterion), checksumService);
     }
 
+    public ChecksumService getChecksumService() {
+        return checksumService;
+    }
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/CompositeLocallyAvailableResourceFinder.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/CompositeLocallyAvailableResourceFinder.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.local;
 
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.HashCode;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -38,7 +38,7 @@ public class CompositeLocallyAvailableResourceFinder<C> implements LocallyAvaila
 
         return new CompositeLocallyAvailableResourceCandidates(allCandidates);
     }
-    
+
     private static class CompositeLocallyAvailableResourceCandidates implements LocallyAvailableResourceCandidates {
         private final List<LocallyAvailableResourceCandidates> allCandidates;
 
@@ -58,7 +58,7 @@ public class CompositeLocallyAvailableResourceFinder<C> implements LocallyAvaila
         }
 
         @Override
-        public LocallyAvailableResource findByHashValue(HashValue hashValue) {
+        public LocallyAvailableResource findByHashValue(HashCode hashValue) {
             for (LocallyAvailableResourceCandidates candidates : allCandidates) {
                 LocallyAvailableResource match = candidates.findByHashValue(hashValue);
                 if (match != null) {

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/DefaultLocallyAvailableResource.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/DefaultLocallyAvailableResource.java
@@ -15,18 +15,20 @@
  */
 package org.gradle.internal.resource.local;
 
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.ChecksumService;
+import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
 
 public class DefaultLocallyAvailableResource extends AbstractLocallyAvailableResource {
     private final File origin;
 
-    public DefaultLocallyAvailableResource(File origin) {
+    public DefaultLocallyAvailableResource(File origin, ChecksumService checksumService) {
+        super(() -> checksumService.sha1(origin));
         this.origin = origin;
     }
 
-    public DefaultLocallyAvailableResource(File origin, HashValue sha1) {
+    public DefaultLocallyAvailableResource(File origin, HashCode sha1) {
         super(sha1);
         this.origin = origin;
     }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/LazyLocallyAvailableResourceCandidates.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/LazyLocallyAvailableResourceCandidates.java
@@ -17,8 +17,8 @@
 package org.gradle.internal.resource.local;
 
 import org.gradle.internal.Factory;
-import org.gradle.internal.hash.HashUtil;
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.ChecksumService;
+import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
 import java.util.List;
@@ -26,10 +26,12 @@ import java.util.List;
 public class LazyLocallyAvailableResourceCandidates implements LocallyAvailableResourceCandidates {
 
     private final Factory<List<File>> filesFactory;
+    private final ChecksumService checksumService;
     private List<File> files;
 
-    public LazyLocallyAvailableResourceCandidates(Factory<List<File>> filesFactory) {
-        this.filesFactory = filesFactory;        
+    public LazyLocallyAvailableResourceCandidates(Factory<List<File>> filesFactory, ChecksumService checksumService) {
+        this.filesFactory = filesFactory;
+        this.checksumService = checksumService;
     }
 
     protected List<File> getFiles() {
@@ -38,17 +40,17 @@ public class LazyLocallyAvailableResourceCandidates implements LocallyAvailableR
         }
         return files;
     }
-    
+
     @Override
     public boolean isNone() {
         return getFiles().isEmpty();
     }
 
     @Override
-    public LocallyAvailableResource findByHashValue(HashValue targetHash) {
-        HashValue thisHash;
+    public LocallyAvailableResource findByHashValue(HashCode targetHash) {
+        HashCode thisHash;
         for (File file : getFiles()) {
-            thisHash = HashUtil.sha1(file);
+            thisHash = checksumService.sha1(file);
             if (thisHash.equals(targetHash)) {
                 return new DefaultLocallyAvailableResource(file, thisHash);
             }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/LocallyAvailableResourceCandidates.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/LocallyAvailableResourceCandidates.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.local;
 
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.HashCode;
 
 /**
  * A set of locally available resources that were “selected” through some means.
@@ -25,6 +25,6 @@ public interface LocallyAvailableResourceCandidates {
 
     boolean isNone();
 
-    LocallyAvailableResource findByHashValue(HashValue hashValue);
+    LocallyAvailableResource findByHashValue(HashCode hashValue);
 
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/LocallyAvailableResourceFinderSearchableFileStoreAdapter.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/LocallyAvailableResourceFinderSearchableFileStoreAdapter.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.local;
 
 import org.gradle.api.Transformer;
 import org.gradle.internal.Factory;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.util.CollectionUtils;
 
 import java.io.File;
@@ -31,7 +32,7 @@ import java.util.Set;
  */
 public class LocallyAvailableResourceFinderSearchableFileStoreAdapter<C> extends AbstractLocallyAvailableResourceFinder<C> {
 
-    public LocallyAvailableResourceFinderSearchableFileStoreAdapter(final FileStoreSearcher<C> fileStore) {
+    public LocallyAvailableResourceFinderSearchableFileStoreAdapter(final FileStoreSearcher<C> fileStore, ChecksumService checksumService) {
         super(new Transformer<Factory<List<File>>, C>() {
             @Override
             public Factory<List<File>> transform(final C criterion) {
@@ -48,7 +49,7 @@ public class LocallyAvailableResourceFinderSearchableFileStoreAdapter<C> extends
                     }
                 };
             }
-        });
+        }, checksumService);
     }
 
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/metadata/DefaultExternalResourceMetaData.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/metadata/DefaultExternalResourceMetaData.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.metadata;
 
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.HashCode;
 
 import javax.annotation.Nullable;
 import java.net.URI;
@@ -27,18 +27,18 @@ public class DefaultExternalResourceMetaData implements ExternalResourceMetaData
     private final Date lastModified;
     private final long contentLength;
     private final String etag;
-    private final HashValue sha1;
+    private final HashCode sha1;
     private final String contentType;
 
     public DefaultExternalResourceMetaData(URI location, long lastModified, long contentLength) {
         this(location, lastModified > 0 ? new Date(lastModified) : null, contentLength, null, null, null);
     }
 
-    public DefaultExternalResourceMetaData(URI location, long lastModified, long contentLength, @Nullable String contentType, @Nullable String etag, @Nullable HashValue sha1) {
+    public DefaultExternalResourceMetaData(URI location, long lastModified, long contentLength, @Nullable String contentType, @Nullable String etag, @Nullable HashCode sha1) {
         this(location, lastModified > 0 ? new Date(lastModified) : null, contentLength, contentType, etag, sha1);
     }
 
-    public DefaultExternalResourceMetaData(URI location, @Nullable Date lastModified, long contentLength, @Nullable String contentType, @Nullable String etag, @Nullable HashValue sha1) {
+    public DefaultExternalResourceMetaData(URI location, @Nullable Date lastModified, long contentLength, @Nullable String contentType, @Nullable String etag, @Nullable HashCode sha1) {
         this.location = location;
         this.lastModified = lastModified;
         this.contentLength = contentLength;
@@ -77,7 +77,7 @@ public class DefaultExternalResourceMetaData implements ExternalResourceMetaData
 
     @Nullable
     @Override
-    public HashValue getSha1() {
+    public HashCode getSha1() {
         return sha1;
     }
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/metadata/ExternalResourceMetaData.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/metadata/ExternalResourceMetaData.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.resource.metadata;
 
-import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.hash.HashCode;
 
 import javax.annotation.Nullable;
 import java.net.URI;
@@ -56,6 +56,6 @@ public interface ExternalResourceMetaData {
      * @return The sha1, or null if it's unknown.
      */
     @Nullable
-    HashValue getSha1();
+    HashCode getSha1();
 
 }

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/DefaultLocallyAvailableResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/DefaultLocallyAvailableResourceTest.groovy
@@ -16,11 +16,11 @@
 package org.gradle.internal.resource.local
 
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.internal.hash.HashUtil
+import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 
-public class DefaultLocallyAvailableResourceTest extends Specification {
+class DefaultLocallyAvailableResourceTest extends Specification {
     @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
 
     def "uses value from origin file"() {
@@ -29,10 +29,10 @@ public class DefaultLocallyAvailableResourceTest extends Specification {
         origin << "some text"
 
         when:
-        def DefaultLocallyAvailableResource resource = new DefaultLocallyAvailableResource(origin)
+        def resource = new DefaultLocallyAvailableResource(origin, TestUtil.checksumService)
 
         then:
-        resource.sha1 == HashUtil.createHash(origin, 'SHA1')
+        resource.sha1 == TestUtil.checksumService.sha1(origin)
         resource.contentLength == origin.length()
         resource.lastModified == origin.lastModified()
     }
@@ -44,7 +44,7 @@ public class DefaultLocallyAvailableResourceTest extends Specification {
 
 
         when:
-        def DefaultLocallyAvailableResource resource = new DefaultLocallyAvailableResource(origin)
+        def resource = new DefaultLocallyAvailableResource(origin, TestUtil.checksumService)
         def originalSha1 = resource.sha1
         def originalContentLength = resource.contentLength
         def originalLastModified = resource.lastModified
@@ -54,7 +54,7 @@ public class DefaultLocallyAvailableResourceTest extends Specification {
         origin.setLastModified(11)
 
         then:
-        resource.sha1 != HashUtil.createHash(origin, 'SHA1')
+        resource.sha1 != TestUtil.checksumService.sha1(origin)
         resource.contentLength != origin.length()
         resource.lastModified != origin.lastModified()
 

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/metadata/DefaultExternalResourceMetaDataTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/metadata/DefaultExternalResourceMetaDataTest.groovy
@@ -16,18 +16,18 @@
 
 package org.gradle.internal.resource.metadata
 
+import org.gradle.internal.hash.HashCode
 import spock.lang.Specification
-import org.gradle.internal.hash.HashValue
 
 class DefaultExternalResourceMetaDataTest extends Specification {
 
     def "hash value is preserved"() {
         given:
-        def sha1 = "abc"
-        def md = new DefaultExternalResourceMetaData(new URI("scheme:thing"), -1, -1, null, null, new HashValue(sha1))
+        def sha1 = "abcd"*10
+        def md = new DefaultExternalResourceMetaData(new URI("scheme:thing"), -1, -1, null, null, HashCode.fromString(sha1))
 
         expect:
-        md.sha1.equals(new HashValue(sha1))
+        md.sha1.equals(HashCode.fromString(sha1))
     }
 
 }


### PR DESCRIPTION
### Context

There are different places where we compute checksums for files. A lot of those places use `HashUtil.sha1(...)` and other utility methods which are _uncached_, meaning that in a single build we can compute the same checksum for the same file multiple times.

This PR introduces a checksum service with a cross-build cache which makes sure that we don't compute the same checksums multiple times as this can be quite expensive.

Fixes #11062