### PR TITLE
Support for scala compiler plugins.

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.scala.ScalaCompile.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.scala.ScalaCompile.xml
@@ -12,6 +12,10 @@
                 <td>scalaClasspath</td>
                 <td><literal>scala-compiler</literal> dependency matching the <literal>scala-library</literal> version found on <literal>classpath</literal></td>
             </tr>
+            <tr>
+                <td>scalaCompilerPlugins</td>
+                <td>The list of compiler plugins is resolved from the <literal>scalaCompilerPlugins</literal> <literal>configuration</literal></td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -175,6 +175,17 @@ You can diagnose problems with the version of the Zinc compiler selected by runn
 
 |===
 
+[[sec:scala_compiler_plugins]]
+== Adding plugins to the Scala compiler
+
+The Scala plugin adds a configuration named `scalaCompilerPlugins` which is used to declare and resolve optional compiler plugins.
+
+.Adding a dependency on a Scala compiler plugin
+====
+include::sample[dir="snippets/scala/compilerPlugin/groovy",files="build.gradle[tags=compiler-plugin]"]
+include::sample[dir="snippets/scala/compilerPlugin/kotlin",files="build.gradle.kts[tags=compiler-plugin]"]
+====
+
 [[sec:scala_convention_properties]]
 == Convention properties
 
@@ -276,5 +287,4 @@ When the IDEA plugin encounters a Scala project, it adds additional configuratio
 include::sample[dir="snippets/userguide/scala/ideaTargetVersion/groovy",files="build.gradle[tags=scala-idea-target-version]"]
 include::sample[dir="snippets/userguide/scala/ideaTargetVersion/kotlin",files="build.gradle.kts[tags=scala-idea-target-version]"]
 ====
-
 

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/compilerPlugin.sample.conf
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/compilerPlugin.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: tasks
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: tasks
+}]

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/groovy/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'scala'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::compiler-plugin[]
+dependencies {
+    implementation "org.scala-lang:scala-library:2.13.1"
+    scalaCompilerPlugins "org.typelevel:kind-projector_2.13.1:0.11.0"
+}
+// end::compiler-plugin[]

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'compilerPlugin'

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/groovy/src/main/scala/org/gradle/sample/Test.scala
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/groovy/src/main/scala/org/gradle/sample/Test.scala
@@ -1,0 +1,8 @@
+package org.gradle.sample
+
+object Test {
+    def main(args: Array[String]): Unit = {
+        class A[X[_]]
+        new A[Map[Int, *]]
+    }
+}

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/kotlin/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    scala
+}
+
+repositories {
+    mavenCentral()
+}
+
+// tag::compiler-plugin[]
+dependencies {
+    implementation("org.scala-lang:scala-library:2.13.1")
+    scalaCompilerPlugins("org.typelevel:kind-projector_2.13.1:0.11.0")
+}
+// end::compiler-plugin[]

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "compilerPlugin"

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/kotlin/src/main/scala/org/gradle/sample/Test.scala
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/kotlin/src/main/scala/org/gradle/sample/Test.scala
@@ -1,0 +1,8 @@
+package org.gradle.sample
+
+object Test {
+    def main(args: Array[String]): Unit = {
+        class A[X[_]]
+        new A[Map[Int, *]]
+    }
+}

--- a/subprojects/docs/src/snippets/scala/compilerPlugin/readme.xml
+++ b/subprojects/docs/src/snippets/scala/compilerPlugin/readme.xml
@@ -1,0 +1,3 @@
+<sample>
+    <para>Scala project with compiler plugin.</para>
+</sample>

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpec.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpec.java
@@ -26,6 +26,7 @@ public class DefaultScalaJavaJointCompileSpec extends DefaultJavaCompileSpec imp
     private BaseScalaCompileOptions options;
     private Iterable<File> scalaClasspath;
     private Iterable<File> zincClasspath;
+    private Iterable<File> scalaCompilerPlugins;
     private Map<File, File> analysisMap;
     private File analysisFile;
     private long buildStartTimestamp;
@@ -63,6 +64,16 @@ public class DefaultScalaJavaJointCompileSpec extends DefaultJavaCompileSpec imp
 
     public void setZincClasspath(Iterable<File> zincClasspath) {
         this.zincClasspath = zincClasspath;
+    }
+
+    @Override
+    public Iterable<File> getScalaCompilerPlugins() {
+        return scalaCompilerPlugins;
+    }
+
+    @Override
+    public void setScalaCompilerPlugins(Iterable<File> scalaCompilerPlugins) {
+        this.scalaCompilerPlugins = scalaCompilerPlugins;
     }
 
     @Override

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompileSpec.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompileSpec.java
@@ -25,6 +25,10 @@ import java.util.Map;
 public interface ScalaCompileSpec extends JvmLanguageCompileSpec {
     BaseScalaCompileOptions getScalaCompileOptions();
 
+    Iterable<File> getScalaCompilerPlugins();
+
+    void setScalaCompilerPlugins(Iterable<File> plugins);
+
     File getAnalysisFile();
 
     void setAnalysisFile(File analysisFile);

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerArgumentsGenerator.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerArgumentsGenerator.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.scala;
 import com.google.common.collect.Lists;
 import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
 
+import java.io.File;
 import java.util.List;
 
 public class ZincScalaCompilerArgumentsGenerator {
@@ -40,6 +41,11 @@ public class ZincScalaCompilerArgumentsGenerator {
         }
         if (options.getAdditionalParameters() != null) {
             result.addAll(options.getAdditionalParameters());
+        }
+        if (spec.getScalaCompilerPlugins() != null) {
+            for (File plugin : spec.getScalaCompilerPlugins()) {
+                result.add("-Xplugin:" + plugin.getPath());
+            }
         }
 
         return result;

--- a/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/ZincScalaCompilerArgumentsGeneratorTest.groovy
+++ b/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/ZincScalaCompilerArgumentsGeneratorTest.groovy
@@ -107,4 +107,21 @@ class ZincScalaCompilerArgumentsGeneratorTest extends Specification {
         args.contains("-other")
         args.contains("value")
     }
+
+    def "adds compiler plugins"() {
+        def relFile = new File("path/to/plugin1")
+        def absFile = new File("/abspath/to/plugin2")
+
+        spec.scalaCompilerPlugins = [
+            relFile,
+            absFile]
+
+        when:
+        def args = generator.generate(spec)
+
+        then:
+        args.contains("-Xplugin:" + relFile.getPath())
+        args.contains("-Xplugin:" + absFile.getPath())
+
+    }
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -31,6 +32,9 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
+import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
@@ -60,6 +64,9 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.concurrent.Callable;
 
+import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE;
+import static org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE;
+
 /**
  * <p>A {@link Plugin} which compiles and tests Scala sources.</p>
  */
@@ -76,6 +83,13 @@ public class ScalaBasePlugin implements Plugin<Project> {
     @VisibleForTesting
     public static final String ZINC_CONFIGURATION_NAME = "zinc";
     public static final String SCALA_RUNTIME_EXTENSION_NAME = "scalaRuntime";
+    /**
+     * Configuration for scala compiler plugins.
+     *
+     * @since 6.4
+     */
+    @Incubating
+    public static final String SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME = "scalaCompilerPlugins";
 
 
     private final ObjectFactory objectFactory;
@@ -103,6 +117,14 @@ public class ScalaBasePlugin implements Plugin<Project> {
 
     private void configureConfigurations(final Project project, final Usage incrementalAnalysisUsage, ScalaPluginExtension scalaPluginExtension) {
         DependencyHandler dependencyHandler = project.getDependencies();
+
+        Configuration plugins = project.getConfigurations().create(SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME);
+        plugins.setTransitive(false);
+        plugins.setCanBeConsumed(false);
+        plugins.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        plugins.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
+        plugins.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
+        plugins.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
 
         Configuration zinc = project.getConfigurations().create(ZINC_CONFIGURATION_NAME);
         zinc.setVisible(false);
@@ -135,9 +157,9 @@ public class ScalaBasePlugin implements Plugin<Project> {
         incrementalAnalysisElements.setDescription("Incremental compilation analysis files");
         incrementalAnalysisElements.setCanBeResolved(false);
         incrementalAnalysisElements.setCanBeConsumed(true);
-        incrementalAnalysisElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, incrementalAnalysisUsage);
+        incrementalAnalysisElements.getAttributes().attribute(USAGE_ATTRIBUTE, incrementalAnalysisUsage);
 
-        AttributeMatchingStrategy<Usage> matchingStrategy = dependencyHandler.getAttributesSchema().attribute(Usage.USAGE_ATTRIBUTE);
+        AttributeMatchingStrategy<Usage> matchingStrategy = dependencyHandler.getAttributesSchema().attribute(USAGE_ATTRIBUTE);
         matchingStrategy.getDisambiguationRules().add(UsageDisambiguationRules.class, actionConfiguration -> {
             actionConfiguration.params(incrementalAnalysisUsage);
             actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_API));
@@ -172,7 +194,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
                 incrementalAnalysis.setCanBeResolved(true);
                 incrementalAnalysis.setCanBeConsumed(false);
                 incrementalAnalysis.extendsFrom(classpath);
-                incrementalAnalysis.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, incrementalAnalysisUsage);
+                incrementalAnalysis.getAttributes().attribute(USAGE_ATTRIBUTE, incrementalAnalysisUsage);
 
                 configureScalaCompile(project, sourceSet, incrementalAnalysis, incrementalAnalysisUsage);
             }
@@ -246,6 +268,12 @@ public class ScalaBasePlugin implements Plugin<Project> {
                     @Override
                     public Configuration call() throws Exception {
                         return project.getConfigurations().getAt(ZINC_CONFIGURATION_NAME);
+                    }
+                });
+                compile.getConventionMapping().map("scalaCompilerPlugins", new Callable<FileCollection>() {
+                    @Override
+                    public FileCollection call() throws Exception {
+                        return project.getConfigurations().getAt(SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME);
                     }
                 });
             }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.tasks.scala;
 
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ClassPathRegistry;
@@ -40,6 +42,7 @@ public class ScalaCompile extends AbstractScalaCompile {
 
     private FileCollection scalaClasspath;
     private FileCollection zincClasspath;
+    private FileCollection scalaCompilerPlugins;
 
     private org.gradle.language.base.internal.compile.Compiler<ScalaJavaJointCompileSpec> compiler;
 
@@ -64,6 +67,37 @@ public class ScalaCompile extends AbstractScalaCompile {
 
     public void setScalaClasspath(FileCollection scalaClasspath) {
         this.scalaClasspath = scalaClasspath;
+    }
+
+    /**
+     * Returns the Scala compiler plugins to use.
+     *
+     * @since 6.4
+     */
+    @Classpath
+    @Incubating
+    public FileCollection getScalaCompilerPlugins() {
+        return scalaCompilerPlugins;
+    }
+
+    /**
+     * Sets the Scala compiler plugins to use.
+     *
+     * @param scalaCompilerPlugins Collection of Scala compiler plugins.
+     * @since 6.4
+     */
+    @Incubating
+    public void setScalaCompilerPlugins(FileCollection scalaCompilerPlugins) {
+        this.scalaCompilerPlugins = scalaCompilerPlugins;
+    }
+
+    @Override
+    protected ScalaJavaJointCompileSpec createSpec() {
+        ScalaJavaJointCompileSpec spec = super.createSpec();
+        if (getScalaCompilerPlugins() != null) {
+            spec.setScalaCompilerPlugins(ImmutableList.copyOf(getScalaCompilerPlugins()));
+        }
+        return spec;
     }
 
     /**

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
@@ -33,6 +33,7 @@ class ScalaCompileTest extends AbstractCompileTest {
 
     private scalaCompiler = Mock(Compiler)
     private scalaClasspath = Mock(FileTreeInternal)
+    private scalaCompilerPlugins = Mock(FileTreeInternal)
 
     @Override
     AbstractCompile getCompile() {
@@ -101,6 +102,8 @@ class ScalaCompileTest extends AbstractCompileTest {
         super.setUpMocksAndAttributes(compile)
         compile.setScalaClasspath(scalaClasspath)
         compile.setZincClasspath(compile.getClasspath())
+        compile.setScalaCompilerPlugins(scalaCompilerPlugins)
+        scalaCompilerPlugins.iterator() >> Collections.emptyIterator()
         BaseScalaCompileOptions options = compile.getScalaCompileOptions()
         options.getIncrementalOptions().setAnalysisFile(new File("analysisFile"))
     }


### PR DESCRIPTION
Issue: #8659
Signed-off-by: Sheliak Lyr <sheliak.lyr@gmail.com>

<!--- The issue this PR addresses -->
Fixes #8659

### Context
Until now, adding plugins to scala compilation required somewhat complicated setup:
1. Create an extra configuration
2. Add a plugin dependency
3. Manually add path to resolved plugin to compiler arguments

Example: https://github.com/ghik/silencer#setup

Furthermore, this setup causes the build cache key to be host-dependent. Paths to plugins are absolute and are different for different users/hosts.

This PR fixes both issues. New way is simpler, and correctly handles plugins in build cache key computation (classpath fingerprint):
```
dependencies {
     implementation 'org.scala-lang:scala-library:2.13.1'
     scalaCompilerPlugins "org.typelevel:kind-projector_2.13.1:0.11.0"
}
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
