### PR TITLE
Kotlin DSL Tooling Builders don't clutter output

### DIFF
--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -134,7 +134,7 @@ If the above doesn't work and you suspect an issue with the Kotlin DSL script ed
 From version 5.1 onwards, the log directory is cleaned up automatically.
 It is checked periodically (at most every 24 hours) and log files are deleted if they haven’t been used for 7 days.
 
-If the above isn't enough to pinpoint the problem, you can enable the `org.gradle.kotlin.dsl.logging.tapi` system property in your IDE. This will cause the Gradle Daemon to log extra information in its log file located in `&HOME/.gradle/daemons`. In IntelliJ IDEA this can be done by opening `Help > Edit Custom VM Options...` and adding `-Dorg.gradle.kotlin.dsl.logging.tapi=true`.
+If the above isn't enough to pinpoint the problem, you can enable the `org.gradle.kotlin.dsl.logging.tapi` system property in your IDE. This will cause the Gradle Daemon to log extra information in its log file located in `$HOME/.gradle/daemons`. In IntelliJ IDEA this can be done by opening `Help > Edit Custom VM Options...` and adding `-Dorg.gradle.kotlin.dsl.logging.tapi=true`.
 
 For IDE problems outside of the Kotlin DSL script editor, please open issues in the corresponding IDE's issue tracker:
 

--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -134,7 +134,7 @@ If the above doesn't work and you suspect an issue with the Kotlin DSL script ed
 From version 5.1 onwards, the log directory is cleaned up automatically.
 It is checked periodically (at most every 24 hours) and log files are deleted if they haven’t been used for 7 days.
 
-If the above isn't enough to pinpoint the problem, you can enable the `org.gradle.kotlin.dsl.logging.tapi` system property in your IDE. This will cause the Gradle Daemon to log extra information in its log file located in `$HOME/.gradle/daemons`. In IntelliJ IDEA this can be done by opening `Help > Edit Custom VM Options...` and adding `-Dorg.gradle.kotlin.dsl.logging.tapi=true`.
+If the above isn't enough to pinpoint the problem, you can enable the `org.gradle.kotlin.dsl.logging.tapi` system property in your IDE. This will cause the Gradle Daemon to log extra information in its log file located in `$HOME/.gradle/daemon`. In IntelliJ IDEA this can be done by opening `Help > Edit Custom VM Options...` and adding `-Dorg.gradle.kotlin.dsl.logging.tapi=true`.
 
 For IDE problems outside of the Kotlin DSL script editor, please open issues in the corresponding IDE's issue tracker:
 

--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -134,6 +134,8 @@ If the above doesn't work and you suspect an issue with the Kotlin DSL script ed
 From version 5.1 onwards, the log directory is cleaned up automatically.
 It is checked periodically (at most every 24 hours) and log files are deleted if they haven’t been used for 7 days.
 
+If the above isn't enough to pinpoint the problem, you can enable the `org.gradle.kotlin.dsl.logging.tapi` system property in your IDE. This will cause the Gradle Daemon to log extra information in its log file located in `&HOME/.gradle/daemons`. In IntelliJ IDEA this can be done by opening `Help > Edit Custom VM Options...` and adding `-Dorg.gradle.kotlin.dsl.logging.tapi=true`.
+
 For IDE problems outside of the Kotlin DSL script editor, please open issues in the corresponding IDE's issue tracker:
 
 * link:[JetBrains's IDEA issue tracker],

--- a/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -167,9 +167,14 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
             (modelRequestProject.findProperty(KotlinBuildScriptModel.SCRIPT_GRADLE_PROPERTY_NAME) as? String)?.let(::canonicalFile),
             modelRequestProject.findProperty(KotlinDslModelsParameters.CORRELATION_ID_GRADLE_PROPERTY_NAME) as? String
         )
+}
 
-    private
-    fun log(message: String) = println(message)
+
+internal
+fun log(message: String) {
+    if (System.getProperty("org.gradle.kotlin.dsl.logging.tapi") == "true") {
+        println(message)
+    }
 }
 
 

--- a/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -117,10 +117,10 @@ object KotlinDslScriptsModelBuilder : ToolingModelBuilder {
         val parameter = project.parameterFromRequest()
         try {
             return buildFor(parameter, project).also {
-                println("$parameter => $it - took ${timer.elapsed}")
+                log("$parameter => $it - took ${timer.elapsed}")
             }
         } catch (ex: Exception) {
-            println("$parameter => $ex - took ${timer.elapsed}")
+            log("$parameter => $ex - took ${timer.elapsed}")
             throw ex
         }
     }


### PR DESCRIPTION
Kotlin DSL Tooling Builders do print diagnostic information to stdout.
It ends up in the daemon log files, for diagnostics.
But it also clutters output in IDEs querying for script dependencies during build import.

This PR is about removing the noise in output in IDEs.