### PR TITLE
Route invalidateAll to global VFS with retention

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipper.java
@@ -70,7 +70,7 @@ public class DefaultEmptySourceTaskSkipper implements EmptySourceTaskSkipper {
                 );
                 for (FileCollectionFingerprint outputFingerprints : outputFileSnapshots.values()) {
                     try {
-                        outputChangeListener.beforeOutputChange(outputFingerprints.getRootHashes().keySet());
+                        outputChangeListener.beforeOutputChange(outputFingerprints.getRootPaths());
                         outputsCleaner.cleanupOutputs(outputFingerprints);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -324,13 +324,13 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
 
                     @Override
                     public void beforeComplete(GradleInternal gradle) {
-                        buildSessionsScopedVirtualFileSystem.invalidateAll();
+                        routingVirtualFileSystem.invalidateAll();
                     }
                 });
                 listenerManager.addListener(new OutputChangeListener() {
                     @Override
                     public void beforeOutputChange() {
-                        buildSessionsScopedVirtualFileSystem.invalidateAll();
+                        routingVirtualFileSystem.invalidateAll();
                     }
 
                     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -324,7 +324,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
 
                     @Override
                     public void beforeComplete(GradleInternal gradle) {
-                        routingVirtualFileSystem.invalidateAll();
+                        buildSessionsScopedVirtualFileSystem.invalidateAll();
                     }
                 });
                 listenerManager.addListener(new OutputChangeListener() {

--- a/subprojects/core/src/main/java/org/gradle/internal/vfs/RoutingVirtualFileSystem.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/vfs/RoutingVirtualFileSystem.java
@@ -83,8 +83,10 @@ public class RoutingVirtualFileSystem implements VirtualFileSystem {
 
     @Override
     public void invalidateAll() {
-        gradleUserHomeVirtualFileSystem.invalidateAll();
         buildScopedVirtualFileSystem.invalidateAll();
+        if (vfsRetained.getAsBoolean()) {
+            gradleUserHomeVirtualFileSystem.invalidateAll();
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/vfs/RoutingVirtualFileSystem.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/vfs/RoutingVirtualFileSystem.java
@@ -83,9 +83,10 @@ public class RoutingVirtualFileSystem implements VirtualFileSystem {
 
     @Override
     public void invalidateAll() {
-        buildScopedVirtualFileSystem.invalidateAll();
         if (vfsRetained.getAsBoolean()) {
             gradleUserHomeVirtualFileSystem.invalidateAll();
+        } else {
+            buildScopedVirtualFileSystem.invalidateAll();
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
@@ -40,13 +40,12 @@ import org.junit.Rule
 import spock.lang.Specification
 
 import javax.annotation.Nullable
-import java.util.function.Consumer
 
 class DefaultFileCollectionSnapshotterTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def snapshotter = TestFiles.fileCollectionSnapshotter()
-    def noopAction = {} as Consumer<String>
+    def noopGenerationListener = {} as GeneratedSingletonFileTree.FileGenerationListener
 
 
     def "snapshots a singletonFileTree as RegularFileSnapshot"() {
@@ -188,7 +187,7 @@ class DefaultFileCollectionSnapshotterTest extends Specification {
         }
 
         when:
-        def tree = new FileTreeAdapter(new GeneratedSingletonFileTree(factory, file.name, noopAction, action))
+        def tree = new FileTreeAdapter(new GeneratedSingletonFileTree(factory, file.name, noopGenerationListener, action))
 
         then:
         assertSingleFileTree(tree)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes
+
+import org.gradle.StartParameter
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.cache.StringInterner
+import org.gradle.initialization.RootBuildLifecycleListener
+import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.hash.FileHasher
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.snapshot.FileMetadata
+import org.gradle.internal.snapshot.RegularFileSnapshot
+import org.gradle.internal.vfs.AdditiveCacheLocations
+import org.gradle.internal.vfs.RoutingVirtualFileSystem
+import org.gradle.internal.vfs.VirtualFileSystem
+import org.gradle.internal.vfs.watch.FileWatcherRegistry
+import org.gradle.internal.vfs.watch.FileWatcherRegistryFactory
+import spock.lang.Specification
+
+class VirtualFileSystemServicesTest extends Specification {
+    def additiveCacheLocations = Mock(AdditiveCacheLocations)
+    def fileHasher = Mock(FileHasher)
+    def fileSystem = Mock(FileSystem)
+    def listenerManager = Mock(ListenerManager)
+    def startParameter = Mock(StartParameter)
+    def stringInterner = Mock(StringInterner)
+    def gradle = Mock(GradleInternal)
+    def watcherRegistryFactory = Mock(FileWatcherRegistryFactory)
+    def watcherRegistry = Mock(FileWatcherRegistry)
+
+    def "global virtual file system is not invalidated from the build session scope listener after the build completed"() {
+        def gradleUserHomeVirtualFileSystem = Mock(VirtualFileSystem)
+        RootBuildLifecycleListener rootBuildLifecycleListener
+        _ * startParameter.getSystemPropertiesArgs() >> systemPropertyArgs(retentionEnabled)
+
+        when:
+        def buildSessionScopedVirtualFileSystem = new VirtualFileSystemServices.BuildSessionServices().createVirtualFileSystem(
+            additiveCacheLocations,
+            fileHasher,
+            fileSystem,
+            listenerManager,
+            startParameter,
+            fileSystem,
+            stringInterner,
+            gradleUserHomeVirtualFileSystem
+        )
+        then:
+        buildSessionScopedVirtualFileSystem instanceof RoutingVirtualFileSystem
+
+        1 * listenerManager.addListener(_ as RootBuildLifecycleListener) >> { RootBuildLifecycleListener listener ->
+            rootBuildLifecycleListener = listener
+        }
+
+        when:
+        rootBuildLifecycleListener.beforeComplete(gradle)
+        then:
+        0 * _
+
+        where:
+        retentionEnabled << [true, false]
+    }
+
+    def "global virtual file system is not invalidated after the build completed when retention is enabled"() {
+        RootBuildLifecycleListener rootBuildLifecycleListener
+        _ * startParameter.getSystemPropertiesArgs() >> systemPropertyArgs(true)
+        _ * gradle.getStartParameter() >> startParameter
+        def path = "/some/path"
+        def snapshot = new RegularFileSnapshot(path, "path", HashCode.fromInt(1234), new FileMetadata(0, 0))
+
+        when:
+        def virtualFileSystem = new VirtualFileSystemServices.GradleUserHomeServices().createVirtualFileSystem(
+            additiveCacheLocations,
+            fileHasher,
+            fileSystem,
+            watcherRegistryFactory,
+            listenerManager,
+            fileSystem,
+            stringInterner
+        )
+        then:
+        1 * listenerManager.addListener(_ as RootBuildLifecycleListener) >> { RootBuildLifecycleListener listener ->
+            rootBuildLifecycleListener = listener
+        }
+
+        when:
+        virtualFileSystem.updateWithKnownSnapshot(snapshot)
+        rootBuildLifecycleListener.beforeComplete(gradle)
+        then:
+        virtualFileSystem.read(path, { it }) == snapshot
+        1 * watcherRegistryFactory.startWatching(_) >> watcherRegistry
+    }
+
+    Map<String, String> systemPropertyArgs(boolean retentionEnabled) {
+        retentionEnabled
+            ? [(VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY): "true"]
+            : [:]
+    }
+
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/VirtualFileSystemServicesTest.groovy
@@ -32,7 +32,9 @@ import org.gradle.internal.vfs.VirtualFileSystem
 import org.gradle.internal.vfs.watch.FileWatcherRegistry
 import org.gradle.internal.vfs.watch.FileWatcherRegistryFactory
 import spock.lang.Specification
+import spock.lang.Unroll
 
+@Unroll
 class VirtualFileSystemServicesTest extends Specification {
     def additiveCacheLocations = Mock(AdditiveCacheLocations)
     def fileHasher = Mock(FileHasher)
@@ -44,7 +46,7 @@ class VirtualFileSystemServicesTest extends Specification {
     def watcherRegistryFactory = Mock(FileWatcherRegistryFactory)
     def watcherRegistry = Mock(FileWatcherRegistry)
 
-    def "global virtual file system is not invalidated from the build session scope listener after the build completed"() {
+    def "global virtual file system is not invalidated from the build session scope listener after the build completed (retention enabled: #retentionEnabled)"() {
         def gradleUserHomeVirtualFileSystem = Mock(VirtualFileSystem)
         RootBuildLifecycleListener rootBuildLifecycleListener
         _ * startParameter.getSystemPropertiesArgs() >> systemPropertyArgs(retentionEnabled)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/vfs/RoutingVirtualFileSystemTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/vfs/RoutingVirtualFileSystemTest.groovy
@@ -98,7 +98,6 @@ class RoutingVirtualFileSystemTest extends Specification {
         when:
         routingVirtualFileSystem.invalidateAll()
         then:
-        0 * gradleUserHomeVirtualFileSystem.invalidateAll()
         1 * buildSessionScopedVirtualFileSystem.invalidateAll()
         0 * _
 
@@ -181,7 +180,6 @@ class RoutingVirtualFileSystemTest extends Specification {
         routingVirtualFileSystem.invalidateAll()
         then:
         1 * gradleUserHomeVirtualFileSystem.invalidateAll()
-        1 * buildSessionScopedVirtualFileSystem.invalidateAll()
         0 * _
 
         where:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/vfs/RoutingVirtualFileSystemTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/vfs/RoutingVirtualFileSystemTest.groovy
@@ -37,6 +37,7 @@ class RoutingVirtualFileSystemTest extends Specification {
     VirtualFileSystem buildSessionScopedVirtualFileSystem = Mock(VirtualFileSystem)
     VirtualFileSystem routingVirtualFileSystem
     TestFile cacheDir
+    boolean vfsRetained
 
     def setup() {
         cacheDir = tmpDir.createDir("cache")
@@ -46,7 +47,7 @@ class RoutingVirtualFileSystemTest extends Specification {
             new DefaultAdditiveCacheLocations([fileStore]),
             gradleUserHomeVirtualFileSystem,
             buildSessionScopedVirtualFileSystem,
-            { false }
+            { vfsRetained }
         )
     }
 
@@ -97,7 +98,7 @@ class RoutingVirtualFileSystemTest extends Specification {
         when:
         routingVirtualFileSystem.invalidateAll()
         then:
-        1 * gradleUserHomeVirtualFileSystem.invalidateAll()
+        0 * gradleUserHomeVirtualFileSystem.invalidateAll()
         1 * buildSessionScopedVirtualFileSystem.invalidateAll()
         0 * _
 
@@ -128,5 +129,62 @@ class RoutingVirtualFileSystemTest extends Specification {
         1 * gradleUserHomeVirtualFileSystem.update({ it as List == [userHomeFile.absolutePath] }, updateAction)
         1 * buildSessionScopedVirtualFileSystem.update({ it as List == [projectFile.absolutePath] }, updateAction)
         0 * _
+    }
+
+    def "routes to the Gradle user home virtual file system when retention is enabled"() {
+        vfsRetained = true
+
+        def userHomeFile = cacheDir.file("some/dir/a")
+        def projectFile = tmpDir.file("build/some/file.txt")
+        def snapshottingFilter = Mock(SnapshottingFilter)
+        def action = {} as Runnable
+        def hashFunction = { it } as Function<HashCode, HashCode>
+        def location = inGradleUserHome ? userHomeFile.absolutePath : projectFile.absolutePath
+        def fileSnapshot = Stub(RegularFileSnapshot) {
+            getAbsolutePath() >> location
+        }
+        def consumer = {} as Consumer<CompleteFileSystemLocationSnapshot>
+        def snapshotFunction = { it } as Function<CompleteFileSystemLocationSnapshot, CompleteFileSystemLocationSnapshot>
+
+
+        when:
+        routingVirtualFileSystem.updateWithKnownSnapshot(fileSnapshot)
+        then:
+        1 * gradleUserHomeVirtualFileSystem.updateWithKnownSnapshot(fileSnapshot)
+        0 * _
+
+        when:
+        routingVirtualFileSystem.read(location, snapshotFunction)
+        then:
+        1 * gradleUserHomeVirtualFileSystem.read(location, snapshotFunction)
+        0 * _
+
+        when:
+        routingVirtualFileSystem.read(location, snapshottingFilter, consumer)
+        then:
+        1 * gradleUserHomeVirtualFileSystem.read(location, snapshottingFilter, consumer)
+        0 * _
+
+        when:
+        routingVirtualFileSystem.update([location], action)
+        then:
+        1 * gradleUserHomeVirtualFileSystem.update([location], action)
+        0 * _
+
+        when:
+        routingVirtualFileSystem.readRegularFileContentHash(location, hashFunction)
+        then:
+        1 * gradleUserHomeVirtualFileSystem.readRegularFileContentHash(location, hashFunction)
+        0 * _
+
+        when:
+        routingVirtualFileSystem.invalidateAll()
+        then:
+        1 * gradleUserHomeVirtualFileSystem.invalidateAll()
+        1 * buildSessionScopedVirtualFileSystem.invalidateAll()
+        0 * _
+
+        where:
+        inGradleUserHome << [true, false]
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CleanupOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CleanupOutputsStep.java
@@ -93,7 +93,7 @@ public class CleanupOutputsStep<C extends InputChangesContext, R extends Result>
             for (FileCollectionFingerprint fileCollectionFingerprint : previousOutputs.getOutputFileProperties().values()) {
                 try {
                     // Previous outputs can be in a different place than the current outputs
-                    outputChangeListener.beforeOutputChange(fileCollectionFingerprint.getRootHashes().keySet());
+                    outputChangeListener.beforeOutputChange(fileCollectionFingerprint.getRootPaths());
                     cleaner.cleanupOutputs(fileCollectionFingerprint);
                 } catch (IOException e) {
                     throw new UncheckedIOException("Failed to clean up output files for " + work.getDisplayName(), e);

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
@@ -191,8 +191,8 @@ class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements Fi
         }
         _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecution)
         1 * afterPreviousExecution.outputFileProperties >> ImmutableSortedMap.<String, FileCollectionFingerprint>of("dir", outputs.dirFingerprint, "file", outputs.fileFingerprint)
-        1 * outputChangeListener.beforeOutputChange(outputs.dirFingerprint.rootHashes.keySet())
-        1 * outputChangeListener.beforeOutputChange(outputs.fileFingerprint.rootHashes.keySet())
+        1 * outputChangeListener.beforeOutputChange(outputs.dirFingerprint.rootPaths)
+        1 * outputChangeListener.beforeOutputChange(outputs.fileFingerprint.rootPaths)
     }
 
     void cleanupExclusiveOutputs(WorkOutputs outputs, boolean incrementalExecution = false) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
-import java.util.function.Consumer;
 
 /**
  * A {@link SingletonFileTree} which is composed using a mapping from relative path to file source.
@@ -43,18 +42,18 @@ public class GeneratedSingletonFileTree extends AbstractSingletonFileTree implem
     private final FileSystem fileSystem = FileSystems.getDefault();
 
     private final String fileName;
-    private final Consumer<String> beforeFileChange;
+    private final FileGenerationListener fileGenerationListener;
     private final Action<OutputStream> contentWriter;
 
-    public GeneratedSingletonFileTree(Factory<File> tmpDirSource, String fileName, Consumer<String> beforeFileChange, Action<OutputStream> contentWriter) {
-        this(tmpDirSource, fileName, new PatternSet(), beforeFileChange, contentWriter);
+    public GeneratedSingletonFileTree(Factory<File> tmpDirSource, String fileName, FileGenerationListener fileGenerationListener, Action<OutputStream> contentWriter) {
+        this(tmpDirSource, fileName, new PatternSet(), fileGenerationListener, contentWriter);
     }
 
-    public GeneratedSingletonFileTree(Factory<File> tmpDirSource, String fileName, PatternSet patternSet, Consumer<String> beforeFileChange, Action<OutputStream> contentWriter) {
+    public GeneratedSingletonFileTree(Factory<File> tmpDirSource, String fileName, PatternSet patternSet, FileGenerationListener fileGenerationListener, Action<OutputStream> contentWriter) {
         super(patternSet);
         this.tmpDirSource = tmpDirSource;
         this.fileName = fileName;
-        this.beforeFileChange = beforeFileChange;
+        this.fileGenerationListener = fileGenerationListener;
         this.contentWriter = contentWriter;
     }
 
@@ -87,7 +86,18 @@ public class GeneratedSingletonFileTree extends AbstractSingletonFileTree implem
 
     @Override
     public MinimalFileTree filter(PatternFilterable patterns) {
-        return new GeneratedSingletonFileTree(tmpDirSource, fileName, filterPatternSet(patterns), beforeFileChange, contentWriter);
+        return new GeneratedSingletonFileTree(tmpDirSource, fileName, filterPatternSet(patterns), fileGenerationListener, contentWriter);
+    }
+
+    /**
+     * Listener for users of `GeneratedSingletonFileTree` for listening to file changes caused
+     * by generating files.
+     */
+    public interface FileGenerationListener {
+        /**
+         * Called just before (re-) generating the file with the absolute path.
+         */
+        void beforeFileGenerated(String absolutePath);
     }
 
     private class FileVisitDetailsImpl extends AbstractFileTreeElement implements FileVisitDetails {
@@ -135,7 +145,7 @@ public class GeneratedSingletonFileTree extends AbstractSingletonFileTree implem
             byte[] generatedContent = generateContent();
             if (!hasContent(generatedContent, file)) {
                 try {
-                    beforeFileChange.accept(file.getAbsolutePath());
+                    fileGenerationListener.beforeFileGenerated(file.getAbsolutePath());
                     Files.write(generatedContent, file);
                 } catch (IOException e) {
                     throw new org.gradle.api.UncheckedIOException(e);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FileCollectionFingerprint.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.fingerprint;
 
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.internal.hash.HashCode;
 
@@ -37,6 +38,13 @@ public interface FileCollectionFingerprint {
      */
     ImmutableMultimap<String, HashCode> getRootHashes();
 
+    /**
+     * The absolute paths for the roots of this file collection fingerprint.
+     */
+    default ImmutableSet<String> getRootPaths() {
+        return getRootHashes().keySet();
+    }
+
     FileCollectionFingerprint EMPTY = new FileCollectionFingerprint() {
         @Override
         public Map<String, FileSystemLocationFingerprint> getFingerprints() {
@@ -46,6 +54,11 @@ public interface FileCollectionFingerprint {
         @Override
         public ImmutableMultimap<String, HashCode> getRootHashes() {
             return ImmutableMultimap.of();
+        }
+
+        @Override
+        public ImmutableSet<String> getRootPaths() {
+            return ImmutableSet.of();
         }
 
         @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.fingerprint.impl;
 
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.hash.HashCode;
@@ -58,6 +59,11 @@ public class EmptyCurrentFileCollectionFingerprint implements CurrentFileCollect
     @Override
     public ImmutableMultimap<String, HashCode> getRootHashes() {
         return ImmutableMultimap.of();
+    }
+
+    @Override
+    public ImmutableSet<String> getRootPaths() {
+        return ImmutableSet.of();
     }
 
     @Override


### PR DESCRIPTION
Then the routing takes care that no events are lost. Before that change,
any call to `beforeOutputChange()` had no effect when VFS retention is
enabled.
