### PR TITLE
DependencyHandler support for lazy dependencies

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -260,6 +260,11 @@ import java.util.Map;
  *
  * The module notation is the same as the dependency notations described above, except that the classifier property is
  * not available. Client modules are represented using a {@link org.gradle.api.artifacts.ClientModule}.
+ *
+ * <h3>Lazy dependencies</h3>
+ *
+ * <p>All {@link DependencyHandler#add} methods also support accepting {@link org.gradle.api.provider.Provider} instances
+ * that supply any of the supported dependency formats.</p>
  */
 public interface DependencyHandler extends ExtensionAware {
     /**

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+
+/**
+ * Tests covering the use of {@link org.gradle.api.provider.Provider} as an argument in the
+ * {@link org.gradle.api.artifacts.dsl.DependencyHandler} block.
+ */
+class DependencyHandlerProviderIntegrationTest extends AbstractHttpDependencyResolutionTest {
+
+    def "mutating the provider value before it's added resolves to the correct dependency"() {
+        when:
+        buildFile << """
+        configurations { conf }
+        
+        def lazyDep = objects.property(String).convention("org.mockito:mockito-core:1.8")
+        
+        dependencies {
+            conf lazyDep
+        }
+        
+        lazyDep.set("junit:junit:4.12")
+        
+        task checkDeps {
+            doLast {
+                def deps = configurations.conf.incoming.dependencies
+                assert deps.find { it instanceof ExternalDependency && it.group == 'junit' && it.name == 'junit' && it.version == '4.12' }
+                assert !deps.find { it instanceof ExternalDependency && it.group == 'org.mockito' && it.name == 'mockito-core' && it.version == '1.8'  }
+            }
+        }
+        """
+        then:
+        succeeds('checkDeps')
+    }
+
+    def "mutation after dependencies have been queried provide a reasonable error message"() {
+        given:
+        buildFile << """
+        configurations { conf }
+        
+        def lazyDep = objects.property(String).convention("org.mockito:mockito-core:1.8")
+        
+        dependencies {
+            conf lazyDep
+        }
+        // Do the resolve
+        configurations.conf.incoming.dependencies
+        // Exception do to the property having been finalized
+        lazyDep.set("junit:junit:4.12")
+        """
+        when:
+        fails("help")
+        then:
+        errorOutput.contains("The value for this property cannot be changed any further.")
+    }
+
+    def "works correctly with up-to-date checking"() {
+        given:
+        mavenHttpRepo.module("group", "projectA", "1.1").publish()
+        mavenHttpRepo.module("group", "projectA", "1.2").publish()
+
+        when:
+        buildFile << """
+        repositories {
+            maven {
+                url = "${mavenRepo.uri}"
+            }
+        }
+        configurations { conf }
+        
+        dependencies {
+            conf provider { "group:projectA:\${property('project.version')}" }
+        }
+        
+        task retrieve (type: Sync) {
+            into 'build'
+            from configurations.conf
+        }
+        """
+        then:
+        // First run
+        args('-Pproject.version=1.1')
+        succeeds("retrieve").assertTaskExecuted(":retrieve")
+        // Second run, task should be 'UP-TO-DATE'
+        args('-Pproject.version=1.1')
+        succeeds("retrieve").assertTaskSkipped(":retrieve")
+        // Third run, new version, should not be 'UP-TO-DATE'
+        args('-Pproject.version=1.2')
+        succeeds("retrieve").assertTaskExecuted(":retrieve")
+    }
+
+    def "property has no value"() {
+        when:
+        buildFile << """
+        configurations { conf }
+        
+        def emptyDep = objects.property(String)
+        
+        dependencies {
+            conf emptyDep
+        }
+        // Do the resolve
+        configurations.conf.incoming.dependencies
+        """
+        then:
+        fails("help")
+        errorOutput.contains("No value has been specified for this property.")
+    }
+
+    def "provider throws an exception"() {
+        when:
+        buildFile << """
+        configurations { conf }
+        
+        def lazyDep = provider {
+            throw new GradleException("Boom!")
+        }
+        
+        dependencies {
+            conf lazyDep
+        }
+        // Do the resolve
+        configurations.conf.incoming.dependencies
+        """
+        then:
+        fails("help")
+        errorOutput.contains("Boom!")
+        errorOutput.contains("build.gradle:5")
+        errorOutput.contains("build.gradle:12")
+    }
+
+    def "reasonable error message when the provider doesn't provide a supported dependency notation"() {
+        when:
+        buildFile << """
+        configurations { conf }
+        
+        def lazyDep = provider { 
+            42
+        }
+        
+        dependencies {
+            conf lazyDep
+        }
+        // Do the resolve
+        configurations.conf.incoming.dependencies
+        """
+        then:
+        fails("help")
+        errorOutput.contains("Cannot convert the provided notation to an object of type Dependency: 42.")
+        errorOutput.contains("The following types/formats are supported:")
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
@@ -49,27 +49,6 @@ class DependencyHandlerProviderIntegrationTest extends AbstractHttpDependencyRes
         succeeds('checkDeps')
     }
 
-    def "mutation after dependencies have been queried provide a reasonable error message"() {
-        given:
-        buildFile << """
-        configurations { conf }
-        
-        def lazyDep = objects.property(String).convention("org.mockito:mockito-core:1.8")
-        
-        dependencies {
-            conf lazyDep
-        }
-        // Do the resolve
-        configurations.conf.incoming.dependencies
-        // Exception do to the property having been finalized
-        lazyDep.set("junit:junit:4.12")
-        """
-        when:
-        fails("help")
-        then:
-        errorOutput.contains("The value for this property cannot be changed any further.")
-    }
-
     def "works correctly with up-to-date checking"() {
         given:
         mavenHttpRepo.module("group", "projectA", "1.1").publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Ignore
 
@@ -67,6 +68,7 @@ class DependencyHandlerProviderIntegrationTest extends AbstractHttpDependencyRes
         }
     }
 
+    @ToBeFixedForInstantExecution
     def "works correctly with up-to-date checking"() {
         given:
         mavenHttpRepo.module("group", "projectA", "1.1").publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -39,6 +39,8 @@ dependencies {
     conf someDependency
     conf "org.mockito:mockito-core:1.8"
     conf group: 'org.spockframework', name: 'spock-core', version: '1.0'
+    conf provider { "junit:junit:4.12" }
+
     conf('org.test:configured') {
         version {
            prefer '1.1'
@@ -60,6 +62,7 @@ task checkDeps {
         assert deps.contains(someDependency)
         assert deps.find { it instanceof ExternalDependency && it.group == 'org.mockito' && it.name == 'mockito-core' && it.version == '1.8'  }
         assert deps.find { it instanceof ExternalDependency && it.group == 'org.spockframework' && it.name == 'spock-core' && it.version == '1.0'  }
+        assert deps.find { it instanceof ExternalDependency && it.group == 'junit' && it.name == 'junit' && it.version == '4.12' }
         def configuredDep = deps.find { it instanceof ExternalDependency && it.group == 'org.test' && it.name == 'configured' }
         assert configuredDep.version == '1.1'
         assert configuredDep.transitive == false
@@ -236,6 +239,27 @@ task checkDeps
             }
         """
 
+        then:
+        succeeds "check"
+    }
+
+    def "dependencies block supports provider dependencies"() {
+        when:
+        buildFile << """
+            configurations {
+              conf
+            }
+            
+            dependencies {
+              conf provider { gradleApi() } 
+            }
+            
+            task check {
+                doLast {
+                    assert configurations.conf.dependencies.contains(dependencies.gradleApi())
+                }
+            }
+        """
         then:
         succeeds "check"
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -40,7 +40,6 @@ import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
-import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.component.external.model.ProjectTestFixtures;
 import org.gradle.internal.Factory;
@@ -131,14 +130,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         }
         if (dependencyNotation instanceof Provider<?>) {
             Provider<?> lazy = (Provider<?>) dependencyNotation;
-
-            Provider<Dependency> lazyDependency = lazy.map(lazyNotation -> {
-                if (lazy instanceof HasConfigurableValue) {
-                    HasConfigurableValue configurableLazy = (HasConfigurableValue) lazy;
-                    configurableLazy.disallowChanges();
-                }
-                return create(lazyNotation, configureClosure);
-            });
+            Provider<Dependency> lazyDependency = lazy.map(lazyNotation -> create(lazyNotation, configureClosure));
             configuration.getDependencies().addLater(lazyDependency);
             // Return null here because we don't want to prematurely realize the dependency
             return null;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -121,24 +121,35 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
 
     private Dependency doAdd(Configuration configuration, Object dependencyNotation, Closure configureClosure) {
         if (dependencyNotation instanceof Configuration) {
-            Configuration other = (Configuration) dependencyNotation;
-            if (!configurationContainer.contains(other)) {
-                throw new UnsupportedOperationException("Currently you can only declare dependencies on configurations from the same project.");
-            }
-            configuration.extendsFrom(other);
-            return null;
+            return doAddConfiguration(configuration, (Configuration) dependencyNotation);
         }
         if (dependencyNotation instanceof Provider<?>) {
-            Provider<?> lazy = (Provider<?>) dependencyNotation;
-            Provider<Dependency> lazyDependency = lazy.map(lazyNotation -> create(lazyNotation, configureClosure));
-            configuration.getDependencies().addLater(lazyDependency);
-            // Return null here because we don't want to prematurely realize the dependency
-            return null;
+            return doAddProvider(configuration, (Provider<?>) dependencyNotation, configureClosure);
         } else {
-            Dependency dependency = create(dependencyNotation, configureClosure);
-            configuration.getDependencies().add(dependency);
-            return dependency;
+            return doAddRegularDependency(configuration, dependencyNotation, configureClosure);
         }
+    }
+
+    private Dependency doAddRegularDependency(Configuration configuration, Object dependencyNotation, Closure<?> configureClosure) {
+        Dependency dependency = create(dependencyNotation, configureClosure);
+        configuration.getDependencies().add(dependency);
+        return dependency;
+    }
+
+    private Dependency doAddProvider(Configuration configuration, Provider<?> dependencyNotation, Closure<?> configureClosure) {
+        Provider<Dependency> lazyDependency = dependencyNotation.map(lazyNotation -> create(lazyNotation, configureClosure));
+        configuration.getDependencies().addLater(lazyDependency);
+        // Return null here because we don't want to prematurely realize the dependency
+        return null;
+    }
+
+    private Dependency doAddConfiguration(Configuration configuration, Configuration dependencyNotation) {
+        Configuration other = dependencyNotation;
+        if (!configurationContainer.contains(other)) {
+            throw new UnsupportedOperationException("Currently you can only declare dependencies on configurations from the same project.");
+        }
+        configuration.extendsFrom(other);
+        return null;
     }
 
     @Override

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -38,6 +38,30 @@ details of 2
 ## n
 -->
 
+<a name="lazy-dependencies"><a>
+## Lazy Dependencies
+
+Gradle 6.2 now supports accepting an instance of the [`org.gradle.api.provider.Provider`](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Provider.html)
+type in the [`DependencyHandler`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/dsl/DependencyHandler.html) block.
+
+For example:
+```kotlin
+dependencies {
+    implementation(playDep.ws()) // Becomes: 'com.typesafe.play:play-ws_2.11:2.4.2
+}
+// This is declared later, so we need to support providers
+play {
+    platform {
+        playVersion.set("2.4.2")
+        scalaVersion.set("2.11.6")
+    }
+}
+```
+
+In this above example, the method `playDep.json()` returns the type `Provider<ExternalModuleDependency>`.
+This new capability will be useful to plugin authors that wish to create plugins that supply different versions of dependencies
+based upon how the plugin extension is configured.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -230,7 +230,7 @@ project(':consumer') {
         outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
-    
+
     def "provides runtime classes variant"() {
         buildFile << """
             project(':consumer') {


### PR DESCRIPTION
The `dependencies` block now supports adding a `Provider` type as a dependency to a configuration.

### Context

This allows plugins to create extensions that supply instances of `Provider<ExternalModuleDependency>`.

This is useful when you have a plugin that's `extension` can change what artifact is resolved.

For example:

```
dependencies {
    implementation(playDep.json()) // Becomes: 'com.typesafe.play:play-json_2.11:2.4.2
}
// This is declared later, so we need to support providers
play {
    platform {
        playVersion.set("2.4.2")
        scalaVersion.set("2.11.6")
    }
}
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
