### PR TITLE
Make `Project` instantiation more efficient

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
@@ -16,60 +16,64 @@
 
 package org.gradle.api.internal.project;
 
-import org.gradle.api.Action;
-import org.gradle.api.Project;
 import org.gradle.api.initialization.ProjectDescriptor;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.groovy.scripts.TextResourceScriptSource;
 import org.gradle.initialization.DefaultProjectDescriptor;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.resource.TextResource;
 import org.gradle.internal.resource.TextFileResourceLoader;
+import org.gradle.internal.resource.TextResource;
 import org.gradle.util.NameValidator;
+import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 public class ProjectFactory implements IProjectFactory {
     private final Instantiator instantiator;
     private final TextFileResourceLoader textFileResourceLoader;
     private final ProjectRegistry<ProjectInternal> projectRegistry;
+    private final BuildState owner;
+    private final ProjectStateRegistry projectStateRegistry;
 
-    public ProjectFactory(Instantiator instantiator, TextFileResourceLoader textFileResourceLoader, ProjectRegistry<ProjectInternal> projectRegistry) {
+    public ProjectFactory(Instantiator instantiator, TextFileResourceLoader textFileResourceLoader, ProjectRegistry<ProjectInternal> projectRegistry, BuildState owner, ProjectStateRegistry projectStateRegistry) {
         this.instantiator = instantiator;
         this.textFileResourceLoader = textFileResourceLoader;
         this.projectRegistry = projectRegistry;
+        this.owner = owner;
+        this.projectStateRegistry = projectStateRegistry;
     }
 
     @Override
-    public DefaultProject createProject(GradleInternal gradle, ProjectDescriptor projectDescriptor, ProjectInternal parent, ClassLoaderScope selfClassLoaderScope, ClassLoaderScope baseClassLoaderScope) {
+    public ProjectInternal createProject(GradleInternal gradle, ProjectDescriptor projectDescriptor, @Nullable ProjectInternal parent, ClassLoaderScope selfClassLoaderScope, ClassLoaderScope baseClassLoaderScope) {
+        Path projectPath = ((DefaultProjectDescriptor) projectDescriptor).path();
+        ProjectState projectContainer = projectStateRegistry.stateFor(owner.getBuildIdentifier(), projectPath);
+
         File buildFile = projectDescriptor.getBuildFile();
         TextResource resource = textFileResourceLoader.loadFile("build file", buildFile);
         ScriptSource source = new TextResourceScriptSource(resource);
         DefaultProject project = instantiator.newInstance(DefaultProject.class,
-                projectDescriptor.getName(),
-                parent,
-                projectDescriptor.getProjectDir(),
-                buildFile,
-                source,
-                gradle,
-                gradle.getServiceRegistryFactory(),
-                selfClassLoaderScope,
-                baseClassLoaderScope
+            projectDescriptor.getName(),
+            parent,
+            projectDescriptor.getProjectDir(),
+            buildFile,
+            source,
+            gradle,
+            projectContainer,
+            gradle.getServiceRegistryFactory(),
+            selfClassLoaderScope,
+            baseClassLoaderScope
         );
-        project.beforeEvaluate(new Action<Project>() {
-            @Override
-            public void execute(Project project) {
-                NameValidator.validate(project.getName(), "project name", DefaultProjectDescriptor.INVALID_NAME_IN_INCLUDE_HINT);
-            }
-        });
+        project.beforeEvaluate(p -> NameValidator.validate(project.getName(), "project name", DefaultProjectDescriptor.INVALID_NAME_IN_INCLUDE_HINT));
 
         if (parent != null) {
             parent.addChildProject(project);
         }
         projectRegistry.addProject(project);
-
+        projectContainer.attachMutableModel(project);
         return project;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -22,6 +22,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.resources.ResourceLock;
+import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -48,9 +49,26 @@ public interface ProjectState extends ModelContainer {
     String getName();
 
     /**
+     * Returns an identifying path for this project in the build tree.
+     */
+    Path getIdentityPath();
+
+    /**
+     * Returns a path for this project within its containing build. These are not unique within a build tree.
+     */
+    Path getProjectPath();
+
+    /**
      * Returns the identifier of the default component produced by this project.
      */
     ProjectComponentIdentifier getComponentIdentifier();
+
+    void attachMutableModel(ProjectInternal project);
+
+    /**
+     * Returns the mutable model for this project. This should not be used directly. This property is here to help with migration away from direct usage.
+     */
+    ProjectInternal getMutableModel();
 
     /**
      * Returns the lock that will be acquired when accessing the mutable state of this project via {@link #withMutableState(Runnable)} and {@link #withMutableState(Factory)}.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.project;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildState;
 import org.gradle.util.Path;
@@ -36,29 +37,29 @@ public interface ProjectStateRegistry {
     Collection<? extends ProjectState> getAllProjects();
 
     /**
-     * Locates the state object that owns the given public project model.
+     * Locates the state object that owns the given public project model. Can use {@link ProjectInternal#getMutationState()} instead.
      */
-    ProjectState stateFor(Project project);
+    ProjectState stateFor(Project project) throws IllegalArgumentException;
 
     /**
      * Locates the state object that owns the project with the given identifier.
      */
-    ProjectState stateFor(ProjectComponentIdentifier identifier);
+    ProjectState stateFor(ProjectComponentIdentifier identifier) throws IllegalArgumentException;
 
     /**
      * Locates the state object for the given project.
      */
-    ProjectState stateFor(BuildIdentifier buildIdentifier, Path projectPath);
-
-    /**
-     * Registers a project.
-     */
-    ProjectState register(BuildState owner, ProjectInternal project);
+    ProjectState stateFor(BuildIdentifier buildIdentifier, Path projectPath) throws IllegalArgumentException;
 
     /**
      * Registers the projects of a build.
      */
     void registerProjects(BuildState build);
+
+    /**
+     * Registers a single project.
+     */
+    void registerProject(BuildState owner, DefaultProjectDescriptor projectDescriptor);
 
     /**
      * Allows a section of code to be run with state locking disabled.  This should be used to allow

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -35,7 +35,7 @@ public interface BuildState {
     BuildIdentifier getBuildIdentifier();
 
     /**
-     * Returns an identifying path for this build. This path is fixed for the lifetime of the build.
+     * Returns an identifying path for this build in the build tree. This path is fixed for the lifetime of the build.
      */
     Path getIdentityPath();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -51,12 +51,12 @@ public interface BuildStateRegistry {
     /**
      * Locates an included build by {@link BuildIdentifier}, if present. Fails if not an included build.
      */
-    IncludedBuildState getIncludedBuild(BuildIdentifier buildIdentifier);
+    IncludedBuildState getIncludedBuild(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
 
     /**
      * Locates a build. Fails if not present.
      */
-    BuildState getBuild(BuildIdentifier buildIdentifier);
+    BuildState getBuild(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
 
     /**
      * Notification that the settings have been loaded for the root build.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -119,6 +119,7 @@ import org.gradle.initialization.ClassLoaderScopeListeners;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
 import org.gradle.initialization.DefaultClassLoaderScopeRegistry;
 import org.gradle.initialization.DefaultGradlePropertiesLoader;
+import org.gradle.initialization.DefaultProjectDescriptorRegistry;
 import org.gradle.initialization.DefaultSettingsLoaderFactory;
 import org.gradle.initialization.DefaultSettingsPreparer;
 import org.gradle.initialization.IGradlePropertiesLoader;
@@ -127,6 +128,7 @@ import org.gradle.initialization.InstantiatingBuildLoader;
 import org.gradle.initialization.ModelConfigurationListener;
 import org.gradle.initialization.NotifyingBuildLoader;
 import org.gradle.initialization.ProjectAccessListener;
+import org.gradle.initialization.ProjectDescriptorRegistry;
 import org.gradle.initialization.ProjectPropertySettingBuildLoader;
 import org.gradle.initialization.PropertiesLoadingSettingsProcessor;
 import org.gradle.initialization.RootBuildCacheControllerSettingsProcessor;
@@ -243,12 +245,16 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new TaskStatistics();
     }
 
-    protected ProjectRegistry<ProjectInternal> createProjectRegistry() {
+    protected DefaultProjectRegistry<ProjectInternal> createProjectRegistry() {
         return new DefaultProjectRegistry<ProjectInternal>();
     }
 
-    protected IProjectFactory createProjectFactory(Instantiator instantiator, ProjectRegistry<ProjectInternal> projectRegistry) {
-        return new ProjectFactory(instantiator, new DefaultTextFileResourceLoader(), projectRegistry);
+    protected IProjectFactory createProjectFactory(Instantiator instantiator, ProjectRegistry<ProjectInternal> projectRegistry, BuildState owner, ProjectStateRegistry projectStateRegistry) {
+        return new ProjectFactory(instantiator, new DefaultTextFileResourceLoader(), projectRegistry, owner, projectStateRegistry);
+    }
+
+    protected ProjectDescriptorRegistry createProjectDescriptorRegistry() {
+        return new DefaultProjectDescriptorRegistry();
     }
 
     protected ListenerManager createListenerManager(ListenerManager listenerManager) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -52,7 +52,6 @@ import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.api.internal.project.DefaultAntBuilderFactory;
 import org.gradle.api.internal.project.DeferredProjectConfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.project.ant.DefaultAntLoggingAdapterFactory;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
@@ -156,10 +155,10 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
 
     protected DefaultResourceHandler.Factory createResourceHandlerFactory(FileResolver fileResolver, FileSystem fileSystem, TemporaryFileProvider temporaryFileProvider, ApiTextResourceAdapter.Factory textResourceAdapterFactory) {
         return DefaultResourceHandler.Factory.from(
-                fileResolver,
-                fileSystem,
-                temporaryFileProvider,
-                textResourceAdapterFactory
+            fileResolver,
+            fileSystem,
+            temporaryFileProvider,
+            textResourceAdapterFactory
         );
     }
 
@@ -221,18 +220,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
 
     protected ModelRegistry createModelRegistry(ModelRuleExtractor ruleExtractor) {
         return new DefaultModelRegistry(ruleExtractor, project.getPath(), run -> {
-            ProjectState projectState = null;
-            try {
-                projectState = project.getMutationState();
-            } catch (IllegalArgumentException e) {
-                // Ignore because project registration differ between real Gradle and Gradle under test
-            }
-
-            if (projectState != null) {
-                projectState.withMutableState(run);
-            } else {
-                run.run();
-            }
+            project.getMutationState().withMutableState(run);
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
@@ -30,8 +30,6 @@ import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.api.internal.plugins.PluginTarget;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
-import org.gradle.initialization.DefaultProjectDescriptorRegistry;
-import org.gradle.initialization.ProjectDescriptorRegistry;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
@@ -66,10 +64,6 @@ public class SettingsScopeServices extends DefaultServiceRegistry {
     protected PluginManagerInternal createPluginManager(Instantiator instantiator, PluginRegistry pluginRegistry, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext, CollectionCallbackActionDecorator decorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         PluginTarget target = new ImperativeOnlyPluginTarget<SettingsInternal>(settings);
         return instantiator.newInstance(DefaultPluginManager.class, pluginRegistry, instantiatorFactory.inject(this), target, buildOperationExecutor, userCodeApplicationContext, decorator, domainObjectCollectionFactory);
-    }
-
-    protected ProjectDescriptorRegistry createProjectDescriptorRegistry() {
-        return new DefaultProjectDescriptorRegistry();
     }
 
     protected ConfigurationTargetIdentifier createConfigurationTargetIdentifier() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -159,7 +159,11 @@ class DefaultProjectSpec extends Specification {
         def objectFactory = Stub(ObjectFactory)
         objectFactory.fileCollection() >> TestFiles.fileCollectionFactory().configurableFiles()
 
-        return Spy(DefaultProject, constructorArgs: [name, parent, projectDir, new File("build file"), Stub(ScriptSource), build, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope)]) {
+        def container = Mock(ProjectState)
+        _ * container.projectPath >> (parent == null ? Path.ROOT : parent.projectPath.child(name))
+        _ * container.identityPath >> (parent == null ? build.identityPath : build.identityPath.append(parent.projectPath).child(name))
+
+        return Spy(DefaultProject, constructorArgs: [name, parent, projectDir, new File("build file"), Stub(ScriptSource), build, container, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope)]) {
             getFileOperations() >> fileOperations
             getObjects() >> objectFactory
         }

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -423,7 +423,7 @@ class DefaultGradleSpec extends Specification {
         def project = Spy(DefaultProject, constructorArgs: [
             name,
             null, null, null, Stub(ScriptSource),
-            gradle, serviceRegistryFactory,
+            gradle, Stub(ProjectState), serviceRegistryFactory,
             Stub(ClassLoaderScope), Stub(ClassLoaderScope)
         ])
         project.getProjectConfigurator() >> crossProjectConfigurator

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginRules.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginRules.java
@@ -17,6 +17,7 @@
 package org.gradle.ide.visualstudio.plugins;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.internal.project.DefaultProjectRegistry;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
@@ -48,7 +49,7 @@ class VisualStudioPluginRules {
         @Mutate
         public static void ensureSubprojectsAreRealized(TaskContainer tasks, ProjectIdentifier projectIdentifier, ServiceRegistry serviceRegistry) {
             ProjectModelResolver projectModelResolver = serviceRegistry.get(ProjectModelResolver.class);
-            ProjectRegistry<ProjectInternal> projectRegistry = Cast.uncheckedCast(serviceRegistry.get(ProjectRegistry.class));
+            ProjectRegistry<ProjectInternal> projectRegistry = Cast.uncheckedCast(serviceRegistry.get(DefaultProjectRegistry.class));
 
             for (ProjectInternal subproject : projectRegistry.getSubProjects(projectIdentifier.getPath())) {
                 projectModelResolver.resolveProjectModel(subproject.getPath()).find("visualStudio", VisualStudioExtension.class);

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -205,8 +205,8 @@ class DefaultInstantExecution internal constructor(
 
         readRelevantProjects(build)
 
-        build.autoApplyPlugins()
         build.registerProjects()
+        build.autoApplyPlugins()
 
         initProjectProvider(build::getProject)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
@@ -25,7 +25,7 @@ interface InstantExecutionBuild {
 
     val gradle: GradleInternal
 
-    fun createProject(path: String): ProjectInternal
+    fun createProject(path: String)
 
     fun getProject(path: String): ProjectInternal
 

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
@@ -25,15 +25,11 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.project.ProjectIdentifier;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.project.ProjectRegistry;
-import org.gradle.api.internal.resolve.ProjectModelResolver;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.tasks.TaskContainer;
-import org.gradle.internal.Cast;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.base.ProjectSourceSet;
 import org.gradle.language.base.internal.ProjectLayout;
@@ -280,9 +276,7 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
 
         @Defaults
         void registerBaseDependentBinariesResolutionStrategy(DependentBinariesResolver resolver, ServiceRegistry serviceRegistry) {
-            ProjectRegistry<ProjectInternal> projectRegistry = Cast.uncheckedCast(serviceRegistry.get(ProjectRegistry.class));
-            ProjectModelResolver projectModelResolver = serviceRegistry.get(ProjectModelResolver.class);
-            resolver.register(new BaseDependentBinariesResolutionStrategy(projectRegistry, projectModelResolver));
+            resolver.register(new BaseDependentBinariesResolutionStrategy());
         }
     }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/dependents/BaseDependentBinariesResolutionStrategy.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/dependents/BaseDependentBinariesResolutionStrategy.java
@@ -16,9 +16,6 @@
 
 package org.gradle.platform.base.internal.dependents;
 
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.project.ProjectRegistry;
-import org.gradle.api.internal.resolve.ProjectModelResolver;
 import org.gradle.platform.base.internal.BinarySpecInternal;
 
 import javax.annotation.Nullable;
@@ -27,13 +24,6 @@ import java.util.List;
 public class BaseDependentBinariesResolutionStrategy extends AbstractDependentBinariesResolutionStrategy {
 
     public static final String NAME = "base";
-    private final ProjectRegistry<ProjectInternal> projectRegistry;
-    private final ProjectModelResolver projectModelResolver;
-
-    public BaseDependentBinariesResolutionStrategy(ProjectRegistry<ProjectInternal> projectRegistry, ProjectModelResolver projectModelResolver) {
-        this.projectRegistry = projectRegistry;
-        this.projectModelResolver = projectModelResolver;
-    }
 
     @Override
     public String getName() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.project.DefaultProjectRegistry;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.internal.resolve.ProjectModelResolver;
@@ -419,7 +420,7 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
 
         @Defaults
         void registerNativeDependentBinariesResolutionStrategy(DependentBinariesResolver resolver, ServiceRegistry serviceRegistry) {
-            ProjectRegistry<ProjectInternal> projectRegistry = Cast.uncheckedCast(serviceRegistry.get(ProjectRegistry.class));
+            ProjectRegistry<ProjectInternal> projectRegistry = Cast.uncheckedCast(serviceRegistry.get(DefaultProjectRegistry.class));
             ProjectModelResolver projectModelResolver = serviceRegistry.get(ProjectModelResolver.class);
             resolver.register(new NativeDependentBinariesResolutionStrategy(projectRegistry, projectModelResolver));
         }


### PR DESCRIPTION

### Context

Project instantiation was previously causing an `IllegalArgumentException` to be thrown and silently ignored, which is not great for performance. This PR restructures the relationship between `ProjectState` and `Project` to remove this and to continue to evolve towards `ProjectState` owning the `Project` instance and mediating all access to it.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
