### PR TITLE
Allow a capability request without version to be published

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/capabilities/Capability.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/capabilities/Capability.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.capabilities;
 
+import javax.annotation.Nullable;
+
 /**
  * Represents a capability. Capabilities are versioned. Only one component for a specific capability
  * can be found on a dependency graph.
@@ -24,5 +26,6 @@ package org.gradle.api.capabilities;
 public interface Capability {
     String getGroup();
     String getName();
+    @Nullable
     String getVersion();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilityRequestsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilityRequestsIntegrationTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.capabilities
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+@RequiredFeatures(
+    [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
+)
+class PublishedCapabilityRequestsIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def "capability request without versions can be consumed"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('runtimeAlt') {
+                    attribute('custom', 'c1')
+                    capability('alt')
+                }
+            }
+            'org:bar:1.0' {
+                dependsOn([group: 'org', artifact: 'foo', version: '1.0', requireCapability: 'org.test:alt'])
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:bar:1.0')
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectResolve()
+            }
+            'org:bar:1.0' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:bar:1.0') {
+                    module('org:foo:1.0') {
+                        variant('runtimeAlt', [custom: 'c1', 'org.gradle.status': defaultStatus()])
+                    }
+                }
+            }
+        }
+    }
+
+    static Closure<String> defaultStatus() {
+        { -> GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release' }
+    }
+
+}

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -52,6 +52,14 @@
             "changes": [
                 "From non-null returning to null returning breaking change"
             ]
+        },
+        {
+            "type": "org.gradle.api.capabilities.Capability",
+            "member": "Method org.gradle.api.capabilities.Capability.getVersion()",
+            "acceptation": "The annotation was missing: if the Capability instance is representing a required capability, the version can be null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
         }
     ]
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -35,7 +35,7 @@ class DependencySpec {
     List<CapabilitySpec> requestedCapabilities = []
     ArtifactSelectorSpec artifactSelector
 
-    DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, List<String> rejects, Collection<Map> excludes, Boolean endorseStrictVersions, String reason, Map<String, Object> attributes, ArtifactSelectorSpec artifactSelector) {
+    DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, List<String> rejects, Collection<Map> excludes, Boolean endorseStrictVersions, String reason, Map<String, Object> attributes, ArtifactSelectorSpec artifactSelector, String requestedCapability) {
         group = g
         module = m
         version = v
@@ -53,6 +53,10 @@ class DependencySpec {
         this.reason = reason
         this.attributes = attributes
         this.artifactSelector = artifactSelector
+        if (requestedCapability) {
+            def parts = requestedCapability.split(':')
+            this.requestedCapabilities << new CapabilitySpec(parts[0], parts[1], parts.size() > 2 ? parts[2] : null)
+        }
     }
 
     DependencySpec attribute(String name, Object value) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -53,11 +53,11 @@ class VariantMetadataSpec {
     }
 
     void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes = [:]) {
-        dependencies << new DependencySpec(group, module, version, null, null, null, null, null, reason, attributes, null)
+        dependencies << new DependencySpec(group, module, version, null, null, null, null, null, reason, attributes, null, null)
     }
 
     void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {
-        def spec = new DependencySpec(group, module, version, null, null, null, null, null, null, [:], null)
+        def spec = new DependencySpec(group, module, version, null, null, null, null, null, null, [:], null, null)
         config.delegate = spec
         config.resolveStrategy = Closure.DELEGATE_FIRST
         config()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -441,7 +441,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->
                         new DependencySpec(d.organisation, d.module, d.revision, d.prefers, d.strictly,d.rejects, d.exclusions, d.endorseStrictVersions, d.reason, d.attributes,
-                            d.classifier ? new ArtifactSelectorSpec(d.module, 'jar', 'jar', d.classifier) : null)
+                            d.classifier ? new ArtifactSelectorSpec(d.module, 'jar', 'jar', d.classifier) : null, d.requireCapability)
                     },
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
                         new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.rejects, d.reason, d.attributes)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -138,7 +138,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                               type: attributes.type, scope: attributes.scope, classifier: attributes.classifier,
                               optional: attributes.optional, exclusions: attributes.exclusions, rejects: attributes.rejects,
                               prefers: attributes.prefers, strictly: attributes.strictly,
-                              endorseStrictVersions: attributes.endorseStrictVersions, reason: attributes.reason
+                              endorseStrictVersions: attributes.endorseStrictVersions, reason: attributes.reason,
+                              requireCapability: attributes.requireCapability
         ]
         return this
     }
@@ -503,7 +504,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
                         new DependencySpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.rejects, d.exclusions, d.endorseStrictVersions, d.reason, d.attributes,
-                            d.classifier ? new ArtifactSelectorSpec(d.artifactId, 'jar', 'jar', d.classifier) : null)
+                            d.classifier ? new ArtifactSelectorSpec(d.artifactId, 'jar', 'jar', d.classifier) : null, d.requireCapability)
                     },
                     v.dependencyConstraints + dependencies.findAll { it.optional }.collect { d ->
                         new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.rejects, d.reason, d.attributes)

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -584,7 +584,9 @@ public class GradleModuleMetadataWriter {
                 jsonWriter.beginObject();
                 jsonWriter.name("group").value(capability.getGroup());
                 jsonWriter.name("name").value(capability.getName());
-                jsonWriter.name("version").value(capability.getVersion());
+                if (StringUtils.isNotEmpty(capability.getVersion())) {
+                    jsonWriter.name("version").value(capability.getVersion());
+                }
                 jsonWriter.endObject();
             }
             jsonWriter.endArray();


### PR DESCRIPTION
If a capability is required by a dependency, the request can be made
without specifying a version. This was not fully supported:

- At publishing time, we published 'version: null' (instead of nothing)
- At consuming time, we failed for a missing version (although this is fine)

Both cases are fixed in this commit and test coverage was added.
The test fixtures are extended to work with dependencies published
with a capability requests.

Fixes #11616