### PR TITLE
Notify VFS about removed output when sources are removed

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipper.java
@@ -63,7 +63,6 @@ public class DefaultEmptySourceTaskSkipper implements EmptySourceTaskSkipper {
                 LOGGER.info("Skipping {} as it has no source files and no previous output files.", task);
                 skipOutcome = ExecutionOutcome.SHORT_CIRCUITED;
             } else {
-                outputChangeListener.beforeOutputChange();
                 OutputsCleaner outputsCleaner = new OutputsCleaner(
                     deleter,
                     buildOutputCleanupRegistry::isOutputOwnedByBuild,
@@ -71,6 +70,7 @@ public class DefaultEmptySourceTaskSkipper implements EmptySourceTaskSkipper {
                 );
                 for (FileCollectionFingerprint outputFingerprints : outputFileSnapshots.values()) {
                     try {
+                        outputChangeListener.beforeOutputChange(outputFingerprints.getRootHashes().keySet());
                         outputsCleaner.cleanupOutputs(outputFingerprints);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipperTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipperTest.groovy
@@ -74,7 +74,7 @@ class DefaultEmptySourceTaskSkipperTest extends Specification {
         1 * sourceFiles.empty >> true
 
         then:
-        1 * outputChangeListener.beforeOutputChange()
+        1 * outputChangeListener.beforeOutputChange(rootPaths(previousFile))
 
         then:
         1 * cleanupRegistry.isOutputOwnedByBuild(previousFile) >> true
@@ -103,7 +103,7 @@ class DefaultEmptySourceTaskSkipperTest extends Specification {
         1 * sourceFiles.empty >> true
 
         then:
-        1 * outputChangeListener.beforeOutputChange()
+        1 * outputChangeListener.beforeOutputChange(rootPaths(previousFile))
 
         then:
         1 * cleanupRegistry.isOutputOwnedByBuild(previousFile) >> false
@@ -148,7 +148,7 @@ class DefaultEmptySourceTaskSkipperTest extends Specification {
         1 * sourceFiles.empty >> true
 
         then:
-        1 * outputChangeListener.beforeOutputChange()
+        1 * outputChangeListener.beforeOutputChange(rootPaths(outputDir, outputFile))
 
         then:
         _ * cleanupRegistry.isOutputOwnedByBuild(subDir) >> true
@@ -187,7 +187,7 @@ class DefaultEmptySourceTaskSkipperTest extends Specification {
         1 * sourceFiles.empty >> true
 
         then:
-        1 * outputChangeListener.beforeOutputChange()
+        1 * outputChangeListener.beforeOutputChange(rootPaths(previousFile))
 
         then: "deleting the previous file fails"
         1 * cleanupRegistry.isOutputOwnedByBuild(previousFile) >> {
@@ -229,5 +229,9 @@ class DefaultEmptySourceTaskSkipperTest extends Specification {
         ImmutableSortedMap.<String, CurrentFileCollectionFingerprint>of(
             "output", fingerprinter.fingerprint(ImmutableFileCollection.of(files))
         )
+    }
+
+    Set<String> rootPaths(File... files) {
+        files*.absolutePath as Set
     }
 }

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -31,6 +31,7 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
     def setup() {
         // Make the first build in each test drop the VFS state
         executer.withArgument("-D$VFS_DROP_PROPERTY=true")
+        executer.requireIsolatedDaemons()
     }
 
     @ToBeFixedForInstantExecution


### PR DESCRIPTION
`outputChangeListener.beforeOutputChange()` with no arguments has no effect on the VFS when retention is enabled. This PR notifies the VFS about the outputs to be removed when the sources become empty, so it invalidates those locations.

Split out of #11639.