### PR TITLE
Some improvements to JavaInstallationRegistry

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildTree.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildTree.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Attached to a service interface to indicate that the service is provided in a 'build tree' scope.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BuildTree {
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -106,6 +106,10 @@ public class TestFiles {
         return new DefaultDeleter(Time.clock()::getCurrentTime, fileSystem()::isSymlink, false);
     }
 
+    public static FileFactory fileFactory() {
+        return new DefaultFilePropertyFactory(resolver(), fileCollectionFactory());
+    }
+
     public static FileOperations fileOperations(File basedDir) {
         return fileOperations(basedDir, null);
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -86,6 +86,10 @@ class TestUtil {
         return services().get(DomainObjectCollectionFactory)
     }
 
+    static ProviderFactory providerFactory() {
+        return services().get(ProviderFactory)
+    }
+
     static ObjectFactory objectFactory() {
         return services().get(ObjectFactory)
     }
@@ -109,9 +113,11 @@ class TestUtil {
                 InstantiatorFactory createInstantiatorFactory() {
                     instantiatorFactory()
                 }
+
                 ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, NamedObjectInstantiator namedObjectInstantiator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
                     return new DefaultObjectFactory(instantiatorFactory.decorate(services), namedObjectInstantiator, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver, fileCollectionFactory), fileCollectionFactory, domainObjectCollectionFactory)
                 }
+
                 ChecksumService createChecksumService() {
                     new ChecksumService() {
                         @Override

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
 
     integTestImplementation(project(":jvmServices"))
     integTestImplementation(project(":toolingApi"))
+    integTestImplementation(project(":platformJvm"))
 
     integTestImplementation(library("guava"))
     integTestImplementation(library("ant"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.initialization.LoadProjectsBuildOperationType
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.event.ListenerManager
 import org.gradle.invocation.DefaultGradle
+import org.gradle.jvm.toolchain.JavaInstallationRegistry
 import org.gradle.process.ExecOperations
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.workers.WorkerExecutor
@@ -472,6 +473,7 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         FileSystemOperations.name        | "project.services.get(${FileSystemOperations.name})"        | "toString()"
         ExecOperations.name              | "project.services.get(${ExecOperations.name})"              | "toString()"
         ListenerManager.name             | "project.services.get(${ListenerManager.name})"             | "toString()"
+        JavaInstallationRegistry.name    | "project.services.get(${JavaInstallationRegistry.name})"    | "installationForCurrentVirtualMachine"
     }
 
     @Unroll

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -152,6 +152,7 @@ class Codecs(
         bind(ownerService<BuildOperationListenerManager>())
         bind(ownerService<BuildRequestMetaData>())
         bind(ownerService<ListenerManager>())
+        bind(ServicesCodec())
 
         bind(ProxyCodec)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ServicesCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/ServicesCodec.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.internal.service.scopes.BuildTree
+
+
+class ServicesCodec : EncodingProducer, Decoding {
+    override fun encodingForType(type: Class<*>): Encoding? {
+        // Only handle build tree scoped service for now
+        // TODO - perhaps query the isolate owner to see whether the value is in fact a service
+        return if (type.getAnnotation(BuildTree::class.java) != null) {
+            OwnerServiceEncoding
+        } else {
+            null
+        }
+    }
+
+    override suspend fun ReadContext.decode(): Any? {
+        return isolate.owner.service(readClass())
+    }
+}
+
+
+internal
+object OwnerServiceEncoding : Encoding {
+    override suspend fun WriteContext.encode(value: Any) {
+        writeClass(value.javaClass)
+    }
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/CrossCompilationIntegrationTest.groovy
@@ -46,7 +46,7 @@ class CrossCompilationIntegrationTest extends AbstractIntegrationSpec {
                 sourceCompatibility = JavaVersion.${version.name()}
             }
 
-            def javaInstallation = project.javaInstalls.installationForDirectory(file("${jvm.javaHome.toURI()}"))
+            def javaInstallation = project.javaInstalls.installationForDirectory(project.layout.projectDirectory.dir("${jvm.javaHome.toURI()}"))
 
             tasks.named("compileJava") {
                 options.fork = true

--- a/subprojects/platform-jvm/platform-jvm.gradle.kts
+++ b/subprojects/platform-jvm/platform-jvm.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(library("asm"))
 
     testImplementation(project(":native"))
+    testImplementation(project(":snapshots"))
     testImplementation(library("ant"))
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":diagnostics")))

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Unroll
 
 import javax.inject.Inject
 
-class JavaInstallationFactoryIntegrationTest extends AbstractIntegrationSpec {
+class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
     def "plugin can query information about the current JVM"() {
         taskTypeShowsJavaInstallationDetails()
         pluginShowsCurrentJvm()
@@ -77,7 +77,7 @@ class JavaInstallationFactoryIntegrationTest extends AbstractIntegrationSpec {
         taskTypeShowsJavaInstallationDetails()
         buildFile << """
             task show(type: ShowTask) {
-                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.file("${jvm.javaHome.toURI()}"))
+                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.layout.projectDirectory.dir("${jvm.javaHome.toURI()}"))
             }
         """
 
@@ -101,7 +101,7 @@ class JavaInstallationFactoryIntegrationTest extends AbstractIntegrationSpec {
         taskTypeShowsJavaInstallationDetails()
         buildFile << """
             task show(type: ShowTask) {
-                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.file("${jvm.javaHome.toURI()}"))
+                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.layout.projectDirectory.dir("${jvm.javaHome.toURI()}"))
             }
         """
 
@@ -128,7 +128,7 @@ class JavaInstallationFactoryIntegrationTest extends AbstractIntegrationSpec {
         taskTypeShowsJavaInstallationDetails()
         buildFile << """
             task show(type: ShowTask) {
-                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.file("${jre.homeDir.toURI()}"))
+                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.layout.projectDirectory.dir("${jre.homeDir.toURI()}"))
             }
         """
 
@@ -152,7 +152,7 @@ class JavaInstallationFactoryIntegrationTest extends AbstractIntegrationSpec {
         taskTypeShowsJavaInstallationDetails()
         buildFile << """
             task show(type: ShowTask) {
-                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.file("${jre.homeDir.toURI()}"))
+                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.layout.projectDirectory.dir("${jre.homeDir.toURI()}"))
             }
         """
 
@@ -177,7 +177,7 @@ class JavaInstallationFactoryIntegrationTest extends AbstractIntegrationSpec {
         taskTypeShowsJavaInstallationDetails()
         buildFile << """
             task show(type: ShowTask) {
-                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.file("install"))
+                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.layout.projectDirectory.dir("install"))
             }
         """
 
@@ -206,7 +206,7 @@ class JavaInstallationFactoryIntegrationTest extends AbstractIntegrationSpec {
         taskTypeShowsJavaInstallationDetails()
         buildFile << """
             task show(type: ShowTask) {
-                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.file("install"))
+                installation = services.get(JavaInstallationRegistry).installationForDirectory(project.layout.projectDirectory.dir("install"))
             }
         """
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationRegistry.java
@@ -17,12 +17,11 @@
 package org.gradle.jvm.toolchain;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 
-import java.io.File;
-
 /**
- * Allows information about Java installations to be queried.
+ * Allows information about Java installations to be queried. A Java installation may contain a JDK, or a JRE, or both.
  *
  * <p>An instance of this service is available for injection into tasks, plugins and other types.
  *
@@ -41,6 +40,19 @@ public interface JavaInstallationRegistry {
      * <p>Note that this method may return an installation whose Java home directory is not the same as the installation directory. For example, if the given directory
      * points to a JRE installation contained within a JDK installation (as was the case for Java 8 and earlier), then the {@code JavaInstallation} for outer installation will be returned.
      * </p>
+     *
+     * @param installationDirectory The directory containing the Java installation.
      */
-    Provider<JavaInstallation> installationForDirectory(File installationDirectory);
+    Provider<JavaInstallation> installationForDirectory(Directory installationDirectory);
+
+    /**
+     * Returns information about the Java installation at the given location.
+     *
+     * <p>Note that this method may return an installation whose Java home directory is not the same as the installation directory. For example, if the given directory
+     * points to a JRE installation contained within a JDK installation (as was the case for Java 8 and earlier), then the {@code JavaInstallation} for outer installation will be returned.
+     * </p>
+     *
+     * @param installationDirectory The directory containing the Java installation.
+     */
+    Provider<JavaInstallation> installationForDirectory(Provider<Directory> installationDirectory);
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistry.java
@@ -28,6 +28,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.service.scopes.BuildTree;
 import org.gradle.jvm.toolchain.JavaDevelopmentKit;
 import org.gradle.jvm.toolchain.JavaInstallation;
 import org.gradle.jvm.toolchain.JavaInstallationRegistry;
@@ -36,6 +37,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Optional;
 
+@BuildTree
 public class DefaultJavaInstallationRegistry implements JavaInstallationRegistry {
     private final JavaInstallationProbe installationProbe;
     private final ProviderFactory providerFactory;

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistryTest.groovy
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.api.file.Directory
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.provider.Providers
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class DefaultJavaInstallationRegistryTest extends Specification {
+    def probe = Mock(JavaInstallationProbe)
+    def registry = new DefaultJavaInstallationRegistry(probe, TestUtil.providerFactory(), TestFiles.fileCollectionFactory(), TestFiles.fileFactory())
+
+    def "can query information for current JVM"() {
+        def probeResult = Stub(JavaInstallationProbe.ProbeResult)
+        def javaHome = new File("java-home").absoluteFile
+
+        when:
+        def provider = registry.installationForCurrentVirtualMachine
+
+        then:
+        1 * probe.current() >> probeResult
+        _ * probeResult.javaHome >> javaHome
+
+        and:
+        provider.present
+        provider.get().installationDirectory.asFile == javaHome
+
+        when:
+        def result = provider.get()
+
+        then:
+        0 * probe._
+
+        and:
+        result.installationDirectory.asFile == javaHome
+    }
+
+    def "can lazily query information for installation in directory"() {
+        def dir = Stub(Directory)
+        def probeResult = Stub(JavaInstallationProbe.ProbeResult)
+        def javaHome = new File("java-home").absoluteFile
+
+        when:
+        def provider = registry.installationForDirectory(dir)
+
+        then:
+        0 * probe._
+
+        when:
+        def result = provider.get()
+
+        then:
+        1 * probe.checkJdk(javaHome) >> probeResult
+        _ * dir.asFile >> javaHome
+        _ * probeResult.javaHome >> javaHome
+
+        and:
+        result.installationDirectory.asFile == javaHome
+
+        when:
+        def result2 = provider.get()
+
+        then:
+        0 * probe._
+
+        and:
+        result2.is(result)
+    }
+
+    def "has no information when no directory defined"() {
+        def dir = Stub(Directory)
+        when:
+        def provider = registry.installationForDirectory(Providers.notDefined())
+
+        then:
+        0 * probe._
+
+        when:
+        def result = provider.getOrNull()
+
+        then:
+        0 * probe._
+
+        and:
+        result == null
+    }
+}


### PR DESCRIPTION

### Context

Some improvements to `JavaInstallationRegistry` so that it is easier to use from the Gradle build:

- Allow a `Provider<Directory>` to be used to specify where a Java installation may be found.
- Allow a task that references an instance of `JavaInstallationRegistry` to be used with instant execution.

This PR also adds a `@BuildTree` annotation to be attached to services to indicate that they are available in the build tree scope. This change does just enough to allow the `JavaInstallationService` service to be recognized by instant execution as such a service and references to it serialized. More usages plus more scopes plus validation and other useful things can be added later.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
