### PR TITLE
Notify VFS about removed outputs for non-incremental execution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -163,7 +163,7 @@ public class ExecutionGradleServices {
             new TimeoutStep<>(timeoutHandler,
             new CancelExecutionStep<>(cancellationToken,
             new ResolveInputChangesStep<>(
-            new CleanupOutputsStep<>(deleter,
+            new CleanupOutputsStep<>(deleter, outputChangeListener,
             new ExecuteStep<>(
         ))))))))))))))))))))));
         // @formatter:on

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -157,7 +157,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         new CatchExceptionStep<>(
         new CancelExecutionStep<>(cancellationToken,
         new ResolveInputChangesStep<>(
-        new CleanupOutputsStep<>(deleter,
+        new CleanupOutputsStep<>(deleter, outputChangeListener,
         new ExecuteStep<>(
     )))))))))))))))
     // @formatter:on

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -58,7 +58,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.internal.hash.ChecksumService;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
@@ -156,6 +155,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter;
 import org.gradle.internal.fingerprint.overlap.OverlappingOutputDetector;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.id.UniqueId;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -275,7 +275,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 new CatchExceptionStep<>(
                 new TimeoutStep<>(timeoutHandler,
                 new ResolveInputChangesStep<>(
-                new CleanupOutputsStep<>(deleter,
+                new CleanupOutputsStep<>(deleter, outputChangeListener,
                 new ExecuteStep<>(
             ))))))))))))))));
             // @formatter:on

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -150,7 +150,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
             new CreateOutputsStep<>(
             new CatchExceptionStep<>(
             new ResolveInputChangesStep<>(
-            new CleanupOutputsStep<>(deleter,
+            new CleanupOutputsStep<>(deleter, outputChangeListener,
             new ExecuteStep<>(
         ))))))))))))))))
         // @formatter:on

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSortedMap
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.ImmutableFileCollection
 import org.gradle.internal.execution.InputChangesContext
+import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.execution.Result
 import org.gradle.internal.execution.UnitOfWork.OutputPropertyVisitor
 import org.gradle.internal.execution.history.AfterPreviousExecutionState
@@ -36,9 +37,10 @@ class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements Fi
     def afterPreviousExecution = Mock(AfterPreviousExecutionState)
     def beforeExecutionState = Mock(BeforeExecutionState)
     def delegateResult = Mock(Result)
+    def outputChangeListener = Mock(OutputChangeListener)
     def deleter = TestFiles.deleter()
 
-    def step = new CleanupOutputsStep<>(deleter, delegate)
+    def step = new CleanupOutputsStep<>(deleter, outputChangeListener, delegate)
 
     @Override
     protected InputChangesContext createContext() {
@@ -189,6 +191,8 @@ class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements Fi
         }
         _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecution)
         1 * afterPreviousExecution.outputFileProperties >> ImmutableSortedMap.<String, FileCollectionFingerprint>of("dir", outputs.dirFingerprint, "file", outputs.fileFingerprint)
+        1 * outputChangeListener.beforeOutputChange(outputs.dirFingerprint.rootHashes.keySet())
+        1 * outputChangeListener.beforeOutputChange(outputs.fileFingerprint.rootHashes.keySet())
     }
 
     void cleanupExclusiveOutputs(WorkOutputs outputs, boolean incrementalExecution = false) {


### PR DESCRIPTION
The previous outputs can be in a different place for the cleanup, e.g.
when the task is re-configured. Therefore, the VFS needs to be informed
that something will change there.

Split out of #11719.