### PR TITLE
Improve performance for DefaultExecutionPlan.hasOverlap (fix #11792)

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -694,8 +694,14 @@ public class DefaultExecutionPlan implements ExecutionPlan {
     private static boolean hasOverlap(Iterable<String> paths1, Iterable<String> paths2) {
         //build a helper TreeSet with the contents of paths2
         final TreeSet<String> set = new TreeSet<>();
+        int minPath2Length = Integer.MAX_VALUE;
         for (final String path : paths2) {
             set.add(path);
+            minPath2Length = Math.min(minPath2Length, path.length());
+        }
+
+        if (set.isEmpty()) {
+            return false;
         }
 
         for (final String path1 : paths1) {
@@ -704,7 +710,8 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                 return true;
             }
             //first iterate over all path segments (prefixes)
-            int endIndex = path1.indexOf(File.separatorChar);
+            //  those that are too short to have a chance are skipped
+            int endIndex = path1.indexOf(File.separatorChar, minPath2Length);
             while (endIndex >= 0) {
                 final String currentPrefix = path1.substring(0, endIndex);
                 if (set.contains(currentPrefix)) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -843,6 +843,48 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         executesNodes(node1, node2, node3)
     }
 
+    def "hasOverlap positive examples"() {
+        expect:
+        DefaultExecutionPlan.hasOverlap(normalizeSeparator(list1), normalizeSeparator(list2))
+        DefaultExecutionPlan.hasOverlap(normalizeSeparator(list2), normalizeSeparator(list1))
+
+        where:
+        list1        | list2
+        ["a"]        | ["a"] 
+        ["a"]        | ["a/b"] 
+        ["a", "b"]   | ["a", "c"] 
+        ["b", "a"]   | ["a", "c"] 
+        ["A"]        | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["A/B"]      | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["A/B/C"]    | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["A/C/D"]    | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["XYZ"]      | ["XYZ.ABC", "XYZ/ABC"] 
+    }
+
+    def "hasOverlap negative examples"() {
+        expect:
+        !DefaultExecutionPlan.hasOverlap(normalizeSeparator(list1), normalizeSeparator(list2))
+        !DefaultExecutionPlan.hasOverlap(normalizeSeparator(list2), normalizeSeparator(list1))
+
+        where:
+        list1        | list2
+        ["a"]        | [] 
+        ["a"]        | ["b"] 
+        ["ab"]       | ["ac"] 
+        ["a/b"]      | ["a/c"] 
+        ["a/"]       | ["a/b/"] 
+        ["a", "b"]   | ["c", "d"] 
+        ["0"]        | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["D"]        | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["B/B"]      | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["AB"]       | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+        ["ABBB"]     | ["A", "A/B", "A/C", "A.B", "ABB", "AbB"] 
+    }
+
+    private List<String> normalizeSeparator(List<String> list) {
+        return list.collect { it.replace('/'.charAt(0), File.separatorChar) };
+    }
+
     private Node node(Node... dependencies) {
         def action = Stub(WorkNodeAction)
         _ * action.project >> null


### PR DESCRIPTION
Fixes #11792

### Context
Improves the performance of DefaultExecutionPlan.hasOverlap by an order of magnitude when there are many items in both sets. For small sets, it got a bit slower in my tests, but this should be negligible I hope.

Detailed timings from my micro-benchmarks:
- 10 items x 10 items: before: 0.0004ms, after: 0.0009ms
- 10000 items x 10 items: before: 0.9ms, after: 0.9ms
- 10 items x 10000 items: before: 1ms, after: 1.6ms
- 10000 items x 10000 items: before: 604ms, after: 4ms

The timings even for the large sets are not as horrible as they were in #11792, so either the sets were even larger in my build, or the performance got worse due to long paths (I used rather short strings in my tests).

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [N/A] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [N/A] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
