### PR TITLE
Remove dependency between build-cache-packaging and native

### DIFF
--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -24,7 +24,6 @@ description = "Package build cache results"
 
 dependencies {
     implementation(project(":baseServices"))
-    implementation(project(":native"))
     implementation(project(":coreApi"))
     implementation(project(":buildCache"))
     implementation(project(":files"))
@@ -40,7 +39,7 @@ dependencies {
     testImplementation(project(":processServices"))
     testImplementation(project(":fileCollections"))
     testImplementation(project(":resources"))
-    
+
     testImplementation(testFixtures(project(":baseServices")))
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":snapshots")))

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PermissionUtils.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PermissionUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradle.caching.internal.packaging.impl;
 
 import java.io.File;

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PermissionUtils.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PermissionUtils.java
@@ -67,7 +67,7 @@ public class PermissionUtils {
 
     public static void setPermissions(File file, int mode) throws IOException {
         if (IS_POSIX) {
-            Files.setPosixFilePermissions(file.toPath(), PermissionUtils.permissions(mode));
+            Files.setPosixFilePermissions(file.toPath(), permissions(mode));
         } else if (IS_DOS) {
             Files.getFileAttributeView(file.toPath(), DosFileAttributeView.class)
                 .setReadOnly((mode & posixPermissionToInteger.get(PosixFilePermission.OWNER_WRITE)) == 0);

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PermissionUtils.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/PermissionUtils.java
@@ -1,0 +1,139 @@
+package org.gradle.caching.internal.packaging.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.DosFileAttributeView;
+import java.nio.file.attribute.DosFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helps dealing with file permissions.
+ */
+public class PermissionUtils {
+
+    /**
+     * XXX: When using standard Java permissions, we treat 'owner' and 'group' equally and give no
+     * permissions for 'others'.
+     */
+    private enum StandardFilePermission {
+        EXECUTE(0110), WRITE(0220), READ(0440);
+
+        private int mode;
+
+        StandardFilePermission(int mode) {
+            this.mode = mode;
+        }
+    }
+
+    private static Map<PosixFilePermission, Integer> posixPermissionToInteger = new EnumMap<>(PosixFilePermission.class);
+
+    static {
+        posixPermissionToInteger.put(PosixFilePermission.OWNER_EXECUTE, 0100);
+        posixPermissionToInteger.put(PosixFilePermission.OWNER_WRITE, 0200);
+        posixPermissionToInteger.put(PosixFilePermission.OWNER_READ, 0400);
+
+        posixPermissionToInteger.put(PosixFilePermission.GROUP_EXECUTE, 0010);
+        posixPermissionToInteger.put(PosixFilePermission.GROUP_WRITE, 0020);
+        posixPermissionToInteger.put(PosixFilePermission.GROUP_READ, 0040);
+
+        posixPermissionToInteger.put(PosixFilePermission.OTHERS_EXECUTE, 0001);
+        posixPermissionToInteger.put(PosixFilePermission.OTHERS_WRITE, 0002);
+        posixPermissionToInteger.put(PosixFilePermission.OTHERS_READ, 0004);
+    }
+
+    public static void setPermissions(File file, int mode) throws IOException {
+        if (IS_POSIX) {
+            Files.setPosixFilePermissions(file.toPath(), PermissionUtils.permissions(mode));
+        } else if (IS_DOS) {
+            Files.getFileAttributeView(file.toPath(), DosFileAttributeView.class)
+                .setReadOnly((mode & posixPermissionToInteger.get(PosixFilePermission.OWNER_WRITE)) == 0);
+        }
+    }
+
+    private static Set<PosixFilePermission> permissions(int mode) {
+        Set<PosixFilePermission> result = new HashSet<>();
+        for (Map.Entry<PosixFilePermission, Integer> entry : posixPermissionToInteger.entrySet()) {
+            if ((mode & entry.getValue()) != 0) {
+                result.add(entry.getKey());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get file permissions in octal mode, e.g. 0755.
+     * <p>
+     * Note: it uses `java.nio.file.attribute.PosixFilePermission` if OS supports this, otherwise reverts to
+     * using standard Java file operations, e.g. `java.io.File#canExecute()`. In the first case permissions will
+     * be precisely as reported by the OS, in the second case 'owner' and 'group' will have equal permissions and
+     * 'others' will have no permissions, e.g. if file on Windows OS is `read-only` permissions will be `0550`.
+     *
+     * @throws NullPointerException     if file is null.
+     * @throws IllegalArgumentException if file does not exist.
+     */
+    public static int permissions(File f) {
+        if (f == null) {
+            throw new NullPointerException("File is null.");
+        }
+        if (!f.exists()) {
+            throw new IllegalArgumentException("File " + f + " does not exist.");
+        }
+
+        return IS_POSIX ? posixPermissions(f) : (IS_DOS ? dosPermissions(f) : defaultPermissions(f));
+    }
+
+    private static int defaultPermissions(File f) {
+        return f.isDirectory() ? 0755 : 0644;
+    }
+
+    private static final boolean IS_POSIX = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    private static final boolean IS_DOS = FileSystems.getDefault().supportedFileAttributeViews().contains("dos");
+
+    private static int posixPermissions(File f) {
+        try {
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(f.toPath());
+            int number = 0;
+            for (Map.Entry<PosixFilePermission, Integer> entry : posixPermissionToInteger.entrySet()) {
+                if (permissions.contains(entry.getKey())) {
+                    number += entry.getValue();
+                }
+            }
+            return number;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Set<StandardFilePermission> readDosPermissions(File f) {
+        Set<StandardFilePermission> permissions = EnumSet.allOf(StandardFilePermission.class);
+        if (readDosFileAttributes(f).isReadOnly()) {
+            permissions.remove(StandardFilePermission.WRITE);
+        }
+        return permissions;
+    }
+
+    private static DosFileAttributes readDosFileAttributes(File f) {
+        try {
+            return Files.getFileAttributeView(f.toPath(), DosFileAttributeView.class).readAttributes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Integer dosPermissions(File f) {
+        int number = 0;
+        Set<StandardFilePermission> permissions = readDosPermissions(f);
+        for (StandardFilePermission permission : permissions) {
+            number += permission.mode;
+        }
+        return number;
+    }
+}

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -322,7 +322,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
         try {
             PermissionUtils.setPermissions(file, entry.getMode() & UnixPermissions.PERM_MASK);
         } catch (IOException e) {
-            throw new java.io.UncheckedIOException(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
@@ -30,7 +30,6 @@ import org.gradle.internal.fingerprint.FingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
 import org.gradle.internal.hash.DefaultStreamHasher
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -46,14 +45,12 @@ abstract class AbstractTarBuildCacheEntryPackerSpec extends Specification {
     def readOrigin = Stub(OriginReader)
     def writeOrigin = Stub(OriginWriter)
 
-    def fileSystem = createFileSystem()
     def deleter = createDeleter()
     def streamHasher = new DefaultStreamHasher()
     def stringInterner = new StringInterner()
-    def packer = new TarBuildCacheEntryPacker(deleter, fileSystem, streamHasher, stringInterner)
+    def packer = new TarBuildCacheEntryPacker(deleter, streamHasher, stringInterner)
     def virtualFileSystem = TestFiles.virtualFileSystem()
 
-    abstract protected FileSystem createFileSystem()
     abstract protected Deleter createDeleter()
 
     def pack(OutputStream output, OriginWriter writeOrigin = this.writeOrigin, TreeDefinition... treeDefs) {

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerTest.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.internal.file.TreeType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.FingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
@@ -35,10 +34,6 @@ import static org.gradle.internal.file.TreeType.DIRECTORY
 import static org.gradle.internal.file.TreeType.FILE
 
 class TarBuildCacheEntryPackerTest extends AbstractTarBuildCacheEntryPackerSpec {
-    @Override
-    protected FileSystem createFileSystem() {
-        TestFiles.fileSystem()
-    }
 
     @Override
     protected Deleter createDeleter() {

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -100,6 +100,9 @@ dependencies {
     testFixturesApi(project(":execution")) {
         because("test fixtures expose OutputChangeListener")
     }
+    testFixturesApi(project(":native")) {
+        because("test fixtures expose FileSystem")
+    }
     testFixturesImplementation(project(":fileCollections"))
     testFixturesImplementation(project(":native"))
     testFixturesImplementation(project(":resources"))

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
@@ -34,7 +34,6 @@ import org.gradle.internal.SystemProperties;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
-import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.nativeintegration.network.HostnameLookup;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.os.OperatingSystem;

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheServices.java
@@ -57,12 +57,11 @@ public class BuildCacheServices {
 
     BuildCacheEntryPacker createResultPacker(
         Deleter deleter,
-        FileSystem fileSystem,
         StreamHasher fileHasher,
         StringInterner stringInterner
     ) {
         return new GZipBuildCacheEntryPacker(
-            new TarBuildCacheEntryPacker(deleter, fileSystem, fileHasher, stringInterner));
+            new TarBuildCacheEntryPacker(deleter, fileHasher, stringInterner));
     }
 
     OriginMetadataFactory createOriginMetadataFactory(


### PR DESCRIPTION
By replacing the usage of FileSystem with a little utility class we can
get rid of the dependency between build-cache-packaging and native. For
this to work the TarBuildCacheEntryPackerPermissionTest hat to be
changes to assert correct permissions instead of checking for
interactions.

<!--- The issue this PR addresses -->
Part of https://github.com/gradle/gradle-private/issues/2417

