### PR TITLE
Dependency verification documentation: Adjust sample commands and XML

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -83,10 +83,10 @@ The dependency verification file can be generated with the following CLI instruc
 
 
 ----
-gradle --write-verification-file sha256 help
+gradle --write-verification-metadata sha256 help
 ----
 
-The `write-verification-file` flag requires the list of <<#sec:checksum-verification,checksums>> that you want to generate or `pgp` for <<#sec:signature-verification,signatures>>.
+The `write-verification-metadata` flag requires the list of <<#sec:checksum-verification,checksums>> that you want to generate or `pgp` for <<#sec:signature-verification,signatures>>.
 
 Executing this command line will cause Gradle to:
 
@@ -133,7 +133,7 @@ For this purpose, you can just add `--dry-run`:
 
 
 ----
-gradle --write-verification-file sha256 help --dry-run
+gradle --write-verification-metadata sha256 help --dry-run
 ----
 
 Then instead of generating the `verification-metadata.xml` file, a _new file_ will be generated, called `verification-metadata.dryrun.xml`.
@@ -157,7 +157,7 @@ If you understand the risks of doing so, set the `<verify-metadata>` flag to `fa
 <?xml version="1.0" encoding="UTF-8"?>
 <verification-metadata>
    <configuration>
-      <verify-metadata>true</verify-metadata>
+      <verify-metadata>false</verify-metadata>
       <verify-signatures>false</verify-signatures>
     </configuration>
     <!-- the rest of this file doesn't need to declare anything about metadata files -->


### PR DESCRIPTION
<!--- The issue this PR addresses -->

Adjust some sample commands and sample XML in the documentation:
* Change remaining `write-verification-file` to `write-verification-metadata`
* Adjust XML snippet where `verify-metadata` should be `false`

/cc @melix 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
