### PR TITLE
Fix convention mapping applied to a property with a setter with a covariant return type

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -610,13 +610,12 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         }
 
         public void addSetter(Method method) {
-            for (Method setter : setters) {
-                if (setter.getParameterTypes()[0].equals(method.getParameterTypes()[0])) {
-                    return;
-                }
+            if (method.isBridge()) {
+                // Ignore bridge methods and use the real method instead
+                return;
             }
             setters.add(method);
-            if (!Modifier.isFinal(method.getModifiers()) && !method.isBridge()) {
+            if (!Modifier.isFinal(method.getModifiers())) {
                 overridableSetters.add(method);
             }
         }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -142,7 +142,7 @@ public class AsmBackedClassGeneratorTest {
     public void mixesInGeneratedSubclassInterface() throws Exception {
         Bean bean = newInstance(Bean.class);
         assertTrue(bean instanceof GeneratedSubclass);
-        assertEquals(Bean.class, ((GeneratedSubclass)bean).publicType());
+        assertEquals(Bean.class, ((GeneratedSubclass) bean).publicType());
         assertEquals(Bean.class, GeneratedSubclasses.unpackType(bean));
         assertEquals(Bean.class, GeneratedSubclasses.unpack(bean.getClass()));
     }
@@ -151,7 +151,7 @@ public class AsmBackedClassGeneratorTest {
     public void mixesInGeneratedSubclassInterfaceToInterface() throws Exception {
         InterfaceWithDefaultMethods bean = newInstance(InterfaceWithDefaultMethods.class);
         assertTrue(bean instanceof GeneratedSubclass);
-        assertEquals(InterfaceWithDefaultMethods.class, ((GeneratedSubclass)bean).publicType());
+        assertEquals(InterfaceWithDefaultMethods.class, ((GeneratedSubclass) bean).publicType());
         assertEquals(InterfaceWithDefaultMethods.class, GeneratedSubclasses.unpackType(bean));
         assertEquals(InterfaceWithDefaultMethods.class, GeneratedSubclasses.unpack(bean.getClass()));
     }
@@ -571,6 +571,22 @@ public class AsmBackedClassGeneratorTest {
 
         bean.setValue(12);
         assertThat(bean.getValue(), equalTo("12"));
+    }
+
+    @Test
+    public void appliesConventionMappingToPropertyWithSetterCovariantType() throws Exception {
+        CovariantPropertyTypes bean = newInstance(CovariantPropertyTypes.class);
+
+        new DslObject(bean).getConventionMapping().map("value2", new Callable<String>() {
+            public String call() {
+                return "conventionValue";
+            }
+        });
+
+        assertThat(bean.getValue2(), equalTo("conventionValue"));
+
+        bean.setValue2(12);
+        assertThat(bean.getValue2(), equalTo(12));
     }
 
     @Test
@@ -1043,6 +1059,7 @@ public class AsmBackedClassGeneratorTest {
 
         dynamicObject.setProperty("prop", providerFactory.provider(new Callable<String>() {
             int count;
+
             @Override
             public String call() {
                 return "[" + ++count + "]";
@@ -1064,6 +1081,7 @@ public class AsmBackedClassGeneratorTest {
 
         dynamicObject.setProperty("aProp", providerFactory.provider(new Callable<String>() {
             int count;
+
             @Override
             public String call() {
                 return "[" + ++count + "]";
@@ -1088,6 +1106,7 @@ public class AsmBackedClassGeneratorTest {
 
         dynamicObject.setProperty("prop2", providerFactory.provider(new Callable<String>() {
             int count;
+
             @Override
             public String call() {
                 return "[" + ++count + "]";
@@ -1148,6 +1167,7 @@ public class AsmBackedClassGeneratorTest {
 
     public static class ParentBean {
         Object value;
+        Object value2;
 
         public Object getValue() {
             return value;
@@ -1156,12 +1176,27 @@ public class AsmBackedClassGeneratorTest {
         public void setValue(Object value) {
             this.value = value;
         }
+
+        public Object getValue2() {
+            return value2;
+        }
+
+        public ParentBean setValue2(Object value2) {
+            this.value2 = value2;
+            return this;
+        }
     }
 
     public static class CovariantPropertyTypes extends ParentBean {
         @Override
         public String getValue() {
             return String.valueOf(super.getValue());
+        }
+
+        @Override
+        public CovariantPropertyTypes setValue2(Object value2) {
+            super.setValue2(value2);
+            return this;
         }
     }
 
@@ -1880,13 +1915,12 @@ public class AsmBackedClassGeneratorTest {
     }
 
     public interface InterfaceWithDefaultMethods {
-        default
-        String getName() {
+        default String getName() {
             return "name";
         }
 
-        default
-        void thing() {}
+        default void thing() {
+        }
     }
 
     public static abstract class BeanWithAbstractProperty {


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context

Previously, during class generation, sometimes the bridge setter method would be selected for overriding and then later discarded because it is a bridge method, so that the convention mapping would always be applied to the property and the assigned value ignored.

This PR discards the bridge setter method earlier in the process.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
