### PR TITLE
Improve documentation on capabilities conflict solving

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_capability_conflict.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_capability_conflict.adoc
@@ -83,4 +83,17 @@ bindings are basically different logger implementations and you need only one.
 However, the selected implementation may depend on the configuration being resolved.
 For example, for tests, `slf4j-simple` may be enough but for production, `slf4-over-log4j` may be better.
 
+[NOTE]
+====
+Resolution can only be made in favor of a module _found_ in the graph.
+
+The `select` method only accepts a module found in the _current_ candidates.
+If the module you want to select is not part of the conflict, you can abstain from performing a selection, effectively not resolving _this_ conflict.
+It might be that another conflict exists in the graph for the same capability and will have the module you want to select.
+
+If no resolution is given for all conflicts on a given capability, the build will fail given the module chosen for resolution was not part of the graph at all.
+
+In addition `select(null)` will result in an error and so should be avoided.
+====
+
 For more information, check out the link:{javadocPath}/org/gradle/api/artifacts/ResolutionStrategy.html#capabilitiesResolution[the capabilities resolution API].

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/groovy/build.gradle
@@ -89,7 +89,10 @@ if (project.hasProperty("replace")) {
     // tag::use_slf4j[]
     configurations.all {
         resolutionStrategy.capabilitiesResolution.withCapability("log4j:log4j") {
-            select(candidates.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'log4j-over-slf4j' } )
+            def toBeSelected = candidates.find { it.id instanceof ModuleComponentIdentifier && it.id.module == 'log4j-over-slf4j' }
+            if (toBeSelected != null) {
+                select(toBeSelected)
+            }
             because 'use slf4j in place of log4j'
         }
     }

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/kotlin/build.gradle.kts
@@ -84,7 +84,10 @@ if (project.hasProperty("replace")) {
     // tag::use_slf4j[]
     configurations.all {
         resolutionStrategy.capabilitiesResolution.withCapability("log4j:log4j") {
-            select(candidates.first { it.id.let { id -> id is ModuleComponentIdentifier && id.module == "log4j-over-slf4j" } } )
+            val toBeSelected = candidates.firstOrNull { it.id.let { id -> id is ModuleComponentIdentifier && id.module == "log4j-over-slf4j" } }
+            if (toBeSelected != null) {
+                select(toBeSelected)
+            }
             because("use slf4j in place of log4j")
         }
     }


### PR DESCRIPTION
Clearly states that skipping conflict resolution when desired module is
not a candidate is the expected pattern.