### PR TITLE
Stop when max number of instant execution problems is reached

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
@@ -70,7 +70,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         def jsFile = reportDir.file("instant-execution-report-data.js")
         jsFile.isFile()
         outputContains """
-            3 instant execution problems found:
+            6 instant execution problems were found, 3 of which seem unique:
               - field 'gradle' from type 'SomeBean': cannot serialize object of type 'org.gradle.invocation.DefaultGradle', a subtype of 'org.gradle.api.invocation.Gradle', as these are not supported with instant execution.
               - field 'gradle' from type 'NestedBean': cannot serialize object of type 'org.gradle.invocation.DefaultGradle', a subtype of 'org.gradle.api.invocation.Gradle', as these are not supported with instant execution.
               - field 'project' from type 'NestedBean': cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject', a subtype of 'org.gradle.api.Project', as these are not supported with instant execution.
@@ -114,7 +114,8 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         def reportDir = stateDirForTasks("foo")
         def jsFile = reportDir.file("instant-execution-report-data.js")
         numberOfProblemsIn(jsFile) == expectedNumberOfProblems
-        outputContains "$expectedNumberOfProblems instant execution problems found:"
+        def problemOrProblems = expectedNumberOfProblems == 1 ? "problem was" : "problems were"
+        outputContains "$expectedNumberOfProblems instant execution $problemOrProblems found"
         failureHasCause "Maximum number of instant execution problems has been exceeded"
 
         where:
@@ -143,7 +144,7 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         def reportDir = stateDirForTasks("foo")
         def jsFile = reportDir.file("instant-execution-report-data.js")
         numberOfProblemsIn(jsFile) == 1
-        outputContains "1 instant execution problems found:"
+        outputContains "1 instant execution problem was found"
         failureDescriptionStartsWith "Problems found while caching instant execution state"
     }
 

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionReportIntegrationTest.groovy
@@ -116,11 +116,11 @@ class InstantExecutionReportIntegrationTest extends AbstractInstantExecutionInte
         numberOfProblemsIn(jsFile) == expectedNumberOfProblems
         def problemOrProblems = expectedNumberOfProblems == 1 ? "problem was" : "problems were"
         outputContains "$expectedNumberOfProblems instant execution $problemOrProblems found"
-        failureHasCause "Maximum number of instant execution problems has been exceeded"
+        failureHasCause "Maximum number of instant execution problems has been reached"
 
         where:
         maxProblems << [0, 1, 2]
-        expectedNumberOfProblems = maxProblems + 1
+        expectedNumberOfProblems = Math.max(1, maxProblems)
     }
 
     def "can request to fail on problems"() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionException.kt
@@ -31,7 +31,7 @@ class InstantExecutionErrorsException : InstantExecutionException(
 
 
 class TooManyInstantExecutionProblemsException : InstantExecutionException(
-    "Maximum number of instant execution problems has been exceeded. This behavior can be adjusted via -D${SystemProperties.maxProblems}=<integer>."
+    "Maximum number of instant execution problems has been reached. This behavior can be adjusted via -D${SystemProperties.maxProblems}=<integer>."
 )
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
@@ -139,7 +139,11 @@ class InstantExecutionReport(
             propertyDescriptionFor(it) to it.message
         }
         return StringBuilder().apply {
-            appendln("${uniquePropertyProblems.size} instant execution problems found:")
+            val totalProblemCount = problems.size
+            val problemOrProblems = if (totalProblemCount == 1) "problem was" else "problems were"
+            val uniqueProblemCount = uniquePropertyProblems.size
+            val seemsOrSeem = if (uniqueProblemCount == 1) "seems" else "seem"
+            appendln("$totalProblemCount instant execution $problemOrProblems found, $uniqueProblemCount of which $seemsOrSeem unique:")
             uniquePropertyProblems.keys.forEach { (property, message) ->
                 append("  - ")
                 append(property)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionReport.kt
@@ -55,7 +55,7 @@ class InstantExecutionReport(
 
     fun add(problem: PropertyProblem) {
         problems.add(problem)
-        if (problems.size > maxProblems) {
+        if (problems.size >= maxProblems) {
             throw TooManyInstantExecutionProblemsException()
         }
     }


### PR DESCRIPTION
Instead of exceeded. This makes the report less confusing as the number of reported problems can no longer be greater than the set maximum.