### PR TITLE
Do not publish stale signature files

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/PublishArtifactInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/PublishArtifactInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.PublishArtifact;
+
+public interface PublishArtifactInternal extends PublishArtifact {
+    boolean shouldBePublished();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/AbstractPublishArtifact.java
@@ -16,14 +16,14 @@
 package org.gradle.api.internal.artifacts.publish;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.tasks.TaskDependency;
 
 import javax.annotation.Nullable;
 
-public abstract class AbstractPublishArtifact implements PublishArtifact {
+public abstract class AbstractPublishArtifact implements PublishArtifactInternal {
     private final DefaultTaskDependency taskDependency;
 
     public AbstractPublishArtifact(@Nullable TaskResolver resolver, Object... tasks) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifact.java
@@ -116,4 +116,9 @@ public class ArchivePublishArtifact extends AbstractPublishArtifact implements C
     public void setFile(File file) {
         this.file = file;
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return archiveTask.isEnabled();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.publish;
 
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.util.GUtil;
 
 import java.io.File;
@@ -97,5 +98,14 @@ public class DecoratingPublishArtifact extends AbstractPublishArtifact implement
     public void setClassifier(String classifier) {
         this.classifier = classifier;
         this.classifierSet = true;
+    }
+
+    @Override
+    public boolean shouldBePublished() {
+        if (publishArtifact instanceof PublishArtifactInternal) {
+            return ((PublishArtifactInternal) publishArtifact).shouldBePublished();
+        }
+        // This can happen for custom publish artifacts
+        return true;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DefaultPublishArtifact.java
@@ -116,4 +116,9 @@ public class DefaultPublishArtifact extends AbstractPublishArtifact implements C
     public void setFile(File file) {
         this.file = file;
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return true;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.dsl;
 
-import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.tasks.TaskDependency;
@@ -24,7 +24,7 @@ import org.gradle.api.tasks.TaskDependency;
 import java.io.File;
 import java.util.Date;
 
-public class FileSystemPublishArtifact implements PublishArtifact {
+public class FileSystemPublishArtifact implements PublishArtifactInternal {
 
     private final FileSystemLocation fileSystemLocation;
     private final String version;
@@ -75,5 +75,10 @@ public class FileSystemPublishArtifact implements PublishArtifact {
             artifactFile = new ArtifactFile(getFile(), version);
         }
         return artifactFile;
+    }
+
+    @Override
+    public boolean shouldBePublished() {
+        return true;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/LazyPublishArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/LazyPublishArtifact.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact;
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact;
@@ -32,10 +33,10 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import java.io.File;
 import java.util.Date;
 
-public class LazyPublishArtifact implements PublishArtifact {
+public class LazyPublishArtifact implements PublishArtifactInternal {
     private final ProviderInternal<?> provider;
     private final String version;
-    private PublishArtifact delegate;
+    private PublishArtifactInternal delegate;
 
     public LazyPublishArtifact(Provider<?> provider) {
         this.provider = Providers.internal(provider);
@@ -107,5 +108,10 @@ public class LazyPublishArtifact implements PublishArtifact {
                 context.add(provider);
             }
         };
+    }
+
+    @Override
+    public boolean shouldBePublished() {
+        return delegate.shouldBePublished();
     }
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishIssuesIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishIssuesIntegTest.groovy
@@ -17,6 +17,9 @@
 package org.gradle.api.publish.ivy
 
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.ivy.IvyFileModule
+import org.gradle.test.fixtures.ivy.IvyFileRepository
 import org.spockframework.util.TextUtil
 import spock.lang.Issue
 
@@ -113,6 +116,8 @@ public class IvyPublishIssuesIntegTest extends AbstractIvyPublishIntegTest {
     @ToBeFixedForInstantExecution
     @Issue("https://github.com/gradle/gradle/issues/5136")
     void "doesn't publish stale files"() {
+        IvyFileModule publishedModule
+
         settingsFile << 'rootProject.name = "test"'
         buildFile << """
             apply plugin: "java-library"
@@ -146,16 +151,21 @@ public class IvyPublishIssuesIntegTest extends AbstractIvyPublishIntegTest {
 
         when:
         succeeds "publish", "-PjavadocEnabled=true"
+        publishedModule = new IvyFileRepository(new TestFile(file("build/repo"))).module("org.gradle", "test")
 
         then:
         file("build/repo/org.gradle/test/1.0/test-1.0-javadoc.jar").exists()
         file("build/repo/org.gradle/test/1.0/test-1.0-javadoc.jar.sha1").exists()
         file("build/repo/org.gradle/test/1.0/test-1.0-javadoc.jar.sha256").exists()
         file("build/repo/org.gradle/test/1.0/test-1.0-javadoc.jar.sha512").exists()
+        publishedModule.parsedModuleMetadata.variant("javadocElements") {
+            assert files*.name == ['test-1.0-javadoc.jar']
+        }
 
         when:
         file("build/repo").deleteDir()
         succeeds "publish", "-PjavadocEnabled=false"
+        publishedModule = new IvyFileRepository(new TestFile(file("build/repo"))).module("org.gradle", "test")
 
         then:
         skipped(":javadocJar")
@@ -163,5 +173,8 @@ public class IvyPublishIssuesIntegTest extends AbstractIvyPublishIntegTest {
         !file("build/repo/org.gradle/test/1.0/test-1.0-javadoc.jar.sha1").exists()
         !file("build/repo/org.gradle/test/1.0/test-1.0-javadoc.jar.sha256").exists()
         !file("build/repo/org.gradle/test/1.0/test-1.0-javadoc.jar.sha512").exists()
+        publishedModule.parsedModuleMetadata.variant("javadocElements") {
+            assert files*.name == []
+        }
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/AbstractIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/AbstractIvyArtifact.java
@@ -21,12 +21,13 @@ import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.publish.internal.PublicationArtifactInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.tasks.TaskDependency;
 
 import javax.annotation.Nullable;
 
-public abstract class AbstractIvyArtifact implements IvyArtifact {
+public abstract class AbstractIvyArtifact implements IvyArtifact, PublicationArtifactInternal {
     private final TaskDependency allBuildDependencies;
     private final DefaultTaskDependency additionalBuildDependencies;
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/ArchiveTaskBasedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/ArchiveTaskBasedIvyArtifact.java
@@ -69,4 +69,9 @@ public class ArchiveTaskBasedIvyArtifact extends AbstractIvyArtifact {
     public File getFile() {
         return archiveTask.getArchiveFile().get().getAsFile();
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return archiveTask.isEnabled();
+    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DerivedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DerivedIvyArtifact.java
@@ -17,8 +17,8 @@
 package org.gradle.api.publish.ivy.internal.artifact;
 
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
-import org.gradle.internal.Factory;
 
 import java.io.File;
 
@@ -26,9 +26,9 @@ import static com.google.common.io.Files.getFileExtension;
 
 public class DerivedIvyArtifact extends AbstractIvyArtifact {
     private final IvyArtifact original;
-    private final Factory<File> derived;
+    private final PublicationInternal.DerivedArtifact derived;
 
-    public DerivedIvyArtifact(IvyArtifact original, Factory<File> derived) {
+    public DerivedIvyArtifact(IvyArtifact original, PublicationInternal.DerivedArtifact derived) {
         this.original = original;
         this.derived = derived;
     }
@@ -66,5 +66,9 @@ public class DerivedIvyArtifact extends AbstractIvyArtifact {
     @Override
     public File getFile() {
         return derived.create();
+    }
+
+    public boolean shouldBePublished() {
+        return derived.shouldBePublished();
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/FileBasedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/FileBasedIvyArtifact.java
@@ -67,4 +67,9 @@ public class FileBasedIvyArtifact extends AbstractIvyArtifact {
     public File getFile() {
         return file;
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return true;
+    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/PublishArtifactBasedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/PublishArtifactBasedIvyArtifact.java
@@ -16,17 +16,17 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
-import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 
 import java.io.File;
 
 public class PublishArtifactBasedIvyArtifact extends AbstractIvyArtifact {
-    private final PublishArtifact artifact;
+    private final PublishArtifactInternal artifact;
     private final IvyPublicationIdentity identity;
 
-    public PublishArtifactBasedIvyArtifact(PublishArtifact artifact, IvyPublicationIdentity identity) {
+    public PublishArtifactBasedIvyArtifact(PublishArtifactInternal artifact, IvyPublicationIdentity identity) {
         this.artifact = artifact;
         this.identity = identity;
     }
@@ -64,5 +64,10 @@ public class PublishArtifactBasedIvyArtifact extends AbstractIvyArtifact {
     @Override
     public File getFile() {
         return artifact.getFile();
+    }
+
+    @Override
+    public boolean shouldBePublished() {
+        return artifact.shouldBePublished();
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
@@ -88,4 +88,9 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
             context.add(generator.get());
         }
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return isEnabled();
+    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyNormalizedPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyNormalizedPublication.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.publish.ivy.internal.publisher;
 
+import org.gradle.api.publish.internal.PublicationArtifactInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
+import org.gradle.api.publish.ivy.IvyArtifactSet;
 
 import java.io.File;
 import java.util.Set;
@@ -27,12 +29,14 @@ public class IvyNormalizedPublication {
     private final IvyPublicationIdentity projectIdentity;
     private final File ivyDescriptorFile;
     private final Set<IvyArtifact> allArtifacts;
+    private final IvyArtifactSet mainArtifacts;
 
-    public IvyNormalizedPublication(String name, IvyPublicationIdentity projectIdentity, File ivyDescriptorFile, Set<IvyArtifact> allArtifacts) {
+    public IvyNormalizedPublication(String name, IvyArtifactSet mainArtifacts, IvyPublicationIdentity projectIdentity, File ivyDescriptorFile, Set<IvyArtifact> allArtifacts) {
         this.name = name;
         this.projectIdentity = projectIdentity;
         this.ivyDescriptorFile = ivyDescriptorFile;
         this.allArtifacts = allArtifacts;
+        this.mainArtifacts = mainArtifacts;
     }
 
     public String getName() {
@@ -48,6 +52,17 @@ public class IvyNormalizedPublication {
     }
 
     public Set<IvyArtifact> getAllArtifacts() {
+        assertMainArtifactsPublishable();
         return allArtifacts;
+    }
+
+    private void assertMainArtifactsPublishable() {
+        mainArtifacts.all(artifact -> {
+            if (artifact.getClassifier() == null) {
+                if (!((PublicationArtifactInternal) artifact).shouldBePublished()) {
+                    throw new IllegalStateException("Artifact " + artifact.getFile().getName() + " wasn't produced by this build.");
+                }
+            }
+        });
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
@@ -141,9 +141,6 @@ public class ValidatingIvyPublisher implements IvyPublisher {
 
     private void checkCanPublish(String name, IvyArtifact artifact) {
         File artifactFile = artifact.getFile();
-        if (artifactFile == null || !artifactFile.exists()) {
-            throw new InvalidIvyPublicationException(name, String.format("artifact file does not exist: '%s'", artifactFile));
-        }
         if (artifactFile.isDirectory()) {
             throw new InvalidIvyPublicationException(name, String.format("artifact file is a directory: '%s'", artifactFile));
         }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactoryTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.publish.ivy.internal.artifact
 
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.Task
-import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.publish.ivy.IvyArtifact
@@ -34,7 +34,7 @@ public class IvyArtifactNotationParserFactoryTest extends AbstractProjectBuilder
     def fileNotationParser = Mock(NotationParser)
     def task = Mock(Task)
     def taskDependency = new DefaultTaskDependency(null, ImmutableSet.of(task))
-    def publishArtifact = Stub(PublishArtifact) {
+    def publishArtifact = Stub(PublishArtifactInternal) {
         getName() >> 'name'
         getExtension() >> 'extension'
         getType() >> 'type'

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleM
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.ivy.InvalidIvyPublicationException
 import org.gradle.api.publish.ivy.IvyArtifact
+import org.gradle.api.publish.ivy.IvyArtifactSet
 import org.gradle.api.publish.ivy.internal.artifact.FileBasedIvyArtifact
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublicationIdentity
 import org.gradle.test.fixtures.file.TestFile
@@ -48,6 +49,7 @@ class ValidatingIvyPublisherTest extends Specification {
 
     def publisher = new ValidatingIvyPublisher(delegate, moduleIdentifierFactory, TestFiles.fileRepository(), metadataFactory)
     def repository = Mock(IvyArtifactRepository)
+    def mainArtifacts = Mock(IvyArtifactSet)
 
     def "delegates when publication is valid"() {
         when:
@@ -55,7 +57,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def generator = ivyGenerator("the-group", "the-artifact", "the-version")
                             .withBranch("the-branch")
                             .withStatus("release")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile(generator), emptySet())
 
         and:
         publisher.publish(publication, repository)
@@ -74,7 +76,7 @@ class ValidatingIvyPublisherTest extends Specification {
                 }))
 
         and:
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("the-group", "the-artifact", "the-version"), ivyFile, emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity("the-group", "the-artifact", "the-version"), ivyFile, emptySet())
 
         and:
         publisher.publish(publication, repository)
@@ -86,7 +88,7 @@ class ValidatingIvyPublisherTest extends Specification {
     def "validates project coordinates"() {
         given:
         def projectIdentity = projectIdentity(group, name, version)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(group, name, version), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile(group, name, version), emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -114,7 +116,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def generator = ivyGenerator("org", "module", "version")
                             .withBranch(branch)
                             .withStatus(status)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile(generator), emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -144,7 +146,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def generator = ivyGenerator("org", "module", "version")
                             .withBranch(branch)
                             .withStatus(status)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile(generator), emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -165,7 +167,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def projectIdentity = projectIdentity("org", "module", "version")
         def generator = ivyGenerator("org", "module", "version")
         elements.each { generator.withExtraInfo(it, "${it}Value") }
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(generator), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile(generator), emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -183,7 +185,7 @@ class ValidatingIvyPublisherTest extends Specification {
     def "project coordinates must match ivy descriptor file"() {
         given:
         def projectIdentity = projectIdentity("org", "module", "version")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile(organisation, module, version), emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile(organisation, module, version), emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -210,7 +212,7 @@ class ValidatingIvyPublisherTest extends Specification {
         def ivyFile = ivyFile(ivyFileGenerator)
 
         and:
-        def publication = new IvyNormalizedPublication("pub-name", identity, ivyFile, emptySet())
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, identity, ivyFile, emptySet())
 
         when:
         publisher.publish(publication, repository)
@@ -232,7 +234,7 @@ class ValidatingIvyPublisherTest extends Specification {
             getExtension() >> extension
             getClassifier() >> classifier
         }
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("org", "module", "version"), ivyFile("org", "module", "version"), toSet([ivyArtifact]))
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity("org", "module", "version"), ivyFile("org", "module", "version"), toSet([ivyArtifact]))
 
         when:
         publisher.publish(publication, repository)
@@ -256,14 +258,12 @@ class ValidatingIvyPublisherTest extends Specification {
     }
 
     @Unroll
-    def "cannot publish with file that #message"() {
+    def "cannot publish with file that is a directory"() {
         def ivyArtifact = Mock(IvyArtifact)
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity("group", "artifact", "version"), ivyFile("group", "artifact", "version"), toSet([ivyArtifact]))
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity("group", "artifact", "version"), ivyFile("group", "artifact", "version"), toSet([ivyArtifact]))
 
-        File theFile = new TestFile(testDirectoryProvider.testDirectory, "testFile")
-        if (createDir) {
-            theFile.createDir()
-        }
+        File someDir = new TestFile(testDirectoryProvider.testDirectory, "testFile")
+        someDir.createDir()
 
         when:
         publisher.publish(publication, repository)
@@ -272,16 +272,12 @@ class ValidatingIvyPublisherTest extends Specification {
         ivyArtifact.name >> "name"
         ivyArtifact.type >> "type"
         ivyArtifact.extension >> "ext"
-        ivyArtifact.file >> theFile
+        ivyArtifact.file >> someDir
 
         and:
         def t = thrown InvalidIvyPublicationException
-        t.message == "Invalid publication 'pub-name': artifact file ${message}: '${theFile}'"
+        t.message == "Invalid publication 'pub-name': artifact file is a directory: '${someDir}'"
 
-        where:
-        message          | createDir
-        'does not exist' | false
-        'is a directory' | true
     }
 
     def "cannot publish with duplicate artifacts"() {
@@ -301,7 +297,7 @@ class ValidatingIvyPublisherTest extends Specification {
             getFile() >> testDirectoryProvider.createFile('artifact2')
         }
         def projectIdentity = projectIdentity("org", "module", "revision")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1, artifact2]))
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1, artifact2]))
 
         when:
         publisher.publish(publication, repository)
@@ -321,7 +317,7 @@ class ValidatingIvyPublisherTest extends Specification {
             getFile() >> testDirectoryProvider.createFile('artifact1')
         }
         def projectIdentity = projectIdentity("org", "module", "revision")
-        def publication = new IvyNormalizedPublication("pub-name", projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1]))
+        def publication = new IvyNormalizedPublication("pub-name", mainArtifacts, projectIdentity, ivyFile("org", "module", "revision"), toSet([artifact1]))
 
         when:
         publisher.publish(publication, repository)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.language.plugins
 
 import org.gradle.api.Task
-import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.component.PublishableComponent
 import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
@@ -412,7 +412,7 @@ class NativeBasePluginTest extends Specification {
 
     def "adds Maven publications for component with main publication"() {
         def usage1 = Stub(UsageContext)
-        def artifact1 = Stub(PublishArtifact)
+        def artifact1 = Stub(PublishArtifactInternal)
         artifact1.getFile() >> projectDir.file("artifact1")
         usage1.artifacts >> [artifact1]
         def variant1 = Stub(PublishableVariant)
@@ -421,7 +421,7 @@ class NativeBasePluginTest extends Specification {
         variant1.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_debug", "1.2")
 
         def usage2 = Stub(UsageContext)
-        def artifact2 = Stub(PublishArtifact)
+        def artifact2 = Stub(PublishArtifactInternal)
         artifact2.getFile() >> projectDir.file("artifact1")
         usage2.artifacts >> [artifact2]
         def variant2 = Stub(PublishableVariant)

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -260,4 +260,109 @@ subprojects {
         output.contains(":sub2:publishMavenPublicationToMavenLocal")
         output.contains(":customPublish")
     }
+
+    @ToBeFixedForInstantExecution
+    @Issue("https://github.com/gradle/gradle/issues/5136")
+    void "doesn't publish if main artifact is missing"() {
+        settingsFile << 'rootProject.name = "test"'
+        buildFile << """
+            apply plugin: "java-library"
+            apply plugin: "maven-publish"
+
+            group = "org.gradle"
+            version = "1.0"
+
+            jar {
+                enabled = Boolean.valueOf(project.getProperty("jarEnabled"))
+            }
+
+            publishing {
+                repositories {
+                    maven { url "\${buildDir}/repo" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+        file("src/main/java/hello/Hello.java") << """package hello;
+            public class Hello {}
+        """
+
+        when:
+        succeeds "publish", "-PjarEnabled=true"
+
+        then:
+        file("build/repo/org/gradle/test/1.0/test-1.0.jar").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0.jar.md5").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0.jar.sha1").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0.jar.sha256").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0.jar.sha512").exists()
+
+        when:
+        fails "publish", "-PjarEnabled=false"
+
+        then:
+        skipped(":jar")
+        failure.assertHasCause("Artifact test-1.0.jar wasn't produced by this build.")
+    }
+
+    @ToBeFixedForInstantExecution
+    @Issue("https://github.com/gradle/gradle/issues/5136")
+    void "doesn't publish stale files"() {
+        settingsFile << 'rootProject.name = "test"'
+        buildFile << """
+            apply plugin: "java-library"
+            apply plugin: "maven-publish"
+
+            group = "org.gradle"
+            version = "1.0"
+
+            java {
+                withJavadocJar()
+            }
+
+            javadocJar {
+                enabled = Boolean.valueOf(project.getProperty("javadocEnabled"))
+            }
+
+            publishing {
+                repositories {
+                    maven { url "\${buildDir}/repo" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+        file("src/main/java/hello/Hello.java") << """package hello;
+            public class Hello {}
+        """
+
+        when:
+        succeeds "publish", "-PjavadocEnabled=true"
+
+        then:
+        file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.md5").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.sha1").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.sha256").exists()
+        file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.sha512").exists()
+
+        when:
+        file("build/repo").deleteDir()
+        succeeds "publish", "-PjavadocEnabled=false"
+
+        then:
+        skipped(":javadocJar")
+        !file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar").exists()
+        !file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.md5").exists()
+        !file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.sha1").exists()
+        !file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.sha256").exists()
+        !file("build/repo/org/gradle/test/1.0/test-1.0-javadoc.jar.sha512").exists()
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/DefaultArtifactPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/DefaultArtifactPom.java
@@ -169,6 +169,11 @@ public class DefaultArtifactPom implements ArtifactPom {
         public Date getDate() {
             return null;
         }
+
+        @Override
+        public boolean shouldBePublished() {
+            return true;
+        }
     }
 
     private class MavenArtifact extends AbstractMavenArtifact {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/AbstractMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/AbstractMavenArtifact.java
@@ -21,12 +21,13 @@ import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.publish.internal.PublicationArtifactInternal;
 import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 
-public abstract class AbstractMavenArtifact implements MavenArtifact {
+public abstract class AbstractMavenArtifact implements MavenArtifact, PublicationArtifactInternal {
     private final TaskDependency allBuildDependencies;
     private final DefaultTaskDependency additionalBuildDependencies;
     private String extension;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/ArchiveTaskBasedMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/ArchiveTaskBasedMavenArtifact.java
@@ -51,4 +51,9 @@ public class ArchiveTaskBasedMavenArtifact extends AbstractMavenArtifact {
     protected TaskDependencyInternal getDefaultBuildDependencies() {
         return buildDependencies;
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return archiveTask.isEnabled();
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/DerivedMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/DerivedMavenArtifact.java
@@ -17,18 +17,17 @@
 package org.gradle.api.publish.maven.internal.artifact;
 
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
-import org.gradle.api.publish.maven.MavenArtifact;
-import org.gradle.internal.Factory;
+import org.gradle.api.publish.internal.PublicationInternal;
 
 import java.io.File;
 
 import static com.google.common.io.Files.getFileExtension;
 
 public class DerivedMavenArtifact extends AbstractMavenArtifact {
-    private final MavenArtifact original;
-    private final Factory<File> derivedFile;
+    private final AbstractMavenArtifact original;
+    private final PublicationInternal.DerivedArtifact derivedFile;
 
-    public DerivedMavenArtifact(MavenArtifact original, Factory<File> derivedFile) {
+    public DerivedMavenArtifact(AbstractMavenArtifact original, PublicationInternal.DerivedArtifact derivedFile) {
         this.original = original;
         this.derivedFile = derivedFile;
     }
@@ -51,5 +50,9 @@ public class DerivedMavenArtifact extends AbstractMavenArtifact {
     @Override
     protected TaskDependencyInternal getDefaultBuildDependencies() {
         return TaskDependencyInternal.EMPTY;
+    }
+
+    public boolean shouldBePublished() {
+        return original.shouldBePublished() && derivedFile.shouldBePublished();
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/FileBasedMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/FileBasedMavenArtifact.java
@@ -49,4 +49,9 @@ public class FileBasedMavenArtifact extends AbstractMavenArtifact {
     protected TaskDependencyInternal getDefaultBuildDependencies() {
         return TaskDependencyInternal.EMPTY;
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return true;
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/PublishArtifactBasedMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/PublishArtifactBasedMavenArtifact.java
@@ -17,15 +17,16 @@
 package org.gradle.api.publish.maven.internal.artifact;
 
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 
 import java.io.File;
 
 public class PublishArtifactBasedMavenArtifact extends AbstractMavenArtifact {
-    private final PublishArtifact publishArtifact;
+    private final PublishArtifactInternal publishArtifact;
 
     public PublishArtifactBasedMavenArtifact(PublishArtifact publishArtifact) {
-        this.publishArtifact = publishArtifact;
+        this.publishArtifact = (PublishArtifactInternal) publishArtifact;
     }
 
     @Override
@@ -46,5 +47,10 @@ public class PublishArtifactBasedMavenArtifact extends AbstractMavenArtifact {
     @Override
     protected TaskDependencyInternal getDefaultBuildDependencies() {
         return (TaskDependencyInternal) publishArtifact.getBuildDependencies();
+    }
+
+    @Override
+    public boolean shouldBePublished() {
+        return publishArtifact.shouldBePublished();
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
@@ -67,4 +67,9 @@ public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
             context.add(generator.get());
         }
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return isEnabled();
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenNormalizedPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenNormalizedPublication.java
@@ -18,6 +18,7 @@ package org.gradle.api.publish.maven.internal.publisher;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.publish.internal.PublicationArtifactInternal;
 import org.gradle.api.publish.maven.MavenArtifact;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 
@@ -82,6 +83,9 @@ public class MavenNormalizedPublication {
     }
 
     public MavenArtifact getMainArtifact() {
+        if (mainArtifact != null && !((PublicationArtifactInternal) mainArtifact).shouldBePublished()) {
+            throw new IllegalStateException("Artifact " + mainArtifact.getFile().getName() + " wasn't produced by this build.");
+        }
         return mainArtifact;
     }
 

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.publish.maven.internal.artifact
 
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.Task
-import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.publish.maven.MavenArtifact
@@ -35,7 +35,7 @@ public class MavenArtifactNotationParserFactoryTest extends AbstractProjectBuild
     def dependencies = ImmutableSet.of(task)
     def taskDependency = new DefaultTaskDependency(null, dependencies)
     def fileNotationParser = Mock(NotationParser)
-    def publishArtifact = Stub(PublishArtifact) {
+    def publishArtifact = Stub(PublishArtifactInternal) {
         getExtension() >> 'extension'
         getClassifier() >> 'classifier'
         getFile() >> new File('foo')

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -23,18 +23,19 @@ import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Category
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.publish.internal.PublicationArtifactInternal
 import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
 import org.gradle.api.publish.maven.MavenArtifact
@@ -128,10 +129,14 @@ class DefaultMavenPublicationTest extends Specification {
 
     def "packaging determines main artifact"() {
         when:
-        def mavenArtifact = Mock(MavenArtifact)
+        def mavenArtifact = Mock(MavenTestArtifact) {
+            shouldBePublished() >> true
+        }
         notationParser.parseNotation("artifact") >> mavenArtifact
         mavenArtifact.extension >> "ext"
-        def attachedMavenArtifact = Mock(MavenArtifact)
+        def attachedMavenArtifact = Mock(MavenTestArtifact) {
+            shouldBePublished() >> true
+        }
         notationParser.parseNotation("attached") >> attachedMavenArtifact
         attachedMavenArtifact.extension >> "jar"
 
@@ -148,7 +153,9 @@ class DefaultMavenPublicationTest extends Specification {
 
     def 'if there is only one artifact it is the main artifact even if packaging is different'() {
         when:
-        def mavenArtifact = Mock(MavenArtifact)
+        def mavenArtifact = Mock(MavenTestArtifact) {
+            shouldBePublished() >> true
+        }
         notationParser.parseNotation("artifact") >> mavenArtifact
         mavenArtifact.extension >> "ext"
 
@@ -175,7 +182,7 @@ class DefaultMavenPublicationTest extends Specification {
     def "artifacts are taken from added component"() {
         given:
         def publication = createPublication()
-        def artifact = Mock(PublishArtifact)
+        def artifact = Mock(PublishArtifactInternal)
         artifact.file >> artifactFile
         artifact.classifier >> ""
         artifact.extension >> "jar"
@@ -207,11 +214,11 @@ class DefaultMavenPublicationTest extends Specification {
     def "multiple usages of a component can provide the same artifact"() {
         given:
         def publication = createPublication()
-        def artifact1 = Mock(PublishArtifact)
+        def artifact1 = Mock(PublishArtifactInternal)
         artifact1.file >> artifactFile
         artifact1.classifier >> ""
         artifact1.extension >> "jar"
-        def artifact2 = Mock(PublishArtifact)
+        def artifact2 = Mock(PublishArtifactInternal)
         artifact2.file >> artifactFile
         artifact2.classifier >> ""
         artifact2.extension >> "jar"
@@ -604,5 +611,8 @@ class DefaultMavenPublicationTest extends Specification {
 
     def platformAttribute() {
         return AttributeTestUtil.attributesFactory().of(Category.CATEGORY_ATTRIBUTE, TestUtil.objectFactory().named(Category, Category.REGULAR_PLATFORM))
+    }
+
+    interface MavenTestArtifact extends MavenArtifact, PublicationArtifactInternal {
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -278,5 +278,10 @@ public class JvmPluginsHelper {
         public Date getDate() {
             return null;
         }
+
+        @Override
+        public boolean shouldBePublished() {
+            return false;
+        }
     }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -43,6 +43,7 @@ import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
+import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
@@ -379,6 +380,11 @@ public class GradleModuleMetadataWriter {
     }
 
     private void writeArtifact(PublicationInternal publication, PublishArtifact artifact, JsonWriter jsonWriter) throws IOException {
+        if (artifact instanceof PublishArtifactInternal) {
+            if (!((PublishArtifactInternal) artifact).shouldBePublished()) {
+                return;
+            }
+        }
         PublicationInternal.PublishedFile publishedFile = publication.getPublishedFile(artifact);
 
         jsonWriter.beginObject();

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationArtifactInternal.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationArtifactInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.publish.internal;
+
+import org.gradle.api.publish.PublicationArtifact;
+
+public interface PublicationArtifactInternal extends PublicationArtifact {
+    boolean shouldBePublished();
+}

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/PublicationInternal.java
@@ -57,7 +57,7 @@ public interface PublicationInternal<T extends PublicationArtifact> extends Publ
      * @param file The file to be used for publishing the derived artifact.
      * @return The newly created derived artifact.
      */
-    T addDerivedArtifact(T originalArtifact, Factory<File> file);
+    T addDerivedArtifact(T originalArtifact, DerivedArtifact file);
 
     void removeDerivedArtifact(T artifact);
 
@@ -76,5 +76,9 @@ public interface PublicationInternal<T extends PublicationArtifact> extends Publ
         String getName();
 
         String getUri();
+    }
+
+    interface DerivedArtifact extends Factory<File> {
+        boolean shouldBePublished();
     }
 }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningIntegrationSpec.groovy
@@ -209,6 +209,14 @@ abstract class SigningIntegrationSpec extends AbstractIntegrationSpec {
         m2RepoFile("${name}.pom.asc")
     }
 
+    TestFile module(String name = "sign-1.0") {
+        m2RepoFile("${name}.module")
+    }
+
+    TestFile moduleSignature(String name = "sign-1.0") {
+        m2RepoFile("${name}.module.asc")
+    }
+
     SignMethod getSignMethod() {
         return SignMethod.OPEN_GPG
     }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -621,4 +621,119 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         ivyRepoFile("ivy-${version}.xml").assertExists()
         ivyRepoFile("ivy-${version}.xml.asc").assertDoesNotExist()
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/5136")
+    def "doesn't publish stale signatures"() {
+        buildFile << """
+            apply plugin: 'ivy-publish'
+            apply plugin: 'maven-publish'
+
+            ${keyInfo.addAsPropertiesScript()}
+
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        module '$artifactId'
+                    }
+                    maven(MavenPublication) {
+                        from components.java
+                        artifactId '$artifactId'
+                    }
+                }
+                repositories {
+                    maven {
+                        url "file://\$buildDir/m2Repo/"
+                    }
+                    ivy {
+                        url "file://\$buildDir/ivyRepo/"
+                        patternLayout {
+                            artifact "[artifact]-[revision](-[classifier])(.[ext])"
+                            ivy "[artifact]-[revision](-[classifier])(.[ext])"
+                        }
+                    }
+                }
+            }
+
+            signing {
+                ${signingConfiguration()}
+                sign publishing.publications
+            }
+
+            tasks.register("cleanRepo") {
+                doLast {
+                    new File("\${buildDir}/m2Repo").deleteDir()
+                    new File("\${buildDir}/ivyRepo").deleteDir()
+                }
+            }
+            def sign = project.getProperty("sign")
+            if (sign == 'skip') {
+                tasks.withType(Sign)*.onlyIf { false }
+            } else {
+                tasks.withType(Sign)*.enabled = Boolean.valueOf(sign)
+            }
+
+        """
+
+        when:
+        succeeds "publish", "-Psign=true"
+
+        then:
+        executedAndNotSkipped(":signIvyPublication", ":publishIvyPublicationToIvyRepository")
+        executedAndNotSkipped(":signMavenPublication", ":publishMavenPublicationToMavenRepository")
+
+        and:
+        pom().assertExists()
+        pomSignature().assertExists()
+        module().assertExists()
+        moduleSignature().assertExists()
+        m2RepoFile(jarFileName).assertExists()
+        m2RepoFile("${jarFileName}.asc").assertExists()
+        ivyRepoFile(jarFileName).assertExists()
+        ivyRepoFile("${jarFileName}.asc").assertExists()
+        ivyRepoFile("ivy-${version}.xml").assertExists()
+        ivyRepoFile("ivy-${version}.xml.asc").assertExists()
+
+        when:
+        succeeds "cleanRepo", "publish", "-Psign=false"
+
+        then:
+        skipped(":signIvyPublication")
+        skipped(":signMavenPublication")
+        executedAndNotSkipped(":publishIvyPublicationToIvyRepository")
+        executedAndNotSkipped(":publishMavenPublicationToMavenRepository")
+
+        and:
+        pom().assertExists()
+        pomSignature().assertDoesNotExist()
+        module().assertExists()
+        moduleSignature().assertDoesNotExist()
+        m2RepoFile(jarFileName).assertExists()
+        m2RepoFile("${jarFileName}.asc").assertDoesNotExist()
+        ivyRepoFile(jarFileName).assertExists()
+        ivyRepoFile("${jarFileName}.asc").assertDoesNotExist()
+        ivyRepoFile("ivy-${version}.xml").assertExists()
+        ivyRepoFile("ivy-${version}.xml.asc").assertDoesNotExist()
+
+        when:
+        succeeds "cleanRepo", "publish", "-Psign=skip"
+
+        then:
+        skipped(":signIvyPublication")
+        skipped(":signMavenPublication")
+        executedAndNotSkipped(":publishIvyPublicationToIvyRepository")
+        executedAndNotSkipped(":publishMavenPublicationToMavenRepository")
+
+        and:
+        pom().assertExists()
+        pomSignature().assertDoesNotExist()
+        module().assertExists()
+        moduleSignature().assertDoesNotExist()
+        m2RepoFile(jarFileName).assertExists()
+        m2RepoFile("${jarFileName}.asc").assertDoesNotExist()
+        ivyRepoFile(jarFileName).assertExists()
+        ivyRepoFile("${jarFileName}.asc").assertDoesNotExist()
+        ivyRepoFile("ivy-${version}.xml").assertExists()
+        ivyRepoFile("ivy-${version}.xml.asc").assertDoesNotExist()
+    }
 }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -622,6 +622,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         ivyRepoFile("ivy-${version}.xml.asc").assertDoesNotExist()
     }
 
+    @ToBeFixedForInstantExecution
     @Issue("https://github.com/gradle/gradle/issues/5136")
     def "doesn't publish stale signatures"() {
         buildFile << """

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
@@ -439,4 +439,9 @@ public class Signature extends AbstractPublishArtifact {
 
         signatureType.sign(signatory, toSign);
     }
+
+    @Override
+    public boolean shouldBePublished() {
+        return true;
+    }
 }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -660,7 +660,7 @@ public class SigningExtension {
 
         @Override
         public File create() {
-            return  signature.getFile();
+            return signature.getFile();
         }
 
         @Override

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -33,7 +33,6 @@ import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationArtifact;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.tasks.TaskContainer;
-import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.signing.internal.SignOperationInternal;
 import org.gradle.plugins.signing.signatory.Signatory;
@@ -426,12 +425,7 @@ public class SigningExtension {
         signTask.getSignatures().all(new Action<Signature>() {
             @Override
             public void execute(final Signature signature) {
-                T artifact = publicationToSign.addDerivedArtifact((T) signature.getSource(), new Factory<File>() {
-                    @Override
-                    public File create() {
-                        return signature.getFile();
-                    }
-                });
+                T artifact = publicationToSign.addDerivedArtifact((T) signature.getSource(), new DefaultDerivedArtifactFile(signature, signTask));
                 artifact.builtBy(signTask);
                 artifacts.put(signature, artifact);
             }
@@ -653,5 +647,27 @@ public class SigningExtension {
 
     private Object force(Object maybeCallable) {
         return DeferredUtil.unpack(maybeCallable);
+    }
+
+    private static class DefaultDerivedArtifactFile implements PublicationInternal.DerivedArtifact {
+        private final Signature signature;
+        private final Sign signTask;
+
+        public DefaultDerivedArtifactFile(Signature signature, Sign signTask) {
+            this.signature = signature;
+            this.signTask = signTask;
+        }
+
+        @Override
+        public File create() {
+            return  signature.getFile();
+        }
+
+        @Override
+        public boolean shouldBePublished() {
+            return signTask.isEnabled() &&
+                signTask.getOnlyIf().isSatisfiedBy(signTask) &&
+                create().exists();
+        }
     }
 }


### PR DESCRIPTION
This commit fixes the publication of stale signature files:
prior to this change it was possible that a signature generated
in a previous build for a different artifact was uploaded even
if no signature was generated during the build, which would
lead to inconsistent publications.

In addition, it makes it an error to publish something which
doesn't have the main artifact created (or, at least up-to-date)
in this build. In other words, if the task which generates the
main artifact is disabled, it's an error to publish.

Other stale artifacts are going to be ignored.

Fixes #5136

