### PR TITLE
Fix typo in dep man docu

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -29,7 +29,7 @@ include::sample[dir="snippets/java-platform/recommender/kotlin/consumer",files="
 This `platform` notation is a short-hand notation which actually performs several operations under the hood:
 
 * it sets the link:{javadocPath}/org/gradle/api/attributes/Category.html[org.gradle.category attribute] to `platform`, which means that Gradle will select the _platform_ component of the dependency.
-* it set the link:{javadocPath}/org/gradle/api/artifacts/ModuleDependency.html#endorseStrictVersions--[endorseStrictVersions] behavior by default, meaning that if the platform declares strict dependencies, they will be enforced.
+* it sets the link:{javadocPath}/org/gradle/api/artifacts/ModuleDependency.html#endorseStrictVersions--[endorseStrictVersions] behavior by default, meaning that if the platform declares strict dependencies, they will be enforced.
 
 This means that by default, a dependency to a platform triggers the inheritance of all <<rich_versions.adoc#sec:strict-version,strict versions>> defined in that platform, which can be useful for platform authors to make sure that all consumers respect their decisions in terms of versions of dependencies.
 This can be turned off by explicitly calling the `doNotEndorseStrictVersions` method.

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -1,7 +1,7 @@
-[[sec:using-platform-to-control-transitive-deps]]
+[[sec:sharing-dep-versions-between-projects]]
 = Sharing dependency versions between projects
 
-[[sub:sharing-dep-versions-between-projects]]
+[[sub:using-platform-to-control-transitive-deps]]
 == Using a platform to control transitive versions
 
 A <<dependency_management_terminology.adoc#sub::terminology_platform,platform>> is a special software component which can be used to control transitive dependency versions.


### PR DESCRIPTION
<!--- The issue this PR addresses -->
- Fixed typo in [Dependency management in Gradle](https://docs.gradle.org/current/userguide/dependency_management.html#sec:using-platform-to-control-transitive-deps) documentation:
  - replaced "_it set the endorseStrictVersions behavior by default_"
  - by "_it set**s** the endorseStrictVersions behavior by default_"
- Swapped anchor names that seem to got swapped accidentally

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
