### PR TITLE
Remove Maven API usage from javadoc

### DIFF
--- a/buildSrc/subprojects/docs/src/main/groovy/org/gradle/gradlebuild/docs/GradleJavadocsPlugin.java
+++ b/buildSrc/subprojects/docs/src/main/groovy/org/gradle/gradlebuild/docs/GradleJavadocsPlugin.java
@@ -77,7 +77,7 @@ public class GradleJavadocsPlugin implements Plugin<Project> {
             options.addStringOption("stylesheetfile", javadocs.getJavadocCss().get().getAsFile().getAbsolutePath());
             options.addStringOption("source", "8");
             // TODO: This breaks the provider
-            options.links(javadocs.getJavaApi().get().toString(), javadocs.getGroovyApi().get().toString(), javadocs.getMavenApi().get().toString());
+            options.links(javadocs.getJavaApi().get().toString(), javadocs.getGroovyApi().get().toString());
 
             task.source(extension.getDocumentedSource());
 

--- a/buildSrc/subprojects/docs/src/main/groovy/org/gradle/gradlebuild/docs/Javadocs.java
+++ b/buildSrc/subprojects/docs/src/main/groovy/org/gradle/gradlebuild/docs/Javadocs.java
@@ -35,11 +35,6 @@ public abstract class Javadocs {
      */
     public abstract Property<URI> getGroovyApi();
     /**
-     * Link to Maven API to use when generating Javadoc
-     */
-    public abstract Property<URI> getMavenApi();
-
-    /**
      * The CSS file to style Javadocs with
      */
     public abstract RegularFileProperty getJavadocCss();

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -94,7 +94,6 @@ gradleDocumentation {
     javadocs {
         javaApi = project.uri("https://docs.oracle.com/javase/8/docs/api")
         groovyApi = project.uri("https://docs.groovy-lang.org/docs/groovy-${groovyVersion}/html/gapi")
-        mavenApi = project.uri("https://maven.apache.org/ref/${libraries.maven3.version}/maven-model/apidocs")
     }
 }
 
@@ -193,7 +192,7 @@ samples {
                 from(templates.javaApplicationAsSubproject)
                 from(templates.javaJunit4TestForApplication)
                 from(templates.javaJunit4IntegrationTestForApplication)
-                
+
                 from(templates.javaListLibraryAsSubproject)
                 from(templates.javaJunit4TestForListLibrary)
                 from(templates.javaJunit4IntegrationTestForListLibrary)

--- a/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/MavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/MavenPom.java
@@ -157,7 +157,7 @@ public interface MavenPom {
     List<?> getDependencies();
 
     /**
-     * Returns the underlying native Maven {@link org.apache.maven.model.Model} object. The MavenPom object
+     * Returns the underlying native Maven <a href="https://maven.apache.org/ref/3.0.4/maven-model/apidocs/org/apache/maven/model/Model.html">org.apache.maven.model.Model</a> object. The MavenPom object
      * delegates all the configuration information to this object. There Gradle MavenPom objects provides
      * delegation methods just for setting the groupId, artifactId, version and packaging. For all other
      * elements, either use the model object or {@link #project(groovy.lang.Closure)}.
@@ -167,7 +167,7 @@ public interface MavenPom {
     Object getModel();
 
     /**
-     * Sets the underlying native Maven {@link org.apache.maven.model.Model} object.
+     * Sets the underlying native Maven <a href="https://maven.apache.org/ref/3.0.4/maven-model/apidocs/org/apache/maven/model/Model.html">org.apache.maven.model.Model</a> object.
      *
      * @return this
      * @see #getModel()


### PR DESCRIPTION
Previously we use -link https://maven.apache.org/ref/3.0.4/maven-model/apidocs/ in javadoc,
which failed the build upon network issues. This commit removes such usages.