### PR TITLE
Fix integration tests running with VFS retention enabled

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstyleRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstyleRelocationIntegrationTest.groovy
@@ -53,6 +53,7 @@ class CheckstyleRelocationIntegrationTest extends AbstractProjectRelocationInteg
             "package org.gradle; class Class1Test { public boolean is() { return true; } }"
 
         projectDir.file("build.gradle") << """
+            apply plugin: 'base'
             apply plugin: "checkstyle"
 
             ${mavenCentralRepository()}

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcRelocationIntegrationTest.groovy
@@ -47,6 +47,7 @@ class CodeNarcRelocationIntegrationTest extends AbstractProjectRelocationIntegra
         """
 
         projectDir.file("build.gradle") << """
+            apply plugin: 'base'
             apply plugin: "codenarc"
 
             ${mavenCentralRepository()}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -74,6 +75,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://github.com/gradle/gradle/issues/1365")
     @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
+    @ToBeFixedForVfsRetention("symlinks")
     def "detect changes to broken symlink outputs in OutputDirectory"() {
         def root = file("root").createDir()
         def target = file("target")
@@ -133,6 +135,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://github.com/gradle/gradle/issues/1365")
     @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
+    @ToBeFixedForVfsRetention("symlinks")
     def "detect changes to broken symlink outputs in OutputFile"() {
         def root = file("root").createDir()
         def target = file("target")
@@ -220,6 +223,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue('https://github.com/gradle/gradle/issues/9904')
     @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
+    @ToBeFixedForVfsRetention("symlinks")
     def "task with broken symlink in InputDirectory is valid"() {
         def inputFileTarget = file("brokenInputFileTarget")
         def inputDirectoryWithBrokenLink = file('inputDirectoryWithBrokenLink')
@@ -267,6 +271,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue('https://github.com/gradle/gradle/issues/9904')
     @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
+    @ToBeFixedForVfsRetention("symlinks")
     def "task with broken symlink in InputFiles is valid"() {
         def inputFileTarget = file("brokenInputFileTarget")
         def brokenInputFile = file('brokenInputFile').createLink(inputFileTarget)
@@ -314,6 +319,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue('https://github.com/gradle/gradle/issues/9904')
     @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
+    @ToBeFixedForVfsRetention("symlinks")
     def "unbreaking a symlink in InputFiles is detected incrementally"() {
         def inputFileTarget = file("brokenInputFileTarget")
         def brokenInputFile = file('brokenInputFile').createLink(inputFileTarget)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
@@ -108,6 +108,10 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
                     localStateFile.text = message
                 }
             }
+
+            task clean(type: Delete) {
+                delete('build')
+            }
         """
     }
 
@@ -664,7 +668,7 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
     }
 
     private void cleanBuildDir() {
-        file("build").deleteDir()
+        run(":clean")
     }
 
     // We ignore external.txt as an input because the file doesn't change after executing A

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
@@ -17,9 +17,8 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestBuildCache
-import org.gradle.test.fixtures.file.TestFile
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -35,6 +34,7 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         executer.beforeExecute { withBuildCacheEnabled() }
         settingsFile << localCache.localCacheConfiguration()
+        buildFile << 'apply plugin: "base"'
     }
 
     def "fails build when packing archive fails"() {
@@ -43,7 +43,6 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
 
         // Just a way to induce a packing error, i.e. corrupt/partial archive
         buildFile << """
-            apply plugin: "base"
             task customTask {
                 inputs.file "input.txt"
                 outputs.file "build/output" withPropertyName "output"
@@ -71,7 +70,6 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
 
         // Just a way to induce a packing error, i.e. corrupt/partial archive
         buildFile << """
-            apply plugin: "base"
             task customTask {
                 inputs.file "input.txt"
                 outputs.file "build/output" withPropertyName "output"
@@ -96,7 +94,6 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         file("input.txt") << "data"
         settingsFile << remoteCache.remoteCacheConfiguration()
         buildFile << """
-            apply plugin: "base"
             task customTask {
                 inputs.file "input.txt"
                 outputs.file "build/output" withPropertyName "output"
@@ -129,7 +126,6 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         when:
         file("input.txt") << "data"
         buildFile << """
-            apply plugin: "base"
             task customTask {
                 inputs.file "input.txt"
                 outputs.file "build/output" withPropertyName "output"
@@ -223,8 +219,8 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         errorOutput.contains("Couldn't read content of file '${link}'")
     }
 
-    private TestFile cleanBuildDir() {
-        file("build").deleteDir()
+    private void cleanBuildDir() {
+        run(":clean")
     }
 
     def corruptMetadata(Consumer<File> corrupter, Predicate<File> matcher = { true }) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
@@ -25,6 +25,10 @@ class CachedPathSensitivityIntegrationTest extends AbstractPathSensitivityIntegr
     def setup() {
         buildFile << """
             task clean {
+                def cleanTask = delegate
+                tasks.all { otherTask ->
+                    cleanTask.destroyables.register(otherTask.outputs.files)
+                }
                 doLast {
                     delete(tasks*.outputs*.files)
                 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ConcurrentBuildsIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ConcurrentBuildsIncrementalBuildIntegrationTest.groovy
@@ -32,6 +32,7 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
@@ -86,6 +87,7 @@ public class TransformerTask extends DefaultTask {
 '''
     }
 
+    @ToBeFixedForVfsRetention("changes to inputs during the build")
     def "task history is shared between multiple build processes"() {
         prepareTransformTask()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -307,7 +307,7 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         run("other")
 
         then:
-        result.assertNotOutput("Received")
+        result.assertNotOutput("Received :")
         result.assertNotOutput("task1")
         result.assertNotOutput("task2")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -49,6 +50,7 @@ task work {
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("symlinks")
     def "uses the target of symlink for input file content"() {
         file("in-dir").createDir()
         def inFile = file("other").createFile()
@@ -75,6 +77,7 @@ task work {
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("symlinks")
     def "uses the target of symlink for input directory content"() {
         file('in.txt').touch()
         def inDir = file("other").createDir()
@@ -101,6 +104,7 @@ task work {
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("symlinks")
     def "follows symlinks in input directories"() {
         file('in.txt').touch()
         def inFile = file("other").createFile()
@@ -139,6 +143,7 @@ task work {
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("symlinks")
     def "can replace input file with symlink to file with same content"() {
         file("in-dir").createDir()
         def inFile = file("in.txt").createFile()
@@ -174,6 +179,7 @@ task work {
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("symlinks")
     def "can replace input directory with symlink to directory with same content"() {
         file('in.txt').touch()
         def inDir = file("in-dir").createDir()
@@ -211,6 +217,7 @@ task work {
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("symlinks")
     def "can replace output file with symlink to file with same content"() {
         file('in.txt').touch()
         file("in-dir").createDir()
@@ -248,6 +255,7 @@ task work {
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("symlinks")
     def "can replace output directory with symlink to directory with same content"() {
         file('in.txt').touch()
         file("in-dir").createDir()

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
@@ -24,6 +24,9 @@ import spock.lang.Unroll
 @Unroll
 class BuildScanEndOfBuildNotifierIntegrationTest extends AbstractIntegrationSpec {
 
+    private static final VFS_RETENTION_OUTPUT = '''(Watching \\d* directory hierarchies to track changes between builds in \\d* directories
+)?'''
+
     def setup() {
         buildFile << """
             def notifier = services.get(${BuildScanEndOfBuildNotifier.name})
@@ -51,7 +54,7 @@ build finished
 BUILD SUCCESSFUL in [ \\dms]+
 1 actionable task: 1 executed
 failure is null: true
-\$""")
+${VFS_RETENTION_OUTPUT}\$""")
     }
 
     def "can observe failed build after completion of user logic and build outcome is reported"() {
@@ -76,7 +79,7 @@ failure is null: true
 build finished
 1 actionable task: 1 executed
 failure message: Execution failed for task ':t'.
-\$""")
+${VFS_RETENTION_OUTPUT}\$""")
 
         result.error.matches("""(?s)build finished
 
@@ -116,7 +119,7 @@ notified
         output.matches("""(?s).*
 1 actionable task: 1 executed
 failure message: broken
-\$""")
+${VFS_RETENTION_OUTPUT}\$""")
     }
 
     def "can only register one listener"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 @Unroll
 class BuildScanEndOfBuildNotifierIntegrationTest extends AbstractIntegrationSpec {
 
-    private static final VFS_RETENTION_OUTPUT = '''(Watching \\d* directory hierarchies to track changes between builds in \\d* directories
+    private static final VFS_RETENTION_OUTPUT = '''(Watching \\d* (directory hierarchies to track changes between builds in \\d* directories|directories to track changes between builds)
 )?'''
 
     def setup() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -55,7 +55,9 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         instantRun "help"
 
         then:
-        firstRunOutput == result.normalizedOutput.replace('Reusing instant execution cache. This is not guaranteed to work in any way.', '')
+        firstRunOutput == result.normalizedOutput
+            .replace('Reusing instant execution cache. This is not guaranteed to work in any way.', '')
+            .replaceAll('Received \\d* file system events since last build\n', '')
     }
 
     def "restores some details of the project structure"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -46,10 +46,14 @@ import javax.inject.Inject
 
 class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
+    private static final VFS_WATCHING_MESSAGE_PATTERN = 'Watching \\d* directories to track changes between builds\n'
+
     def "instant execution for help on empty project"() {
         given:
         instantRun "help"
-        def firstRunOutput = result.normalizedOutput.replace('Calculating task graph as no instant execution cache is available for tasks: help', '')
+        def firstRunOutput = result.normalizedOutput
+            .replace('Calculating task graph as no instant execution cache is available for tasks: help', '')
+            .replaceAll(VFS_WATCHING_MESSAGE_PATTERN, '')
 
         when:
         instantRun "help"
@@ -58,6 +62,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         firstRunOutput == result.normalizedOutput
             .replace('Reusing instant execution cache. This is not guaranteed to work in any way.', '')
             .replaceAll('Received \\d* file system events since last build\n', '')
+            .replaceAll(VFS_WATCHING_MESSAGE_PATTERN, '')
     }
 
     def "restores some details of the project structure"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
@@ -76,7 +76,7 @@ abstract class AbstractProjectRelocationIntegrationTest extends AbstractIntegrat
 
     @SuppressWarnings("GrMethodMayBeStatic")
     protected void removeResults(TestFile projectDir) {
-        projectDir.file("build").deleteDir()
+        inDirectory(projectDir).withTasks(":clean").run()
     }
 
     @SuppressWarnings("GrMethodMayBeStatic")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CatchFeatureFailuresRunListener.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CatchFeatureFailuresRunListener.groovy
@@ -72,13 +72,13 @@ class CatchFeatureFailuresRunListener extends AbstractRunListener {
     void afterFeature(FeatureInfo featureInfo) {
         if (featureInfo == feature) {
             if (failuresInterceptor.failures.empty) {
-                throw new UnexpectedSuccessException()
+                throw new UnexpectedSuccessException(failsBecause)
             } else {
                 System.err.println("Failed with ${failsBecause} as expected:")
                 if (failuresInterceptor.failures.size() == 1) {
                     failuresInterceptor.failures.first().printStackTrace()
                 } else {
-                    new ExpectedFailureException(failuresInterceptor.failures).printStackTrace()
+                    new ExpectedFailureException(failsBecause, failuresInterceptor.failures).printStackTrace()
                 }
             }
         }
@@ -119,14 +119,14 @@ class CatchFeatureFailuresRunListener extends AbstractRunListener {
     }
 
     static class UnexpectedSuccessException extends Exception {
-        UnexpectedSuccessException() {
-            super("Expected to fail with instant execution, but succeeded!")
+        UnexpectedSuccessException(String failsBecause) {
+            super("Expected to fail with ${failsBecause}, but succeeded!")
         }
     }
 
     static class ExpectedFailureException extends Exception {
-        ExpectedFailureException(List<Throwable> failures) {
-            super("Expected failure with instant execution")
+        ExpectedFailureException(String failsBecause, List<Throwable> failures) {
+            super("Expected failure with ${failsBecause}")
             failures.each { addSuppressed(it) }
         }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CatchFeatureFailuresRunListener.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CatchFeatureFailuresRunListener.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.spockframework.runtime.AbstractRunListener
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.IterationInfo
+import org.spockframework.runtime.model.SpecInfo
+
+/**
+ * Spock spec listener that registers failure collecting method interceptors for the given feature.
+ *
+ * The feature then passes if a failure is collected and fails if it isn't.
+ *
+ * Registration happens as late as possible and to the utmost position in the stack in order to catch
+ * failures without being sensible to other spock extensions that re-order interceptors nor to the place
+ * of annotated spock features in hierarchies of spec classes.
+ */
+class CatchFeatureFailuresRunListener extends AbstractRunListener {
+
+    private final FeatureInfo feature
+    private final RecordFailuresInterceptor failuresInterceptor
+    private final FeatureFilterInterceptor fixturesInterceptor
+    private final String failsBecause
+
+    CatchFeatureFailuresRunListener(String failsBecause, FeatureInfo feature) {
+        this.failsBecause = failsBecause
+        this.feature = feature
+        this.failuresInterceptor = new RecordFailuresInterceptor()
+        this.fixturesInterceptor = new FeatureFilterInterceptor(feature, failuresInterceptor)
+    }
+
+    @Override
+    void beforeSpec(SpecInfo spec) {
+        spec.specsTopToBottom*.each { s ->
+            s.setupMethods*.interceptors*.add(0, fixturesInterceptor)
+            s.cleanupMethods*.interceptors*.add(0, fixturesInterceptor)
+        }
+    }
+
+    @Override
+    void beforeFeature(FeatureInfo featureInfo) {
+        if (featureInfo == feature) {
+            featureInfo.featureMethod.interceptors.add(0, failuresInterceptor)
+        }
+    }
+
+    @Override
+    void beforeIteration(IterationInfo iteration) {
+        if (iteration.feature == feature) {
+            iteration.feature.iterationInterceptors.add(0, failuresInterceptor)
+        }
+    }
+
+    @Override
+    void afterFeature(FeatureInfo featureInfo) {
+        if (featureInfo == feature) {
+            if (failuresInterceptor.failures.empty) {
+                throw new UnexpectedSuccessException()
+            } else {
+                System.err.println("Failed with ${failsBecause} as expected:")
+                if (failuresInterceptor.failures.size() == 1) {
+                    failuresInterceptor.failures.first().printStackTrace()
+                } else {
+                    new ExpectedFailureException(failuresInterceptor.failures).printStackTrace()
+                }
+            }
+        }
+    }
+
+    private static class FeatureFilterInterceptor implements IMethodInterceptor {
+
+        private final FeatureInfo feature
+        private final IMethodInterceptor next
+
+        FeatureFilterInterceptor(FeatureInfo feature, IMethodInterceptor next) {
+            this.feature = feature
+            this.next = next
+        }
+
+        @Override
+        void intercept(IMethodInvocation invocation) throws Throwable {
+            if (invocation.feature == feature) {
+                next.intercept(invocation)
+            } else {
+                invocation.proceed()
+            }
+        }
+    }
+
+    private static class RecordFailuresInterceptor implements IMethodInterceptor {
+
+        List<Throwable> failures = []
+
+        @Override
+        void intercept(IMethodInvocation invocation) throws Throwable {
+            try {
+                invocation.proceed()
+            } catch (Throwable ex) {
+                failures += ex
+            }
+        }
+    }
+
+    static class UnexpectedSuccessException extends Exception {
+        UnexpectedSuccessException() {
+            super("Expected to fail with instant execution, but succeeded!")
+        }
+    }
+
+    static class ExpectedFailureException extends Exception {
+        ExpectedFailureException(List<Throwable> failures) {
+            super("Expected failure with instant execution")
+            failures.each { addSuppressed(it) }
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExpectingFailureRuleStatement.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ExpectingFailureRuleStatement.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.junit.runners.model.Statement
+
+class ExpectingFailureRuleStatement extends Statement {
+    private final Statement next
+    private final String failsBecause
+
+    ExpectingFailureRuleStatement(String failsBecause, Statement next) {
+        this.failsBecause = failsBecause
+        this.next = next
+    }
+
+    @Override
+    void evaluate() throws Throwable {
+        try {
+            next.evaluate()
+            throw new CatchFeatureFailuresRunListener.UnexpectedSuccessException()
+        } catch (CatchFeatureFailuresRunListener.UnexpectedSuccessException ex) {
+            throw ex
+        } catch (Throwable ex) {
+            System.err.println("Failed with ${failsBecause} as expected:")
+            ex.printStackTrace()
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionRule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionRule.groovy
@@ -50,8 +50,8 @@ class ToBeFixedForInstantExecutionRule implements TestRule {
         void evaluate() throws Throwable {
             try {
                 next.evaluate()
-                throw new ToBeFixedForInstantExecutionExtension.UnexpectedSuccessException()
-            } catch (ToBeFixedForInstantExecutionExtension.UnexpectedSuccessException ex) {
+                throw new CatchFeatureFailuresRunListener.UnexpectedSuccessException()
+            } catch (CatchFeatureFailuresRunListener.UnexpectedSuccessException ex) {
                 throw ex
             } catch (Throwable ex) {
                 System.err.println("Failed with instant execution as expected:")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetention.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetention.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures;
+
+import org.spockframework.runtime.extension.ExtensionAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Assert that this test fails when run with vfs retention enabled.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@ExtensionAnnotation(ToBeFixedForVfsRetentionExtension.class)
+public @interface ToBeFixedForVfsRetention {
+    /**
+     * Reason why the test doesn't work with VFS retention enabled.
+     */
+    String value();
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetentionExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetentionExtension.groovy
@@ -21,26 +21,21 @@ import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
 import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.SpecInfo
 
-class ToBeFixedForInstantExecutionExtension extends AbstractAnnotationDrivenExtension<ToBeFixedForInstantExecution> {
-
+class ToBeFixedForVfsRetentionExtension extends AbstractAnnotationDrivenExtension<ToBeFixedForVfsRetention> {
     @Override
     void visitSpec(SpecInfo spec) {
-        if (GradleContextualExecuter.isInstant()) {
+        if (GradleContextualExecuter.isVfsRetention()) {
             spec.allFeatures.each { feature ->
-                def annotation = feature.featureMethod.reflection.getAnnotation(ToBeFixedForInstantExecution)
+                def annotation = feature.featureMethod.reflection.getAnnotation(ToBeFixedForVfsRetention)
                 if (annotation != null) {
-                    if (annotation.value() == ToBeFixedForInstantExecution.Skip.DO_NOT_SKIP) {
-                        spec.addListener(new CatchFeatureFailuresRunListener("instant execution", feature))
-                    } else {
-                        feature.skipped = true
-                    }
+                    spec.addListener(new CatchFeatureFailuresRunListener("vfs retention", feature))
                 }
             }
         }
     }
 
     @Override
-    void visitFeatureAnnotation(ToBeFixedForInstantExecution annotation, FeatureInfo feature) {
+    void visitFeatureAnnotation(ToBeFixedForVfsRetention annotation, FeatureInfo feature) {
         // This override is required to satisfy spock's zealous runtime checks
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetentionRule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetentionRule.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * JUnit Rule supporting the {@link ToBeFixedForVfsRetention} annotation.
+ */
+class ToBeFixedForVfsRetentionRule implements TestRule {
+
+    @Override
+    Statement apply(Statement base, Description description) {
+        def annotation = description.getAnnotation(ToBeFixedForVfsRetention.class)
+        if (GradleContextualExecuter.isVfsRetention() && annotation != null) {
+            return new ExpectingFailureRuleStatement("instant execution", base)
+        }
+        return base
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
@@ -80,6 +80,10 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
         return getSystemPropertyExecuter() == Executer.instant;
     }
 
+    public static boolean isVfsRetention() {
+        return getSystemPropertyExecuter() == Executer.vfsRetention;
+    }
+
     private GradleExecuter gradleExecuter;
 
     public GradleContextualExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider, IntegrationTestBuildContext buildContext) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
@@ -130,6 +130,7 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
             case instant:
                 return new InstantExecutionGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
             case vfsRetention:
+                requireIsolatedDaemons();
                 return new VfsRetentionGradleExecuter(getDistribution(), getTestDirectoryProvider(), gradleVersion, buildContext);
             default:
                 throw new RuntimeException("Not a supported executer type: " + executerType);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
@@ -32,6 +32,7 @@ class VfsRetentionGradleExecuter extends DaemonGradleExecuter {
         IntegrationTestBuildContext buildContext
     ) {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext)
+        requireIsolatedDaemons()
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
@@ -33,6 +33,10 @@ class VfsRetentionGradleExecuter extends DaemonGradleExecuter {
     ) {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext)
         requireIsolatedDaemons()
+        beforeExecute {
+            // Wait a second to pick up changes
+            Thread.sleep(1000)
+        }
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
@@ -32,7 +32,6 @@ class VfsRetentionGradleExecuter extends DaemonGradleExecuter {
         IntegrationTestBuildContext buildContext
     ) {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext)
-        requireIsolatedDaemons()
         beforeExecute {
             // Wait a second to pick up changes
             Thread.sleep(1000)
@@ -46,5 +45,11 @@ class VfsRetentionGradleExecuter extends DaemonGradleExecuter {
         super.getAllArgs() + ([
             "-D${VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY}=true",
         ] + conditionalArgs).collect { it.toString() }
+    }
+
+    @Override
+    protected Map<String, String> getImplicitJvmSystemProperties() {
+        requireIsolatedDaemons()
+        return super.getImplicitJvmSystemProperties()
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
@@ -46,10 +46,4 @@ class VfsRetentionGradleExecuter extends DaemonGradleExecuter {
             "-D${VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY}=true",
         ] + conditionalArgs).collect { it.toString() }
     }
-
-    @Override
-    protected Map<String, String> getImplicitJvmSystemProperties() {
-        requireIsolatedDaemons()
-        return super.getImplicitJvmSystemProperties()
-    }
 }

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
@@ -37,6 +37,8 @@ class GroovyCompileRelocationIntegrationTest extends AbstractProjectRelocationIn
         projectDir.file("src/main/groovy/Foo.java") << "class Foo {}"
 
         projectDir.file("build.gradle") << """
+            apply plugin: 'base'
+
             task compile(type: GroovyCompile) {
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
@@ -37,6 +37,8 @@ class JavaCompileRelocationIntegrationTest extends AbstractProjectRelocationInte
         projectDir.file("src/main/java/Foo.java") << "public class Foo {}"
 
         projectDir.file("build.gradle") << """
+            apply plugin: 'base'
+
             task compile(type: JavaCompile) {
                 sourceCompatibility = JavaVersion.current()
                 targetCompatibility = JavaVersion.current()

--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/CachedPlatformScalaCompileIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/CachedPlatformScalaCompileIntegrationTest.groovy
@@ -143,8 +143,8 @@ class CachedPlatformScalaCompileIntegrationTest extends AbstractCachedCompileInt
         classes.analysisFile.assertDoesNotExist()
 
         when:
-        expectDeprecationWarnings()
         cleanBuildDir()
+        expectDeprecationWarnings()
         withBuildCache().succeeds compilationTask
 
         then:
@@ -166,7 +166,9 @@ class CachedPlatformScalaCompileIntegrationTest extends AbstractCachedCompileInt
     }
 
     private void cleanBuildDir() {
-        file("build").assertIsDir().deleteDir()
+        file("build").assertIsDir()
+        expectDeprecationWarnings()
+        run(":clean")
     }
 
     private static void assertAllRecompiled(List<Long> lastModified, List<Long> oldLastModified) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.api.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
@@ -127,6 +129,8 @@ class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Could not compile build file '$buildFile.canonicalPath'.")
     }
 
+    // Removes directory at configuration time - no chance for VFS to pick that up
+    @IgnoreIf({ GradleContextualExecuter.vfsRetention })
     def "build uses jar from buildSrc"() {
         writeBuildSrcPlugin("buildSrc", "MyPlugin")
         buildFile << """
@@ -140,6 +144,8 @@ class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
         outputContains("From MyPlugin")
     }
 
+    // Removes directory at configuration time - no chance for VFS to pick that up
+    @IgnoreIf({ GradleContextualExecuter.vfsRetention })
     def "build uses jars from multi-project buildSrc"() {
         writeBuildSrcPlugin("buildSrc", "MyPlugin")
         writeBuildSrcPlugin("buildSrc/subproject", "MyPluginSub")

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemPartialInvalidationIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemPartialInvalidationIntegrationTest.groovy
@@ -17,9 +17,12 @@
 package org.gradle.internal.vfs
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
 
 import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY
 
+@IgnoreIf({ GradleContextualExecuter.vfsRetention })
 class VirtualFileSystemPartialInvalidationIntegrationTest extends AbstractIntegrationSpec {
 
     private static final INCUBATING_MESSAGE = "Partial virtual file system invalidation is an incubating feature"

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -25,7 +25,7 @@ import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_D
 import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY
 
 // The whole test makes no sense if there isn't a daemon to retain the state.
-@IgnoreIf({ GradleContextualExecuter.noDaemon })
+@IgnoreIf({ GradleContextualExecuter.noDaemon || GradleContextualExecuter.vfsRetention })
 class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultWatchingVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultWatchingVirtualFileSystem.java
@@ -88,7 +88,7 @@ public class DefaultWatchingVirtualFileSystem extends AbstractDelegatingVirtualF
                 // so we learn about new children spawning. If the directory
                 // has children, it would be watched through them already.
                 // This is here to make sure we also watch empty directories.
-                if (snapshot.getType() == FileType.Directory && Files.exists(path)) {
+                if (snapshot.getType() == FileType.Directory) {
                     watchedDirectories.add(path);
                 }
             });

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultWatchingVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultWatchingVirtualFileSystem.java
@@ -88,7 +88,7 @@ public class DefaultWatchingVirtualFileSystem extends AbstractDelegatingVirtualF
                 // so we learn about new children spawning. If the directory
                 // has children, it would be watched through them already.
                 // This is here to make sure we also watch empty directories.
-                if (snapshot.getType() == FileType.Directory) {
+                if (snapshot.getType() == FileType.Directory && Files.exists(path)) {
                     watchedDirectories.add(path);
                 }
             });

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultWatchingVirtualFileSystem.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultWatchingVirtualFileSystem.java
@@ -78,7 +78,7 @@ public class DefaultWatchingVirtualFileSystem extends AbstractDelegatingVirtualF
                     if (ancestor == null) {
                         break;
                     }
-                    if (Files.exists(ancestor)) {
+                    if (Files.isDirectory(ancestor)) {
                         watchedDirectories.add(ancestor);
                         break;
                     }


### PR DESCRIPTION
We want that all our integration tests pass with VFS retention enabled.