### PR TITLE
Allow a build service to be passed as a parameter to an isolated object

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -23,11 +23,12 @@ import org.gradle.internal.Try;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.service.DefaultServiceRegistry;
+import org.gradle.internal.state.Managed;
 
 import javax.annotation.Nullable;
 
 // TODO - complain when used at configuration time, except when opted in to this
-public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServiceParameters> extends AbstractReadOnlyProvider<T> {
+public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServiceParameters> extends AbstractReadOnlyProvider<T> implements Managed {
     private final String name;
     private final Class<T> implementationType;
     private final InstantiationScheme instantiationScheme;
@@ -67,6 +68,16 @@ public class BuildServiceProvider<T extends BuildService<P>, P extends BuildServ
     @Override
     public boolean isPresent() {
         return true;
+    }
+
+    @Override
+    public boolean immutable() {
+        return true;
+    }
+
+    @Override
+    public Object unpackState() {
+        throw new UnsupportedOperationException("Build services cannot be serialized.");
     }
 
     // TODO - rename this method

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeValuesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AttributeValuesIntegrationTest.groovy
@@ -25,11 +25,11 @@ class AttributeValuesIntegrationTest extends AbstractIntegrationSpec {
     def "cannot use an attribute value that cannot be made isolated - #type"() {
         given:
         buildFile << """
-    class Thing implements Named { 
+    class Thing implements Named {
         String name
     }
     def attr = Attribute.of($type)
-    
+
     configurations {
         broken
     }
@@ -40,8 +40,8 @@ class AttributeValuesIntegrationTest extends AbstractIntegrationSpec {
         fails()
 
         then:
-        failure.assertHasCause("Could not isolate value: [")
-        failure.assertHasCause("Could not serialize value of type '")
+        failure.assertHasCause("Could not isolate value ")
+        failure.assertHasCause("Could not serialize value of type ")
 
         where:
         type      | value
@@ -56,7 +56,7 @@ class AttributeValuesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
     interface Flavor extends Named { }
     def attr = Attribute.of($type)
-    
+
     configurations {
         ok
     }
@@ -81,17 +81,17 @@ class AttributeValuesIntegrationTest extends AbstractIntegrationSpec {
     def "attribute value is isolated from original value"() {
         given:
         buildFile << """
-    class Thing implements Named, Serializable { 
+    class Thing implements Named, Serializable {
         String name
     }
     def attr = Attribute.of(List)
-    
+
     configurations {
         ok
     }
     def value = [new Thing(name: 'a'), new Thing(name: 'b')]
     configurations.ok.attributes.attribute(attr, value)
-    
+
     value[0].name = 'other'
     value.add(new Thing(name: 'c'))
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -38,13 +38,13 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
         buildFile << """
             import org.gradle.api.artifacts.transform.TransformParameters
-            
+
             def usage = Attribute.of('usage', String)
             def artifactType = Attribute.of('artifactType', String)
             def extraAttribute = Attribute.of('extra', String)
-                
+
             allprojects {
-            
+
                 dependencies {
                     attributesSchema {
                         attribute(usage)
@@ -56,7 +56,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     }
                 }
             }
-            
+
             $fileSizer
         """
     }
@@ -74,10 +74,10 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                 FileSizer() {
                     println "Creating FileSizer"
                 }
-                
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     def output = outputs.file(input.name + ".txt")
@@ -135,7 +135,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
     def "can use transformations in build script dependencies"() {
         file("buildSrc/src/main/groovy/FileSizer.groovy") << fileSizer
 
-        file("script-with-buildscript-block.gradle") << """   
+        file("script-with-buildscript-block.gradle") << """
             buildscript {
 
                 def artifactType = Attribute.of('artifactType', String)
@@ -148,17 +148,17 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
                     classpath 'org.apache.commons:commons-math3:3.6.1'
                 }
-                ${jcenterRepository()} 
+                ${jcenterRepository()}
                 println(
                     configurations.classpath.incoming.artifactView {
                             attributes.attribute(artifactType, "size")
                         }.artifacts.artifactFiles.files
-                )                                   
+                )
                 println(
                     configurations.classpath.incoming.artifactView {
                             attributes.attribute(artifactType, "size")
                         }.artifacts.artifactFiles.files
-                )                                   
+                )
             }
         """
 
@@ -568,11 +568,11 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
                 task resolve(type: Copy) {
                     def artifacts = configurations.compile.incoming.artifactView {
-                        attributes { 
-                            it.attribute(artifactType, 'jar') 
-                            it.attribute(Attribute.of('javaVersion', String), '7') 
+                        attributes {
+                            it.attribute(artifactType, 'jar')
+                            it.attribute(Attribute.of('javaVersion', String), '7')
                             it.attribute(Attribute.of('color', String), 'red')
-                        } 
+                        }
                     }.artifacts
                     from artifacts.artifactFiles
                     into "\${buildDir}/libs"
@@ -664,7 +664,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
 
                 dependencies {
                     compile project(':lib')
-                    
+
                     registerTransform(MakeBlueToRedThings) {
                         from.attribute(Attribute.of('color', String), "blue")
                         to.attribute(Attribute.of('color', String), "red")
@@ -674,14 +674,14 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                         to.attribute(Attribute.of('color', String), "blue")
                     }
                 }
-        
+
                 task resolve(type: Copy) {
                     def artifacts = configurations.compile.incoming.artifactView {
-                        attributes { 
-                            it.attribute(artifactType, 'jar') 
-                            it.attribute(Attribute.of('javaVersion', String), '7') 
+                        attributes {
+                            it.attribute(artifactType, 'jar')
+                            it.attribute(Attribute.of('javaVersion', String), '7')
                             it.attribute(Attribute.of('color', String), 'red')
-                        } 
+                        }
                     }.artifacts
                     from artifacts.artifactFiles
                     into "\${buildDir}/libs"
@@ -757,7 +757,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         buildFile << """
             def f = file("lib.jar")
             f.text = "1234"
- 
+
             dependencies {
                 compile files(f)
                 compile project(':lib')
@@ -817,7 +817,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         buildFile << """
             def f = file("lib.jar")
             f.text = "1234"
- 
+
             dependencies {
                 compile files(f)
             }
@@ -828,11 +828,11 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     to.attribute(artifactType, 'identity')
                 }
             }
-            
+
             abstract class IdentityTransform implements TransformAction<TransformParameters.None> {
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInput()
-                
+
                 void transform(TransformOutputs outputs) {
                     println("Transforming")
                     outputs.file(input)
@@ -886,7 +886,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     File outputA = outputs.file(input.name + ".A.txt")
                     assert outputA.parentFile.directory && outputA.parentFile.list().length == 0
                     outputA.text = "Output A"
-            
+
                     File outputB = outputs.file(input.name + ".B.txt")
                     outputB.text = "Output B"
                 }
@@ -985,7 +985,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                         to.attribute(extraAttribute, 'baz')
                     }
                 }
-    
+
                 task resolve(type: Copy) {
                     def artifacts = configurations.compile.incoming.artifactView {
                         attributes { it.attribute (artifactType, 'transformed') }
@@ -994,7 +994,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
                     into "\${buildDir}/libs"
                 }
             }
-    
+
             abstract class BrokenTransform implements TransformAction<TransformParameters.None> {
                 void transform(TransformOutputs outputs) {
                     throw new AssertionError("should not be used")
@@ -1028,13 +1028,13 @@ Found the following transforms:
     def "user receives reasonable error message when multiple variants can be transformed to produce requested variant"() {
         given:
         buildFile << """
-            def buildType = Attribute.of("buildType", String) 
+            def buildType = Attribute.of("buildType", String)
             def flavor = Attribute.of("flavor", String)
             allprojects {
                 dependencies.attributesSchema.attribute(buildType)
                 dependencies.attributesSchema.attribute(flavor)
             }
- 
+
             project(':lib') {
                 task jar1(type: Jar) {
                     destinationDirectory = buildDir
@@ -1079,11 +1079,11 @@ Found the following transforms:
                         to.attribute(artifactType, 'transformed')
                     }
                 }
-    
+
                 task resolve(type: Copy) {
                     def artifacts = configurations.compile.incoming.artifactView {
-                        attributes { 
-                            attribute(artifactType, 'transformed') 
+                        attributes {
+                            attribute(artifactType, 'transformed')
                         }
                     }.artifacts
                     from artifacts.artifactFiles
@@ -1187,7 +1187,7 @@ Found the following transforms:
                         checkFiles configurations.compile.files
                         checkFiles configurations.compile.incoming.files
                         checkFiles configurations.compile.resolvedConfiguration.files
-                        
+
                         checkFiles configurations.compile.resolvedConfiguration.lenientConfiguration.files
                         checkFiles configurations.compile.resolve()
                         checkFiles configurations.compile.files { true }
@@ -1310,7 +1310,7 @@ Found the following transforms:
                 Hasher() {
                     println "Creating Transform"
                 }
-                
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
 
@@ -1444,10 +1444,10 @@ Found the following transforms:
             repositories {
                 ivy { url "${ivyHttpRepo.uri}" }
             }
-        
+
             dependencies {
-                compile "test:test:1.3" 
-                compile "test:test-2:0.1" 
+                compile "test:test:1.3"
+                compile "test:test-2:0.1"
             }
         """
 
@@ -1485,13 +1485,13 @@ Found the following transforms:
         given:
         buildFile << """
             ${configurationAndTransform('FileSizer')}
-            
+
             def broken = false
             gradle.taskGraph.whenReady { broken = true }
 
             dependencies {
                 compile files('thing1.jar')
-                compile files { if (broken) { throw new RuntimeException("broken") }; [] } 
+                compile files { if (broken) { throw new RuntimeException("broken") }; [] }
                 compile files('thing2.jar')
             }
         """
@@ -1604,7 +1604,7 @@ Found the following transforms:
                         case FileType.Missing:
                             return """
                                 outputs.${method}('this_file_does_not.exist').delete()
-                                
+
                             """
                         case FileType.Directory:
                             return """
@@ -1709,7 +1709,7 @@ Found the following transforms:
 
             abstract class MyTransform implements TransformAction<TransformParameters.None> {
                 @InputArtifact
-                abstract Provider<FileSystemLocation> getInput() 
+                abstract Provider<FileSystemLocation> getInput()
 
                 void transform(TransformOutputs outputs) {
                     println "Hello?"
@@ -1864,7 +1864,7 @@ Found the following transforms:
             a.text = '123'
             def b = file("broken.jar")
             b.text = '123'
-            def c = file("c.jar")       
+            def c = file("c.jar")
             c.text = '123'
 
             dependencies {
@@ -1944,16 +1944,16 @@ Found the following transforms:
     def "provides useful error message when configuration value cannot be serialized"() {
         when:
         buildFile << """
-            // Not serializable  
+            // Not serializable
             class CustomType {
                 String toString() { return "<custom>" }
             }
 
-            class Custom extends ArtifactTransform { 
+            class Custom extends ArtifactTransform {
                 Custom(CustomType value) { }
                 List<File> transform(File input) { [] }
             }
-            
+
             dependencies {
                 registerTransform {
                     from.attribute(usage, 'any')
@@ -1968,7 +1968,8 @@ Found the following transforms:
         and:
         failure.assertHasDescription("A problem occurred evaluating root project 'root'.")
         failure.assertHasCause("Could not register artifact transform Custom (from {usage=any} to {usage=any})")
-        failure.assertHasCause("Could not serialize value of type 'CustomType'")
+        failure.assertHasCause("Could not isolate value [<custom>] of type Object[]")
+        failure.assertHasCause("Could not serialize value of type CustomType")
     }
 
     @Unroll
@@ -2001,7 +2002,7 @@ Found the following transforms:
                 String toString() { return "<custom>" }
             }
 
-            abstract class Custom implements TransformAction<Parameters> { 
+            abstract class Custom implements TransformAction<Parameters> {
                 interface Parameters extends TransformParameters {
                     @Input
                     CustomType getInput()
@@ -2010,7 +2011,7 @@ Found the following transforms:
 
                 void transform(TransformOutputs outputs) {  }
             }
-            
+
             dependencies {
                 registerTransform(Custom) {
                     from.attribute(artifactType, 'jar')
@@ -2040,7 +2041,7 @@ Found the following transforms:
             failure.assertHasDescription("Execution failed for task ':resolve'.")
             failure.assertThatCause(matchesCannotIsolate)
         }
-        failure.assertHasCause("Could not serialize value of type 'CustomType'")
+        failure.assertHasCause("Could not serialize value of type CustomType")
 
         where:
         scheduled | dependency
@@ -2063,17 +2064,17 @@ Found the following transforms:
                 compile 'test:test:1.3:foo'
                 compile 'test:test:1.3:bar'
             }
-            
+
             /*
-             * This transform creates a name that is independent of 
+             * This transform creates a name that is independent of
              * the original file name, thus losing the classifier that
              * was encoded in it.
-             */ 
+             */
             abstract class NameManglingTransform implements TransformAction<TransformParameters.None> {
                 NameManglingTransform() {
                     println "Creating NameManglingTransform"
                 }
-                
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
 
@@ -2108,7 +2109,7 @@ Found the following transforms:
                 task lib1(type: Jar) {
                     destinationDirectory = buildDir
                 }
-    
+
                 dependencies {
                     compile files(lib1)
                 }
@@ -2116,14 +2117,14 @@ Found the following transforms:
                     compile file1
                 }
             }
-    
+
             project(':app') {
                 dependencies {
                     compile project(':lib')
                 }
                 ${configurationAndTransform('FileSizer')}
             }
-    
+
             project(':app2') {
                 dependencies {
                     compile project(':lib')
@@ -2156,7 +2157,7 @@ Found the following transforms:
                     compile file1
                 }
             }
-    
+
             project(':app') {
                 dependencies {
                     compile project(':lib')
@@ -2191,7 +2192,7 @@ Found the following transforms:
         def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
         given:
-        buildFile << """                                                                   
+        buildFile << """
             import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
             import org.gradle.internal.event.ListenerManager
 
@@ -2200,7 +2201,7 @@ Found the following transforms:
                 void beforeTransformerInvocation(Describable transformer, Describable subject) {
                     println "Before transformer \${transformer.displayName} on \${subject.displayName}"
                 }
-                
+
                 @Override
                 void afterTransformerInvocation(Describable transformer, Describable subject) {
                     println "After transformer \${transformer.displayName} on \${subject.displayName}"
@@ -2210,13 +2211,13 @@ Found the following transforms:
             project(":lib") {
                 task jar(type: Jar) {
                     archiveFileName = 'lib.jar'
-                    destinationDirectory = buildDir                    
+                    destinationDirectory = buildDir
                 }
                 artifacts {
                     compile jar
                 }
             }
-            
+
             project(":app") {
                 dependencies {
                     compile project(":lib")
@@ -2246,7 +2247,7 @@ Found the following transforms:
         def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
         given:
-        buildFile << """                                                                   
+        buildFile << """
             import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
             import org.gradle.internal.event.ListenerManager
 
@@ -2255,7 +2256,7 @@ Found the following transforms:
                 void beforeTransformerInvocation(Describable transformer, Describable subject) {
                     println "Before transformer \${transformer.displayName} on \${subject.displayName}"
                 }
-                
+
                 @Override
                 void afterTransformerInvocation(Describable transformer, Describable subject) {
                     println "After transformer \${transformer.displayName} on \${subject.displayName}"
@@ -2265,13 +2266,13 @@ Found the following transforms:
             project(":lib") {
                 task jar(type: Jar) {
                     archiveFileName = 'lib.jar'
-                    destinationDirectory = buildDir                    
+                    destinationDirectory = buildDir
                 }
                 artifacts {
                     compile jar
                 }
             }
-            
+
             project(":app") {
                 dependencies {
                     compile project(":lib")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -37,10 +37,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     $inputAnnotations
                     ConfigurableFileCollection getSomeFiles()
                 }
-            
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name} using \${parameters.someFiles*.name}"
@@ -61,7 +61,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             allprojects {
                 ext.inputFiles = files('a.txt', 'b.txt')
             }
-            
+
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -96,7 +96,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 repositories.maven { url = '${mavenRepo.uri}' }
                 ext.inputFiles = configurations.tools
             }
-            
+
             project(':a') {
                 dependencies {
                     tools 'test:tool-a:1.2'
@@ -150,10 +150,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     @Nested
                     NestedInputFiles getNestedBean()
                 }
-            
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def inputFiles = parameters.nestedBean.inputFiles
                     def input = inputArtifact.get().asFile
@@ -183,7 +183,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 task tool(type: FileProducer) {
                     output = file("build/tool-\${project.name}.jar")
                 }
-                ext.inputFiles = files(tool.output)                
+                ext.inputFiles = files(tool.output)
             }
 
             project(':a') {
@@ -214,7 +214,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             abstract class MakeRed implements TransformAction<TransformParameters.None> {
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name} wit MakeRedAction"
@@ -245,7 +245,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     }
                 }
             }
-            
+
             project(':a') {
                 dependencies {
                     tools project(':d')
@@ -273,7 +273,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             include 'tool-a', 'tool-b'
         """
         file("tools/build.gradle") << """
-            allprojects { 
+            allprojects {
                 group = 'test'
                 configurations.create("default")
                 task producer(type: Producer) {
@@ -281,11 +281,11 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 }
                 artifacts."default" producer.outputFile
             }
-            
+
             class Producer extends DefaultTask {
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
-            
+
                 @TaskAction
                 def go() {
                     outputFile.get().asFile.text = "output"
@@ -302,7 +302,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 configurations.create("tools") { }
                 ext.inputFiles = configurations.tools
             }
-            
+
             project(':a') {
                 dependencies {
                     tools 'test:tool-a:1.2'
@@ -324,6 +324,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @ToBeFixedForInstantExecution
     def "transform can receive a task output file as parameter"() {
         settingsFile << """
                 include 'a', 'b', 'c', 'd', 'e'
@@ -354,10 +355,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     @InputFile
                     RegularFileProperty getSomeFile()
                 }
-            
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name} using \${parameters.someFile.get().asFile.name}"
@@ -376,6 +377,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("processing c.jar using tool-a.jar")
     }
 
+    @ToBeFixedForInstantExecution
     def "transform can receive a task output directory as parameter"() {
         settingsFile << """
                 include 'a', 'b', 'c', 'd', 'e'
@@ -406,10 +408,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     @InputDirectory
                     DirectoryProperty getSomeDir()
                 }
-            
+
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name} using \${parameters.someDir.get().asFile.name}"
@@ -439,7 +441,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     output = file("build/tool-\${project.name}.jar")
                     doLast { throw new RuntimeException('broken') }
                 }
-                ext.inputFiles = files(tool.output)                
+                ext.inputFiles = files(tool.output)
             }
 
             project(':a') {
@@ -473,7 +475,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             allprojects {
                 ext.inputFiles = files(rootProject.file(project.property('fileName')))
             }
-            
+
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -528,7 +530,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             allprojects {
                 ext.inputFiles = files(rootProject.file("inputDir"), rootProject.file("input.jar"))
             }
-            
+
             project(':a') {
                 dependencies {
                     implementation project(':b')

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -54,7 +54,7 @@ trait ArtifactTransformTestFixture extends TasksWithInputsAndOutputs {
 
         buildFile << """
 import ${javax.inject.Inject.name}
-// TODO: Default imports should work for of inner classes 
+// TODO: Default imports should work for of inner classes
 import ${org.gradle.api.artifacts.transform.TransformParameters.name}
 
 def color = Attribute.of('color', String)
@@ -127,8 +127,6 @@ class JarProducer extends DefaultTask {
      * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a transform that converts 'blue' to 'red'
      * and another transform that converts 'red' to 'green'.
      * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
-     *
-     *
      */
     void setupBuildWithChainedSimpleColorTransform() {
         setupBuildWithColorAttributes()
@@ -147,16 +145,16 @@ class JarProducer extends DefaultTask {
                     }
                 }
             }
-            
+
             interface TargetColor extends TransformParameters {
                 @Input
                 Property<String> getTargetColor()
             }
-            
+
             abstract class MakeColor implements TransformAction<TargetColor> {
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -177,7 +175,7 @@ class JarProducer extends DefaultTask {
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -321,7 +319,7 @@ allprojects { p ->
             producerTaskClassName = "DirProducer"
             producerConfig = """
                 output = layout.buildDir.dir("\${project.name}-dir")
-                content = project.name  
+                content = project.name
                 names = [project.name]
             """.stripIndent()
             producerConfigOverrides = """

--- a/subprojects/docs/src/docs/userguide/extending-gradle/build_services.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/build_services.adoc
@@ -110,6 +110,15 @@ The plugin registers the service and receives a `Provider<WebService>` back. Thi
 Generally, build services are intended to be used by tasks, as they usually represent some state that is potentially expensive to create, and you should avoid using
 them at configuration time. However, sometimes it can make sense to use the service at configuration time. This is possible, simply call `get()` on the provider.
 
+== Other ways of using a build service
+
+In addition to using a build service from a task, you can use a build service from a worker API action, an artifact transform or another build service.
+To do this, pass the build service `Provider` as a parameter of the consuming action or service, in the same way you pass other parameters to the action or service.
+For example, to pass a `MyServiceType` service to worker API action, you might add a property of type `Property<MyServiceType>` to the action's parameters object and
+then connect the `Provider<MyServiceType>` that you receive when registering the service to this property.
+
+Currently, it is not possible to use a build service with a worker API action that uses ClassLoader or process isolation modes.
+
 == Concurrent access to the service
 
 You can constrain concurrent execution when you register the service, by using the `Property` object returned from link:{javadocPath}/org/gradle/api/services/BuildServiceSpec.html#getMaxParallelUsages--[BuildServiceSpec.getMaxParallelUsages()].

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory.FixedDirectory;
+import org.gradle.api.provider.Provider;
 import org.gradle.internal.state.ManagedFactory;
 
 import java.io.File;
@@ -63,7 +64,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new DefaultFilePropertyFactory.DefaultRegularFileVar(fileResolver).value((RegularFile) state));
+            return type.cast(new DefaultFilePropertyFactory.DefaultRegularFileVar(fileResolver).value((Provider<RegularFile>) state));
         }
 
         @Override
@@ -117,7 +118,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new DefaultFilePropertyFactory.DefaultDirectoryVar(fileResolver, fileCollectionFactory).value((Directory) state));
+            return type.cast(new DefaultFilePropertyFactory.DefaultDirectoryVar(fileResolver, fileCollectionFactory).value((Provider<Directory>) state));
         }
 
         @Override

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -395,7 +395,7 @@ class DefaultInstantExecution internal constructor(
             valueSnapshotter = service(),
             fileCollectionFingerprinterRegistry = service(),
             buildServiceRegistry = service(),
-            isolatableSerializerRegistry = service(),
+            managedFactoryRegistry = service(),
             parameterScheme = service(),
             actionScheme = service(),
             attributesFactory = service(),

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/IsolatedCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/IsolatedCodecs.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableSet
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.internal.isolation.Isolatable
+import org.gradle.internal.snapshot.impl.BooleanValueSnapshot
+import org.gradle.internal.snapshot.impl.FileValueSnapshot
+import org.gradle.internal.snapshot.impl.IntegerValueSnapshot
+import org.gradle.internal.snapshot.impl.IsolatedArray
+import org.gradle.internal.snapshot.impl.IsolatedEnumValueSnapshot
+import org.gradle.internal.snapshot.impl.IsolatedImmutableManagedValue
+import org.gradle.internal.snapshot.impl.IsolatedList
+import org.gradle.internal.snapshot.impl.IsolatedManagedValue
+import org.gradle.internal.snapshot.impl.IsolatedMap
+import org.gradle.internal.snapshot.impl.IsolatedSet
+import org.gradle.internal.snapshot.impl.MapEntrySnapshot
+import org.gradle.internal.snapshot.impl.NullValueSnapshot
+import org.gradle.internal.snapshot.impl.StringValueSnapshot
+import org.gradle.internal.state.Managed
+import org.gradle.internal.state.ManagedFactoryRegistry
+
+
+object NullValueSnapshotCodec : Codec<NullValueSnapshot> {
+    override suspend fun WriteContext.encode(value: NullValueSnapshot) {
+    }
+
+    override suspend fun ReadContext.decode(): NullValueSnapshot {
+        return NullValueSnapshot.INSTANCE
+    }
+}
+
+
+object IsolatedEnumValueSnapshotCodec : Codec<IsolatedEnumValueSnapshot> {
+    override suspend fun WriteContext.encode(value: IsolatedEnumValueSnapshot) {
+        write(value.value)
+    }
+
+    override suspend fun ReadContext.decode(): IsolatedEnumValueSnapshot {
+        val value = read() as Enum<*>
+        return IsolatedEnumValueSnapshot(value)
+    }
+}
+
+
+object IsolatedSetCodec : Codec<IsolatedSet> {
+    override suspend fun WriteContext.encode(value: IsolatedSet) {
+        write(value.elements)
+    }
+
+    override suspend fun ReadContext.decode(): IsolatedSet {
+        val elements = read() as ImmutableSet<Isolatable<*>>
+        return IsolatedSet(elements)
+    }
+}
+
+
+object IsolatedListCodec : Codec<IsolatedList> {
+    override suspend fun WriteContext.encode(value: IsolatedList) {
+        write(value.elements)
+    }
+
+    override suspend fun ReadContext.decode(): IsolatedList {
+        val elements = read() as ImmutableList<Isolatable<*>>
+        return IsolatedList(elements)
+    }
+}
+
+
+object IsolatedMapCodec : Codec<IsolatedMap> {
+    override suspend fun WriteContext.encode(value: IsolatedMap) {
+        write(value.entries)
+    }
+
+    override suspend fun ReadContext.decode(): IsolatedMap {
+        val elements = read() as ImmutableList<MapEntrySnapshot<Isolatable<*>>>
+        return IsolatedMap(elements)
+    }
+}
+
+
+object MapEntrySnapshotCodec : Codec<MapEntrySnapshot<Any>> {
+    override suspend fun WriteContext.encode(value: MapEntrySnapshot<Any>) {
+        write(value.key)
+        write(value.value)
+    }
+
+    override suspend fun ReadContext.decode(): MapEntrySnapshot<Any> {
+        val key = read() as Any
+        val value = read() as Any
+        return MapEntrySnapshot(key, value)
+    }
+}
+
+
+object IsolatedArrayCodec : Codec<IsolatedArray> {
+    override suspend fun WriteContext.encode(value: IsolatedArray) {
+        writeClass(value.arrayType)
+        write(value.elements)
+    }
+
+    override suspend fun ReadContext.decode(): IsolatedArray {
+        val arrayType = readClass()
+        val elements = read() as ImmutableList<Isolatable<*>>
+        return IsolatedArray(elements, arrayType)
+    }
+}
+
+
+object StringValueSnapshotCodec : Codec<StringValueSnapshot> {
+    override suspend fun WriteContext.encode(value: StringValueSnapshot) {
+        writeString(value.value)
+    }
+
+    override suspend fun ReadContext.decode(): StringValueSnapshot {
+        val value = readString()
+        return StringValueSnapshot(value)
+    }
+}
+
+
+object IntegerValueSnapshotCodec : Codec<IntegerValueSnapshot> {
+    override suspend fun WriteContext.encode(value: IntegerValueSnapshot) {
+        writeInt(value.value)
+    }
+
+    override suspend fun ReadContext.decode(): IntegerValueSnapshot {
+        val value = readInt()
+        return IntegerValueSnapshot(value)
+    }
+}
+
+
+object FileValueSnapshotCodec : Codec<FileValueSnapshot> {
+    override suspend fun WriteContext.encode(value: FileValueSnapshot) {
+        writeString(value.value)
+    }
+
+    override suspend fun ReadContext.decode(): FileValueSnapshot {
+        val value = readString()
+        return FileValueSnapshot(value)
+    }
+}
+
+
+object BooleanValueSnapshotCodec : Codec<BooleanValueSnapshot> {
+    override suspend fun WriteContext.encode(value: BooleanValueSnapshot) {
+        writeBoolean(value.value)
+    }
+
+    override suspend fun ReadContext.decode(): BooleanValueSnapshot {
+        val value = readBoolean()
+        return BooleanValueSnapshot(value)
+    }
+}
+
+
+class IsolatedManagedValueCodec(private val managedFactory: ManagedFactoryRegistry) : Codec<IsolatedManagedValue> {
+    override suspend fun WriteContext.encode(value: IsolatedManagedValue) {
+        writeClass(value.targetType)
+        writeSmallInt(value.factoryId)
+        write(value.state)
+    }
+
+    override suspend fun ReadContext.decode(): IsolatedManagedValue {
+        val targetType = readClass()
+        val factoryId = readSmallInt()
+        val state = read() as Isolatable<Any>
+        return IsolatedManagedValue(targetType, managedFactory.lookup(factoryId), state)
+    }
+}
+
+
+class IsolatedImmutableManagedValueCodec(private val managedFactory: ManagedFactoryRegistry) : Codec<IsolatedImmutableManagedValue> {
+    override suspend fun WriteContext.encode(value: IsolatedImmutableManagedValue) {
+        write(value.value)
+    }
+
+    override suspend fun ReadContext.decode(): IsolatedImmutableManagedValue {
+        val state = read() as Managed
+        return IsolatedImmutableManagedValue(state, managedFactory)
+    }
+}

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -346,7 +346,7 @@ class UserTypesCodecTest {
         valueSnapshotter = mock(),
         fileCollectionFingerprinterRegistry = mock(),
         buildServiceRegistry = mock(),
-        isolatableSerializerRegistry = mock(),
+        managedFactoryRegistry = mock(),
         parameterScheme = mock(),
         actionScheme = mock(),
         attributesFactory = mock(),

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging.text;
 
+import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.util.TextUtil;
 
 import javax.annotation.Nullable;
@@ -105,7 +106,7 @@ public class TreeFormatter implements DiagnosticsVisitor {
     public void appendType(Type type) {
         // Implementation is currently dumb, can be made smarter
         if (type instanceof Class) {
-            Class<?> classType = (Class<?>) type;
+            Class<?> classType = GeneratedSubclasses.unpack((Class<?>) type);
             appendOuter(classType);
             append(classType.getSimpleName());
         } else if (type instanceof ParameterizedType) {
@@ -160,6 +161,8 @@ public class TreeFormatter implements DiagnosticsVisitor {
         // Implementation is currently dumb, can be made smarter
         if (value == null) {
             append("null");
+        } else if (value.getClass().isArray()) {
+            appendValues((Object[]) value);
         } else if (value instanceof String) {
             append("'");
             append(value.toString());
@@ -172,11 +175,11 @@ public class TreeFormatter implements DiagnosticsVisitor {
     /**
      * Appends some user provided values to the current node.
      */
-    public void appendValues(Object[] values) {
+    public <T> void appendValues(T[] values) {
         // Implementation is currently dumb, can be made smarter
         append("[");
         for (int i = 0; i < values.length; i++) {
-            Object value = values[i];
+            T value = values[i];
             if (i > 0) {
                 append(", ");
             }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
@@ -367,6 +367,15 @@ Some thing.''')
         formatter.toString() == toPlatformLineSeparators("thing 'value'")
     }
 
+    def "can append array value"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendValue([12, "value", null] as Object[])
+
+        then:
+        formatter.toString() == toPlatformLineSeparators("thing [12, 'value', null]")
+    }
+
     def "can append null value"() {
         when:
         formatter.node("thing ")
@@ -383,6 +392,15 @@ Some thing.''')
 
         then:
         formatter.toString() == toPlatformLineSeparators("thing ['a', 12, null]")
+    }
+
+    def "can append typed array of values"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendValues([1, 2, 3] as Number[])
+
+        then:
+        formatter.toString() == toPlatformLineSeparators("thing [1, 2, 3]")
     }
 
     def "can append empty array of values"() {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -39,6 +39,11 @@ public class DefaultProperty<T> extends AbstractProperty<T> implements Property<
     }
 
     @Override
+    public Object unpackState() {
+        return getProvider();
+    }
+
+    @Override
     public Class<?> publicType() {
         return Property.class;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ManagedFactories.java
@@ -59,14 +59,11 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            if (state == null) {
-                return type.cast(new DefaultProperty<>(Object.class));
-            } else {
-                return type.cast(propertyOf(state.getClass(), Cast.uncheckedCast(state)));
-            }
+            ProviderInternal<S> provider = Cast.uncheckedCast(state);
+            return type.cast(propertyOf(provider.getType(), provider));
         }
 
-        static <V> Property<V> propertyOf(Class<V> type, V value) {
+        static <V> Property<V> propertyOf(Class<V> type, Provider<V> value) {
             return new DefaultProperty<V>(type).value(value);
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.internal.snapshot.ValueSnapshottingException;
@@ -171,7 +172,10 @@ public class DefaultValueSnapshotter implements ValueSnapshotter, IsolatableFact
             objectStr.writeObject(value);
             objectStr.flush();
         } catch (IOException e) {
-            throw new ValueSnapshottingException(String.format("Could not serialize value of type '%s'", value.getClass().getName()), e);
+            TreeFormatter formatter = new TreeFormatter();
+            formatter.node("Could not serialize value of type ");
+            formatter.appendType(value.getClass());
+            throw new ValueSnapshottingException(formatter.toString(), e);
         }
 
         return visitor.serialized(value, outputStream.toByteArray());

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolatedEnumValueSnapshot.java
@@ -32,6 +32,10 @@ public class IsolatedEnumValueSnapshot extends EnumValueSnapshot implements Isol
         this.value = value;
     }
 
+    public Enum<?> getValue() {
+        return value;
+    }
+
     @Override
     public ValueSnapshot asSnapshot() {
         return new EnumValueSnapshot(value);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolationException.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/IsolationException.java
@@ -17,19 +17,27 @@
 package org.gradle.internal.snapshot.impl;
 
 import org.gradle.internal.exceptions.Contextual;
+import org.gradle.internal.logging.text.TreeFormatter;
 
 /**
  * Represents a problem while attempting to isolate an instance.
  */
 @Contextual
 public class IsolationException extends RuntimeException {
-    private static final String MSG_FORMAT="Could not isolate value: [%s] of type: [%s]";
-
     public IsolationException(Object value) {
-        super(String.format(MSG_FORMAT, value, value.getClass()));
+        super(format(value));
     }
 
     public IsolationException(Object value, Throwable cause) {
-        super(String.format(MSG_FORMAT, value, value.getClass()), cause);
+        super(format(value), cause);
+    }
+
+    private static String format(Object value) {
+        TreeFormatter formatter = new TreeFormatter();
+        formatter.node("Could not isolate value ");
+        formatter.appendValue(value);
+        formatter.append(" of type ");
+        formatter.appendType(value.getClass());
+        return formatter.toString();
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/state/Managed.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.state;
 
+import javax.annotation.Nullable;
+
 /**
  * Implemented by types whose state is fully managed by Gradle. Mixed into generated classes whose state is fully managed.
  */
@@ -26,6 +28,7 @@ public interface Managed {
      *
      * <p><em>Note that currently the state should reference only JVM and core Gradle types when {@link #immutable()} returns true.</em></p>
      */
+    @Nullable
     Object unpackState();
 
     /**

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -593,7 +593,8 @@ class DefaultValueSnapshotterTest extends Specification {
         original.set(originalValue)
 
         given:
-        1 * managedFactoryRegistry.lookup(_) >> new ManagedFactories.PropertyManagedFactory()
+        1 * managedFactoryRegistry.lookup(ManagedFactories.PropertyManagedFactory.FACTORY_ID) >> new ManagedFactories.PropertyManagedFactory()
+        1 * managedFactoryRegistry.lookup(ManagedFactories.ProviderManagedFactory.FACTORY_ID) >> new ManagedFactories.ProviderManagedFactory()
 
         expect:
         def isolated = snapshotter.isolate(original)

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -44,10 +44,10 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         actionThatThrowsUnserializableMemberException.with {
             extraFields = """
                 private class Bar { }
-                    
+
                 private class UnserializableMemberException extends RuntimeException {
                     private Bar bar = new Bar();
-                    
+
                     UnserializableMemberException(String message) {
                         super(message);
                     }
@@ -149,7 +149,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
                 isolationMode = $isolationMode
                 workActionClass = ${alternateExecution.name}.class
             }
-            
+
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
                 foo = new FooWithUnserializableBar()
@@ -162,8 +162,8 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
         then:
         failureHasCause("A failure occurred while executing ${workAction.packageName}.${workAction.name}")
-        failureHasCause("Could not isolate value")
-        failureHasCause("Could not serialize value of type 'org.gradle.other.FooWithUnserializableBar'")
+        failureHasCause("Could not isolate value ")
+        failureHasCause("Could not serialize value of type FooWithUnserializableBar")
 
         and:
         executedAndNotSkipped(":runAgainInWorker")
@@ -180,7 +180,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         def alternateExecution = fixture.alternateWorkAction.writeToBuildSrc()
         withParameterMemberThatFailsDeserialization()
 
-        buildFile << """  
+        buildFile << """
             task runAgainInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.$isolationMode
                 workActionClass = ${alternateExecution.name}.class
@@ -295,10 +295,10 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
             abstract class BadWorkAction implements WorkAction<WorkParameters> {
                 @Inject
                 BadWorkAction() { }
-                
+
                 void execute() { }
             }
-            
+
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
                 workActionClass = BadWorkAction.class
@@ -342,10 +342,10 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
     String getClassThatFailsDeserialization() {
         return """
             package org.gradle.other;
-            
+
             import java.io.Serializable;
             import java.io.IOException;
-            
+
             public class Bar implements Serializable {
                 private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
                     throw new IOException("Broken");
@@ -357,10 +357,10 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
     String getClassThatFailsSerialization() {
         return """
             package org.gradle.other;
-            
+
             import java.io.Serializable;
             import java.io.IOException;
-            
+
             public class Bar implements Serializable {
                 private void writeObject(java.io.ObjectOutputStream out) throws IOException {
                     throw new IOException("Broken");
@@ -372,9 +372,9 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
     String getParameterClassWithUnserializableMember() {
         return """
             package org.gradle.other;
-            
+
             import java.io.Serializable;
-            
+
             public class FooWithUnserializableBar extends Foo implements Serializable {
                 private final Bar bar = new Bar();
             }


### PR DESCRIPTION

### Context

This PR allows a build service to be passed as a parameter to isolated object, such as other build services, worker API actions or artifact transform actions.

There are some things that don't yet work:

- Worker classloader and process isolation is not supported.
- Services are stopped in the order they are created, rather than in reverse dependency order.
- Parallel usage constraints specified for these services are not honoured.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
