### PR TITLE
Add API to disable dependency verification

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -161,6 +161,25 @@ public interface ResolutionStrategy {
 
 
     /**
+     * Deactivates dependency verification for this configuration.
+     * You should always be careful when disabling verification, and in particular avoid
+     * disabling it for verification of plugins, because a plugin could use this to disable
+     * verification itself.
+     *
+     * @since 6.2
+     */
+    @Incubating
+    ResolutionStrategy disableDependencyVerification();
+
+    /**
+     * Enabled dependency verification for this configuration.
+     *
+     * @since 6.2
+     */
+    @Incubating
+    ResolutionStrategy enableDependencyVerification();
+
+    /**
      * Allows forcing certain versions of dependencies, including transitive dependencies.
      * <b>Appends</b> new forced modules to be considered when resolving dependencies.
      * <p>
@@ -251,6 +270,7 @@ public interface ResolutionStrategy {
      *
      * <p>A convenience method for {@link #cacheDynamicVersionsFor(int, java.util.concurrent.TimeUnit)} with units expressed as a String.
      * Units are resolved by calling the {@code valueOf(String)} method of {@link java.util.concurrent.TimeUnit} with the upper-cased string value.</p>
+     *
      * @param value The number of time units
      * @param units The units
      * @since 1.0-milestone-6
@@ -263,6 +283,7 @@ public interface ResolutionStrategy {
      * <p>Gradle keeps a cache of dynamic version =&gt; resolved version (ie 2.+ =&gt; 2.3). By default, these cached values are kept for 24 hours, after which the cached entry is expired
      * and the dynamic version is resolved again.</p>
      * <p>Use this method to provide a custom expiry time after which the cached value for any dynamic version will be expired.</p>
+     *
      * @param value The number of time units
      * @param units The units
      * @since 1.0-milestone-6
@@ -274,6 +295,7 @@ public interface ResolutionStrategy {
      *
      * <p>A convenience method for {@link #cacheChangingModulesFor(int, java.util.concurrent.TimeUnit)} with units expressed as a String.
      * Units are resolved by calling the {@code valueOf(String)} method of {@link java.util.concurrent.TimeUnit} with the upper-cased string value.</p>
+     *
      * @param value The number of time units
      * @param units The units
      * @since 1.0-milestone-6
@@ -286,6 +308,7 @@ public interface ResolutionStrategy {
      * <p>Gradle caches the contents and artifacts of changing modules. By default, these cached values are kept for 24 hours,
      * after which the cached entry is expired and the module is resolved again.</p>
      * <p>Use this method to provide a custom expiry time after which the cached entries for any changing module will be expired.</p>
+     *
      * @param value The number of time units
      * @param units The units
      * @since 1.0-milestone-6
@@ -360,9 +383,7 @@ public interface ResolutionStrategy {
      * Configures the capabilities resolution strategy.
      *
      * @param action the configuration action.
-     *
      * @return this resolution strategy
-     *
      * @since 5.6
      */
     @Incubating

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -903,6 +903,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
   - On artifact foo-1.0.pom (org:foo:1.0) in repository 'maven': checksum is missing from verification metadata.""")
     }
 
+    @ToBeFixedForInstantExecution
     def "can disable verification of a detached configuration"() {
         createMetadataFile {
             addChecksum("org:foo:1.0", 'sha1', "invalid")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -1241,6 +1241,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
 """
     }
 
+    @ToBeFixedForInstantExecution
     def "doesn't write verification metadata for skipped configurations"() {
         javaLibrary()
         uncheckedModule("org", "foo")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -96,4 +96,6 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     boolean isFailingOnDynamicVersions();
 
     boolean isFailingOnChangingVersions();
+
+    boolean isDependencyVerificationEnabled();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -138,7 +138,7 @@ public class ResolveIvyFactory {
             }
             moduleComponentRepository = new ErrorHandlingModuleComponentRepository(moduleComponentRepository, repositoryBlacklister);
             moduleComponentRepository = filterRepository(repository, moduleComponentRepository, resolveContextName, consumerAttributes);
-            moduleComponentRepository = dependencyVerificationOverride.overrideDependencyVerification(moduleComponentRepository);
+            moduleComponentRepository = dependencyVerificationOverride.overrideDependencyVerification(moduleComponentRepository, resolveContextName, resolutionStrategy);
             moduleResolver.add(moduleComponentRepository);
             parentModuleResolver.add(moduleComponentRepository);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyingModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlReader;
@@ -158,7 +159,7 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
     }
 
     @Override
-    public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original) {
+    public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
         return new DependencyVerifyingModuleComponentRepository(original, this, verifier.getConfiguration().isVerifySignatures());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
 
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.api.invocation.Gradle;
 
@@ -24,7 +25,7 @@ import java.io.File;
 public interface DependencyVerificationOverride {
     DependencyVerificationOverride NO_VERIFICATION = new DependencyVerificationOverride() {
         @Override
-        public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original) {
+        public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
             return original;
         }
     };
@@ -50,7 +51,7 @@ public interface DependencyVerificationOverride {
         return gradleDir;
     }
 
-    ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original);
+    ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy);
 
     default void buildFinished(Gradle gradle) {
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -28,6 +28,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyingModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ArtifactVerificationOperation;
@@ -158,7 +159,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     @Override
-    public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original) {
+    public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
         return new DependencyVerifyingModuleComponentRepository(original, this, generatePgpInfo);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -73,6 +73,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private SortOrder sortOrder = SortOrder.DEFAULT;
     private boolean failOnDynamicVersions;
     private boolean failOnChangingVersions;
+    private boolean verifyDependencies = true;
 
     private static final String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies";
 
@@ -304,6 +305,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         if (isFailingOnChangingVersions()) {
             out.failOnChangingVersions();
         }
+        if (!isDependencyVerificationEnabled()) {
+            out.disableDependencyVerification();
+        }
         return out;
     }
 
@@ -334,5 +338,22 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Override
     public boolean isFailingOnChangingVersions() {
         return failOnChangingVersions;
+    }
+
+    @Override
+    public boolean isDependencyVerificationEnabled() {
+        return verifyDependencies;
+    }
+
+    @Override
+    public ResolutionStrategy disableDependencyVerification() {
+        verifyDependencies = false;
+        return this;
+    }
+
+    @Override
+    public ResolutionStrategy enableDependencyVerification() {
+        verifyDependencies = true;
+        return this;
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -310,4 +310,20 @@ class DefaultResolutionStrategySpec extends Specification {
         then:
         strategy.dependencyLockingProvider.is( NoOpDependencyLockingProvider.instance)
     }
+
+    def "copies dependency verification state"() {
+        when:
+        strategy.disableDependencyVerification()
+
+        then:
+        !strategy.dependencyVerificationEnabled
+        !strategy.copy().dependencyVerificationEnabled
+
+        when:
+        strategy.enableDependencyVerification()
+
+        then:
+        strategy.dependencyVerificationEnabled
+        strategy.copy().dependencyVerificationEnabled
+    }
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
@@ -52,6 +52,12 @@ class DependencyVerificationFixture {
         assert !verificationFile.exists() : "Expected verification file ${verificationFile} to be absent but it exists"
     }
 
+    void deleteMetadataFile() {
+        assertMetadataExists()
+        verificationFile.delete()
+        verifier = null
+    }
+
     void hasModules(List<String> modules, boolean strictly = true) {
         withVerifier {
             def seenModules = verificationMetadata.collect {

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -922,3 +922,37 @@ If you want to retry immediately, you can run with the `--refresh-keys` CLI flag
 ./gradlew build --refresh-keys
 ----
 
+[[sub:disabling-specific-verification]]
+== Disabling dependency verification for some configurations only
+
+In order to provide the strongest security level possible, dependency verification is enabled globally.
+This will ensure, for example, that you trust all the plugins you use.
+However, the plugins themselves may need to resolve additional dependencies that it doesn't make sense to ask the user to accept.
+For this purpose, Gradle provides an API which allows _disabling dependency verification on some specific configurations_.
+
+[WARNING]
+====
+Disabling dependency verification, if you care about security, is not a good idea.
+This API mostly exist for cases where it doesn't make sense to check dependencies.
+However, in order to be on the safe side, Gradle will systematically print a warning whenever verification has been disabled for a specific configuration.
+====
+
+As an example, a plugin may want to check if there are _newer_ versions of a library available and list those versions.
+It doesn't make sense, in this context, to ask the user to put the checksums of the POM files of the newer releases because by definition, they don't know about them.
+So the plugin might need to run its code _independently of the dependency verification configuration_.
+
+To do this, you need to call the `ResolutionStrategy#disableDependencyVerification` method:
+
+.Disabling dependency verification
+====
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy",files="build.gradle[tags=disabling-one-configuration]"]
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin",files="build.gradle.kts[tags=disabling-one-configuration]"]
+====
+
+It's also possible to disable verification on detached configurations like in the following example:
+
+.Disabling dependency verification
+====
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy",files="build.gradle[tags=disabling-detached-configuration]"]
+include::sample[dir="snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin",files="build.gradle.kts[tags=disabling-detached-configuration]"]
+====

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/disabling_verification.sample.conf
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/disabling_verification.sample.conf
@@ -1,0 +1,11 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: "checkDependencies"
+    flags: --quiet
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: "checkDependencies"
+    flags: --quiet
+}]

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy/build.gradle
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    myPlugin {
+        canBeConsumed = false
+        canBeResolved = false
+    }
+    myPluginClasspath {
+        extendsFrom(myPlugin)
+        canBeConsumed = false
+        canBeResolved = true
+    }
+}
+
+dependencies {
+    myPlugin "org.apache.commons:commons-lang3:3.3.1"
+}
+
+// tag::disabling-one-configuration[]
+configurations {
+    myPluginClasspath {
+        resolutionStrategy {
+            disableDependencyVerification()
+        }
+    }
+}
+// end::disabling-one-configuration[]
+
+tasks.register("checkDependencies") {
+    inputs.files(configurations.myPluginClasspath)
+    doLast {
+        println(configurations.myPluginClasspath.files)
+    }
+}
+
+// tag::disabling-detached-configuration[]
+tasks.register("checkDetachedDependencies") {
+    doLast {
+        def detachedConf = configurations.detachedConfiguration(dependencies.create("org.apache.commons:commons-lang3:3.3.1"))
+        detachedConf.resolutionStrategy.disableDependencyVerification()
+        println(detachedConf.files)
+    }
+}
+// end::disabling-detached-configuration[]

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy/gradle/verification-metadata.xml
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy/gradle/verification-metadata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<verification-metadata xmlns="https://schema.gradle.org/dependency-verification"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/verification-1.0.xsd">
+    <configuration>
+        <verify-metadata>false</verify-metadata>
+        <verify-signatures>true</verify-signatures>
+    </configuration>
+</verification-metadata>

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/groovy/settings.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "disabling-verification"

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin/build.gradle.kts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+repositories {
+    mavenCentral()
+}
+
+val myPlugin by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+val myPluginClasspath by configurations.creating {
+    extendsFrom(myPlugin)
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    myPlugin("org.apache.commons:commons-lang3:3.3.1")
+}
+
+// tag::disabling-one-configuration[]
+configurations {
+    "myPluginClasspath" {
+        resolutionStrategy {
+            disableDependencyVerification()
+        }
+    }
+}
+// end::disabling-one-configuration[]
+
+tasks.register("checkDependencies") {
+    inputs.files(myPluginClasspath)
+    doLast {
+        println(myPluginClasspath.files)
+    }
+}
+
+// tag::disabling-detached-configuration[]
+tasks.register("checkDetachedDependencies") {
+    doLast {
+        val detachedConf = configurations.detachedConfiguration(dependencies.create("org.apache.commons:commons-lang3:3.3.1"))
+        detachedConf.resolutionStrategy.disableDependencyVerification()
+        println(detachedConf.files)
+    }
+}
+// end::disabling-detached-configuration[]

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin/gradle/verification-metadata.xml
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin/gradle/verification-metadata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<verification-metadata xmlns="https://schema.gradle.org/dependency-verification"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/verification-1.0.xsd">
+    <configuration>
+        <verify-metadata>false</verify-metadata>
+        <verify-signatures>true</verify-signatures>
+    </configuration>
+</verification-metadata>

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/dependencyVerification/disablingVerification/kotlin/settings.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "disabling-verification"


### PR DESCRIPTION
### Context

This commit adds an API to disable verification on a specific
configuration (using `resolutionStrategy.disableDependencyVerification`.

This would let tasks which perform special dependency resolution (like
checking newer versions of dependencies) to pass even if dependency
verification is enabled.

