### PR TITLE
Notify VFS about removed stale outputs

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CleanupStaleOutputsExecuter implements TaskExecuter {
 
@@ -82,7 +83,11 @@ public class CleanupStaleOutputsExecuter implements TaskExecuter {
             }
         }
         if (!filesToDelete.isEmpty()) {
-            outputChangeListener.beforeOutputChange();
+            outputChangeListener.beforeOutputChange(
+                filesToDelete.stream()
+                    .map(File::getAbsolutePath)
+                    .collect(Collectors.toList())
+            );
             buildOperationExecutor.run(new RunnableBuildOperation() {
                 @Override
                 public void run(BuildOperationContext context) {

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -265,6 +265,46 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         outputFile.assertDoesNotExist()
     }
 
+    @ToBeFixedForInstantExecution
+    def "detects when stale outputs are removed"() {
+        buildFile << """
+            apply plugin: 'base'
+            
+            task producer {
+                inputs.files("input.txt")
+                outputs.file("build/output.txt")
+                doLast {
+                    file("build/output.txt").text = file("input.txt").text
+                }
+            }            
+        """
+
+        file("input.txt").text = "input"
+        def outputFile = file("build/output.txt")
+
+        when:
+        withRetention().run ":producer"
+        then:
+        executedAndNotSkipped(":producer")
+        outputFile.assertExists()
+
+        when:
+        invalidateBuildOutputCleanupState()
+        waitForChangesToBePickedUp()
+        withRetention().run ":producer", "--info"
+        then:
+        output.contains("Deleting stale output file: ${outputFile.absolutePath}")
+        executedAndNotSkipped(":producer")
+        outputFile.assertExists()
+    }
+
+    // This makes sure the next Gradle run starts with a clean BuildOutputCleanupRegistry
+    private void invalidateBuildOutputCleanupState() {
+        file(".gradle/buildOutputCleanup/cache.properties").text = """
+            gradle.version=1.0
+        """
+    }
+
     private def withRetention() {
         executer.withArgument  "-D${VFS_RETENTION_ENABLED_PROPERTY}"
         this


### PR DESCRIPTION
`CleanupStaleOutputsExecuter` uses `beforeOutputChange()` without arguments, that has no effects on the VFS. Therefore, when stale outputs are removed those changes go undetected.

Split out of #11719.