### PR TITLE
Allow a property or file collection to be finalized on next read

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
@@ -59,7 +59,7 @@ public interface HasConfigurableValue {
      *
      * @since 6.1
      */
-    void finalizeOnRead();
+    void finalizeValueOnRead();
 
     /**
      * Disallows further direct changes to this object.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasConfigurableValue.java
@@ -23,8 +23,8 @@ import org.gradle.api.Incubating;
  * can be specified directly on the object.
  *
  * <p>This interface provides methods to manage the lifecycle of the value. Using these methods, the value of the object can be <em>finalized</em>, which means that the value will
- * no longer change. Note that this is not the same as an <em>immutable</em> value. You can think of a finalized value as similar to a {@code final} variable in Java. While the value does not change,
- * the value itself may still be mutable.</p>
+ * no longer change. Note that this is not the same as an <em>immutable</em> value. You can think of a finalized value as similar to a {@code final} variable in Java,
+ * so while the value of the variable does not change, the value itself may still be mutable.</p>
  *
  * <p>When a task property has a value of this type, it will be implicitly finalized when the task starts execution, to prevent accidental changes to the task parameters as the task runs.</p>
  *
@@ -43,14 +43,31 @@ public interface HasConfigurableValue {
      *
      * <p>Note that although the value of this object will no longer change, the value may itself be mutable.
      * Calling this method does not guarantee that the value will become immutable, though some implementations may support this.</p>
+     *
+     * <p>If the value of this object is already final, this method does nothing.</p>
      */
     void finalizeValue();
+
+    /**
+     * Requests that the final value of this object be calculated on the next read of the value, if not already known.
+     *
+     * <p>You can use this method along with {@link #disallowChanges()} to indicate that the value has been configured and that the final value is ready to calculate,
+     * without actually calculating the final value until it is required. This can be a useful alternative to {@link #finalizeValue()} for values that are expensive to calculate.
+     * </p>
+     *
+     * <p>If the value of this object is already final, this method does nothing.</p>
+     *
+     * @since 6.1
+     */
+    void finalizeOnRead();
 
     /**
      * Disallows further direct changes to this object.
      *
      * <p>This differs from {@link #finalizeValue()} in that it does not calculate the final value of this object, and so any source for the value will continue to be used until
      * the value is finalized.</p>
+     *
+     * <p>If the value of this object is already final, this method does nothing.</p>
      */
     void disallowChanges();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -153,6 +153,6 @@ public interface HasMultipleValues<T> extends HasConfigurableValue {
      *
      * @since 5.0
      */
-    @Incubating
+    @Incubating @Override
     void finalizeValue();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -186,5 +186,6 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      *
      * <p>Note that although the value of the property will not change, the resulting map may contain mutable objects. Calling this method does not guarantee that the value will become immutable.</p>
      */
+    @Override
     void finalizeValue();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -109,6 +109,6 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue {
      *
      * @since 5.0
      */
-    @Incubating
+    @Incubating @Override
     void finalizeValue();
 }

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
@@ -179,7 +179,7 @@ The services are made available through _service injection_.
 The following services are available for injection:
 
 - link:{javadocPath}/org/gradle/api/model/ObjectFactory.html[ObjectFactory] - Allows model objects to be created. See <<#nested_objects>> for more details.
-- link:{javadocPath}/org/gradle/api/file/ProjectLayout.html[ProjectLayout] - Provides access to key project locations. See <<lazy_configuration.adoc#sec:working_with_files_in_lazy_properties,lazy configuration>> for more details.
+- link:{javadocPath}/org/gradle/api/file/ProjectLayout.html[ProjectLayout] - Provides access to key project locations. See <<lazy_configuration.adoc#working_with_files_in_lazy_properties,lazy configuration>> for more details.
 - link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html[ProviderFactory] - Creates `Provider` instances. See <<lazy_configuration.adoc#lazy_configuration,lazy configuration>> for more details.
 - link:{javadocPath}/org/gradle/workers/WorkerExecutor.html[WorkerExecutor] - Allows a task to run work in parallel. See <<custom_tasks.adoc#worker_api,the worker API>> for more details.
 - link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html[FileSystemOperations] - Allows a task to run operations on the filesystem such as deleting files, copying files or syncing directories.

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_tasks.adoc
@@ -162,7 +162,7 @@ In addition, the task needs to declare at least one incremental file input prope
 To query incremental changes for an input file property, that property always needs to return the same instance.
 The easiest way to accomplish this is to use one of the following types for such properties: link:{javadocPath}/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty], link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty] or link:{javadocPath}/org/gradle/api/file/ConfigurableFileCollection.html[ConfigurableFileCollection].
 
-You can learn more about `RegularFileProperty` and `DirectoryProperty` in the <<lazy_configuration#lazy_configuration,Lazy Configuration>> chapter, especially the sections on <<lazy_configuration#sec:lazy_properties,using read-only and configurable properties>> and <<lazy_configuration#sec:working_with_files_in_lazy_properties,lazy file properties>>.
+You can learn more about `RegularFileProperty` and `DirectoryProperty` in the <<lazy_configuration#lazy_configuration,Lazy Configuration>> chapter, especially the sections on <<lazy_configuration#lazy_properties,using read-only and configurable properties>> and <<lazy_configuration#working_with_files_in_lazy_properties,lazy file properties>>.
 ====
 
 The incremental task action can use link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges()] to find out what files have changed for a given file-based input property, be it of type `RegularFileProperty`, `DirectoryProperty` or `ConfigurableFileCollection`.

--- a/subprojects/docs/src/docs/userguide/extending-gradle/lazy_configuration.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/lazy_configuration.adoc
@@ -17,7 +17,7 @@
 
 As a build grows in complexity, knowing when and where a particular value is configured can become difficult to reason about. Gradle provides several ways to manage this complexity using _lazy configuration_.
 
-[[sec:lazy_properties]]
+[[lazy_properties]]
 == Lazy properties
 
 Gradle provides lazy properties, which delay the calculation of a property’s value until it’s actually required. These provide three main benefits to build script and plugin authors:
@@ -68,10 +68,10 @@ Kotlin DSL conveniences will be added in a future release.
 
 ====
 
-[[sec:creating_property_provider]]
+[[creating_property_provider]]
 == Creating a Property or Provider instance
 
-Neither `Provider` nor its subtypes such as `Property` are intended to be implemented by a build script or plugin author.  Gradle provides factory methods to create instances of these types instead. See the <<#sec:lazy_configuration_reference,Quick Reference>> for all of the types and factories available. In the previous example, we have seen 2 factory methods:
+Neither `Provider` nor its subtypes such as `Property` are intended to be implemented by a build script or plugin author.  Gradle provides factory methods to create instances of these types instead. See the <<#lazy_configuration_reference,Quick Reference>> for all of the types and factories available. In the previous example, we have seen 2 factory methods:
 
 - link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#property-java.lang.Class-[ObjectFactory.property(Class)] create a new `Property` instance. An instance of the link:{javadocPath}/org/gradle/api/model/ObjectFactory.html[ObjectFactory] can be referenced from link:{javadocPath}/org/gradle/api/Project.html#getObjects--[Project.getObjects()] or by injecting `ObjectFactory` through a constructor or method.
 - link:{javadocPath}/org/gradle/api/provider/Provider.html#map-org.gradle.api.Transformer-[Provider.map(Transformer)] creates a new `Provider` from an existing `Provider` or `Property` instance.
@@ -87,7 +87,7 @@ Similarly, when writing a plugin or build script with Kotlin, the Kotlin compile
 
 ====
 
-[[sec:connecting_properties_together]]
+[[connecting_properties_together]]
 == Connecting properties together
 
 An important feature of lazy properties is that they can be connected together so that changes to one property are automatically reflected in other properties. Here's an example where the property of a task is connected to a property of a project extension:
@@ -106,7 +106,7 @@ include::{samplesPath}/providers/connectProperties/connectProperties.out[]
 
 This example calls the link:{javadocPath}/org/gradle/api/provider/Property.html#set-org.gradle.api.provider.Provider-[Property.set(Provider)] method to attach a `Provider` to a `Property` to supply the value of the property. In this case, the `Provider` happens to be a `Property` as well, but you can connect any `Provider` implementation, for example one created using `Provider.map()`
 
-[[sec:working_with_files_in_lazy_properties]]
+[[working_with_files_in_lazy_properties]]
 == Working with files
 
 In <<working_with_files.adoc#working_with_files,Working with Files>>, we introduced four collection types for `File`-like objects:
@@ -154,7 +154,7 @@ This example creates providers that represent locations in the project and build
 
 To close the loop, note that a `DirectoryProperty`, or a simple `Directory`, can be turned into a `FileTree` that allows the files and directories contained in the directory to be queried with link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#getAsFileTree--[DirectoryProperty.getAsFileTree()] or link:{javadocPath}/org/gradle/api/file/Directory.html#getAsFileTree--[Directory.getAsFileTree()]. Moreover, from a `DirectoryProperty`, or a `Directory`, you can also create `FileCollection` instances containing a set of the files contained in the directory with link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#files-java.lang.Object++...++-[DirectoryProperty.files(Object++...++)] or link:{javadocPath}/org/gradle/api/file/Directory.html#files-java.lang.Object++...++-[Directory.files(Object++...++)].
 
-[[sec:working_with_task_dependencies_in_lazy_properties]]
+[[working_with_task_dependencies_in_lazy_properties]]
 == Working with task inputs and outputs
 
 Many builds have several tasks connected together, where one task consumes the outputs of another task as an input. To make this work, we would need to configure each task to know where to look for its inputs and place its outputs, make sure that the producing and consuming tasks are configured with the same location, and attach task dependencies between the tasks. This can be cumbersome and brittle if any of these values are configurable by a user or configured by multiple plugins, as task properties need to be configured in the correct order and locations and task dependencies kept in sync as values change.
@@ -205,7 +205,7 @@ $ gradle consumer
 include::{samplesPath}/providers/implicitTaskInputDependency/implicitTaskInputDependencyKotlin.out[]
 ----
 
-[[sec:working_with_collections]]
+[[working_with_collections]]
 == Working with collections
 
 Gradle provides two lazy property types to help configure `Collection` properties. These work exactly like any other `Provider` and, just like file providers, they have additional modeling around them:
@@ -240,7 +240,7 @@ $ gradle consumer
 include::{samplesPath}/providers/listProperty/listPropertyKotlin.out[]
 ----
 
-[[sec:working_with_maps]]
+[[working_with_maps]]
 == Working with maps
 
 Gradle provides a lazy link:{javadocPath}/org/gradle/api/provider/MapProperty.html[MapProperty] type to allow `Map` values to be configured.
@@ -260,7 +260,7 @@ $ gradle generate
 include::{samplesPath}/providers/mapProperty/mapProperty.out[]
 ----
 
-[[sec:applying_conventions]]
+[[applying_conventions]]
 == Applying a convention to a property
 
 Often you want to apply some _convention_, or default value, to a property to be used if no value has been configured for the property. You can use the `convention()` method for this. This method accepts either a value or a `Provider` and this will be used as the value until some other value is configured.
@@ -277,14 +277,24 @@ $ gradle show
 include::{samplesPath}/providers/propertyConvention/propertyConvention.out[]
 ----
 
-[[sec:unmodifiable_property]]
+[[unmodifiable_property]]
 == Making a property unmodifiable
 
-Most properties of a task or project are intended to be configured by plugins or build scripts and then the resulting value used to do something useful. For example, a property that specifies the output directory for a compilation task may start off with a value specified by a plugin, then a build script might configure the value to some custom location, then this value is used by the task when it runs. However, once the task starts to run, we want to prevent any further change to the property. This way we avoid errors that result from different consumers, such as the task action or Gradle's up-to-date checks or build caching or other tasks, using different values for the property.
+Most properties of a task or project are intended to be configured by plugins or build scripts and then the resulting value used to do something useful. For example, a property that specifies the output directory for a compilation task may start off with a value specified by a plugin, then a build script might change the value to some custom location, then this value is used by the task when it runs.
+However, once the task starts to run, we want to prevent any further change to the property. This way we avoid errors that result from different consumers, such as the task action or Gradle's up-to-date checks or build caching or other tasks, using different values for the property.
 
-Lazy properties provide a link:{javadocPath}/org/gradle/api/provider/Property.html#finalizeValue--[finalizeValue()] method to make this explicit. Calling this method makes a property instance unmodifiable from that point on and any further attempts to change the value of the property will fail. Gradle automatically makes the properties of a task final when the task starts execution.
+Lazy properties provide several methods that you can use to disallow changes to their value once the value has been configured.
+The link:{javadocPath}/org/gradle/api/provider/Property.html#finalizeValue--[finalizeValue()] method calculates the _final_ value for the property and prevents further changes to the property.
+When the value of the property comes from a `Provider`, the provider is queried for its current value and the result becomes the final value for the property.
+This final value replaces the provider and the property no longer tracks the value of the provider.
+Calling this method also makes a property instance unmodifiable and any further attempts to change the value of the property will fail.
+Gradle automatically makes the properties of a task final when the task starts execution.
 
-[[sec:lazy_configuration_faqs]]
+The link:{javadocPath}/org/gradle/api/provider/HasConfigurableValue.html#finalizeValueOnRead--[finalizeValueOnRead()] method is similar, except that the property's final value is not calculated until the value
+of the property is queried. In other words, this method calculates the final value lazily as required, whereas `finalizeValue()` calculates the final value eagerly.
+This method can be used when the value may be expensive to calculate or may not have been configured yet, but you also want to ensure that all consumers of the property see the same value when they query the value.
+
+[[lazy_configuration_faqs]]
 == Guidelines
 
 This section will introduce guidelines to be successful with the Provider API. To see those guidelines in action, have a look at https://github.com/gradle-guides/gradle-site-plugin[gradle-site-plugin], a Gradle plugin demonstrating established techniques and practices for plugin development.
@@ -298,12 +308,12 @@ This section will introduce guidelines to be successful with the Provider API. T
 ** If it's incubating, change it to use a link:{javadocPath}/org/gradle/api/provider/Property.html[Property] or link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider] using a single getter.
 ** If it's a stable property, add a new link:{javadocPath}/org/gradle/api/provider/Property.html[Property] or link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider] and deprecate the old one. You should wire the old getter/setters into the new property as appropriate.
 
-[[sec:lazy_configuration_roadmap]]
+[[lazy_configuration_roadmap]]
 == Future development
 
 Going forward, new properties will use the Provider API. The Groovy Gradle DSL adds convenience methods to make the use of Providers mostly transparent in build scripts. Existing tasks will have their existing "raw" properties replaced by Providers as needed and in a backwards compatible way. New tasks will be designed with the Provider API.
 
-[[sec:lazy_configuration_reference]]
+[[lazy_configuration_reference]]
 == Provider Files API Reference
 
 Use these types for _read-only_ values:

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_4.adoc
@@ -132,7 +132,7 @@ Java builds::
 +
 With the removal of Maven 2 support, the methods that configure unique snapshot behavior have also been removed. Maven 3 only supports unique snapshots, so we decided to remove them.
 Tasks & properties::
- * The following legacy classes and methods related to <<lazy_configuration#sec:lazy_properties,lazy properties>> have been removed — use link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#property-java.lang.Class-[ObjectFactory.property()] to create `Property` instances:
+ * The following legacy classes and methods related to <<lazy_configuration#lazy_properties,lazy properties>> have been removed — use link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#property-java.lang.Class-[ObjectFactory.property()] to create `Property` instances:
  ** `PropertyState`
  ** `DirectoryVar`
  ** `RegularFileVar`

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
@@ -793,7 +793,7 @@ The incubating `operatingSystems` property on native components has been replace
 
 ===== Change in behavior for tasks extending `AbstractArchiveTask`
 
-The `AbstractArchiveTask` has several new properties using the <<lazy_configuration.adoc#sec:lazy_configuration_reference,Provider API>>.
+The `AbstractArchiveTask` has several new properties using the <<lazy_configuration.adoc#lazy_configuration_reference,Provider API>>.
 Plugins that extend these types and override methods from the base class may no longer behave the same way.
 Internally, `AbstractArchiveTask` prefers the new properties and methods like `getArchiveName()` are façades over the new properties.
 

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/internal/file/FileCollectionIntegrationTest.groovy
@@ -62,17 +62,51 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
     def "finalized file collection resolves locations and ignores later changes to source paths"() {
         buildFile << """
             def files = objects.fileCollection()
-            def name = 'a'
-            files.from { name }
+            Integer counter = 0
+            files.from { "a\${++counter}" }
             
             def names = ['b', 'c']
             files.from(names)
 
+            assert files.files as List == [file('a1'), file('b'), file('c')]
+
             files.finalizeValue()
-            name = 'ignore-me'
+            
+            assert counter == 2
+            
+            assert files.files as List == [file('a2'), file('b'), file('c')]
+
+            counter = 45
             names.clear()
             
-            assert files.files as List == [file('a'), file('b'), file('c')]
+            assert files.files as List == [file('a2'), file('b'), file('c')]
+        """
+
+        expect:
+        succeeds()
+    }
+
+    def "finalize on read file collection resolves locations and ignores later changes to source paths"() {
+        buildFile << """
+            def files = objects.fileCollection()
+            Integer counter = 0
+            files.from { "a\${++counter}" }
+            
+            def names = ['b', 'c']
+            files.from(names)
+
+            assert files.files as List == [file('a1'), file('b'), file('c')]
+
+            files.finalizeValueOnRead()
+            
+            assert counter == 1
+            
+            assert files.files as List == [file('a2'), file('b'), file('c')]
+
+            counter = 45
+            names.clear()
+            
+            assert files.files as List == [file('a2'), file('b'), file('c')]
         """
 
         expect:

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -90,7 +90,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     }
 
     @Override
-    public void finalizeOnRead() {
+    public void finalizeValueOnRead() {
         if (state == State.Mutable || state == State.ImplicitFinalizeNextQuery) {
             state = State.FinalizeNextQuery;
         }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -726,6 +726,253 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.files as List == [file1, file2]
     }
 
+    def resolvesPathToFileWhenQueriedAfterFinalizeOnRead() {
+        given:
+        def file = new File('one')
+        collection.from('a')
+
+        when:
+        collection.finalizeOnRead()
+
+        then:
+        0 * fileResolver._
+
+        when:
+        def files = collection.files
+
+        then:
+        1 * fileResolver.resolve('a') >> file
+        0 * fileResolver._
+
+        then:
+        files as List == [file]
+
+        when:
+        def files2 = collection.files
+
+        then:
+        files2 as List == [file]
+
+        and:
+        0 * fileResolver._
+    }
+
+    def resolvesClosureToFilesWhenQueriedAfterFinalizeOnRead() {
+        given:
+        def file1 = new File('one')
+        def file2 = new File('two')
+        def closure = Mock(Closure)
+        collection.from(closure)
+
+        when:
+        collection.finalizeOnRead()
+
+        then:
+        0 * closure._
+        0 * fileResolver._
+
+        when:
+        def files = collection.files
+
+        then:
+        files as List == [file1, file2]
+
+        then:
+        1 * closure.call() >> ['a', 'b']
+        0 * closure._
+        1 * fileResolver.resolve('a') >> file1
+        1 * fileResolver.resolve('b') >> file2
+
+        when:
+        def files2 = collection.files
+
+        then:
+        files2 as List == [file1, file2]
+
+        and:
+        0 * closure._
+        0 * fileResolver._
+    }
+
+    def resolvesCollectionToFilesWhenQueriedAfterFinalizeOnRead() {
+        given:
+        def file1 = new File('one')
+        def file2 = new File('two')
+        def collection = Mock(Collection)
+        this.collection.from(collection)
+
+        when:
+        this.collection.finalizeOnRead()
+
+        then:
+        0 * collection._
+        0 * fileResolver._
+
+        when:
+        def files = this.collection.files
+
+        then:
+        files as List == [file1, file2]
+
+        then:
+        1 * collection.iterator() >> ['a', 'b'].iterator()
+        0 * collection._
+        1 * fileResolver.resolve('a') >> file1
+        1 * fileResolver.resolve('b') >> file2
+
+        when:
+        def files2 = this.collection.files
+
+        then:
+        files2 as List == [file1, file2]
+
+        and:
+        0 * collection._
+        0 * fileResolver._
+    }
+
+    def canSpecifyPathsBeforeQueriedAndFinalizeOnRead() {
+        given:
+        def file = new File('one')
+        collection.finalizeOnRead()
+
+        when:
+        collection.setFrom('a')
+
+        then:
+        0 * fileResolver._
+
+        when:
+        def files = collection.files
+
+        then:
+        1 * fileResolver.resolve('a') >> file
+        0 * fileResolver._
+
+        then:
+        files as List == [file]
+    }
+
+    def canAddPathsBeforeQueriedAndFinalizeOnRead() {
+        given:
+        def file = new File('one')
+        collection.finalizeOnRead()
+
+        when:
+        collection.from('a')
+
+        then:
+        0 * fileResolver._
+
+        when:
+        def files = collection.files
+
+        then:
+        1 * fileResolver.resolve('a') >> file
+        0 * fileResolver._
+
+        then:
+        files as List == [file]
+    }
+
+    def canMutateFromSetBeforeQueriedAndFinalizeOnRead() {
+        given:
+        def file = new File('one')
+        collection.finalizeOnRead()
+
+        when:
+        collection.from.add('a')
+
+        then:
+        0 * fileResolver._
+
+        when:
+        def files = collection.files
+
+        then:
+        1 * fileResolver.resolve('a') >> file
+        0 * fileResolver._
+
+        then:
+        files as List == [file]
+    }
+
+    def cannotSpecifyPathsWhenQueriedAfterFinalizeOnRead() {
+        given:
+        collection.from('a')
+        _ * fileResolver.resolve('a') >> new File('a')
+
+        collection.finalizeOnRead()
+        collection.files
+
+        when:
+        collection.setFrom('some', 'more')
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <display> is final and cannot be changed.'
+
+        when:
+        collection.setFrom(['some', 'more'])
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display> is final and cannot be changed.'
+    }
+
+    def cannotAddPathsWhenQueriedAfterFinalizeOnRead() {
+        given:
+        collection.from('a')
+        _ * fileResolver.resolve('a') >> new File('a')
+
+        collection.finalizeOnRead()
+        collection.files
+
+        when:
+        collection.from('more')
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <display> is final and cannot be changed.'
+    }
+
+    def cannotMutateFromSetWhenQueriedAfterFinalizeOnRead() {
+        given:
+        collection.from('a')
+        _ * fileResolver.resolve('a') >> new File('a')
+
+        collection.finalizeOnRead()
+        collection.files
+
+        when:
+        collection.from.clear()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'The value for <display> is final and cannot be changed.'
+
+        when:
+        collection.from.add('b')
+
+        then:
+        def e2 = thrown(IllegalStateException)
+        e2.message == 'The value for <display> is final and cannot be changed.'
+
+        when:
+        collection.from.remove('a')
+
+        then:
+        def e3 = thrown(IllegalStateException)
+        e3.message == 'The value for <display> is final and cannot be changed.'
+
+        when:
+        collection.from.iterator().remove()
+
+        then:
+        def e4 = thrown(IllegalStateException)
+        e4.message == 'The value for <display> is final and cannot be changed.'
+    }
+
     def cannotSpecifyPathsWhenChangesDisallowed() {
         given:
         collection.from('a')

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -732,7 +732,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.from('a')
 
         when:
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
 
         then:
         0 * fileResolver._
@@ -765,7 +765,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.from(closure)
 
         when:
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
 
         then:
         0 * closure._
@@ -802,7 +802,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         this.collection.from(collection)
 
         when:
-        this.collection.finalizeOnRead()
+        this.collection.finalizeValueOnRead()
 
         then:
         0 * collection._
@@ -834,7 +834,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
     def canSpecifyPathsBeforeQueriedAndFinalizeOnRead() {
         given:
         def file = new File('one')
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
 
         when:
         collection.setFrom('a')
@@ -856,7 +856,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
     def canAddPathsBeforeQueriedAndFinalizeOnRead() {
         given:
         def file = new File('one')
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
 
         when:
         collection.from('a')
@@ -878,7 +878,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
     def canMutateFromSetBeforeQueriedAndFinalizeOnRead() {
         given:
         def file = new File('one')
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
 
         when:
         collection.from.add('a')
@@ -902,7 +902,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.from('a')
         _ * fileResolver.resolve('a') >> new File('a')
 
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
         collection.files
 
         when:
@@ -925,7 +925,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.from('a')
         _ * fileResolver.resolve('a') >> new File('a')
 
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
         collection.files
 
         when:
@@ -941,7 +941,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.from('a')
         _ * fileResolver.resolve('a') >> new File('a')
 
-        collection.finalizeOnRead()
+        collection.finalizeValueOnRead()
         collection.files
 
         when:

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -146,8 +146,43 @@ property.set(provider)
 
 assert property.get() == 1 
 assert property.get() == 2 
+
 property.finalizeValue()
+
+assert counter == 3 // is eager
 assert property.get() == 3 
+
+counter = 45
+assert property.get() == 3 
+
+property.set(12)
+"""
+
+        when:
+        fails()
+
+        then:
+        failure.assertHasCause("The value for this property is final and cannot be changed any further.")
+    }
+
+    def "can finalize the value of a property on next read using API"() {
+        given:
+        buildFile << """
+Integer counter = 0
+def provider = providers.provider { ++counter }
+
+def property = objects.property(Integer)
+property.set(provider)
+
+assert property.get() == 1 
+assert property.get() == 2 
+
+property.finalizeValueOnRead()
+
+assert counter == 2 // is lazy
+assert property.get() == 3
+ 
+counter = 45
 assert property.get() == 3 
 
 property.set(12)

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -118,6 +118,11 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     }
 
     @Override
+    public void finalizeOnRead() {
+        finalizeOnNextGet = true;
+    }
+
+    @Override
     public void implicitFinalizeValue() {
         disallowChanges = true;
         finalizeOnNextGet = true;
@@ -176,7 +181,7 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     }
 
     private boolean canMutate() {
-        if (state == State.Final && disallowChanges) {
+        if (state == State.Final) {
             throw new IllegalStateException(String.format("The value for %s is final and cannot be changed any further.", getDisplayName().getDisplayName()));
         } else if (disallowChanges) {
             throw new IllegalStateException(String.format("The value for %s cannot be changed any further.", getDisplayName().getDisplayName()));

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -118,7 +118,7 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
     }
 
     @Override
-    public void finalizeOnRead() {
+    public void finalizeValueOnRead() {
         finalizeOnNextGet = true;
     }
 

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -671,7 +671,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.set(provider)
 
         when:
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
 
         then:
         0 * _
@@ -1009,7 +1009,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         def property = propertyWithNoValue()
         property.set(someOtherValue())
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
 
         when:
         property.set(someValue())
@@ -1023,7 +1023,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
         property.get()
 
         when:
@@ -1111,7 +1111,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
         property.disallowChanges()
 
         when:
@@ -1199,7 +1199,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
         property.get()
 
         when:
@@ -1316,7 +1316,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
         property.get()
 
         when:
@@ -1418,7 +1418,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         def property = propertyWithDefaultValue()
         property.set(someValue())
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
         property.get()
 
         when:
@@ -1506,7 +1506,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         def property = propertyWithNoValue()
         property.set(someValue())
-        property.finalizeOnRead()
+        property.finalizeValueOnRead()
         property.get()
 
         when:


### PR DESCRIPTION

### Context

Adds `HasConfigurableValue.finalizeValueOnRead()` which causes the property/file collection value to be finalized the next time the value is queried. This method allows build logic to ensure all reads of a property value see the same finalized value, but when the property value might be expensive to calculate or has not been fully configured yet.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
