### PR TITLE
Use normal task dependencies to model build types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,9 +57,9 @@ buildTypes {
 
     create("sanityCheck") {
         tasks(
-            "classes", "docs:checkstyleApi", "codeQuality", "allIncubationReportsZip",
-            "distribution:checkBinaryCompatibility", "docs:javadocAll",
-            "architectureTest:test", "toolingApi:toolingApiShadedJar")
+            "classes", ":docs:checkstyleApi", "codeQuality", ":allIncubationReportsZip",
+            ":distributions:checkBinaryCompatibility", ":docs:javadocAll",
+            ":architectureTest:test", ":toolingApi:toolingApiShadedJar")
     }
 
     // Used by the first phase of the build pipeline, running only last version on multiversion - tests
@@ -101,35 +101,35 @@ buildTypes {
     }
 
     create("performanceTests") {
-        tasks("performance:performanceTest")
+        tasks(":performance:performanceTest")
     }
 
     create("performanceExperiments") {
-        tasks("performance:performanceExperiments")
+        tasks(":performance:performanceExperiments")
     }
 
     create("fullPerformanceTests") {
-        tasks("performance:fullPerformanceTest")
+        tasks(":performance:fullPerformanceTest")
     }
 
     create("distributedPerformanceTests") {
-        tasks("performance:distributedPerformanceTest")
+        tasks(":performance:distributedPerformanceTest")
     }
 
     create("distributedSlowPerformanceTests") {
-        tasks("performance:distributedSlowPerformanceTest")
+        tasks(":performance:distributedSlowPerformanceTest")
     }
 
     create("distributedPerformanceExperiments") {
-        tasks("performance:distributedPerformanceExperiment")
+        tasks(":performance:distributedPerformanceExperiment")
     }
 
     create("distributedHistoricalPerformanceTests") {
-        tasks("performance:distributedHistoricalPerformanceTest")
+        tasks(":performance:distributedHistoricalPerformanceTest")
     }
 
     create("distributedFlakinessDetections") {
-        tasks("performance:distributedFlakinessDetection")
+        tasks(":performance:distributedFlakinessDetection")
     }
 
     // Used for cross version tests on CI
@@ -153,18 +153,18 @@ buildTypes {
     // Used to build production distros and smoke test them
     create("packageBuild") {
         tasks("verifyIsProductionBuildEnvironment", "clean", "buildDists",
-            "distributions:integTest", ":docs:checkSamples", "docs:check")
+            ":distributions:integTest", ":docs:checkSamples", ":docs:check")
     }
 
     // Used to build production distros and smoke test them
     create("promotionBuild") {
         tasks(
-            "verifyIsProductionBuildEnvironment", "clean", "docs:check",
-            "buildDists", "distributions:integTest", "publish")
+            "verifyIsProductionBuildEnvironment", "clean", ":docs:check",
+            "buildDists", ":distributions:integTest", "publish")
     }
 
     create("soakTest") {
-        tasks("soak:soakIntegTest")
+        tasks(":soak:soakIntegTest")
         projectProperties("testVersions" to "all")
     }
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -6,6 +6,8 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 
+import org.gradle.kotlin.dsl.*
+
 class BuildTypesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.TaskProvider
 
 import org.gradle.kotlin.dsl.*
 
+
 class BuildTypesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -6,8 +6,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
 
-import org.gradle.kotlin.dsl.*
-
 class BuildTypesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
@@ -108,12 +106,12 @@ fun Project.insertBuildTypeTasksInto(
             forEachBuildTypeTask {
                 val matchingTasks = ArrayList<Task>()
                 getAllprojects().forEach { p ->
-                    val findByName = p.getTasks().findByName(it)
-                    if (findByName != null) {
+                    val matchingTask = p.getTasks().findByName(it)
+                    if (matchingTask != null) {
                         buildTypeTask.configure {
-                            dependsOn(findByName)
+                            dependsOn(matchingTask)
                         }
-                        matchingTasks.add(findByName)
+                        matchingTasks.add(matchingTask)
                     }
                 }
                 ensureBuildTypeTaskOrdering(matchingTasks)

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -31,7 +31,7 @@ class BuildTypesPlugin : Plugin<Project> {
             description = "The $name build type (can only be abbreviated to '${buildType.abbreviation}')"
 
             doFirst {
-                if(!gradle.startParameter.taskNames.any { it.equals(buildType.name) || it.equals(buildType.abbreviation)}) {
+                if (!gradle.startParameter.taskNames.any { it == buildType.name || it == buildType.abbreviation }) {
                     throw GradleException("'$name' is a build type and must be invoked directly, and its name can only be abbreviated to '${buildType.abbreviation}'.")
                 }
             }
@@ -95,20 +95,19 @@ fun Project.insertBuildTypeTasksInto(
     fun forEachBuildTypeTask(act: (String) -> Unit) =
         buildType.tasks.reversed().forEach(act)
 
-    fun ensureBuildTypeTaskOrdering(matchingTasks: List<Task>) = {
+    fun ensureBuildTypeTaskOrdering(matchingTasks: List<Task>) =
         matchingTasks.forEach { t ->
             taskList.forEach {
-                t.shouldRunAfter(it)
+//                t.shouldRunAfter(it)
             }
         }
-    }
 
     when {
         subproject.isEmpty() ->
             forEachBuildTypeTask {
                 val matchingTasks = ArrayList<Task>()
-                getAllprojects().forEach { p ->
-                    val matchingTask = p.getTasks().findByName(it)
+                allprojects.forEach { p ->
+                    val matchingTask = p.tasks.findByName(it)
                     if (matchingTask != null) {
                         buildTypeTask.configure {
                             dependsOn(matchingTask)
@@ -117,7 +116,7 @@ fun Project.insertBuildTypeTasksInto(
                     }
                 }
                 ensureBuildTypeTaskOrdering(matchingTasks)
-                matchingTasks.map{t -> t.path}.forEach(::insert)
+                matchingTasks.map { t -> t.path }.forEach(::insert)
             }
 
         findProject(subproject) != null ->

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -52,10 +52,14 @@ class BuildTypesPlugin : Plugin<Project> {
         if (usedTaskNames.isNotEmpty()) {
             afterEvaluate {
                 usedTaskNames.forEach { (index, usedName) ->
+                    invokedTaskNames.removeAt(index)
                     val subproject = usedName.substringBeforeLast(":", "")
                     insertBuildTypeTasksInto(invokedTaskNames, buildTypeTask, index, buildType, subproject)
-                    gradle.startParameter.setTaskNames(invokedTaskNames)
                 }
+                if (!invokedTaskNames.contains(buildType.name)) {
+                    invokedTaskNames.add(buildType.name)
+                }
+                gradle.startParameter.setTaskNames(invokedTaskNames)
             }
         }
     }

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
@@ -20,7 +20,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.gradlebuild.test.integrationtests.splitIntoBuckets
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -43,6 +45,9 @@ class BuildTypesPluginTest {
     val buildType = BuildType("BT").apply {
         tasks("BT0", "my:BT1")
     }
+
+    private
+    val buildTypeTaskProvider = mockk<TaskProvider<Task>>()
 
     @Before
     fun setUp() {
@@ -82,7 +87,7 @@ class BuildTypesPluginTest {
         val taskList = mutableListOf("TL0", "TL1")
 
         // when:
-        project.insertBuildTypeTasksInto(taskList, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
 
         // then:
         assertThat(
@@ -98,7 +103,7 @@ class BuildTypesPluginTest {
         val taskList = mutableListOf("TL0", "TL1")
 
         // when:
-        project.insertBuildTypeTasksInto(taskList, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
 
         // then:
         assertThat(
@@ -120,7 +125,7 @@ class BuildTypesPluginTest {
         every { project.findProject(subproject) } returns mockk()
 
         // when:
-        project.insertBuildTypeTasksInto(taskList, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
 
         // then:
         assertThat(
@@ -142,7 +147,7 @@ class BuildTypesPluginTest {
         every { project.findProject(subproject) } returns mockk()
 
         // when:
-        project.insertBuildTypeTasksInto(taskList, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
 
         // then:
         assertThat(

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
@@ -27,6 +27,7 @@ import org.gradle.gradlebuild.test.integrationtests.splitIntoBuckets
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
@@ -34,6 +35,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import java.io.File
 
 
+@Ignore
 class BuildTypesPluginTest {
     private
     val project = mockk<Project>()

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
@@ -132,7 +132,7 @@ class BuildTypesPluginTest {
 
         // given:
         val subproject = ""
-        val taskList = mutableListOf("TL0", "quickTest", "TL1")
+        val taskList = mutableListOf("TL0", "TL1")
 
         // when:
         project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, quickTestBuildType, subproject)
@@ -140,7 +140,7 @@ class BuildTypesPluginTest {
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", ":subproject2:test", ":subproject1:test", ":subproject1:integTest", ":subproject1:crossVersionTest", "quickTest", "TL1")))
+            equalTo(listOf("TL0", ":subproject2:test", ":subproject1:test", ":subproject1:integTest", ":subproject1:crossVersionTest", "TL1")))
     }
 
 
@@ -149,7 +149,7 @@ class BuildTypesPluginTest {
 
         // given:
         val subproject = ""
-        val taskList = mutableListOf("TL0", "sanityCheck", "TL1")
+        val taskList = mutableListOf("TL0", "TL1")
 
         // when:
         project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, sanityCheckBuildType, subproject)
@@ -157,7 +157,7 @@ class BuildTypesPluginTest {
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", ":subproject2:classes", ":subproject1:classes", ":docs:javadocAll", "sanityCheck", "TL1")))
+            equalTo(listOf("TL0", ":subproject2:classes", ":subproject1:classes", ":docs:javadocAll", "TL1")))
     }
 
     @Test
@@ -165,7 +165,7 @@ class BuildTypesPluginTest {
 
         // given:
         val subproject = "unknown"
-        val taskList = mutableListOf("TL0", "sanityCheck", "TL1")
+        val taskList = mutableListOf("TL0", "TL1")
 
         // when:
         project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, sanityCheckBuildType, subproject)
@@ -173,7 +173,7 @@ class BuildTypesPluginTest {
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", "sanityCheck", "TL1")))
+            equalTo(listOf("TL0", "TL1")))
 
         // and:
         verify { project.findProject(subproject) }
@@ -184,7 +184,7 @@ class BuildTypesPluginTest {
 
         // given:
         val subproject = "subproject1"
-        val taskList = mutableListOf("TL0", "subproject1:quickTest", "TL1")
+        val taskList = mutableListOf("TL0", "TL1")
 
         // when:
         project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, quickTestBuildType, subproject)
@@ -192,7 +192,7 @@ class BuildTypesPluginTest {
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", "subproject1:test", "subproject1:integTest", "subproject1:crossVersionTest", "subproject1:quickTest", "TL1")))
+            equalTo(listOf("TL0", "subproject1:test", "subproject1:integTest", "subproject1:crossVersionTest", "TL1")))
 
         // and:
         verify { taskContainer.findByPath("subproject1:test") }
@@ -205,14 +205,14 @@ class BuildTypesPluginTest {
 
         // given:
         val subproject = "subproject2"
-        val taskList = mutableListOf("TL0", "subproject2:quickTest", "TL1")
+        val taskList = mutableListOf("TL0", "TL1")
         // when:
         project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, quickTestBuildType, subproject)
 
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", "subproject2:test", "subproject2:quickTest", "TL1")))
+            equalTo(listOf("TL0", "subproject2:test", "TL1")))
 
         // and:
         verify { taskContainer.findByPath("subproject2:test") }

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/buildtypes/BuildTypesPluginTest.kt
@@ -27,7 +27,6 @@ import org.gradle.gradlebuild.test.integrationtests.splitIntoBuckets
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
@@ -35,7 +34,6 @@ import org.junit.jupiter.params.provider.CsvSource
 import java.io.File
 
 
-@Ignore
 class BuildTypesPluginTest {
     private
     val project = mockk<Project>()
@@ -44,21 +42,69 @@ class BuildTypesPluginTest {
     val taskContainer = mockk<TaskContainer>()
 
     private
-    val buildType = BuildType("BT").apply {
-        tasks("BT0", "my:BT1")
+    val sanityCheckBuildType = BuildType("sanityCheck").apply {
+        tasks("classes", ":docs:javadocAll")
     }
 
     private
-    val buildTypeTaskProvider = mockk<TaskProvider<Task>>()
+    val quickTestBuildType = BuildType("quickTest").apply {
+        tasks("test", "integTest", "crossVersionTest")
+    }
+
+    private
+    val buildTypeTaskProvider = mockk<TaskProvider<Task>>(relaxed = true)
+
+    private
+    val subproject1 = mockk<Project>()
+
+    private
+    val subproject2 = mockk<Project>()
+
+    private
+    val subproject1Tasks = mockk<TaskContainer>()
+
+    private
+    val subproject2Tasks = mockk<TaskContainer>()
 
     @Before
     fun setUp() {
+        val subprojects = setOf(subproject1, subproject2)
         every { project.tasks } returns taskContainer
         every { project.project } returns project
         every { project.findProperty(any()) } returns ""
         every { project.name } returns "project"
-        every { project.findProject(any()) } returns null
-        every { taskContainer.findByPath(any()) } returns null
+        every { project.subprojects } returns subprojects
+        every { project.findProject("subproject1") } returns subproject1
+        every { project.findProject("subproject2") } returns subproject2
+        every { project.findProject("unknown") } returns null
+        every { subproject1.tasks } returns subproject1Tasks
+        every { subproject2.tasks } returns subproject2Tasks
+        // subproject1: test integTest crossVersionTest classes
+        every { subproject1Tasks.findByName(any()) } answers { mockTask(args[0] as String, ":subproject1:${args[0]}") }
+        // subproject2: test classes
+        every { subproject2Tasks.findByName(any()) } answers {
+            if (args[0] == "test" || args[0] == "classes") {
+                mockTask(args[0] as String, ":subproject2:${args[0]}")
+            } else {
+                null
+            }
+        }
+        every { taskContainer.findByPath(any()) } answers {
+            val path = args[0] as String
+            if (path in listOf("subproject1:test", "subproject1:integTest", "subproject1:crossVersionTest", "subproject1:classes", "subproject2:test", "subproject2:classes")) {
+                mockTask(path.substringAfter(':'), ":$path")
+            } else {
+                null
+            }
+        }
+    }
+
+    private
+    fun mockTask(name: String, path: String): Task {
+        val task = mockk<Task>()
+        every { task.name } returns name
+        every { task.path } returns path
+        return task
     }
 
     @ParameterizedTest
@@ -82,35 +128,52 @@ class BuildTypesPluginTest {
     }
 
     @Test
-    fun `given empty subproject, it inserts all BuildType tasks without validation`() {
+    fun `given empty subproject, it inserts all existing subproject tasks`() {
 
         // given:
         val subproject = ""
-        val taskList = mutableListOf("TL0", "TL1")
+        val taskList = mutableListOf("TL0", "quickTest", "TL1")
 
         // when:
-        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, quickTestBuildType, subproject)
 
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", "BT0", "my:BT1", "TL1")))
+            equalTo(listOf("TL0", ":subproject2:test", ":subproject1:test", ":subproject1:integTest", ":subproject1:crossVersionTest", "quickTest", "TL1")))
+    }
+
+
+    @Test
+    fun `given empty subproject, it inserts subproject BuildType tasks without validation`() {
+
+        // given:
+        val subproject = ""
+        val taskList = mutableListOf("TL0", "sanityCheck", "TL1")
+
+        // when:
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, sanityCheckBuildType, subproject)
+
+        // then:
+        assertThat(
+            taskList,
+            equalTo(listOf("TL0", ":subproject2:classes", ":subproject1:classes", ":docs:javadocAll", "sanityCheck", "TL1")))
     }
 
     @Test
     fun `given non-empty subproject, it skips all tasks when project cannot be found`() {
 
         // given:
-        val subproject = "sub"
-        val taskList = mutableListOf("TL0", "TL1")
+        val subproject = "unknown"
+        val taskList = mutableListOf("TL0", "sanityCheck", "TL1")
 
         // when:
-        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, sanityCheckBuildType, subproject)
 
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", "TL1")))
+            equalTo(listOf("TL0", "sanityCheck", "TL1")))
 
         // and:
         verify { project.findProject(subproject) }
@@ -120,44 +183,40 @@ class BuildTypesPluginTest {
     fun `given non-empty subproject, it prepends the subproject path to the BuildType tasks`() {
 
         // given:
-        val subproject = "sub"
-        val taskList = mutableListOf("TL0", "TL1")
-        every { taskContainer.findByPath("sub:BT0") } returns mockk()
-        every { taskContainer.findByPath("sub:my:BT1") } returns mockk()
-        every { project.findProject(subproject) } returns mockk()
+        val subproject = "subproject1"
+        val taskList = mutableListOf("TL0", "subproject1:quickTest", "TL1")
 
         // when:
-        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, quickTestBuildType, subproject)
 
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", "sub:BT0", "sub:my:BT1", "TL1")))
+            equalTo(listOf("TL0", "subproject1:test", "subproject1:integTest", "subproject1:crossVersionTest", "subproject1:quickTest", "TL1")))
 
         // and:
-        verify { taskContainer.findByPath("sub:BT0") }
-        verify { taskContainer.findByPath("sub:my:BT1") }
+        verify { taskContainer.findByPath("subproject1:test") }
+        verify { taskContainer.findByPath("subproject1:integTest") }
+        verify { taskContainer.findByPath("subproject1:crossVersionTest") }
     }
 
     @Test
     fun `given non-empty subproject, it skips tasks which cannot be found`() {
 
         // given:
-        val subproject = "sub"
-        val taskList = mutableListOf("TL0", "TL1")
-        every { taskContainer.findByPath("sub:my:BT1") } returns mockk()
-        every { project.findProject(subproject) } returns mockk()
-
+        val subproject = "subproject2"
+        val taskList = mutableListOf("TL0", "subproject2:quickTest", "TL1")
         // when:
-        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, buildType, subproject)
+        project.insertBuildTypeTasksInto(taskList, buildTypeTaskProvider, 1, quickTestBuildType, subproject)
 
         // then:
         assertThat(
             taskList,
-            equalTo(listOf("TL0", "sub:my:BT1", "TL1")))
+            equalTo(listOf("TL0", "subproject2:test", "subproject2:quickTest", "TL1")))
 
         // and:
-        verify { taskContainer.findByPath("sub:BT0") }
-        verify { taskContainer.findByPath("sub:my:BT1") }
+        verify { taskContainer.findByPath("subproject2:test") }
+        verify { taskContainer.findByPath("subproject2:integTest") }
+        verify { taskContainer.findByPath("subproject2:crossVersionTest") }
     }
 }


### PR DESCRIPTION
- this fixes how build types are handled in the scanslist view.


This change allows it to search for requested build types in the scans list ui. (see e.g. https://e.grdev.net/scans/?failures.failureClassification=non_verification&list.offset=0&list.size=50&list.sortColumn=startTime&list.sortOrder=desc&search.buildToolType=gradle&search.buildToolType=maven&search.startTimeMax=1578045856607&search.startTimeMin=1577441056607&search.tasks=sanityCheck&tests.sortField=FAILED&tests.unstableOnly&trends.section=overview&trends.timeResolution=day&viewer.tzOffset=60)

before that we manipulated the startparameter which resulted in unexpected behaviour and also caused some misunderstandings in our enterprise trials

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->