### PR TITLE
Fix corner case in conflict resolution case

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
@@ -432,6 +432,16 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         resolvedModules 'org:bar'
     }
 
+    @Issue("gradle/gradle#11569")
+    @ToBeFixedForInstantExecution
+    def "handles replacement in parallel of de-select / re-select events"() {
+        declaredDependencies 'a', 'm'
+        declaredReplacements 'from->to'
+        publishedMavenModules 'a->b', 'm->n->o->p->q->a:2->b->c->from->to'
+        expect:
+        resolvedModules 'a:2', 'b', 'c', 'to', 'm', 'n', 'o', 'p', 'q'
+    }
+
     @Unroll
     @ToBeFixedForInstantExecution
     def "can provide custom replacement reason"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.ConflictResolutionResult;
 
 class ReplaceSelectionWithConflictResultAction implements Action<ConflictResolutionResult> {
@@ -29,25 +28,11 @@ class ReplaceSelectionWithConflictResultAction implements Action<ConflictResolut
 
     @Override
     public void execute(final ConflictResolutionResult result) {
-        Object selected = result.getSelected();
-        final ComponentState component = findComponent(selected);
-        result.withParticipatingModules(new Action<ModuleIdentifier>() {
-            @Override
-            public void execute(ModuleIdentifier moduleIdentifier) {
-                // Restart each configuration. For the evicted configuration, this means moving incoming dependencies across to the
-                // matching selected configuration. For the select configuration, this mean traversing its dependencies.
-                resolveState.getModule(moduleIdentifier).restart(component);
-            }
+        result.withParticipatingModules(moduleIdentifier -> {
+            // Restart each configuration. For the evicted configuration, this means moving incoming dependencies across to the
+            // matching selected configuration. For the select configuration, this mean traversing its dependencies.
+            resolveState.getModule(moduleIdentifier).restart(result.getSelected());
         });
     }
 
-    private ComponentState findComponent(Object selected) {
-        if (selected instanceof ComponentState) {
-            return (ComponentState) selected;
-        }
-        if (selected instanceof NodeState) {
-            return ((NodeState) selected).getComponent();
-        }
-        return null;
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictResolutionResult.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
 
 public interface ConflictResolutionResult {
 
@@ -28,8 +29,8 @@ public interface ConflictResolutionResult {
     void withParticipatingModules(Action<? super ModuleIdentifier> action);
 
     /**
-     * The actual selected version.
+     * The actual selected component.
      */
-    <T> T getSelected();
+    ComponentState getSelected();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -128,7 +128,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                 if (details.reason != null) {
                     conflictResolution = conflictResolution.withDescription(details.reason);
                 }
-                details.getSelected().getComponent().addCause(conflictResolution);
+                details.getSelected().addCause(conflictResolution);
                 return;
             }
         }
@@ -264,8 +264,8 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
         }
 
         @Override
-        public NodeState getSelected() {
-            return selected;
+        public ComponentState getSelected() {
+            return selected.getComponent();
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 class DefaultConflictResolutionResult implements ConflictResolutionResult {
 
@@ -40,8 +41,15 @@ class DefaultConflictResolutionResult implements ConflictResolutionResult {
     private final ComponentState selected;
 
     public DefaultConflictResolutionResult(Collection<? extends ModuleIdentifier> participatingModules, Object selected) {
-        this.participatingModules = participatingModules;
         this.selected = findComponent(selected);
+        this.participatingModules = participatingModules.stream().sorted((first, second) -> {
+            if (this.selected.getId().getModule().equals(first)) {
+                return -1;
+            } else if (this.selected.getId().getModule().equals(second)) {
+                return 1;
+            }
+            return 0;
+        }).collect(Collectors.toList());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
@@ -18,16 +18,30 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState;
 
 import java.util.Collection;
 
-class DefaultConflictResolutionResult<T> implements ConflictResolutionResult {
-    private final Collection<? extends ModuleIdentifier> participatingModules;
-    private final T selected;
+class DefaultConflictResolutionResult implements ConflictResolutionResult {
 
-    public DefaultConflictResolutionResult(Collection<? extends ModuleIdentifier> participatingModules, T selected) {
+    private static ComponentState findComponent(Object selected) {
+        if (selected instanceof ComponentState) {
+            return (ComponentState) selected;
+        }
+        if (selected instanceof NodeState) {
+            return ((NodeState) selected).getComponent();
+        }
+        throw new IllegalArgumentException("Cannot extract a ComponentState from " + selected.getClass());
+    }
+
+
+    private final Collection<? extends ModuleIdentifier> participatingModules;
+    private final ComponentState selected;
+
+    public DefaultConflictResolutionResult(Collection<? extends ModuleIdentifier> participatingModules, Object selected) {
         this.participatingModules = participatingModules;
-        this.selected = selected;
+        this.selected = findComponent(selected);
     }
 
     @Override
@@ -38,7 +52,7 @@ class DefaultConflictResolutionResult<T> implements ConflictResolutionResult {
     }
 
     @Override
-    public T getSelected() {
+    public ComponentState getSelected() {
         return selected;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandlerTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -100,7 +100,7 @@ class DefaultConflictHandlerTest extends Specification {
         def candidate = Stub(CandidateModule)
         candidate.getId() >> DefaultModuleIdentifier.newId(group, name)
         candidate.getVersions() >> versions.collect { String version ->
-            def v = Stub(ComponentResolutionState)
+            def v = Stub(ComponentState)
             v.getId() >> newId(group, name, version)
             v
         }


### PR DESCRIPTION
In some corner cases, it matters to select first the conflict winner
before attempting any other selection.