### PR TITLE
Fix direct get resource for GCS

### DIFF
--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/GcsClientIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/GcsClientIntegrationTest.groovy
@@ -70,7 +70,7 @@ class GcsClientIntegrationTest extends Specification {
         object.getSize() == fileContents.length()
         object.getEtag() ==~ /\w{32}/
         ByteArrayOutputStream outStream = new ByteArrayOutputStream()
-        IOUtils.copyLarge(gcsClient.getResourceStream(object), outStream)
+        IOUtils.copyLarge(gcsClient.getResourceStream(uri), outStream)
         outStream.toString() == fileContents
 
         when:
@@ -112,7 +112,7 @@ class GcsClientIntegrationTest extends Specification {
         def uri = new URI("gcs://${bucketName}/maven/release/${new Date().getTime()}-mavenTest.txt")
         gcsClient.put(stream, file.length(), uri)
         ByteArrayOutputStream outStream = new ByteArrayOutputStream()
-        IOUtils.copyLarge(gcsClient.getResourceStream(gcsClient.getResource(uri)), outStream)
+        IOUtils.copyLarge(gcsClient.getResourceStream(uri), outStream)
         outStream.toString() == fileContents
     }
 }

--- a/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsClient.java
+++ b/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsClient.java
@@ -119,6 +119,14 @@ public class GcsClient {
         }
     }
 
+    @VisibleForTesting
+    InputStream getResourceStream(URI uri) throws IOException {
+        String path = cleanResourcePath(uri);
+        Storage.Objects.Get getObject = storage.objects().get(uri.getHost(), path);
+        getObject.getMediaHttpDownloader().setDirectDownloadEnabled(false);
+        return getObject.executeMediaAsInputStream();
+    }
+
     @Nullable
     public List<String> list(URI uri) throws ResourceException {
         List<StorageObject> results = new ArrayList<StorageObject>();
@@ -147,13 +155,6 @@ public class GcsClient {
         }
 
         return resultStrings;
-    }
-
-    @VisibleForTesting
-    InputStream getResourceStream(StorageObject obj) throws IOException {
-        Storage.Objects.Get getObject = storage.objects().get(obj.getBucket(), obj.getName());
-        getObject.getMediaHttpDownloader().setDirectDownloadEnabled(false);
-        return getObject.executeMediaAsInputStream();
     }
 
     private static String cleanResourcePath(URI uri) {

--- a/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsResource.java
+++ b/subprojects/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsResource.java
@@ -40,7 +40,7 @@ public class GcsResource implements ExternalResourceReadResponse {
 
     @Override
     public InputStream openStream() throws IOException {
-        return gcsClient.getResourceStream(gcsObject);
+        return gcsClient.getResourceStream(uri);
     }
 
     @Override


### PR DESCRIPTION
It looks like this code path was never properly tested and working
since this was implemented. It was only working for the case
where we have a populated cache (Maven local) and probe for
metadata before downloading.

Fixes #10835