### PR TITLE
Allow running integration tests with VFS retention enabled

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -100,7 +100,7 @@ data class CIBuildModel(
             runsIndependent = true,
             disablesBuildCache = true,
             functionalTests = listOf(
-                TestCoverage(20, TestType.quick, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))),
+                TestCoverage(26, TestType.quick, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))),
         Stage(StageNames.WINDOWS_10_EVALUATION_PLATFORM,
             trigger = Trigger.never,
             runsIndependent = true,

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -27,6 +27,7 @@ enum class StageNames(override val stageName: String, override val description: 
     EXPERIMENTAL("Experimental", "On demand: Run experimental tests", "Experimental"),
     WINDOWS_10_EVALUATION_QUICK("Experimental Windows10 Quick", "On demand checks to test Windows 10 agents (quick tests)", "ExperimentalWindows10quick"),
     WINDOWS_10_EVALUATION_PLATFORM("Experimental Windows10 Platform", "On demand checks to test Windows 10 agents (platform tests)", "ExperimentalWindows10platform"),
+    EXPERIMENTAL_VFS_RETENTION("Experimental VFS Retention", "On demand checks to run tests with VFS retention enabled", "ExperimentalVfsRetention"),
 }
 
 data class CIBuildModel(
@@ -110,8 +111,14 @@ data class CIBuildModel(
                 TestCoverage(22, TestType.quickFeedbackCrossVersion, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(23, TestType.soak, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(24, TestType.allVersionsCrossVersion, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
-                TestCoverage(25, TestType.noDaemon, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)))
-    ),
+                TestCoverage(25, TestType.noDaemon, Os.windows, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor))),
+        Stage(StageNames.EXPERIMENTAL_VFS_RETENTION,
+            trigger = Trigger.never,
+            runsIndependent = true,
+            functionalTests = listOf(
+                TestCoverage(27, TestType.vfsRetention, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
+                TestCoverage(28, TestType.vfsRetention, Os.linux, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor)))
+        ),
 
     val subProjects: List<GradleSubproject> = listOf(
         GradleSubproject("antlr"),
@@ -424,6 +431,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     parallel(false, true, false),
     noDaemon(false, true, false, 240),
     instant(false, true, false),
+    vfsRetention(false, true, false),
     soak(false, false, false),
     forceRealizeDependencyManagement(false, true, false)
 }

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -209,19 +209,13 @@ class CIConfigIntegrationTests {
         val model = CIBuildModel()
         val rootProject = RootProject(model)
         val triggerNameToTasks = rootProject.buildTypes.map { it.uuid to ((it as StagePasses).steps.items[0] as GradleBuildStep).tasks }.toMap()
-
-        assertEquals(mapOf(
-            "Gradle_Check_Stage_QuickFeedbackLinuxOnly_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_QuickFeedback_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_BranchBuildAccept_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_MasterAccept_Trigger" to "createBuildReceipt updateBranchStatus",
-            "Gradle_Check_Stage_ReleaseAccept_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_HistoricalPerformance_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_Experimental_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_ExperimentalWindows10quick_Trigger" to "createBuildReceipt",
-            "Gradle_Check_Stage_ExperimentalWindows10platform_Trigger" to "createBuildReceipt"),
-            triggerNameToTasks)
+        val readyForNightlyId = toTriggerId("MasterAccept")
+        assertEquals("createBuildReceipt updateBranchStatus", triggerNameToTasks[readyForNightlyId])
+        val otherTaskNames = triggerNameToTasks.filterKeys { it != readyForNightlyId }.values.toSet()
+        assertEquals(setOf("createBuildReceipt"), otherTaskNames)
     }
+
+    private fun toTriggerId(id: String) = "Gradle_Check_Stage_${id}_Trigger"
 
     @Test
     fun allSubprojectsAreListed() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,11 @@ buildTypes {
         tasks("instantIntegTest")
     }
 
+    // Run the integration tests with vfs retention enabled
+    create("vfsRetentionTest") {
+        tasks("vfsRetentionIntegTest")
+    }
+
     create("performanceTests") {
         tasks("performance:performanceTest")
     }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -14,7 +14,7 @@ import java.io.File
 
 
 enum class TestType(val prefix: String, val executers: List<String>, val libRepoRequired: Boolean) {
-    INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel", "instant"), false),
+    INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel", "instant", "vfsRetention"), false),
     CROSSVERSION("crossVersion", listOf("embedded", "forking"), true)
 }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.integtests.fixtures.executer;
 
-import org.gradle.api.Action;
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeoutInterceptor;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 
@@ -37,7 +36,8 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
         forking(true),
         noDaemon(true),
         parallel(true, true),
-        instant(true);
+        instant(true),
+        vfsRetention(true);
 
         final public boolean forks;
         final public boolean executeParallel;
@@ -125,6 +125,8 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
                 return new DaemonGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
             case instant:
                 return new InstantExecutionGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
+            case vfsRetention:
+                return new VfsRetentionGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
             default:
                 throw new RuntimeException("Not a supported executer type: " + executerType);
         }
@@ -132,14 +134,11 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
 
     @Override
     public void cleanup() {
-        new IntegrationTestTimeoutInterceptor(DEFAULT_TIMEOUT_SECONDS).intercept(new Action<Void>() {
-            @Override
-            public void execute(Void ignored) {
-                if (gradleExecuter != null) {
-                    gradleExecuter.stop();
-                }
-                GradleContextualExecuter.super.cleanup();
+        new IntegrationTestTimeoutInterceptor(DEFAULT_TIMEOUT_SECONDS).intercept(ignored -> {
+            if (gradleExecuter != null) {
+                gradleExecuter.stop();
             }
+            GradleContextualExecuter.super.cleanup();
         });
 
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import com.google.common.collect.ImmutableList
+import org.gradle.internal.service.scopes.VirtualFileSystemServices
+import org.gradle.test.fixtures.file.TestDirectoryProvider
+import org.gradle.util.GradleVersion
+
+class VfsRetentionGradleExecuter extends DaemonGradleExecuter {
+
+    private boolean firstUse = true
+
+    VfsRetentionGradleExecuter(
+        GradleDistribution distribution,
+        TestDirectoryProvider testDirectoryProvider,
+        GradleVersion gradleVersion,
+        IntegrationTestBuildContext buildContext
+    ) {
+        super(distribution, testDirectoryProvider, gradleVersion, buildContext)
+    }
+
+    @Override
+    protected List<String> getAllArgs() {
+        List<Object> conditionalArgs = firstUse ? ["-D${VirtualFileSystemServices.VFS_DROP_PROPERTY}=true"] : ImmutableList.of()
+        firstUse = false
+        super.getAllArgs() + ([
+            "-D${VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY}=true",
+        ] + conditionalArgs).collect { it.toString() }
+    }
+}


### PR DESCRIPTION
Allow running integration tests with VFS retention enabled on CI.

Addresses part of https://github.com/gradle/gradle-private/issues/2866
