### PR TITLE
Treat single version ranges as "required"

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -635,18 +635,9 @@ dependencies {
 
         when:
         repositoryInteractions {
-            'org.test:projectA' {
-                expectVersionListing()
-            }
             'org.test:projectA:1.1' {
                 expectGetMetadata()
                 expectGetArtifact()
-            }
-            if (GradleMetadataResolveRunner.isGradleMetadataPublished()) {
-                // todo: is single version in range something we want to allow in Gradle metadata?
-                'org.test:projectB' {
-                    expectVersionListing()
-                }
             }
             'org.test:projectB:2.0' {
                 expectGetMetadata()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -58,7 +58,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.test:projectA:[1.1]", "org.test:projectA:1.1") {
-                    edge("org.test:projectB:[2.0]", "org.test:projectB:2.0") // Transitive version range is lost when converting to Ivy ModuleDescriptor
+                    edge("org.test:projectB:2.0", "org.test:projectB:2.0") // Transitive version range is lost when converting to Ivy ModuleDescriptor
                 }
             }
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy
 
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -35,9 +36,7 @@ class DefaultVersionSelectorSchemeTest extends Specification {
             "[1.0,)",
             "]1.0,)",
             "(,2.0]",
-            "(,2.0)",
-            "[3]",
-            "[1.0]",
+            "(,2.0)"
         ]
     }
 
@@ -81,7 +80,21 @@ class DefaultVersionSelectorSchemeTest extends Specification {
     }
 
     @Unroll
-    def "computes rejection selector for strict dependency version"() {
+    @Issue("https://github.com/gradle/gradle/issues/11185")
+    def "single version range should be considered as exact version selector"() {
+        when:
+        def selector = matcher.parseSelector(version)
+
+        then:
+        selector instanceof ExactVersionSelector
+        selector.selector == '1.0'
+
+        where:
+        version << ["[1.0]", "[1.0, 1.0]"]
+    }
+
+    @Unroll
+    def "computes rejection selector for strict dependency version #selector"() {
         given:
         def normal = matcher.parseSelector(selector)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/MavenVersionSelectorSchemeTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/MavenVersionSelectorSchemeTest.groovy
@@ -35,7 +35,7 @@ class MavenVersionSelectorSchemeTest extends Specification {
         "[2,3["              | "[2,3)"
         "]2,3["              | "(2,3)"
         "1.0"                | "1.0"
-        "[1.0]"              | "[1.0]"
+        "[1.0]"              | "1.0"
         "+"                  | "+"
         "latest.integration" | "LATEST"
         "latest.release"     | "RELEASE"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
@@ -57,19 +57,21 @@ class MavenPublishVersionRangeIntegTest extends AbstractMavenPublishIntegTest {
 
         then:
         mavenModule.assertPublished()
-        mavenModule.assertApiDependencies(
-            "group:projectA:latest.release",
-            "group:projectB:latest.integration",
-            "group:projectC:1.+",
-            "group:projectD:[1.0,2.0)",
-            "group:projectE:[1.0]")
+        mavenModule.parsedModuleMetadata.variant("apiElements") {
+            dependency("group:projectA:latest.release")
+            dependency("group:projectB:latest.integration")
+            dependency("group:projectC:1.+")
+            dependency("group:projectD:[1.0,2.0)")
+            dependency("group:projectE:[1.0]")
+            noMoreDependencies()
+        }
 
         mavenModule.parsedPom.scopes.compile.assertDependsOn(
             "group:projectA:RELEASE",
             "group:projectB:LATEST",
             "group:projectC:1.+",
             "group:projectD:[1.0,2.0)",
-            "group:projectE:[1.0]"
+            "group:projectE:1.0"
         )
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenVersionRangePublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/MavenVersionRangePublishIntegrationTest.groovy
@@ -69,7 +69,7 @@ uploadArchives {
                 "group:projectB:LATEST",
                 "group:projectC:1.+",
                 "group:projectD:[1.0,2.0)",
-                "group:projectE:[1.0]"
+                "group:projectE:1.0"
         )
     }
 


### PR DESCRIPTION
### Context

This commit changes the way Gradle handles single version
ranges to treat them like Maven does: they are effectively
"exact" version selectors (not strictly).

Fixes #11185

