### PR TITLE
Introduce `providers.environmentVariable(variableNameOrProvider)`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -45,6 +45,26 @@ public interface ProviderFactory {
     <T> Provider<T> provider(Callable<? extends T> value);
 
     /**
+     * Creates a {@link Provider} whose value is fetched from the environment variable with the given name.
+     *
+     * @param variableName The name of the environment variable.
+     * @return The provider. Never returns null.
+     * @since 6.1
+     */
+    @Incubating
+    Provider<String> environmentVariable(String variableName);
+
+    /**
+     * Creates a {@link Provider} whose value is fetched from the environment variable with the given name.
+     *
+     * @param variableName The provider for the name of the environment variable; when the given provider has no value, the returned provider has no value.
+     * @return The provider. Never returns null.
+     * @since 6.1
+     */
+    @Incubating
+    Provider<String> environmentVariable(Provider<String> variableName);
+
+    /**
      * Creates a {@link Provider} whose value is fetched from system properties using the given property name.
      *
      * @param propertyName the name of the system property

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.Action;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.provider.sources.EnvironmentVariableValueSource;
 import org.gradle.api.internal.provider.sources.FileBytesValueSource;
 import org.gradle.api.internal.provider.sources.FileTextValueSource;
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource;
@@ -51,6 +52,19 @@ public class DefaultProviderFactory implements ProviderFactory {
             throw new IllegalArgumentException("Value cannot be null");
         }
         return new DefaultProvider<T>(value);
+    }
+
+    @Override
+    public Provider<String> environmentVariable(String variableName) {
+        return environmentVariable(Providers.of(variableName));
+    }
+
+    @Override
+    public Provider<String> environmentVariable(Provider<String> variableName) {
+        return of(
+            EnvironmentVariableValueSource.class,
+            spec -> spec.getParameters().getVariableName().set(variableName)
+        );
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/EnvironmentVariableValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/EnvironmentVariableValueSource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources;
+
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+
+import javax.annotation.Nullable;
+
+public abstract class EnvironmentVariableValueSource implements ValueSource<String, EnvironmentVariableValueSource.Parameters> {
+
+    public interface Parameters extends ValueSourceParameters {
+        Property<String> getVariableName();
+    }
+
+    @Nullable
+    @Override
+    public String obtain() {
+        @Nullable String variableName = getParameters().getVariableName().getOrNull();
+        if (variableName == null) {
+            return null;
+        }
+        return System.getenv(variableName);
+    }
+}


### PR DESCRIPTION
For automatically tracking environment variables used as build logic inputs.
