### PR TITLE
Serialize zip and tar trees and some more CopySpec details to the instant execution cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveTaskPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveTaskPermissionsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
@@ -98,7 +97,6 @@ class ArchiveTaskPermissionsIntegrationTest extends AbstractIntegrationSpec {
 
     @Requires(TestPrecondition.FILE_PERMISSIONS)
     @Unroll
-    @ToBeFixedForInstantExecution
     def "file and directory permissions are preserved for unpacked #taskName archives"() {
         given:
         TestFile testDir = createDir('testdir') {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -57,7 +57,6 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         result.groupedOutput.task(":buildSrc:compileGroovy").outcome == "FROM-CACHE"
     }
 
-    @ToBeFixedForInstantExecution
     def "tasks stay cached after buildSrc with custom Groovy task is rebuilt"() {
         configureCacheForBuildSrc()
         file("buildSrc/src/main/groovy/CustomTask.groovy") << customGroovyTask()
@@ -202,7 +201,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             @CacheableTask
             class CustomTask extends DefaultTask {
                 @OutputFiles Iterable<File> out
-                
+
                 @TaskAction
                 void execute() {
                     out.eachWithIndex { file, index ->
@@ -544,7 +543,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
                     project.delete(missing)
                 }
             }
-            
+
             task customTask(type: CustomTask)
         """
 
@@ -642,10 +641,10 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
                     @InputFile
                     @PathSensitive(PathSensitivity.NONE)
                     File inputFile
-    
+
                     @OutputFile
                     File outputFile
-    
+
                     @TaskAction
                     void action() {
                         outputFile.text = inputFile.text
@@ -911,7 +910,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
                 task test {
                     def outputFile = file("\${project.buildDir}/output.txt")
                     outputs.cacheIf { true }
-                    outputs.file(outputFile).withPropertyName("outputFile") 
+                    outputs.file(outputFile).withPropertyName("outputFile")
                     doFirst {
                         Thread.sleep(new Random().nextInt(30))
                         outputFile.text = "output"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -57,6 +57,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         result.groupedOutput.task(":buildSrc:compileGroovy").outcome == "FROM-CACHE"
     }
 
+    @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
     def "tasks stay cached after buildSrc with custom Groovy task is rebuilt"() {
         configureCacheForBuildSrc()
         file("buildSrc/src/main/groovy/CustomTask.groovy") << customGroovyTask()
@@ -195,7 +196,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         skipped ":customTask"
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
     def "cacheable task with multiple output properties with matching cardinality get cached"() {
         buildFile << """
             @CacheableTask
@@ -520,7 +521,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
     def "missing #type from annotation API is not cached"() {
         given:
         file("input.txt") << "data"
@@ -715,7 +716,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
             "  Additional implementation type was loaded with an unknown classloader (class 'CustomTaskAction')."
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
     def "task stays up-to-date after loaded from cache"() {
         file("input.txt").text = "input"
         buildFile << defineProducerTask()
@@ -789,7 +790,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         skipped ":producer"
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(ToBeFixedForInstantExecution.Skip.FLAKY)
     def "downstream task stays cached when upstream task is loaded from cache"() {
         file("input.txt").text = "input"
         buildFile << defineProducerTask()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -108,7 +108,7 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             task tar(type: Tar) {
                 reproducibleFileOrder = true
-                preserveFileTimestamps = false  
+                preserveFileTimestamps = false
                 compression = '${compression}'
                 from 'dir1', 'dir2', 'dir3'
                 destinationDirectory = buildDir
@@ -142,7 +142,7 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
                 }
                 from('dir1') {
                     into 'dir1'
-                }     
+                }
                 from 'dir1/file13.txt'
                 from 'dir1/file11.txt'
                 destinationDirectory = buildDir
@@ -174,7 +174,6 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
         fileExtension = taskName
     }
 
-    @ToBeFixedForInstantExecution
     def "#taskName can use zipTree and tarTree"() {
         given:
         createTestFiles()
@@ -204,7 +203,7 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
 
                 from zipTree(aZip.archiveFile)
                 from tarTree(aTar.archiveFile)
-                
+
                 dependsOn aZip, aTar
 
                 fileMode = 0644

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipFileTree.java
@@ -57,6 +57,11 @@ public class ZipFileTree implements MinimalFileTree, ArchiveFileTree {
     }
 
     @Override
+    public String toString() {
+        return getDisplayName();
+    }
+
+    @Override
     public String getDisplayName() {
         return String.format("ZIP '%s'", zipFile);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -94,9 +94,10 @@ public class DefaultCopySpec implements CopySpecInternal {
         this.patternSet = patternSet;
     }
 
-    public DefaultCopySpec(FileResolver resolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, FileCollection source, PatternSet patternSet, Collection<CopySpecInternal> children) {
+    public DefaultCopySpec(FileResolver resolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, @Nullable String destPath, FileCollection source, PatternSet patternSet, Collection<CopySpecInternal> children) {
         this(resolver, fileCollectionFactory, instantiator, patternSet);
         sourcePaths.add(source);
+        destDir = destPath;
         for (CopySpecInternal child : children) {
             addChildSpec(child);
         }
@@ -228,6 +229,10 @@ public class DefaultCopySpec implements CopySpecInternal {
         return sourcePaths;
     }
 
+    @Nullable
+    public String getDestPath() {
+        return destDir == null ? null : PATH_NOTATION_PARSER.parseNotation(destDir);
+    }
 
     @Override
     public CopySpec into(Object destDir) {
@@ -538,11 +543,11 @@ public class DefaultCopySpec implements CopySpecInternal {
                 parentPath = parentResolver.getDestPath();
             }
 
-            if (destDir == null) {
+            String path = DefaultCopySpec.this.getDestPath();
+            if (path == null) {
                 return parentPath;
             }
 
-            String path = PATH_NOTATION_PARSER.parseNotation(destDir);
             if (path.startsWith("/") || path.startsWith(File.separator)) {
                 return RelativePath.parse(false, path);
             }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultSingletonFileTree.java
@@ -38,6 +38,11 @@ public class DefaultSingletonFileTree extends AbstractSingletonFileTree {
     }
 
     @Override
+    public String toString() {
+        return getDisplayName();
+    }
+
+    @Override
     public String getDisplayName() {
         return String.format("file '%s'", file);
     }

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":fileCollections"))
     implementation(project(":dependencyManagement"))
     implementation(project(":persistentCache"))
+    implementation(project(":kotlinDsl"))
     // TODO - move the isolatable serializer to model-core to live with the isolatable infrastructure
     implementation(project(":workers"))
     // TODO - it might be good to allow projects to contribute state to save and restore, rather than have this project know about everything

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionScriptTaskDefinitionIntegrationTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.instantexecution
 
 import org.gradle.api.tasks.TasksWithInputsAndOutputs
 
-class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutionIntegrationTest implements TasksWithInputsAndOutputs {
+class InstantExecutionScriptTaskDefinitionIntegrationTest extends AbstractInstantExecutionIntegrationTest implements TasksWithInputsAndOutputs {
 
-    def "task can have doFirst/doLast groovy script closures"() {
+    def "task can have doFirst/doLast Groovy script closures"() {
 
         given:
         settingsFile << """
@@ -83,7 +83,7 @@ class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutio
         result.groupedOutput.task(":b:some").assertOutputContains("FIRST").assertOutputContains("LAST")
     }
 
-    def "task can have doFirst/doLast anonymous script actions"() {
+    def "task can have doFirst/doLast anonymous Groovy script actions"() {
 
         given:
         buildFile << """
@@ -135,7 +135,7 @@ class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutio
         result.groupedOutput.task(":other").assertOutputContains("OTHER")
     }
 
-    def "task can have doFirst/doLast kotlin script lambdas"() {
+    def "task can have doFirst/doLast Kotlin script lambdas"() {
 
         given:
         settingsFile << """
@@ -151,7 +151,7 @@ class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutio
                         println("LAST")
                     }
                 }
-    
+
                 tasks.register("other") {
                     doFirst {
                         println("OTHER")
@@ -199,7 +199,26 @@ class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutio
         result.groupedOutput.task(":b:some").assertOutputContains("FIRST").assertOutputContains("LAST")
     }
 
-    def "task with type declared in Groovy DSL script is up-to-date when no inputs have changed"() {
+    def "warns when closure defined in Kotlin script captures state from the script"() {
+        given:
+        buildKotlinFile << """
+            val message = "message"
+            tasks.register("some") {
+                doFirst {
+                    println(message)
+                }
+            }
+        """
+
+        when:
+        instantRun ":some"
+
+        then:
+        outputContains("instant-execution > cannot serialize object of type 'Build_gradle', a subtype of 'org.gradle.kotlin.dsl.KotlinScript', as these are not supported with instant execution.")
+        noExceptionThrown()
+    }
+
+    def "task with type declared in Groovy script is up-to-date when no inputs have changed"() {
 
         given:
         taskTypeWithOutputFileProperty()
@@ -232,7 +251,7 @@ class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutio
         outputFile.assertIsFile()
     }
 
-    def "task with type declared in Kotlin DSL script is up-to-date when no inputs have changed"() {
+    def "task with type declared in Kotlin script is up-to-date when no inputs have changed"() {
 
         given:
         kotlinTaskTypeWithOutputFileProperty()
@@ -265,7 +284,7 @@ class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutio
         outputFile.assertIsFile()
     }
 
-    def "name conflicts of types declared in groovy scripts"() {
+    def "name conflicts of types declared in Groovy scripts"() {
 
         given:
         settingsFile << """include("a", "b")"""
@@ -297,7 +316,7 @@ class InstantExecutionTaskActionsIntegrationTest extends AbstractInstantExecutio
         outputContains("B")
     }
 
-    def "name conflicts of types declared in kotlin scripts"() {
+    def "name conflicts of types declared in Kotlin scripts"() {
 
         given:
         settingsFile << """include("a", "b")"""

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -17,6 +17,7 @@
 package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.Project
+import org.gradle.api.Script
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.initialization.Settings
@@ -65,6 +66,7 @@ import org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALIZER
 import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.internal.state.ManagedFactoryRegistry
+import org.gradle.kotlin.dsl.*
 import org.gradle.process.ExecOperations
 import org.gradle.process.internal.ExecActionFactory
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
@@ -104,6 +106,8 @@ class Codecs(
         bind(unsupported<Settings>())
         bind(unsupported<TaskContainer>())
         bind(unsupported<ConfigurationContainer>())
+        bind(unsupported<KotlinScript>())
+        bind(unsupported<Script>())
 
         baseTypes()
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -16,14 +16,18 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
+import org.gradle.api.tasks.util.PatternSet
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.readList
+import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.internal.reflect.Instantiator
-import java.io.File
 
 
 internal
@@ -34,24 +38,15 @@ class DefaultCopySpecCodec(
 ) : Codec<DefaultCopySpec> {
 
     override suspend fun WriteContext.encode(value: DefaultCopySpec) {
-        val allSourcePaths = ArrayList<File>()
-        collectSourcePathsFrom(value, allSourcePaths)
-        write(allSourcePaths)
+        write(value.resolveSourceFiles())
+        write(value.patterns)
+        writeCollection(value.children)
     }
 
     override suspend fun ReadContext.decode(): DefaultCopySpec {
-        @Suppress("unchecked_cast")
-        val sourceFiles = read() as List<File>
-        val copySpec = DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator)
-        copySpec.from(sourceFiles)
-        return copySpec
-    }
-
-    private
-    fun collectSourcePathsFrom(copySpec: DefaultCopySpec, files: MutableList<File>) {
-        files.addAll(copySpec.resolveSourceFiles())
-        for (child in copySpec.children) {
-            collectSourcePathsFrom(child as DefaultCopySpec, files)
-        }
+        val sourceFiles = read() as FileCollection
+        val patterns = read() as PatternSet
+        val children = readList() as List<CopySpecInternal>
+        return DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, sourceFiles, patterns, children)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -38,15 +38,17 @@ class DefaultCopySpecCodec(
 ) : Codec<DefaultCopySpec> {
 
     override suspend fun WriteContext.encode(value: DefaultCopySpec) {
+        write(value.destPath)
         write(value.resolveSourceFiles())
         write(value.patterns)
         writeCollection(value.children)
     }
 
     override suspend fun ReadContext.decode(): DefaultCopySpec {
+        val destPath = read() as String?
         val sourceFiles = read() as FileCollection
         val patterns = read() as PatternSet
         val children = readList() as List<CopySpecInternal>
-        return DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, sourceFiles, patterns, children)
+        return DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, destPath, sourceFiles, patterns, children)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCollectionCodec.kt
@@ -100,7 +100,7 @@ class CollectingVisitor : FileCollectionStructureVisitor {
     }
 
     override fun visitFileTreeBackedByFile(file: File, fileTree: FileTreeInternal) {
-        elements.addAll(fileTree)
+        elements.add(fileTree)
     }
 }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -19,7 +19,10 @@ package org.gradle.instantexecution.serialization.codecs
 import org.gradle.api.internal.file.DefaultCompositeFileTree
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionStructureVisitor
+import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.FileTreeInternal
+import org.gradle.api.internal.file.archive.TarFileTree
+import org.gradle.api.internal.file.archive.ZipFileTree
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
 import org.gradle.api.tasks.util.PatternSet
@@ -31,7 +34,19 @@ import java.io.File
 
 
 private
-typealias FileTreeSpec = Pair<File, PatternSet>
+sealed class FileTreeSpec
+
+
+private
+class DirectoryTreeSpec(val file: File, val patterns: PatternSet) : FileTreeSpec()
+
+
+private
+class ZipTreeSpec(val file: File) : FileTreeSpec()
+
+
+private
+class TarTreeSpec(val file: File) : FileTreeSpec()
 
 
 internal
@@ -46,7 +61,11 @@ class FileTreeCodec(
     override suspend fun ReadContext.decode(): FileTreeInternal? =
         DefaultCompositeFileTree(
             read()!!.uncheckedCast<List<FileTreeSpec>>().map {
-                FileTreeAdapter(directoryFileTreeFactory.create(it.first, it.second))
+                when (it) {
+                    is DirectoryTreeSpec -> FileTreeAdapter(directoryFileTreeFactory.create(it.file, it.patterns))
+                    is ZipTreeSpec -> isolate.owner.service(FileOperations::class.java).zipTree(it.file) as FileTreeInternal
+                    is TarTreeSpec -> isolate.owner.service(FileOperations::class.java).tarTree(it.file) as FileTreeInternal
+                }
             }
         )
 
@@ -68,9 +87,21 @@ class FileTreeCodec(
         override fun visitGenericFileTree(fileTree: FileTreeInternal) = throw UnsupportedOperationException()
 
         override fun visitFileTree(root: File, patterns: PatternSet, fileTree: FileTreeInternal) {
-            roots.add(root to patterns)
+            roots.add(DirectoryTreeSpec(root, patterns))
         }
 
-        override fun visitFileTreeBackedByFile(file: File, fileTree: FileTreeInternal) = throw UnsupportedOperationException()
+        override fun visitFileTreeBackedByFile(file: File, fileTree: FileTreeInternal) {
+            if (fileTree is FileTreeAdapter) {
+                val tree = fileTree.tree
+                if (tree is ZipFileTree) {
+                    roots.add(ZipTreeSpec(tree.backingFile!!))
+                    return
+                } else if (tree is TarFileTree) {
+                    roots.add(TarTreeSpec(tree.backingFile!!))
+                    return
+                }
+            }
+            throw UnsupportedOperationException()
+        }
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IncrementalJavaProjectBuildIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IncrementalJavaProjectBuildIntegrationTest.groovy
@@ -23,7 +23,6 @@ import org.junit.Test
 class IncrementalJavaProjectBuildIntegrationTest extends AbstractIntegrationTest {
 
     @Test
-    @ToBeFixedForInstantExecution
     public void removesStaleResources() {
         file('build.gradle') << 'apply plugin: \'java\''
         file('src/main/resources/org/gradle/resource.txt').createFile()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -417,6 +417,7 @@ class AbstractIntegrationSpec extends Specification {
 
     def createZip(String name, Closure cl) {
         TestFile zipRoot = file("${name}.root")
+        zipRoot.deleteDir()
         TestFile zip = file(name)
         zipRoot.create(cl)
         zipRoot.zipTo(zip)

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.file.ClassFile
 import org.junit.Assume
@@ -28,7 +27,6 @@ import spock.lang.Unroll
 
 class CrossCompilationIntegrationTest extends AbstractIntegrationSpec {
     @Unroll
-    @ToBeFixedForInstantExecution
     def "can configure the Java plugin to compile and run tests against Java #version JDK"() {
         def jvm = AvailableJavaHomes.getJdk(version)
         Assume.assumeTrue(jvm != null)

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
@@ -155,7 +155,6 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
         jar.assertContainsFile('dir1/file1.txt')
     }
 
-    @ToBeFixedForInstantExecution
     def usesManifestFromJarTaskWhenMergingJars() {
         given:
         createDir('src1') {
@@ -684,9 +683,9 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << """
             task jar(type: Jar) {
-                manifest { 
+                manifest {
                     attributes(attr: provider { "value" })
-                    attributes(version: archiveVersion) 
+                    attributes(version: archiveVersion)
                 }
                 destinationDirectory = buildDir
                 archiveFileName = 'test.jar'

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.integtests.samples.antmigration
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.util.Requires
 import org.junit.Rule
@@ -75,7 +75,6 @@ class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("userguide/antMigration/fileDeps")
-    @ToBeFixedForInstantExecution
     def "can use task properties to link tasks (#dsl)"() {
         given: "A sample Java project"
         def dslDir = sample.dir.file(dsl)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesArchivesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesArchivesIntegrationTest.groovy
@@ -16,10 +16,9 @@
 
 package org.gradle.integtests.samples.files
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
-import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.util.Requires
 import org.junit.Rule
 import spock.lang.Unroll
@@ -92,7 +91,6 @@ class SamplesArchivesIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("userguide/files/archives")
-    @ToBeFixedForInstantExecution
     def "can unpack a ZIP file with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)
@@ -113,7 +111,6 @@ class SamplesArchivesIntegrationTest extends AbstractSampleIntegrationTest {
 
     @Unroll
     @UsesSample("userguide/files/archivesWithJavaPlugin")
-    @ToBeFixedForInstantExecution
     def "can create an uber JAR with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/organizinggradleprojects/SamplesOrganizingGradleProjectsIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/organizinggradleprojects/SamplesOrganizingGradleProjectsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.samples.organizinggradleprojects
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.archive.ZipTestFixture
@@ -30,7 +29,6 @@ class SamplesOrganizingGradleProjectsIntegrationTest extends AbstractSampleInteg
     Sample sample = new Sample(testDirectoryProvider)
 
     @UsesSample("userguide/organizingGradleProjects/customGradleDistribution")
-    @ToBeFixedForInstantExecution
     def "can build custom gradle distribution"() {
         executer.inDirectory(sample.dir)
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -26,7 +25,6 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class PlayPluginSmokeTest extends AbstractSmokeTest {
 
     @Requires(TestPrecondition.JDK11_OR_EARLIER)
-    @ToBeFixedForInstantExecution
     def 'build basic Play project'() {
         given:
         useSample("play-example")


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Serialize enough to be able to build the Gradle `-bin` zip.

Also improve diagnostics when a closure or function captures its containing script.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
