### PR TITLE
Make `getExecResult()` consistent between `Exec` and `JavaExec`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractExecutionResultExecTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractExecutionResultExecTaskIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
-abstract class AbstractExecTaskIntegrationTest extends AbstractIntegrationSpec {
+abstract class AbstractExecutionResultExecTaskIntegrationTest extends AbstractIntegrationSpec {
     protected abstract void makeExecProject()
     protected abstract void writeSucceedingExec()
     protected abstract void writeFailingExec()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionResultExecTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionResultExecTaskIntegrationTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.internal.jvm.Jvm
+import org.gradle.test.fixtures.file.TestFile
+
+class ExecutionResultExecTaskIntegrationTest extends AbstractExecutionResultExecTaskIntegrationTest {
+    TestFile mainJavaFile
+
+    @Override
+    protected void makeExecProject() {
+        buildFile.text = """
+            apply plugin: "java"
+
+            task run(type: Exec) {
+                dependsOn(compileJava)
+                executable = ${Jvm.canonicalName}.current().javaExecutable
+                args '-cp', project.layout.files(compileJava).asPath, 'driver.Driver', "1"
+            }
+        """
+    }
+
+    @Override
+    protected void writeSucceedingExec() {
+        mainJavaFile = file('src/main/java/Driver.java')
+        file("src/main/java/Driver.java").text = mainClass("""
+            try {
+                FileWriter out = new FileWriter("out.txt");
+                for (String arg: args) {
+                    out.write(arg);
+                    out.write("\\n");
+                }
+                out.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        """)
+    }
+
+    @Override
+    protected void writeFailingExec() {
+        mainJavaFile = file('src/main/java/Driver.java')
+        file("src/main/java/Driver.java").text = mainClass("""
+            System.exit(42);
+        """)
+    }
+
+    @Override
+    protected String getTaskNameUnderTest() {
+        return "run"
+    }
+
+    private static String mainClass(String body) {
+        return """
+            package driver;
+
+            import java.io.*;
+            import java.lang.System;
+
+            public class Driver {
+                public static void main(String[] args) {
+                ${body}
+                }
+            }
+        """
+    }
+
+    @Override
+    protected String getExecResultDsl() {
+        return "${taskUnderTestDsl}.executionResult.getOrNull()"
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionResultJavaExecTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ExecutionResultJavaExecTaskIntegrationTest.groovy
@@ -16,10 +16,9 @@
 
 package org.gradle.api.tasks
 
-import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 
-class ExecTaskIntegrationTest extends AbstractExecTaskIntegrationTest {
+class ExecutionResultJavaExecTaskIntegrationTest extends AbstractExecutionResultExecTaskIntegrationTest {
     TestFile mainJavaFile
 
     @Override
@@ -27,10 +26,10 @@ class ExecTaskIntegrationTest extends AbstractExecTaskIntegrationTest {
         buildFile.text = """
             apply plugin: "java"
 
-            task run(type: Exec) {
-                dependsOn(compileJava)
-                executable = ${Jvm.canonicalName}.current().javaExecutable
-                args '-cp', project.layout.files(compileJava).asPath, 'driver.Driver', "1"
+            task run(type: JavaExec) {
+                classpath = project.layout.files(compileJava)
+                main "driver.Driver"
+                args "1"
             }
         """
     }
@@ -82,6 +81,6 @@ class ExecTaskIntegrationTest extends AbstractExecTaskIntegrationTest {
 
     @Override
     protected String getExecResultDsl() {
-        return "${taskUnderTestDsl}.execResult"
+        return "${taskUnderTestDsl}.executionResult.getOrNull()"
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -694,7 +694,7 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Internal
     @Incubating
-    public Provider<ExecResult> getExecResult() {
+    public Provider<ExecResult> getExecutionResult() {
         return execResult;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
@@ -44,7 +44,7 @@ class ExecTest extends AbstractTaskTest {
         1 * execAction.setExecutable("ls")
         1 * execAction.execute() >> new ExpectedExecResult(0)
         execTask.execResult.exitValue == 0
-
+        execTask.executionResult.get().exitValue == 0
     }
 
     def "execute with non-zero exit value and ignore exit value should not throw exception"() {
@@ -54,6 +54,7 @@ class ExecTest extends AbstractTaskTest {
         then:
         1 * execAction.execute() >> new ExpectedExecResult(1)
         execTask.execResult.exitValue == 1
+        execTask.executionResult.get().exitValue == 1
     }
 
     private class ExpectedExecResult implements ExecResult {

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -373,7 +373,7 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
         then:
         execHandle.state == ExecHandleState.FAILED
         detachResult.processCompleted
-        detachResult.execResult.exitValue == 72
+        detachResult.executionResult.get().exitValue == 72
     }
 
     void "can redirect error stream"() {

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -76,6 +76,11 @@ taskA.threadPoolSize = taskB.outputFile.map { it.text.toInteger() }
 In this case, calling `get()`, or any other query method, on `taskA.threadPoolSize` will produce a deprecation warning if done prior to `taskB` completing, as the file has not yet been generated.
 This will become an error in Gradle 7.0
 
+==== `Exec#getExecResult()` has been deprecated
+
+The `Exec#getExecResult()` has been replaced by `Exec#getExecutionResult()` for consistency with the new `JavaExec#getExecutionResult()`.
+It provide validation through the use of the <<lazy_configuration.adoc#,Provider API>>.
+
 === Potential breaking changes
 
 ==== Updates to bundled Gradle dependencies


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/11493

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fmake-exec-javaexec-consistent)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
