### PR TITLE
Update Checkstyle to latest 8.27

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Callable;
  */
 public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
 
-    public static final String DEFAULT_CHECKSTYLE_VERSION = "8.24";
+    public static final String DEFAULT_CHECKSTYLE_VERSION = "8.27";
     private static final String CONFIG_DIR_NAME = "config/checkstyle";
     private CheckstyleExtension extension;
 

--- a/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
+++ b/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
@@ -19,7 +19,7 @@ package org.gradle.quality.integtest.fixtures
 import org.gradle.api.plugins.quality.CheckstylePlugin
 
 class CheckstyleCoverage {
-    private final static List<String> ALL = ['7.0', '7.6', '8.0', '8.12', '8.17', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
+    private final static List<String> ALL = ['7.0', '7.6', '8.0', '8.12', '8.17', '8.24', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
 
     static List<String> getSupportedVersionsByJdk() {
         ALL

--- a/subprojects/docs/src/docs/userguide/core-plugins/checkstyle_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/checkstyle_plugin.adoc
@@ -15,7 +15,7 @@
 [[checkstyle_plugin]]
 = The Checkstyle Plugin
 
-The Checkstyle plugin performs quality checks on your project's Java source files using http://checkstyle.sourceforge.net/index.html[Checkstyle] and generates reports from these checks.
+The Checkstyle plugin performs quality checks on your project's Java source files using https://checkstyle.org/index.html[Checkstyle] and generates reports from these checks.
 
 
 [[sec:checkstyle_usage]]

--- a/subprojects/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
@@ -87,7 +87,7 @@ Provides support for creating a ZIP distribution of a Java library project that 
 == Code analysis
 
 <<checkstyle_plugin.adoc#,Checkstyle>>::
-Performs quality checks on your project’s Java source files using http://checkstyle.sourceforge.net/index.html[Checkstyle] and generates associated reports.
+Performs quality checks on your project’s Java source files using https://checkstyle.org/index.html[Checkstyle] and generates associated reports.
 
 <<pmd_plugin.adoc#,PMD>>::
 Performs quality checks on your project’s Java source files using http://pmd.github.io/[PMD] and generates associated reports.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -33,6 +33,12 @@ Some plugins will break with this new version of Gradle, for example because the
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+=== Potential breaking changes
+
+==== Updates to default integration versions
+
+- Checkstyle has been updated to https://checkstyle.org/releasenotes.html#Release_8.27[Checkstyle 8.27].
+
 ////
 
 Template for new sections


### PR DESCRIPTION
#11581

- Update Checkstyle version from 8.24 to 8.27
- Update links in documentation
- Update upgrading notes