### PR TITLE
Remove dependency between build-cache-packaging and native

### DIFF
--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     api(project(":buildCacheBase"))
 
     implementation(project(":baseServices"))
-    implementation(project(":native"))
     implementation(project(":coreApi"))
     implementation(project(":buildCache"))
     implementation(project(":files"))

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/FilePermissionAccess.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/FilePermissionAccess.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal.packaging.impl;
+
+import org.gradle.internal.file.FileException;
+
+import java.io.File;
+
+public interface FilePermissionAccess {
+
+    int getUnixMode(File f) throws FileException;
+
+    void chmod(File file, int mode) throws FileException;
+}

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -36,7 +36,6 @@ import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.TreeType;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.StreamHasher;
-import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.snapshot.CompleteDirectorySnapshot;
 import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileMetadata;
@@ -91,13 +90,13 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
     private static final ThreadLocal<byte[]> COPY_BUFFERS = ThreadLocal.withInitial(() -> new byte[BUFFER_SIZE]);
 
     private final Deleter deleter;
-    private final FileSystem fileSystem;
+    private final FilePermissionAccess filePermissionAccess;
     private final StreamHasher streamHasher;
     private final Interner<String> stringInterner;
 
-    public TarBuildCacheEntryPacker(Deleter deleter, FileSystem fileSystem, StreamHasher streamHasher, Interner<String> stringInterner) {
+    public TarBuildCacheEntryPacker(Deleter deleter, FilePermissionAccess filePermissionAccess, StreamHasher streamHasher, Interner<String> stringInterner) {
         this.deleter = deleter;
-        this.fileSystem = fileSystem;
+        this.filePermissionAccess = filePermissionAccess;
         this.streamHasher = streamHasher;
         this.stringInterner = stringInterner;
     }
@@ -142,7 +141,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
     }
 
     private long packTree(String name, TreeType type, FileSystemSnapshot snapshots, TarArchiveOutputStream tarOutput) {
-        PackingVisitor packingVisitor = new PackingVisitor(tarOutput, name, type, fileSystem);
+        PackingVisitor packingVisitor = new PackingVisitor(tarOutput, name, type, filePermissionAccess);
         snapshots.accept(packingVisitor);
         return packingVisitor.finish();
     }
@@ -316,7 +315,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
     }
 
     private void chmodUnpackedFile(TarArchiveEntry entry, File file) {
-        fileSystem.chmod(file, entry.getMode() & UnixPermissions.PERM_MASK);
+        filePermissionAccess.chmod(file, entry.getMode() & UnixPermissions.PERM_MASK);
     }
 
     private static String escape(String name) {
@@ -340,17 +339,17 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
         private final TarArchiveOutputStream tarOutput;
         private final String treePath;
         private final String treeRoot;
-        private final FileSystem fileSystem;
+        private final FilePermissionAccess filePermissionAccess;
         private final TreeType type;
 
         private long entries;
 
-        public PackingVisitor(TarArchiveOutputStream tarOutput, String treeName, TreeType type, FileSystem fileSystem) {
+        public PackingVisitor(TarArchiveOutputStream tarOutput, String treeName, TreeType type, FilePermissionAccess filePermissionAccess) {
             this.tarOutput = tarOutput;
             this.treePath = "tree-" + escape(treeName);
             this.treeRoot = treePath + "/";
             this.type = type;
-            this.fileSystem = fileSystem;
+            this.filePermissionAccess = filePermissionAccess;
             this.relativePathStringTracker = new RelativePathStringTracker();
         }
 
@@ -360,7 +359,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
             relativePathStringTracker.enter(directorySnapshot);
             assertCorrectType(isRoot, directorySnapshot);
             String targetPath = getTargetPath(isRoot);
-            int mode = isRoot ? UnixPermissions.DEFAULT_DIR_PERM : fileSystem.getUnixMode(new File(directorySnapshot.getAbsolutePath()));
+            int mode = isRoot ? UnixPermissions.DEFAULT_DIR_PERM : filePermissionAccess.getUnixMode(new File(directorySnapshot.getAbsolutePath()));
             storeDirectoryEntry(targetPath, mode, tarOutput);
             entries++;
             return true;
@@ -379,7 +378,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
             } else {
                 assertCorrectType(isRoot, fileSnapshot);
                 File file = new File(fileSnapshot.getAbsolutePath());
-                int mode = fileSystem.getUnixMode(file);
+                int mode = filePermissionAccess.getUnixMode(file);
                 storeFileEntry(file, targetPath, file.length(), mode, tarOutput);
             }
             relativePathStringTracker.leave();

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
@@ -30,7 +30,6 @@ import org.gradle.internal.fingerprint.FingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
 import org.gradle.internal.hash.DefaultStreamHasher
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -46,14 +45,14 @@ abstract class AbstractTarBuildCacheEntryPackerSpec extends Specification {
     def readOrigin = Stub(OriginReader)
     def writeOrigin = Stub(OriginWriter)
 
-    def fileSystem = createFileSystem()
+    def filePermissionAccess = createFilePermissionAccess()
     def deleter = createDeleter()
     def streamHasher = new DefaultStreamHasher()
     def stringInterner = new StringInterner()
-    def packer = new TarBuildCacheEntryPacker(deleter, fileSystem, streamHasher, stringInterner)
+    def packer = new TarBuildCacheEntryPacker(deleter, filePermissionAccess, streamHasher, stringInterner)
     def virtualFileSystem = TestFiles.virtualFileSystem()
 
-    abstract protected FileSystem createFileSystem()
+    abstract protected FilePermissionAccess createFilePermissionAccess()
     abstract protected Deleter createDeleter()
 
     def pack(OutputStream output, OriginWriter writeOrigin = this.writeOrigin, TreeDefinition... treeDefs) {

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerPermissionTest.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerPermissionTest.groovy
@@ -17,15 +17,14 @@
 package org.gradle.caching.internal.packaging.impl
 
 import org.gradle.internal.file.Deleter
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import spock.lang.Unroll
 
 import static org.gradle.internal.file.TreeType.FILE
 
 class TarBuildCacheEntryPackerPermissionTest extends AbstractTarBuildCacheEntryPackerSpec {
     @Override
-    protected FileSystem createFileSystem() {
-        Mock(FileSystem)
+    protected FilePermissionAccess createFilePermissionAccess() {
+        Mock(FilePermissionAccess)
     }
 
     @Override
@@ -45,7 +44,7 @@ class TarBuildCacheEntryPackerPermissionTest extends AbstractTarBuildCacheEntryP
         pack output, prop(FILE, sourceOutputFile)
 
         then:
-        1 * fileSystem.getUnixMode(sourceOutputFile) >> unixMode
+        1 * filePermissionAccess.getUnixMode(sourceOutputFile) >> unixMode
         _ * sourceOutputFile._
         0 * _
 
@@ -55,7 +54,7 @@ class TarBuildCacheEntryPackerPermissionTest extends AbstractTarBuildCacheEntryP
 
         then:
         targetOutputFile.text == "output"
-        1 * fileSystem.chmod(targetOutputFile, unixMode)
+        1 * filePermissionAccess.chmod(targetOutputFile, unixMode)
         _ * targetOutputFile._
         0 * _
 

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerTest.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPackerTest.groovy
@@ -36,8 +36,11 @@ import static org.gradle.internal.file.TreeType.FILE
 
 class TarBuildCacheEntryPackerTest extends AbstractTarBuildCacheEntryPackerSpec {
     @Override
-    protected FileSystem createFileSystem() {
-        TestFiles.fileSystem()
+    protected FilePermissionAccess createFilePermissionAccess() {
+        new FilePermissionAccess() {
+            @Delegate
+            FileSystem fs = TestFiles.fileSystem()
+        }
     }
 
     @Override

--- a/subprojects/core/core.gradle.kts
+++ b/subprojects/core/core.gradle.kts
@@ -100,6 +100,9 @@ dependencies {
     testFixturesApi(project(":execution")) {
         because("test fixtures expose OutputChangeListener")
     }
+    testFixturesApi(project(":native")) {
+        because("test fixtures expose FileSystem")
+    }
     testFixturesImplementation(project(":fileCollections"))
     testFixturesImplementation(project(":native"))
     testFixturesImplementation(project(":resources"))


### PR DESCRIPTION
Follow up to: #11821
Part of: https://github.com/gradle/gradle-private/issues/2417