### PR TITLE
Add Artifactory plugin smoke test

### DIFF
--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/DetermineCommitId.kt
@@ -92,7 +92,7 @@ open class DetermineCommitId @Inject constructor(
         val execResult = execActionFactory.newExecAction().apply {
             workingDir = rootDir
             isIgnoreExitValue = true
-            commandLine = listOf("git", "log", "-1", "--format=%H")
+            commandLine = listOf("git", "log", "-1", "--format=%H", "--no-show-signature")
             if (OperatingSystem.current().isWindows) {
                 commandLine = listOf("cmd", "/c") + commandLine
             }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -115,6 +115,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK11_OR_EARLIER({
         JavaVersion.current() <= JavaVersion.VERSION_11
     }),
+    JDK12_OR_EARLIER({
+        JavaVersion.current() <= JavaVersion.VERSION_12
+    }),
     JDK12_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_12
     }),

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -68,7 +68,7 @@ abstract class AbstractSmokeTest extends Specification {
         static spotbugs = "3.0.0"
 
         // https://plugins.gradle.org/plugin/com.bmuschko.docker-java-application
-        static docker = "6.0.0"
+        static docker = "6.1.1"
 
         // https://plugins.gradle.org/plugin/com.bmuschko.tomcat
         static tomcat = "2.5"
@@ -115,6 +115,9 @@ abstract class AbstractSmokeTest extends Specification {
         // https://plugins.gradle.org/plugin/org.gradle.test-retry
         static testRetryPlugin = "1.0.0"
 
+        // https://plugins.gradle.org/plugin/com.jfrog.artifactory
+        static artifactoryPlugin = "4.12.0"
+        static artifactoryRepoOSSVersion = "6.16.0"
     }
 
     static class Versions implements Iterable<String> {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ArtifactoryAndDockerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ArtifactoryAndDockerSmokeTest.groovy
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.util.Requires
+
+import static org.gradle.util.TestPrecondition.JDK12_OR_EARLIER
+import static org.gradle.util.TestPrecondition.LINUX
+
+// Works on MacOS, but let's test on linux only where we know docker is available
+// Does not work on Java 13 as a dependency of the docker plugin (httpclient) is busted on 13
+@Requires([LINUX, JDK12_OR_EARLIER])
+class ArtifactoryAndDockerSmokeTest extends AbstractSmokeTest {
+
+    @ToBeFixedForInstantExecution
+    def 'artifactory with docker and plugin upload'() {
+        when:
+        buildFile << """
+            plugins {
+                id 'java-library'
+                id 'maven-publish'
+                id 'com.bmuschko.docker-remote-api' version '${TestedVersions.docker}'
+                id 'com.jfrog.artifactory' version '${TestedVersions.artifactoryPlugin}'
+            }
+
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStopContainer
+            import com.bmuschko.gradle.docker.tasks.container.extras.DockerLivenessContainer
+
+            group = 'org.test'
+            version = '0.0.1'
+
+            task pullArtifactoryImage(type: DockerPullImage) {
+                image = 'docker.bintray.io/jfrog/artifactory-oss:${TestedVersions.artifactoryRepoOSSVersion}'
+            }
+
+
+            task createArtifactory(type: DockerCreateContainer) {
+                dependsOn pullArtifactoryImage
+                targetImageId(pullArtifactoryImage.getImage())
+                hostConfig.portBindings = ['8081:8081']
+                hostConfig.autoRemove = true
+            }
+
+            task stopArtifactory(type: DockerStopContainer) {
+                targetContainerId(createArtifactory.getContainerId())
+            }
+
+            task startArtifactory(type: DockerStartContainer) {
+                dependsOn createArtifactory
+                targetContainerId(createArtifactory.getContainerId())
+                finalizedBy stopArtifactory
+            }
+
+            task awaitArtifactoryStart(type: DockerLivenessContainer) {
+                dependsOn startArtifactory
+                // So this is a first check, but not enough
+                livenessProbe(60000, 5000, '### Artifactory successfully started')
+                targetContainerId(createArtifactory.getContainerId())
+                finalizedBy stopArtifactory
+                doLast {
+                    // Just need to wait till it tells us we are not authenticated
+                    def pingUrl = new URL("http://localhost:8081/artifactory/api/system/ping")
+                    def connection = pingUrl.openConnection()
+                    while (connection.responseCode != 401) {
+                        // retry
+                        Thread.sleep(500)
+                        connection = pingUrl.openConnection()
+                    }
+                }
+            }
+
+            publishing {
+                publications {
+                    mavenJava(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+
+            artifactory {
+                contextUrl = 'http://localhost:8081/artifactory'
+                publish {
+                    repository {
+                        repoKey = 'example-repo-local'
+                        username = 'admin'
+                        password = 'password'
+                        maven = true
+
+                    }
+                    defaults {
+                        publications('mavenJava')
+                    }
+                }
+            }
+
+            artifactoryDeploy.dependsOn awaitArtifactoryStart
+            artifactoryDeploy.finalizedBy stopArtifactory
+        """
+
+        then:
+        runner('artifactoryPublish').build()
+    }
+}


### PR DESCRIPTION
This also includes a deeper usage of the docker plugin for spinning the
Artifactory instance used by the test