### PR TITLE
Buildship: remove unnecessary check for Usage attribute

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.attributes.LibraryElements;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.tasks.SourceSet;
@@ -102,10 +101,6 @@ public class EclipseDependenciesCreator {
         public void visitProjectDependency(ResolvedArtifactResult artifact) {
             ProjectComponentIdentifier componentIdentifier = (ProjectComponentIdentifier) artifact.getId().getComponentIdentifier();
             if (componentIdentifier.equals(currentProjectId)) {
-                return;
-            }
-            Usage usage = artifact.getVariant().getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
-            if (usage == null || !usage.getName().equals(Usage.JAVA_RUNTIME)) {
                 return;
             }
             LibraryElements libraryElements = artifact.getVariant().getAttributes().getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);


### PR DESCRIPTION
This was introduced after splitting up the JAVA_RUNTIME_JAR attribute
into two attributes. However, the important part here is to
check for JAR, as class folders are not supported here.

This unnecessary limits reconfigurations of the classpath like here:
https://github.com/eclipse/buildship/issues/815#issuecomment-565408634
