### PR TITLE
Add smoke test for test retry plugin

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -111,6 +111,10 @@ abstract class AbstractSmokeTest extends Specification {
         // https://plugins.gradle.org/plugin/com.google.protobuf
         static protobufPlugin = "0.8.10"
         static protobufTools = "3.11.1"
+
+        // https://plugins.gradle.org/plugin/org.gradle.test-retry
+        static testRetryPlugin = "1.0.0"
+
     }
 
     static class Versions implements Iterable<String> {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
@@ -16,12 +16,14 @@
 
 package org.gradle.smoketests
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Issue
 
 class TestRetryPluginSmokeTest extends AbstractSmokeTest {
 
+    @ToBeFixedForInstantExecution
     @Issue('https://plugins.gradle.org/plugin/org.gradle.test-retry')
     def 'test retry plugin'() {
         when:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
+
+class TestRetryPluginSmokeTest extends AbstractSmokeTest {
+
+    @Issue('https://plugins.gradle.org/plugin/org.gradle.test-retry')
+    def 'test retry plugin'() {
+        when:
+        sourceFile()
+        testSourceFile()
+        buildFile << """
+            plugins {
+                id "java"
+                id "org.gradle.test-retry" version "${TestedVersions.testRetryPlugin}"
+            }
+
+            ${jcenterRepository()}
+
+            dependencies {
+                testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
+                testImplementation("org.junit.jupiter:junit-jupiter-params:5.5.2")
+                testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.5.2")
+            }
+
+            test {
+                doFirst {
+                    file("marker.file").delete()
+                }
+            
+                useJUnitPlatform()
+                retry {
+                    maxRetries = 2
+                }
+            }"""
+
+        then:
+        runner('test').build()
+    }
+
+    private TestFile testSourceFile() {
+        file("src/test/java/org.acme/AcmeTest.java") << """
+package org.acme;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class SampleTests {
+
+    @Test
+    void successful() {
+        new Sample().otherFunctionality();
+    }
+
+    @Test
+    void flaky() {
+        new Sample().functionality();
+    }
+
+    @Test
+    void failing() {
+        fail();
+    }
+}
+        """
+    }
+
+    private TestFile sourceFile() {
+        file("src/main/java/org/acme/Acme.java") << """
+package org.acme;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Acme {
+
+    public void functionality() {
+        try {
+            Path marker = Paths.get("marker.file");
+            if (!Files.exists(marker)) {
+                Files.write(marker, "mark".getBytes());
+                throw new RuntimeException("fail me!");
+            }
+            Files.write(marker, "again".getBytes());
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
+        }
+    }
+
+    public void otherFunctionality() {
+        System.out.println("I'm doing things");
+    }
+}
+"""
+    }
+
+}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
@@ -53,9 +53,12 @@ class TestRetryPluginSmokeTest extends AbstractSmokeTest {
             }"""
 
         then:
-        def build = runner('test').buildAndFail()
-        build.task(":test").outcome == TaskOutcome.FAILED
-        def output = build.output
+        def result = runner('test').buildAndFail()
+        expectNoDeprecationWarnings(result)
+
+        and:
+        result.task(":test").outcome == TaskOutcome.FAILED
+        def output = result.output
         output.findAll("flaky\\(\\) FAILED").size() == 1
         output.findAll("failing\\(\\) FAILED").size() == 3
         output.contains("6 tests completed, 4 failed")


### PR DESCRIPTION
As the test retry plugin (https://plugins.gradle.org/plugin/org.gradle.test-retry) relies on some Test task internals, we should have a smoke test for it. All detailed functional test (against latest gradle nightlies and releases) is done in the test retry ci jobs (see https://builds.gradle.org/project/GradlePlugins_GradleTestRetryPlugin)  