### PR TITLE
Usability improvement: declaring exclusive content of repositories

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -17,8 +17,10 @@ package org.gradle.api.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ArtifactRepositoryContainer;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.ExclusiveContentRepository;
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
@@ -87,10 +89,10 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * @since 4.4
      */
     ArtifactRepository gradlePluginPortal();
-    
+
     /**
      * Adds a repository which looks in Gradle Central Plugin Repository for dependencies.
-     * 
+     *
      * @param action a configuration action
      * @return the added resolver
      * @since 5.4
@@ -324,4 +326,14 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      */
     IvyArtifactRepository ivy(Action<? super IvyArtifactRepository> action);
 
+    /**
+     * Defines the an exclusive content repository: whatever is declared in this
+     * repository cannot be found in any other repository.
+     *
+     * @param action the configuration of the repository
+     *
+     * @since 6.2
+     */
+    @Incubating
+    void exclusiveContent(Action<? super ExclusiveContentRepository> action);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -327,10 +327,12 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
     IvyArtifactRepository ivy(Action<? super IvyArtifactRepository> action);
 
     /**
-     * Defines the an exclusive content repository: whatever is declared in this
-     * repository cannot be found in any other repository.
+     * Declares exclusive content repositories. Exclusive content repositories are
+     * repositories for which you can declare an inclusive content filter. Artifacts
+     * matching the filter will then only be searched in the repositories which
+     * exclusively match it.
      *
-     * @param action the configuration of the repository
+     * @param action the configuration of the repositories
      *
      * @since 6.2
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.java
@@ -20,8 +20,8 @@ import org.gradle.api.Incubating;
 import org.gradle.internal.Factory;
 
 /**
- * Describes a repository which contents is exclusive with the other
- * repositories defined with the same {@link org.gradle.api.artifacts.dsl.RepositoryHandler}.
+ * Describes one or more repositories which together constitute the only possible
+ * source for an artifact, independently of the others.
  *
  * This means that if a repository declares an include, other repositories will
  * automatically exclude it.
@@ -36,6 +36,13 @@ public interface ExclusiveContentRepository {
      * @return this repository descriptor
      */
     ExclusiveContentRepository forRepository(Factory<? extends ArtifactRepository> repository);
+
+    /**
+     * Declares the repository
+     * @param repositories the repositories for which we declare exclusive content
+     * @return this repository descriptor
+     */
+    ExclusiveContentRepository forRepositories(ArtifactRepository... repositories);
 
     /**
      * Defines the content filter for this repository

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts.repositories;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.internal.Factory;
+
+/**
+ * Describes a repository which contents is exclusive with the other
+ * repositories defined with the same {@link org.gradle.api.artifacts.dsl.RepositoryHandler}.
+ *
+ * This means that if a repository declares an include, other repositories will
+ * automatically exclude it.
+ *
+ * @since 6.2
+ */
+@Incubating
+public interface ExclusiveContentRepository {
+    /**
+     * Declares the repository
+     * @param repository the repository for which we declare exclusive content
+     * @return this repository descriptor
+     */
+    ExclusiveContentRepository forRepository(Factory<? extends ArtifactRepository> repository);
+
+    /**
+     * Defines the content filter for this repository
+     * @param config the configuration of the filter
+     * @return this repository descriptor
+     */
+    ExclusiveContentRepository filter(Action<? super InclusiveRepositoryContentDescriptor> config);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/InclusiveRepositoryContentDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/InclusiveRepositoryContentDescriptor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts.repositories;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+/**
+ * <p>Descriptor of a repository content, used to avoid reaching to
+ * an external repository when not needed.</p>
+ *
+ * <p>Only inclusions can be defined at this level (cross-repository content).
+ * Excludes need to be defined per-repository using {@link RepositoryContentDescriptor}.
+ * Similarly to declaring includes on specific repositories via {@link ArtifactRepository#content(Action)},
+ * inclusions are <i>extensive</i>, meaning that anything which doesn't match the includes will be
+ * considered missing from the repository.
+ * </p>
+ *
+ * @since 6.2
+ */
+@Incubating
+public interface InclusiveRepositoryContentDescriptor {
+    /**
+     * Declares that an entire group should be searched for in this repository.
+     *
+     * @param group the group name
+     */
+    void includeGroup(String group);
+
+    /**
+     * Declares that an entire group should be searched for in this repository.
+     *
+     * @param groupRegex a regular expression of the group name
+     */
+    void includeGroupByRegex(String groupRegex);
+
+    /**
+     * Declares that an entire module should be searched for in this repository.
+     *
+     * @param group the group name
+     * @param moduleName the module name
+     */
+    void includeModule(String group, String moduleName);
+
+    /**
+     * Declares that an entire module should be searched for in this repository, using regular expressions.
+     *
+     * @param groupRegex the group name regular expression
+     * @param moduleNameRegex the module name regular expression
+     */
+    void includeModuleByRegex(String groupRegex, String moduleNameRegex);
+
+    /**
+     * Declares that a specific module version should be searched for in this repository.
+     *
+     * @param group the group name
+     * @param moduleName the module name
+     * @param version the module version
+     */
+    void includeVersion(String group, String moduleName, String version);
+
+    /**
+     * Declares that a specific module version should be searched for in this repository, using regular expressions.
+     *
+     * @param groupRegex the group name regular expression
+     * @param moduleNameRegex the module name regular expression
+     * @param versionRegex the module version regular expression
+     */
+    void includeVersionByRegex(String groupRegex, String moduleNameRegex, String versionRegex);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
@@ -27,13 +27,14 @@ import org.gradle.api.attributes.Attribute;
  *
  * @since 5.1
  */
-public interface RepositoryContentDescriptor {
+public interface RepositoryContentDescriptor extends InclusiveRepositoryContentDescriptor {
 
     /**
      * Declares that an entire group should be searched for in this repository.
      *
      * @param group the group name
      */
+    @Override
     void includeGroup(String group);
 
     /**
@@ -41,6 +42,7 @@ public interface RepositoryContentDescriptor {
      *
      * @param groupRegex a regular expression of the group name
      */
+    @Override
     void includeGroupByRegex(String groupRegex);
 
     /**
@@ -49,6 +51,7 @@ public interface RepositoryContentDescriptor {
      * @param group the group name
      * @param moduleName the module name
      */
+    @Override
     void includeModule(String group, String moduleName);
 
     /**
@@ -57,6 +60,7 @@ public interface RepositoryContentDescriptor {
      * @param groupRegex the group name regular expression
      * @param moduleNameRegex the module name regular expression
      */
+    @Override
     void includeModuleByRegex(String groupRegex, String moduleNameRegex);
 
     /**
@@ -66,6 +70,7 @@ public interface RepositoryContentDescriptor {
      * @param moduleName the module name
      * @param version the module version
      */
+    @Override
     void includeVersion(String group, String moduleName, String version);
 
     /**
@@ -75,6 +80,7 @@ public interface RepositoryContentDescriptor {
      * @param moduleNameRegex the module name regular expression
      * @param versionRegex the module version regular expression
      */
+    @Override
     void includeVersionByRegex(String groupRegex, String moduleNameRegex, String versionRegex);
 
     /**

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ExclusiveRepositoryContentFilteringIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ExclusiveRepositoryContentFilteringIntegrationTest.groovy
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import spock.lang.Unroll
+
+class ExclusiveRepositoryContentFilteringIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    ResolveTestFixture resolve
+
+    def setup() {
+        settingsFile << "rootProject.name = 'test'"
+        buildFile << """
+            configurations {
+                conf
+            }
+        """
+        resolve = new ResolveTestFixture(buildFile, 'conf')
+        resolve.prepare()
+    }
+
+    @Unroll
+    def "can include a module from a repository using #notation (Maven 1st)"() {
+        def foo = ivyHttpRepo.module('org', 'foo', '1.0').publish()
+        def bar = mavenHttpRepo.module('other', 'bar', '2.0').publish()
+        given:
+        buildFile << """
+            repositories {
+                maven { url "${mavenHttpRepo.uri}" }
+                exclusiveContent {
+                   forRepository {
+                      ivy { url "${ivyHttpRepo.uri}" }
+                   }
+                   filter {
+                      $notation
+                   }
+                }
+            }
+            dependencies {
+                conf "org:foo:1.0"
+                conf "other:bar:2.0"
+            }
+        """
+
+        when:
+        foo.ivy.expectGet()
+        foo.artifact.expectGet()
+        bar.pom.expectGet()
+        bar.artifact.expectGet()
+
+        run 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0')
+                module('other:bar:2.0')
+            }
+        }
+
+        where:
+        notation << [
+            "includeGroup 'org'",
+            "includeGroupByRegex 'org.*'",
+            "includeModule('org', 'foo')",
+            "includeModuleByRegex('or[g]', 'f[o]+')",
+            "includeVersion('org', 'foo', '1.0')",
+            "includeVersionByRegex('or[g]', 'f[o]+', '1[.].+')",
+        ]
+    }
+
+    @Unroll
+    def "can include a module from a repository using #notation and combine with local repository filter"() {
+        def foo = ivyHttpRepo.module('org', 'foo', '1.0').publish()
+        def barIvy = ivyHttpRepo.module('other', 'bar', '2.0')
+        def bar = mavenHttpRepo.module('other', 'bar', '2.0').publish()
+        given:
+        buildFile << """
+            repositories {
+                exclusiveContent {
+                   forRepository {
+                      ivy {
+                         url "${ivyHttpRepo.uri}"
+                         content {
+                            includeGroup('other') // says that we can find "bar", not exclusively
+                         }
+                      }
+                   }
+                   filter {
+                      $notation
+                   }
+                }
+                maven { url "${mavenHttpRepo.uri}" }
+            }
+            dependencies {
+                conf "org:foo:1.0"
+                conf "other:bar:2.0"
+            }
+        """
+
+        when:
+        foo.ivy.expectGet()
+        foo.artifact.expectGet()
+        barIvy.ivy.expectGetMissing()
+        bar.pom.expectGet()
+        bar.artifact.expectGet()
+
+        run 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                module('org:foo:1.0')
+                module('other:bar:2.0')
+            }
+        }
+
+        where:
+        notation << [
+            "includeGroup 'org'",
+            "includeGroupByRegex 'org.*'",
+            "includeModule('org', 'foo')",
+            "includeModuleByRegex('or[g]', 'f[o]+')",
+            "includeVersion('org', 'foo', '1.0')",
+            "includeVersionByRegex('or[g]', 'f[o]+', '1[.].+')",
+        ]
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -17,15 +17,22 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.ExclusiveContentRepository;
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
+import org.gradle.api.artifacts.repositories.InclusiveRepositoryContentDescriptor;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.ConfigureByMapAction;
+import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.ConfigureByMapAction;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
 import org.gradle.api.internal.artifacts.DefaultArtifactRepositoryContainer;
+import org.gradle.internal.Actions;
+import org.gradle.internal.Cast;
+import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.ConfigureUtil;
 
@@ -46,10 +53,12 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     private static final String IVY_REPO_DEFAULT_NAME = "ivy";
 
     private final BaseRepositoryFactory repositoryFactory;
+    private final Instantiator instantiator;
 
     public DefaultRepositoryHandler(BaseRepositoryFactory repositoryFactory, Instantiator instantiator, CollectionCallbackActionDecorator decorator) {
         super(instantiator, decorator);
         this.repositoryFactory = repositoryFactory;
+        this.instantiator = instantiator;
     }
 
     @Override
@@ -75,7 +84,7 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     public ArtifactRepository gradlePluginPortal() {
         return addRepository(repositoryFactory.createGradlePluginPortal(), GRADLE_PLUGIN_PORTAL_REPO_NAME);
     }
-    
+
     @Override
     public ArtifactRepository gradlePluginPortal(Action<? super ArtifactRepository> action) {
         return addRepository(repositoryFactory.createGradlePluginPortal(), GRADLE_PLUGIN_PORTAL_REPO_NAME, action);
@@ -146,4 +155,91 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     public IvyArtifactRepository ivy(Closure closure) {
         return ivy(ConfigureUtil.configureUsing(closure));
     }
+
+    @Override
+    public void exclusiveContent(Action<? super ExclusiveContentRepository> action) {
+        ExclusiveContentRepositorySpec spec = Cast.uncheckedCast(instantiator.newInstance(ExclusiveContentRepositorySpec.class, this));
+        spec.apply(action);
+    }
+
+    private static Action<? super RepositoryContentDescriptor> transformForExclusivity(Action<? super InclusiveRepositoryContentDescriptor> config) {
+        return desc -> {
+            config.execute(new InclusiveRepositoryContentDescriptor() {
+                @Override
+                public void includeGroup(String group) {
+                    desc.excludeGroup(group);
+                }
+
+                @Override
+                public void includeGroupByRegex(String groupRegex) {
+                    desc.excludeGroupByRegex(groupRegex);
+                }
+
+                @Override
+                public void includeModule(String group, String moduleName) {
+                    desc.excludeModule(group, moduleName);
+                }
+
+                @Override
+                public void includeModuleByRegex(String groupRegex, String moduleNameRegex) {
+                    desc.excludeModuleByRegex(groupRegex, moduleNameRegex);
+                }
+
+                @Override
+                public void includeVersion(String group, String moduleName, String version) {
+                    desc.excludeVersion(group, moduleName, version);
+                }
+
+                @Override
+                public void includeVersionByRegex(String groupRegex, String moduleNameRegex, String versionRegex) {
+                    desc.excludeVersionByRegex(groupRegex, moduleNameRegex, versionRegex);
+                }
+            });
+        };
+    }
+
+    public static class ExclusiveContentRepositorySpec implements ExclusiveContentRepository {
+        private final RepositoryHandler repositories;
+        private Factory<? extends ArtifactRepository> repository;
+        private Action<? super InclusiveRepositoryContentDescriptor> filter;
+
+        public ExclusiveContentRepositorySpec(RepositoryHandler repositories) {
+            this.repositories = repositories;
+        }
+
+        @Override
+        public ExclusiveContentRepository forRepository(Factory<? extends ArtifactRepository> repositoryProducer) {
+            if (this.repository != null) {
+                throw new InvalidUserCodeException("Cannot call forRepository multiple times");
+            }
+            this.repository = repositoryProducer;
+            return this;
+        }
+
+        @Override
+        public ExclusiveContentRepository filter(Action<? super InclusiveRepositoryContentDescriptor> config) {
+            filter = filter == null ? config : Actions.composite(filter, config);
+            return this;
+        }
+
+        void apply(Action<? super ExclusiveContentRepository> action) {
+            action.execute(this);
+            if (repository == null) {
+                throw new InvalidUserCodeException("You must declare the repository using forRepository { ... }");
+            }
+            if (filter == null) {
+                throw new InvalidUserCodeException("You must specify the filter for the repository using filter { ... }");
+            }
+            ArtifactRepository target = repository.create();
+            Action<? super RepositoryContentDescriptor> forExclusivity = transformForExclusivity(filter);
+            repositories.all(repo -> {
+                if (repo == target) {
+                    repo.content(filter);
+                } else {
+                    repo.content(forExclusivity);
+                }
+            });
+        }
+    }
+
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -7,6 +7,14 @@
             "changes": [
                 "org.gradle.plugins.signing.signatory.internal.ConfigurableSignatoryProvider"
             ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.repositories.RepositoryContentDescriptor",
+            "member": "Class org.gradle.api.artifacts.repositories.RepositoryContentDescriptor",
+            "acceptation": "A new super interface has been introduced but old methods preserved on this one",
+            "changes": [
+                "org.gradle.api.artifacts.repositories.InclusiveRepositoryContentDescriptor"
+            ]
         }
     ]
 }

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -335,6 +335,7 @@ There are different use cases for it:
 
 It's even more important when considering that the declared order of repositories matter.
 
+[[sec:declaring-repository-filter]]
 === Declaring a repository filter
 
 .Declaring repository contents
@@ -351,6 +352,26 @@ By default, repositories include everything and exclude nothing:
 
 It is possible to filter either by explicit _group_, _module_ or _version_, either strictly or using regular expressions.
 See link:{javadocPath}/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.html[RepositoryContentDescriptor] for details.
+
+=== Declaring content exclusively found in one repository
+
+Filters declared using the <<#sec:declaring-repository-filter,repository-level content filter>> are not exclusive.
+This means that declaring that a repository _includes_ an artifact doesn't mean that the other repositories can't have it either: you must declare what every repository contains in extension.
+
+Alternatively, Gradle provides an API which lets you declare that a repository _exclusively includes_ an artifact.
+If you do so:
+
+- an artifact declared in a repository _can't_ be found in any other
+- exclusive repository content must be declared in extension (just like for <<#sec:declaring-repository-filter, repository-level content))
+
+.Declaring exclusive repository contents
+====
+include::sample[dir="snippets//userguide/dependencyManagement/declaringRepositories/filtering/groovy",files="build.gradle[tags=exclusive-repository-filter]"]
+include::sample[dir="snippets//userguide/dependencyManagement/declaringRepositories/filtering/kotlin",files="build.gradle.kts[tags=exclusive-repository-filter]"]
+====
+
+It is possible to filter either by explicit _group_, _module_ or _version_, either strictly or using regular expressions.
+See link:{javadocPath}/org/gradle/api/artifacts/repositories/InclusiveRepositoryContentDescriptor.html[InclusiveRepositoryContentDescriptor] for details.
 
 === Maven repository filtering
 

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/declaringRepositories/filtering/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/declaringRepositories/filtering/groovy/build.gradle
@@ -32,6 +32,25 @@ repositories {
 }
 // end::repository-filter[]
 
+// tag::exclusive-repository-filter[]
+repositories {
+    // This repository will _not_ be searched for artifacts in my.company
+    // despite being declared first
+    jcenter()
+    exclusiveContent {
+        forRepository {
+            maven {
+                url "https://repo.mycompany.com/maven2"
+            }
+        }
+        filter {
+            // this repository *only* contains artifacts with group "my.company"
+            includeGroup "my.company"
+        }
+    }
+}
+// end::exclusive-repository-filter[]
+
 // tag::repository-snapshots[]
 repositories {
     maven {

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/declaringRepositories/filtering/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/declaringRepositories/filtering/kotlin/build.gradle.kts
@@ -32,6 +32,25 @@ repositories {
 }
 // end::repository-filter[]
 
+// tag::exclusive-repository-filter[]
+repositories {
+    // This repository will _not_ be searched for artifacts in my.company
+    // despite being declared first
+    jcenter()
+    exclusiveContent {
+        forRepository {
+            maven {
+                url = uri("https://repo.mycompany.com/maven2")
+            }
+        }
+        filter {
+            // this repository *only* contains artifacts with group "my.company"
+            includeGroup("my.company")
+        }
+    }
+}
+// end::exclusive-repository-filter[]
+
 // tag::repository-snapshots[]
 repositories {
     maven {


### PR DESCRIPTION
### Context

Fixes #9515

See commits for details.

Example syntax:

```groovy
repositories {
    // This repository will _not_ be searched for artifacts in my.company
    // despite being declared first
    jcenter()
    exclusiveContent {
        forRepository {
            maven {
                url "https://repo.mycompany.com/maven2"
            }
        }
        filter {
            // this repository *only* contains artifacts with group "my.company"
            includeGroup "my.company"
        }
    }
}
```
