### PR TITLE
Update default scans plugin to 3.1.1

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.1")
+    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.1.1")
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.5.0-rc-2")
     implementation("org.jsoup:jsoup:1.11.3")
     implementation(project(":configuration"))

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedGradleEnterprisePlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "gradle-enterprise-gradle-plugin";
-    public static final String VERSION = "3.1";
+    public static final String VERSION = "3.1.1";
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.enterprise");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -45,7 +45,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
 
     private static final List<String> SUPPORTED = [
         "3.0",
-        "3.1"
+        "3.1",
+        "3.1.1"
     ]
 
     @Unroll


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Update the used scans plugin to the latest 3.1.1 patch release

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
