### PR TITLE
Re-add RegularFileSnapshot.getMetadata()

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
@@ -46,6 +46,10 @@ public class RegularFileSnapshot extends AbstractCompleteFileSystemLocationSnaps
         return contentHash;
     }
 
+    public FileMetadata getMetadata() {
+        return metadata;
+    }
+
     @Override
     public boolean isContentAndMetadataUpToDate(CompleteFileSystemLocationSnapshot other) {
         if (!(other instanceof RegularFileSnapshot)) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
@@ -46,6 +46,7 @@ public class RegularFileSnapshot extends AbstractCompleteFileSystemLocationSnaps
         return contentHash;
     }
 
+    // Used by the Maven caching client. Do not remove
     public FileMetadata getMetadata() {
         return metadata;
     }


### PR DESCRIPTION
The getter is used in the Maven cache client.