### PR TITLE
Introduce API for tracking files used as build logic inputs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
@@ -28,7 +28,7 @@ import org.gradle.api.provider.Provider;
 public interface FileContents {
 
     /**
-     * Gets a provider to the entire file contents as a single String.
+     * Gets a provider of the entire file contents as a single String.
      *
      * <p>
      * The file is read only once and only when the value is requested for the first time.
@@ -45,12 +45,12 @@ public interface FileContents {
      *     {@link Provider#get}, {@link Provider#getOrElse}, {@link Provider#getOrNull} and {@link Provider#isPresent}.
      * </p>
      *
-     * @return provider to the entire file contents as a single String.
+     * @return provider of the entire file contents as a single String.
      */
     Provider<String> getAsText();
 
     /**
-     * Gets a provider to the entire file contents as a single byte array.
+     * Gets a provider of the entire file contents as a single byte array.
      *
      * <p>
      * The file is read only once and only when the value is requested for the first time.
@@ -67,7 +67,7 @@ public interface FileContents {
      *     {@link Provider#get}, {@link Provider#getOrElse}, {@link Provider#getOrNull} and {@link Provider#isPresent}.
      * </p>
      *
-     * @return provider to the entire file contents as a single byte array.
+     * @return provider of the entire file contents as a single byte array.
      */
     Provider<byte[]> getAsBytes();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
@@ -30,12 +30,42 @@ public interface FileContents {
     /**
      * Gets a provider to the entire file contents as a single String.
      *
+     * <p>
+     * The file is read only once and only when the value is requested for the first time.
+     * </p>
+     * <p>
+     * The returned provider won't have a value, i.e., {@link Provider#isPresent} will return {@code false} when:
+     * <ul>
+     *     <li>the underlying file does not exist;</li>
+     *     <li>this {@link FileContents} is connected to a {@link Provider}{@code <}{@link RegularFile}{@code >} with no value;</li>
+     * </ul>
+     * </p>
+     * <p>
+     *     When the underlying file exists but reading it fails, the ensuing exception is permanently propagated to callers of
+     *     {@link Provider#get}, {@link Provider#getOrElse}, {@link Provider#getOrNull} and {@link Provider#isPresent}.
+     * </p>
+     *
      * @return provider to the entire file contents as a single String.
      */
     Provider<String> getAsText();
 
     /**
      * Gets a provider to the entire file contents as a single byte array.
+     *
+     * <p>
+     * The file is read only once and only when the value is requested for the first time.
+     * </p>
+     * <p>
+     * The returned provider won't have a value, i.e., {@link Provider#isPresent} will return {@code false} when:
+     * <ul>
+     *     <li>the underlying file does not exist;</li>
+     *     <li>this {@link FileContents} is connected to a {@link Provider}{@code <}{@link RegularFile}{@code >} with no value;</li>
+     * </ul>
+     * </p>
+     * <p>
+     *     When the underlying file exists but reading it fails, the ensuing exception is permanently propagated to callers of
+     *     {@link Provider#get}, {@link Provider#getOrElse}, {@link Provider#getOrNull} and {@link Provider#isPresent}.
+     * </p>
      *
      * @return provider to the entire file contents as a single byte array.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.api.provider;
+package org.gradle.api.file;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.Provider;
 
 /**
  * Provides lazy access to the contents of a given file.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileContents.java
@@ -35,11 +35,11 @@ public interface FileContents {
      * </p>
      * <p>
      * The returned provider won't have a value, i.e., {@link Provider#isPresent} will return {@code false} when:
+     * </p>
      * <ul>
      *     <li>the underlying file does not exist;</li>
      *     <li>this {@link FileContents} is connected to a {@link Provider}{@code <}{@link RegularFile}{@code >} with no value;</li>
      * </ul>
-     * </p>
      * <p>
      *     When the underlying file exists but reading it fails, the ensuing exception is permanently propagated to callers of
      *     {@link Provider#get}, {@link Provider#getOrElse}, {@link Provider#getOrNull} and {@link Provider#isPresent}.
@@ -57,11 +57,11 @@ public interface FileContents {
      * </p>
      * <p>
      * The returned provider won't have a value, i.e., {@link Provider#isPresent} will return {@code false} when:
+     * </p>
      * <ul>
      *     <li>the underlying file does not exist;</li>
      *     <li>this {@link FileContents} is connected to a {@link Provider}{@code <}{@link RegularFile}{@code >} with no value;</li>
      * </ul>
-     * </p>
      * <p>
      *     When the underlying file exists but reading it fails, the ensuing exception is permanently propagated to callers of
      *     {@link Provider#get}, {@link Provider#getOrElse}, {@link Provider#getOrNull} and {@link Provider#isPresent}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/FileContents.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/FileContents.java
@@ -32,4 +32,11 @@ public interface FileContents {
      * @return provider to the entire file contents as a single String.
      */
     Provider<String> getAsText();
+
+    /**
+     * Gets a provider to the entire file contents as a single byte array.
+     *
+     * @return provider to the entire file contents as a single byte array.
+     */
+    Provider<byte[]> getAsBytes();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/FileContents.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/FileContents.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Provides lazy access to the contents of a given file.
+ *
+ * @since 6.1
+ */
+@Incubating
+public interface FileContents {
+
+    /**
+     * Gets a provider to the entire file contents as a single String.
+     *
+     * @return provider to the entire file contents as a single String.
+     */
+    Provider<String> getAsText();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.FileContents;
 import org.gradle.api.file.RegularFile;
 
 import java.util.concurrent.Callable;

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.RegularFile;
 
 import java.util.concurrent.Callable;
 
@@ -61,6 +62,34 @@ public interface ProviderFactory {
      */
     @Incubating
     Provider<String> systemProperty(Provider<String> propertyName);
+
+    /**
+     * Allows lazy access to the contents of the given file.
+     *
+     * When the file contents are read at configuration time the file is automatically considered
+     * as an input to the configuration model.
+     *
+     * @param file the file
+     * @return
+     *
+     * @since 6.1
+     */
+    @Incubating
+    FileContents fileContents(RegularFile file);
+
+    /**
+     * Allows lazy access to the contents of the given file.
+     *
+     * When the file contents are read at configuration time the file is automatically considered
+     * as an input to the configuration model.
+     *
+     * @param file the file
+     * @return
+     *
+     * @since 6.1
+     */
+    @Incubating
+    FileContents fileContents(Provider<RegularFile> file);
 
     /**
      * Creates a {@link Provider} whose value is obtained from the given {@link ValueSource}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -71,7 +71,7 @@ public interface ProviderFactory {
      * as an input to the configuration model.
      *
      * @param file the file whose contents to read.
-     * @return an object that allows lazy access to the contents of the given file.
+     * @return an interface that allows lazy access to the contents of the given file.
      *
      * @see FileContents#getAsText()
      * @see FileContents#getAsBytes()
@@ -88,7 +88,7 @@ public interface ProviderFactory {
      * as an input to the configuration model.
      *
      * @param file provider of the file whose contents to read.
-     * @return an object that allows lazy access to the contents of the given file.
+     * @return an interface that allows lazy access to the contents of the given file.
      *
      * @see FileContents#getAsText()
      * @see FileContents#getAsBytes()

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -70,8 +70,11 @@ public interface ProviderFactory {
      * When the file contents are read at configuration time the file is automatically considered
      * as an input to the configuration model.
      *
-     * @param file the file
-     * @return
+     * @param file the file whose contents to read.
+     * @return an object that allows lazy access to the contents of the given file.
+     *
+     * @see FileContents#getAsText()
+     * @see FileContents#getAsBytes()
      *
      * @since 6.1
      */
@@ -84,8 +87,11 @@ public interface ProviderFactory {
      * When the file contents are read at configuration time the file is automatically considered
      * as an input to the configuration model.
      *
-     * @param file the file
-     * @return
+     * @param file provider of the file whose contents to read.
+     * @return an object that allows lazy access to the contents of the given file.
+     *
+     * @see FileContents#getAsText()
+     * @see FileContents#getAsBytes()
      *
      * @since 6.1
      */

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildOptionsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionBuildOptionsIntegrationTest.groovy
@@ -251,7 +251,7 @@ class InstantExecutionBuildOptionsIntegrationTest extends AbstractInstantExecuti
         def instant = newInstantExecutionFixture()
         buildKotlinFile """
             val ciFile = layout.projectDirectory.file("ci")
-            val isCi = providers.fileContents(ciFile).asText
+            val isCi = providers.fileContents(ciFile)
             if ($expression) {
                 tasks.register("run") {
                     doLast { println("ON CI") }
@@ -298,12 +298,14 @@ class InstantExecutionBuildOptionsIntegrationTest extends AbstractInstantExecuti
         instantRun "run"
 
         then: "cache is NO longer valid"
-        output.count(usage == "presence" ? "ON CI" : "NOT CI") == 1
+        output.count(usage.endsWith("presence") ? "ON CI" : "NOT CI") == 1
         instant.assertStateStored()
 
         where:
-        expression                                     | usage
-        "isCi.map(String::toBoolean).getOrElse(false)" | "value"
-        "isCi.isPresent"                               | "presence"
+        expression                                                     | usage
+        "isCi.asText.map(String::toBoolean).getOrElse(false)"          | "text"
+        "isCi.asText.isPresent"                                        | "text presence"
+        "isCi.asBytes.map { String(it).toBoolean() }.getOrElse(false)" | "bytes"
+        "isCi.asBytes.isPresent"                                       | "bytes presence"
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionCacheInputs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionCacheInputs.kt
@@ -48,7 +48,7 @@ class InstantExecutionCacheInputs(
         obtainedValue: ValueSourceProviderFactory.Listener.ObtainedValue<T, P>
     ) {
         when (val parameters = obtainedValue.valueSourceParameters) {
-            is FileContentValueSource.Parameters -> { // TODO: consider making this a more general interface
+            is FileContentValueSource.Parameters -> {
                 parameters.file.orNull?.asFile?.let { file ->
                     // TODO - consider the potential race condition in computing the hash code here
                     inputFiles.add(

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionCacheInputs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionCacheInputs.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.internal.provider.ValueSourceProviderFactory
+import org.gradle.api.internal.provider.sources.FileTextValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.instantexecution.extensions.uncheckedCast
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.vfs.VirtualFileSystem
+import java.io.File
+
+
+internal
+typealias ObtainedValue = ValueSourceProviderFactory.Listener.ObtainedValue<Any, ValueSourceParameters>
+
+
+internal
+class InstantExecutionCacheInputs(
+    val virtualFileSystem: VirtualFileSystem
+) : ValueSourceProviderFactory.Listener {
+
+    internal
+    data class InputFile(val file: File, val hashCode: HashCode?)
+
+    val inputFiles = mutableListOf<InputFile>()
+
+    val obtainedValues = mutableListOf<ObtainedValue>()
+
+    override fun <T : Any, P : ValueSourceParameters> valueObtained(
+        obtainedValue: ValueSourceProviderFactory.Listener.ObtainedValue<T, P>
+    ) {
+        when (val parameters = obtainedValue.valueSourceParameters) {
+            is FileTextValueSource.Parameters -> { // TODO: consider making this a more general interface
+                parameters.file.orNull?.asFile?.let { file ->
+                    inputFiles.add(
+                        InputFile(file, virtualFileSystem.hashCodeOf(file))
+                    )
+                }
+            }
+            else -> {
+                obtainedValues.add(obtainedValue.uncheckedCast())
+            }
+        }
+    }
+}
+
+
+internal
+fun VirtualFileSystem.hashCodeOf(file: File): HashCode? =
+    readRegularFileContentHash(file.path) { hashCode -> hashCode }
+        .orElse(null)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionCacheInputs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionCacheInputs.kt
@@ -17,7 +17,7 @@
 package org.gradle.instantexecution
 
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
-import org.gradle.api.internal.provider.sources.FileTextValueSource
+import org.gradle.api.internal.provider.sources.FileContentValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.internal.hash.HashCode
@@ -35,7 +35,10 @@ class InstantExecutionCacheInputs(
 ) : ValueSourceProviderFactory.Listener {
 
     internal
-    data class InputFile(val file: File, val hashCode: HashCode?)
+    data class InputFile(
+        val file: File,
+        val hashCode: HashCode?
+    )
 
     val inputFiles = mutableListOf<InputFile>()
 
@@ -45,8 +48,9 @@ class InstantExecutionCacheInputs(
         obtainedValue: ValueSourceProviderFactory.Listener.ObtainedValue<T, P>
     ) {
         when (val parameters = obtainedValue.valueSourceParameters) {
-            is FileTextValueSource.Parameters -> { // TODO: consider making this a more general interface
+            is FileContentValueSource.Parameters -> { // TODO: consider making this a more general interface
                 parameters.file.orNull?.asFile?.let { file ->
+                    // TODO - consider the potential race condition in computing the hash code here
                     inputFiles.add(
                         InputFile(file, virtualFileSystem.hashCodeOf(file))
                     )

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -62,6 +62,7 @@ import org.gradle.internal.serialize.BaseSerializerFactory.LONG_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.PATH_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.SHORT_SERIALIZER
 import org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALIZER
+import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.process.ExecOperations
 import org.gradle.process.internal.ExecActionFactory
@@ -115,6 +116,7 @@ class Codecs(
         bind(DOUBLE_SERIALIZER)
         bind(FILE_SERIALIZER)
         bind(PATH_SERIALIZER)
+        bind(HashCodeSerializer())
         bind(ClassCodec)
         bind(MethodCodec)
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -17,7 +17,11 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.Action;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.provider.sources.FileTextValueSource;
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource;
+import org.gradle.api.provider.FileContents;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.ValueSource;
@@ -59,6 +63,28 @@ public class DefaultProviderFactory implements ProviderFactory {
             SystemPropertyValueSource.class,
             spec -> spec.getParameters().getPropertyName().set(propertyName)
         );
+    }
+
+    @Override
+    public FileContents fileContents(RegularFile file) {
+        return fileContents(property -> property.set(file));
+    }
+
+    @Override
+    public FileContents fileContents(Provider<RegularFile> file) {
+        return fileContents(property -> property.set(file));
+    }
+
+    private FileContents fileContents(Action<RegularFileProperty> setFileProperty) {
+        return new FileContents() {
+            @Override
+            public Provider<String> getAsText() {
+                return of(
+                    FileTextValueSource.class,
+                    spec -> setFileProperty.execute(spec.getParameters().getFile())
+                );
+            }
+        };
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.Action;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.provider.sources.FileBytesValueSource;
 import org.gradle.api.internal.provider.sources.FileTextValueSource;
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource;
 import org.gradle.api.provider.FileContents;
@@ -81,6 +82,14 @@ public class DefaultProviderFactory implements ProviderFactory {
             public Provider<String> getAsText() {
                 return of(
                     FileTextValueSource.class,
+                    spec -> setFileProperty.execute(spec.getParameters().getFile())
+                );
+            }
+
+            @Override
+            public Provider<byte[]> getAsBytes() {
+                return of(
+                    FileBytesValueSource.class,
                     spec -> setFileProperty.execute(spec.getParameters().getFile())
                 );
             }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -22,7 +22,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.provider.sources.FileBytesValueSource;
 import org.gradle.api.internal.provider.sources.FileTextValueSource;
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource;
-import org.gradle.api.provider.FileContents;
+import org.gradle.api.file.FileContents;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.ValueSource;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileBytesValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileBytesValueSource.java
@@ -16,14 +16,20 @@
 
 package org.gradle.api.internal.provider.sources;
 
+import org.gradle.api.UncheckedIOException;
+
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
-import static org.gradle.util.GFileUtils.readFile;
-
-public abstract class FileTextValueSource extends FileContentValueSource<String> {
+public abstract class FileBytesValueSource extends FileContentValueSource<byte[]> {
 
     @Override
-    protected String obtainFrom(File file) {
-        return readFile(file);
+    protected byte[] obtainFrom(File file) {
+        try {
+            return Files.readAllBytes(file.toPath());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileContentValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileContentValueSource.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.provider.sources;
 
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
@@ -35,8 +36,15 @@ public abstract class FileContentValueSource<T> implements ValueSource<T, FileCo
     @Nullable
     @Override
     public T obtain() {
-        final File file = getParameters().getFile().get().getAsFile();
-        return file.isFile() ? obtainFrom(file) : null;
+        @Nullable final RegularFile regularFile = getParameters().getFile().getOrNull();
+        if (regularFile == null) {
+            return null;
+        }
+        final File file = regularFile.getAsFile();
+        if (!file.isFile()) {
+            return null;
+        }
+        return obtainFrom(file);
     }
 
     protected abstract T obtainFrom(File file);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileContentValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileContentValueSource.java
@@ -16,14 +16,28 @@
 
 package org.gradle.api.internal.provider.sources;
 
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.api.tasks.InputFile;
+
+import javax.annotation.Nullable;
 import java.io.File;
 
-import static org.gradle.util.GFileUtils.readFile;
+public abstract class FileContentValueSource<T> implements ValueSource<T, FileContentValueSource.Parameters> {
 
-public abstract class FileTextValueSource extends FileContentValueSource<String> {
+    public interface Parameters extends ValueSourceParameters {
 
-    @Override
-    protected String obtainFrom(File file) {
-        return readFile(file);
+        @InputFile
+        RegularFileProperty getFile();
     }
+
+    @Nullable
+    @Override
+    public T obtain() {
+        final File file = getParameters().getFile().get().getAsFile();
+        return file.isFile() ? obtainFrom(file) : null;
+    }
+
+    protected abstract T obtainFrom(File file);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileTextValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/FileTextValueSource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.api.tasks.InputFile;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+import static org.gradle.util.GFileUtils.readFile;
+
+public abstract class FileTextValueSource implements ValueSource<String, FileTextValueSource.Parameters> {
+
+    public interface Parameters extends ValueSourceParameters {
+
+        @InputFile
+        RegularFileProperty getFile();
+    }
+
+    @Nullable
+    @Override
+    public String obtain() {
+        final File file = getParameters().getFile().get().getAsFile();
+        return file.isFile() ? readFile(file) : null;
+    }
+}


### PR DESCRIPTION
This PR adds the `providers.fileContents(regularFileOrProvider): FileContents` API to allow build logic to read simple configuration files which are automatically tracked as inputs to the instant execution work graph.

As file contents are read, their hash codes are computed and added to the work graph cache fingerprint. In a subsequent run, before loading the work graph from the cache, all recorded file hash codes are verified and, in the case of a change, the cache discarded. 
