### PR TITLE
Refine value source API

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ValueSource.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ValueSource.java
@@ -18,17 +18,51 @@ package org.gradle.api.provider;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.file.RegularFile;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /**
- * Base configuration for value source definitions.
+ * Represents an external source of information used by a Gradle build.
  *
- * @see ProviderFactory#of(Class, Action)
+ * Examples of external sources include client environment variables,
+ * system properties, configuration files, shell commands, network services,
+ * among others.
+ *
+ * <p>
+ * Representing external sources as {@link ValueSource}s allows Gradle to
+ * transparently manage <a href="https://gradle.github.io/instant-execution/">the work graph cache</a>as values obtained from those sources
+ * change. For example, a build might run a different set of tasks depending on whether
+ * the {@code CI} environment variable is set or not.
+ * </p>
+ *
+ * <p>
+ * To integrate a new type of value source, create an abstract subclass of this interface
+ * and use {@link ProviderFactory#of(Class, Action)} to get a provider to a configured source.
+ * The returned {@link org.gradle.api.provider.Provider} can be passed to tasks or queried
+ * by build logic during the configuration phase, in which case the source would be automatically
+ * considered as an input to the work graph cache.
+ * </p>
+ *
+ * <p>
+ * A value source implementation will most likely take parameters. To do this create a
+ * subtype of {@link ValueSourceParameters} and declare this type as the type parameter
+ * to the value source implementation.
+ * </p>
+ *
+ * <p>
+ * A value source implementation doesn't have to be thread-safe, as the single call
+ * to {@link #obtain()} is synchronized.
+ * </p>
  *
  * @param <T> The type of value obtained from this source.
  * @param <P> The source specific parameter type.
+ * @see ProviderFactory#environmentVariable(String)
+ * @see ProviderFactory#systemProperty(String)
+ * @see ProviderFactory#fileContents(RegularFile)
+ * @see ProviderFactory#of(Class, Action)
+ * @see <a href="https://gradle.github.io/instant-execution/">Instant Execution</a>
  * @since 6.1
  */
 @Incubating

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedUserHomeScopeServices.java
@@ -37,7 +37,7 @@ public class WorkerSharedUserHomeScopeServices {
         ListenerManager listenerManager
     ) {
         return new DefaultValueSourceProviderFactory(
-            listenerManager.createAnonymousBroadcaster(ValueSourceProviderFactory.Listener.class),
+            listenerManager,
             instantiatorFactory,
             isolatableFactory,
             services

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -24,6 +24,7 @@ import org.gradle.api.provider.ValueSourceParameters;
 import org.gradle.api.provider.ValueSourceSpec;
 import org.gradle.internal.Try;
 import org.gradle.internal.event.AnonymousListenerBroadcast;
+import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolated.IsolationScheme;
@@ -44,12 +45,12 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
     private final InstanceGenerator specInstantiator;
 
     public DefaultValueSourceProviderFactory(
-        AnonymousListenerBroadcast<Listener> broadcaster,
+        ListenerManager listenerManager,
         InstantiatorFactory instantiatorFactory,
         IsolatableFactory isolatableFactory,
         ServiceLookup services
     ) {
-        this.broadcaster = broadcaster;
+        this.broadcaster = listenerManager.createAnonymousBroadcaster(ValueSourceProviderFactory.Listener.class);
         this.instantiatorFactory = instantiatorFactory;
         this.isolatableFactory = isolatableFactory;
         // TODO - dedupe logic copied from DefaultBuildServicesRegistry

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -173,6 +173,11 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
             return value == null;
         }
 
+        @Override
+        public boolean immutable() {
+            return true;
+        }
+
         @Nullable
         public Try<T> getObtainedValueOrNull() {
             return value;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/SystemPropertyValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/SystemPropertyValueSource.java
@@ -31,6 +31,10 @@ public abstract class SystemPropertyValueSource implements ValueSource<String, S
     @Nullable
     @Override
     public String obtain() {
-        return System.getProperty(getParameters().getPropertyName().get());
+        @Nullable String propertyName = getParameters().getPropertyName().getOrNull();
+        if (propertyName == null) {
+            return null;
+        }
+        return System.getProperty(propertyName);
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.internal.state.Managed
 
 import static org.gradle.api.internal.provider.ValueSourceProviderFactory.Listener.ObtainedValue
 
@@ -74,6 +75,15 @@ class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
         expect:
         !provider.isPresent()
         provider.getOrNull() == null
+    }
+
+    def "provider assumes graph is immutable"() {
+
+        given:
+        def provider = createProviderOf(EchoValueSource) {}
+
+        expect:
+        ((Managed) provider).immutable()
     }
 
     static abstract class EchoValueSource implements ValueSource<String, Parameters> {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
@@ -19,26 +19,10 @@ package org.gradle.api.internal.provider
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
-import org.gradle.internal.event.DefaultListenerManager
-import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter
-import org.gradle.util.TestUtil
-import spock.lang.Specification
 
 import static org.gradle.api.internal.provider.ValueSourceProviderFactory.Listener.ObtainedValue
 
-class DefaultValueSourceProviderFactoryTest extends Specification {
-
-    def listenerManager = new DefaultListenerManager()
-    def isolatableFactory = new DefaultValueSnapshotter(
-        null,
-        TestUtil.managedFactoryRegistry()
-    )
-    def subject = new DefaultValueSourceProviderFactory(
-        listenerManager,
-        TestUtil.instantiatorFactory(),
-        isolatableFactory,
-        TestUtil.services()
-    )
+class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
 
     def "parameters are configured eagerly"() {
 
@@ -46,7 +30,7 @@ class DefaultValueSourceProviderFactoryTest extends Specification {
         def configured = false
 
         when:
-        def provider = subject.createProviderOf(EchoValueSource) {
+        def provider = createProviderOf(EchoValueSource) {
             configured = true
         }
 
@@ -57,11 +41,11 @@ class DefaultValueSourceProviderFactoryTest extends Specification {
     def "listener is notified when value is obtained"() {
 
         given: "a listener is connected to the provider factory"
-        def provider = subject.createProviderOf(EchoValueSource) {
+        def provider = createProviderOf(EchoValueSource) {
             it.parameters.value.set("42")
         }
         List<ObtainedValue<?, ValueSourceParameters>> obtainedValues = []
-        subject.addListener { obtainedValues.add(it) }
+        valueSourceProviderFactory.addListener { obtainedValues.add(it) }
 
         when: "value is obtained for the 1st time"
         provider.get()
@@ -83,7 +67,7 @@ class DefaultValueSourceProviderFactoryTest extends Specification {
     def "provider maps null returned from obtain to not present"() {
 
         given:
-        def provider = subject.createProviderOf(EchoValueSource) {
+        def provider = createProviderOf(EchoValueSource) {
             // give no value so `getParameters().getValue().getOrNull()` returns null
         }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.internal.event.DefaultListenerManager
+import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+import static org.gradle.api.internal.provider.ValueSourceProviderFactory.Listener.ObtainedValue
+
+class DefaultValueSourceProviderFactoryTest extends Specification {
+
+    def listenerManager = new DefaultListenerManager()
+    def isolatableFactory = new DefaultValueSnapshotter(
+        null,
+        TestUtil.managedFactoryRegistry()
+    )
+    def subject = new DefaultValueSourceProviderFactory(
+        listenerManager,
+        TestUtil.instantiatorFactory(),
+        isolatableFactory,
+        TestUtil.services()
+    )
+
+    def "parameters are configured eagerly"() {
+
+        given:
+        def configured = false
+
+        when:
+        def provider = subject.createProviderOf(EchoValueSource) {
+            configured = true
+        }
+
+        then:
+        configured
+    }
+
+    def "listener is notified when value is obtained"() {
+
+        given: "a listener is connected to the provider factory"
+        def provider = subject.createProviderOf(EchoValueSource) {
+            it.parameters.value.set("42")
+        }
+        List<ObtainedValue<?, ValueSourceParameters>> obtainedValues = []
+        subject.addListener { obtainedValues.add(it) }
+
+        when: "value is obtained for the 1st time"
+        provider.get()
+
+        then: "listener is notified"
+        obtainedValues.size() == 1
+        obtainedValues[0].valueSourceType == EchoValueSource
+        obtainedValues[0].valueSourceParametersType == EchoValueSource.Parameters
+        obtainedValues[0].valueSourceParameters.value.get() == "42"
+        obtainedValues[0].value.get() == "42"
+
+        when: "value is accessed a 2nd time"
+        provider.get()
+
+        then: "no notification is sent"
+        obtainedValues.size() == 1
+    }
+
+    def "provider maps null returned from obtain to not present"() {
+
+        given:
+        def provider = subject.createProviderOf(EchoValueSource) {
+            // give no value so `getParameters().getValue().getOrNull()` returns null
+        }
+
+        expect:
+        !provider.isPresent()
+        provider.getOrNull() == null
+    }
+
+    static abstract class EchoValueSource implements ValueSource<String, Parameters> {
+
+        interface Parameters extends ValueSourceParameters {
+            Property<String> getValue()
+        }
+
+        @Override
+        String obtain() {
+            return getParameters().getValue().getOrNull()
+        }
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.Action
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
-import org.gradle.api.provider.ValueSourceSpec
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter
 import org.gradle.util.TestUtil

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.api.Action
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.internal.event.DefaultListenerManager
+import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+abstract class ValueSourceBasedSpec extends Specification {
+
+    def listenerManager = new DefaultListenerManager()
+    def isolatableFactory = new DefaultValueSnapshotter(
+        null,
+        TestUtil.managedFactoryRegistry()
+    )
+    def valueSourceProviderFactory = new DefaultValueSourceProviderFactory(
+        listenerManager,
+        TestUtil.instantiatorFactory(),
+        isolatableFactory,
+        TestUtil.services()
+    )
+
+    protected <T, P extends ValueSourceParameters> Provider<T> createProviderOf(Class<? extends ValueSource<T, P>> valueSourceType, Action<? super org.gradle.api.provider.ValueSourceSpec<P>> configureAction) {
+        return valueSourceProviderFactory.createProviderOf(valueSourceType, configureAction)
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/EnvironmentVariableValueSourceTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/EnvironmentVariableValueSourceTest.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources
+
+import org.gradle.api.internal.provider.ValueSourceBasedSpec
+
+class EnvironmentVariableValueSourceTest extends ValueSourceBasedSpec {
+
+    def "environment variable has no value when variable name has no value"() {
+        given:
+        def provider = createProviderOf(EnvironmentVariableValueSource) {
+            // give variable name no value
+        }
+
+        expect:
+        !provider.isPresent()
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/SystemPropertyValueSourceTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/SystemPropertyValueSourceTest.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources
+
+import org.gradle.api.internal.provider.ValueSourceBasedSpec
+
+class SystemPropertyValueSourceTest extends ValueSourceBasedSpec {
+
+    def "system property has no value when property name has no value"() {
+        given:
+        def provider = createProviderOf(SystemPropertyValueSource) {
+            // give property name no value
+        }
+
+        expect:
+        !provider.isPresent()
+    }
+}


### PR DESCRIPTION
 - Add tests for `DefaultValueSourceProviderFactory`
- Let `systemProperty` provider have no value when property name provider has no value
- Let `ValueSourceProvider` assume provided values are immutable