### PR TITLE
Fix circular dependencies when project have the same name

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -606,33 +606,6 @@ afterEvaluate {
         failure.assertHasCause("Module version 'org.test:b1:1.0' is not unique in composite: can be provided by [project :buildB:b1, project :buildC:b1].")
     }
 
-    def "reports failure to resolve dependencies when substitution is ambiguous within single participant"() {
-        given:
-        buildB
-        def buildC = multiProjectBuild("buildC", ['c1', 'c2']);
-        buildC.settingsFile << """
-            include ':nested:c1'
-"""
-        buildC.buildFile << """
-            allprojects {
-                apply plugin: 'java'
-            }
-"""
-        includedBuilds << buildC
-
-        buildA.buildFile << """
-            dependencies {
-                implementation "org.test:c1:1.0"
-            }
-"""
-
-        when:
-        checkDependenciesFails()
-
-        then:
-        failure.assertHasCause("Module version 'org.test:c1:1.0' is not unique in composite: can be provided by [project :buildC:c1, project :buildC:nested:c1].")
-    }
-
     def "reports failure to resolve dependencies when transitive dependency substitution is ambiguous"() {
         given:
         transitiveDependencyIsAmbiguous("'org.test:b1:2.0'")
@@ -747,22 +720,22 @@ afterEvaluate {
                 maven { url '$mavenRepo.uri' }
             }
 
-            configurations { 
-                buildInputs 
+            configurations {
+                buildInputs
                 create('default')
             }
-            
+
             dependencies {
                 buildInputs "org.test:test:1.2"
             }
-            
+
             task buildOutputs {
                 inputs.files configurations.buildInputs
                 doLast {
                     configurations.buildInputs.each { }
                 }
             }
-            
+
             artifacts {
                 "default" file: file("out.jar"), builtBy: buildOutputs
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectModuleFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectModuleFactory.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.gradle.api.Project;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefaultProjectModuleFactory implements ProjectModuleFactory {
+    private static final Splitter SPLITTER = Splitter.on(':')
+        .omitEmptyStrings();
+
+    private final Map<Project, Module> projectToModule = Maps.newConcurrentMap();
+
+    public DefaultProjectModuleFactory() {
+    }
+
+    private List<Project> findDuplicates(Project project) {
+        Set<Project> projects = project.getRootProject().getAllprojects();
+        String current = toGroupAndArtifact(project);
+        List<Project> duplicates = null;
+        for (Project projectIdentifier : projects) {
+            if (project != projectIdentifier) {
+                String ga = toGroupAndArtifact(projectIdentifier);
+                if (current.equals(ga)) {
+                    if (duplicates == null) {
+                        duplicates = Lists.newArrayList();
+                    }
+                    duplicates.add(projectIdentifier);
+                }
+            }
+        }
+        return duplicates == null ? Collections.emptyList() : duplicates;
+    }
+
+    private static String toGroupAndArtifact(Project projectIdentifier) {
+        return projectIdentifier.getGroup() + ":" + projectIdentifier.getName();
+    }
+
+    @Override
+    public Module getModule(Project project) {
+        return projectToModule.computeIfAbsent(project, this::createId);
+    }
+
+    private Module createId(Project project) {
+        return new DynamicDeduplicatingModuleProjectIdentifier(project);
+    }
+
+    private abstract class AbstractProjectBackedModule implements ProjectBackedModule {
+
+        private final Project project;
+
+        @Override
+        public Project getProject() {
+            return project;
+        }
+
+        public AbstractProjectBackedModule(Project project) {
+            this.project = project;
+        }
+
+        @Override
+        public List<Project> getProjectsWithSameCoordinates() {
+            List<Project> ids = findDuplicates(project);
+            if (ids.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return ids.stream()
+                .filter(id -> id != project)
+                .collect(Collectors.toList());
+        }
+
+        @Override
+        public String getGroup() {
+            return String.valueOf(project.getGroup());
+        }
+
+        @Override
+        public String getVersion() {
+            return project.getVersion().toString();
+        }
+
+        @Override
+        public String getStatus() {
+            return project.getStatus().toString();
+        }
+
+        @Override
+        public String getProjectPath() {
+            return project.getPath();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            AbstractProjectBackedModule that = (AbstractProjectBackedModule) o;
+
+            if (!project.equals(that.project)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return project.hashCode();
+        }
+    }
+
+    private class DynamicDeduplicatingModuleProjectIdentifier extends AbstractProjectBackedModule {
+        private final Project project;
+
+        private DynamicDeduplicatingModuleProjectIdentifier(Project project) {
+            super(project);
+            this.project = project;
+        }
+
+        @Override
+        public String getName() {
+            List<Project> duplicates = findDuplicates(project);
+            if (duplicates.isEmpty()) {
+                return project.getName();
+            }
+            List<String> strings = SPLITTER.splitToList(project.getPath());
+            if (strings.size() <= 1) {
+                return project.getName();
+            }
+            return String.join("-", strings.subList(0, strings.size() - 1)) + "-" + project.getName();
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ProjectModuleFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ProjectModuleFactory.java
@@ -17,9 +17,6 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.Project;
 
-import java.util.List;
-
-public interface ProjectBackedModule extends Module {
-    Project getProject();
-    List<Project> getProjectsWithSameCoordinates();
+public interface ProjectModuleFactory {
+    Module getModule(Project project);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -27,8 +27,10 @@ import org.gradle.api.internal.DependencyClassPathProvider;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.artifacts.DefaultModule;
+import org.gradle.api.internal.artifacts.DefaultProjectModuleFactory;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.Module;
+import org.gradle.api.internal.artifacts.ProjectModuleFactory;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.classpath.PluginModuleRegistry;
@@ -552,5 +554,9 @@ public class BuildScopeServices extends DefaultServiceRegistry {
 
     protected BuildInvocationDetails createBuildInvocationDetails(BuildStartedTime buildStartedTime) {
         return new DefaultBuildInvocationDetails(buildStartedTime);
+    }
+
+    protected ProjectModuleFactory createProjectModuleIdentifierFactory() {
+        return new DefaultProjectModuleFactory();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -556,7 +556,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new DefaultBuildInvocationDetails(buildStartedTime);
     }
 
-    protected ProjectModuleFactory createProjectModuleIdentifierFactory() {
-        return new DefaultProjectModuleFactory();
+    protected ProjectModuleFactory createProjectModuleIdentifierFactory(DefaultProjectRegistry<ProjectInternal> projectRegistry) {
+        return new DefaultProjectModuleFactory(projectRegistry);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.Module;
-import org.gradle.api.internal.artifacts.ProjectBackedModule;
+import org.gradle.api.internal.artifacts.ProjectModuleFactory;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
@@ -279,8 +279,8 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         }
     }
 
-    protected DependencyMetaDataProvider createDependencyMetaDataProvider() {
-        return new ProjectBackedModuleMetaDataProvider();
+    protected DependencyMetaDataProvider createDependencyMetaDataProvider(ProjectModuleFactory projectModuleIdentifierFactory) {
+        return new ProjectBackedModuleMetaDataProvider(projectModuleIdentifierFactory);
     }
 
     protected ServiceRegistryFactory createServiceRegistryFactory(final ServiceRegistry services) {
@@ -301,9 +301,15 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     }
 
     private class ProjectBackedModuleMetaDataProvider implements DependencyMetaDataProvider {
+        private final ProjectModuleFactory projectModuleIdentifierFactory;
+
+        public ProjectBackedModuleMetaDataProvider(ProjectModuleFactory projectModuleIdentifierFactory) {
+            this.projectModuleIdentifierFactory = projectModuleIdentifierFactory;
+        }
+
         @Override
         public Module getModule() {
-            return new ProjectBackedModule(project);
+            return projectModuleIdentifierFactory.getModule(project);
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/ProjectBackedModuleTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/ProjectBackedModuleTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.api.internal.artifacts
 
-
+import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 class ProjectBackedModuleTest extends AbstractProjectBuilderSpec {
-    ProjectModuleFactory factory = new DefaultProjectModuleFactory()
+    ProjectModuleFactory factory = new DefaultProjectModuleFactory(Mock(ProjectRegistry) {
+        getAllProjects() >> []
+    })
 
     def "module exposes project properties"() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/ProjectBackedModuleTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/ProjectBackedModuleTest.groovy
@@ -16,13 +16,15 @@
 
 package org.gradle.api.internal.artifacts
 
+
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 class ProjectBackedModuleTest extends AbstractProjectBuilderSpec {
+    ProjectModuleFactory factory = new DefaultProjectModuleFactory()
 
     def "module exposes project properties"() {
         given:
-        def module = new ProjectBackedModule(project)
+        def module = factory.getModule(project)
 
         expect:
         module.name == project.name

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -39,8 +39,9 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.ProcessOperations
+import org.gradle.api.internal.artifacts.DefaultProjectModuleFactory
 import org.gradle.api.internal.artifacts.Module
-import org.gradle.api.internal.artifacts.ProjectBackedModule
+import org.gradle.api.internal.artifacts.ProjectModuleFactory
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory
 import org.gradle.api.internal.file.DefaultProjectLayout
@@ -154,6 +155,7 @@ class DefaultProjectTest extends Specification {
     CrossProjectConfigurator crossProjectConfigurator = new BuildOperationCrossProjectConfigurator(buildOperationExecutor)
     ClassLoaderScope baseClassLoaderScope = new RootClassLoaderScope("root", getClass().classLoader, getClass().classLoader, new DummyClassLoaderCache(), Stub(ClassLoaderScopeRegistryListener))
     ClassLoaderScope rootProjectClassLoaderScope = baseClassLoaderScope.createChild("root-project")
+    ProjectModuleFactory moduleFactory = new DefaultProjectModuleFactory()
 
     def setup() {
         rootDir = new File("/path/root").absoluteFile
@@ -953,7 +955,7 @@ def scriptMethod(Closure closure) {
 
     def getModule() {
         when:
-        Module moduleDummyResolve = new ProjectBackedModule(project)
+        Module moduleDummyResolve = moduleFactory.getModule(project)
         dependencyMetaDataProviderMock.getModule() >> moduleDummyResolve
         then:
         project.getModule() == moduleDummyResolve

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -155,7 +155,9 @@ class DefaultProjectTest extends Specification {
     CrossProjectConfigurator crossProjectConfigurator = new BuildOperationCrossProjectConfigurator(buildOperationExecutor)
     ClassLoaderScope baseClassLoaderScope = new RootClassLoaderScope("root", getClass().classLoader, getClass().classLoader, new DummyClassLoaderCache(), Stub(ClassLoaderScopeRegistryListener))
     ClassLoaderScope rootProjectClassLoaderScope = baseClassLoaderScope.createChild("root-project")
-    ProjectModuleFactory moduleFactory = new DefaultProjectModuleFactory()
+    ProjectModuleFactory moduleFactory = new DefaultProjectModuleFactory(Mock(ProjectRegistry) {
+        getAllProjects() >> []
+    })
 
     def setup() {
         rootDir = new File("/path/root").absoluteFile

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.DefaultProjectModuleFactory
 import org.gradle.api.internal.artifacts.ProjectModuleFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
@@ -34,7 +35,9 @@ import spock.lang.Specification
 class DefaultComponentIdentifierFactoryTest extends Specification {
     def buildIdentity = Mock(BuildState)
     def componentIdentifierFactory = new DefaultComponentIdentifierFactory(buildIdentity)
-    ProjectModuleFactory moduleFactory = new DefaultProjectModuleFactory()
+    ProjectModuleFactory moduleFactory = new DefaultProjectModuleFactory(Mock(ProjectRegistry) {
+        getAllProjects() >> []
+    })
 
     def "can create project component identifier"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
@@ -21,7 +21,8 @@ import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModule
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
-import org.gradle.api.internal.artifacts.ProjectBackedModule
+import org.gradle.api.internal.artifacts.DefaultProjectModuleFactory
+import org.gradle.api.internal.artifacts.ProjectModuleFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.build.BuildState
@@ -33,12 +34,13 @@ import spock.lang.Specification
 class DefaultComponentIdentifierFactoryTest extends Specification {
     def buildIdentity = Mock(BuildState)
     def componentIdentifierFactory = new DefaultComponentIdentifierFactory(buildIdentity)
+    ProjectModuleFactory moduleFactory = new DefaultProjectModuleFactory()
 
     def "can create project component identifier"() {
         given:
         def project = Mock(ProjectInternal)
         def expectedId = Stub(ProjectComponentIdentifier)
-        def module = new ProjectBackedModule(project)
+        def module = moduleFactory.getModule(project)
 
         when:
         def componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module)

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTask.java
@@ -26,10 +26,12 @@ import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.artifacts.ProjectBackedModule;
+import org.gradle.api.internal.artifacts.Module;
+import org.gradle.api.internal.artifacts.ProjectModuleFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
@@ -92,12 +94,21 @@ public class OutgoingVariantsReportTask extends DefaultTask {
             reportNoMatchingVariant(configurations, output);
         } else {
             Legend legend = new Legend();
-            configurations.forEach(cnf -> reportVariant((ConfigurationInternal) cnf, new ProjectBackedModule(getProject()), output, legend));
+            ProjectModuleFactory factory = getProjectModuleFactory();
+            Module projectBackedModule = factory.getModule(getProject());
+            configurations.forEach(cnf -> {
+                reportVariant((ConfigurationInternal) cnf, projectBackedModule, output, legend);
+            });
             legend.print(output);
         }
     }
 
-    private void reportVariant(ConfigurationInternal cnf, ProjectBackedModule projectBackedModule, StyledTextOutput output, Legend legend) {
+    // private and using internal API to avoid binary compatibility breakage
+    private ProjectModuleFactory getProjectModuleFactory() {
+        return ((ProjectInternal)getProject()).getServices().get(ProjectModuleFactory.class);
+    }
+
+    private void reportVariant(ConfigurationInternal cnf, Module projectBackedModule, StyledTextOutput output, Legend legend) {
         // makes sure the configuration is complete before reporting
         cnf.preventFromFurtherMutation();
         Formatter tree = new Formatter(output);
@@ -185,7 +196,7 @@ public class OutgoingVariantsReportTask extends DefaultTask {
         return false;
     }
 
-    private void formatCapabilities(Collection<? extends Capability> capabilities, ProjectBackedModule projectBackedModule, Formatter tree) {
+    private void formatCapabilities(Collection<? extends Capability> capabilities, Module projectBackedModule, Formatter tree) {
         tree.section("Capabilities", () -> {
             if (capabilities.isEmpty()) {
                 tree.text(String.format("%s:%s:%s (default capability)", projectBackedModule.getGroup(), projectBackedModule.getName(), projectBackedModule.getVersion()));
@@ -195,7 +206,7 @@ public class OutgoingVariantsReportTask extends DefaultTask {
         });
     }
 
-    private boolean formatAttributesAndCapabilities(ConfigurationInternal configuration, ProjectBackedModule projectBackedModule, Formatter tree) {
+    private boolean formatAttributesAndCapabilities(ConfigurationInternal configuration, Module projectBackedModule, Formatter tree) {
         AttributeContainerInternal attributes = configuration.getAttributes();
         if (!attributes.isEmpty()) {
             Collection<? extends Capability> capabilities = configuration.getOutgoing().getCapabilities();

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishMultiProjectIntegTest.groovy
@@ -402,8 +402,8 @@ $append
         }
 
         and:
-        outputContains """Project :b:core has the same (organisation, module name) as :a:core. It has been assigned an automatic module name of b-core as a workaround, but you should set both the organisation and module name of the publication to be safe."""
-        outputContains """Project :a:core has the same (organisation, module name) as :b:core. It has been assigned an automatic module name of a-core as a workaround, but you should set both the organisation and module name of the publication to be safe."""
+        outputContains """Project :b:core has the same (organisation, module name) as :a:core. It has been assigned a synthetic Ivy module name of of b-core as a workaround, but you should set both the organisation and module name of the publication to be safe."""
+        outputContains """Project :a:core has the same (organisation, module name) as :b:core. It has been assigned a synthetic Ivy module name of of a-core as a workaround, but you should set both the organisation and module name of the publication to be safe."""
     }
 
     @ToBeFixedForInstantExecution
@@ -477,8 +477,8 @@ $append
         }
 
         and:
-        outputDoesNotContain "Project :a:core has the same (organisation, module name) as :b:core. It has been assigned an automatic module name of a-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
-        outputDoesNotContain "Project :b:core has the same (organisation, module name) as :a:core. It has been assigned an automatic module name of b-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
+        outputDoesNotContain "Project :a:core has the same (organisation, module name) as :b:core. It has been assigned a synthetic Ivy module name of of a-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
+        outputDoesNotContain "Project :b:core has the same (organisation, module name) as :a:core. It has been assigned a synthetic Ivy module name of of b-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
     }
 
     @ToBeFixedForInstantExecution
@@ -552,8 +552,8 @@ $append
         }
 
         and:
-        outputDoesNotContain "Project :a:core has the same (organisation, module name) as :b:core. It has been assigned an automatic module name of a-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
-        outputDoesNotContain "Project :b:core has the same (organisation, module name) as :a:core. It has been assigned an automatic module name of b-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
+        outputDoesNotContain "Project :a:core has the same (organisation, module name) as :b:core. It has been assigned a synthetic Ivy module name of of a-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
+        outputDoesNotContain "Project :b:core has the same (organisation, module name) as :a:core. It has been assigned a synthetic Ivy module name of of b-core as a workaround, but you should set both the organisation and module name of the publication to be safe."
 
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationIdentity.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationIdentity.java
@@ -132,7 +132,7 @@ public class DefaultIvyPublicationIdentity implements IvyPublicationIdentity {
                         .append(project.getPath())
                         .append(" has the same (organisation, module name) as ")
                         .append(projectsWithSameId.stream().map(Project::getPath).collect(Collectors.joining(" and ")))
-                        .append(". It has been assigned an automatic module name of ")
+                        .append(". It has been assigned a synthetic Ivy module name of of ")
                         .append(projectBackedModule.getName())
                         .append(" as a workaround, but you should set both the organisation and module name of the publication to be safe.");
                     logger.warn(sb.toString());

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationIdentity.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationIdentity.java
@@ -16,23 +16,35 @@
 
 package org.gradle.api.publish.ivy.internal.publication;
 
+import org.gradle.api.Project;
 import org.gradle.api.internal.artifacts.Module;
+import org.gradle.api.internal.artifacts.ProjectBackedModule;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
 
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
 public class DefaultIvyPublicationIdentity implements IvyPublicationIdentity {
+    private final Logger logger;
     private Module delegate;
     private String organisation;
     private String module;
     private String revision;
 
-    public DefaultIvyPublicationIdentity(Module delegate) {
-        this.delegate = delegate;
+    public DefaultIvyPublicationIdentity(Module delegate, Logger logger) {
+        this.delegate = safeProjectCoordinatesProvider(delegate, logger);
+        this.logger = logger;
     }
 
     public DefaultIvyPublicationIdentity(String organisation, String module, String revision) {
         this.organisation = organisation;
         this.module = module;
         this.revision = revision;
+        this.logger = Logging.getLogger(DefaultIvyPublicationIdentity.class);
     }
 
     @Override
@@ -64,4 +76,69 @@ public class DefaultIvyPublicationIdentity implements IvyPublicationIdentity {
     public void setRevision(String revision) {
         this.revision = revision;
     }
+
+    private Module safeProjectCoordinatesProvider(Module module, Logger logger) {
+        if (module instanceof ProjectBackedModule) {
+            return new LazyProjectModuleProvider((ProjectBackedModule) module, logger);
+        }
+        return module;
+    }
+
+    private static final class LazyProjectModuleProvider implements Module {
+        private final ProjectBackedModule projectBackedModule;
+        private final Logger logger;
+        private final AtomicBoolean warned = new AtomicBoolean();
+
+        private LazyProjectModuleProvider(ProjectBackedModule module, Logger logger) {
+            this.projectBackedModule = module;
+            this.logger = logger;
+        }
+
+        @Nullable
+        @Override
+        public String getProjectPath() {
+            return projectBackedModule.getProjectPath();
+        }
+
+        @Override
+        public String getGroup() {
+            maybeWarnAboutDuplicates();
+            return projectBackedModule.getGroup();
+        }
+
+        @Override
+        public String getName() {
+            maybeWarnAboutDuplicates();
+            return projectBackedModule.getName();
+        }
+
+        @Override
+        public String getVersion() {
+            return projectBackedModule.getVersion();
+        }
+
+        @Override
+        public String getStatus() {
+            return projectBackedModule.getStatus();
+        }
+
+        private void maybeWarnAboutDuplicates() {
+            if (!warned.getAndSet(true)) {
+                Project project = projectBackedModule.getProject();
+                List<Project> projectsWithSameId = projectBackedModule.getProjectsWithSameCoordinates();
+                if (!projectsWithSameId.isEmpty()) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Project ")
+                        .append(project.getPath())
+                        .append(" has the same (organisation, module name) as ")
+                        .append(projectsWithSameId.stream().map(Project::getPath).collect(Collectors.joining(" and ")))
+                        .append(". It has been assigned an automatic module name of ")
+                        .append(projectBackedModule.getName())
+                        .append(" as a workaround, but you should set both the organisation and module name of the publication to be safe.");
+                    logger.warn(sb.toString());
+                }
+            }
+        }
+    }
+
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaPlatformPlugin;
@@ -88,7 +89,8 @@ public class IvyPublishPlugin implements Plugin<Project> {
                 objectFactory,
                 fileResolver,
                 project.getPluginManager(),
-                project.getExtensions()));
+                project.getExtensions(),
+                project.getLogger()));
             createTasksLater(project, extension, project.getLayout().getBuildDirectory());
         });
     }
@@ -167,21 +169,23 @@ public class IvyPublishPlugin implements Plugin<Project> {
         private final FileResolver fileResolver;
         private final PluginManager plugins;
         private final ExtensionContainer extensionContainer;
+        private final Logger logger;
 
         private IvyPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver,
-                                      PluginManager plugins, ExtensionContainer extensionContainer) {
+                                      PluginManager plugins, ExtensionContainer extensionContainer, Logger logger) {
             this.dependencyMetaDataProvider = dependencyMetaDataProvider;
             this.instantiator = instantiator;
             this.objectFactory = objectFactory;
             this.fileResolver = fileResolver;
             this.plugins = plugins;
             this.extensionContainer = extensionContainer;
+            this.logger = logger;
         }
 
         @Override
         public IvyPublication create(String name) {
             Module module = dependencyMetaDataProvider.getModule();
-            IvyPublicationIdentity publicationIdentity = new DefaultIvyPublicationIdentity(module);
+            IvyPublicationIdentity publicationIdentity = new DefaultIvyPublicationIdentity(module, logger);
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
             VersionMappingStrategyInternal versionMappingStrategy = objectFactory.newInstance(DefaultVersionMappingStrategy.class);
             configureDefaultConfigurationsUsedWhenMappingToResolvedVersions(versionMappingStrategy);
@@ -202,5 +206,4 @@ public class IvyPublishPlugin implements Plugin<Project> {
             });
         }
     }
-
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -27,7 +27,6 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaPlatformPlugin;
@@ -89,8 +88,8 @@ public class IvyPublishPlugin implements Plugin<Project> {
                 objectFactory,
                 fileResolver,
                 project.getPluginManager(),
-                project.getExtensions(),
-                project.getLogger()));
+                project.getExtensions()
+            ));
             createTasksLater(project, extension, project.getLayout().getBuildDirectory());
         });
     }
@@ -169,23 +168,21 @@ public class IvyPublishPlugin implements Plugin<Project> {
         private final FileResolver fileResolver;
         private final PluginManager plugins;
         private final ExtensionContainer extensionContainer;
-        private final Logger logger;
 
         private IvyPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver,
-                                      PluginManager plugins, ExtensionContainer extensionContainer, Logger logger) {
+                                      PluginManager plugins, ExtensionContainer extensionContainer) {
             this.dependencyMetaDataProvider = dependencyMetaDataProvider;
             this.instantiator = instantiator;
             this.objectFactory = objectFactory;
             this.fileResolver = fileResolver;
             this.plugins = plugins;
             this.extensionContainer = extensionContainer;
-            this.logger = logger;
         }
 
         @Override
         public IvyPublication create(String name) {
             Module module = dependencyMetaDataProvider.getModule();
-            IvyPublicationIdentity publicationIdentity = new DefaultIvyPublicationIdentity(module, logger);
+            IvyPublicationIdentity publicationIdentity = new DefaultIvyPublicationIdentity(module);
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
             VersionMappingStrategyInternal versionMappingStrategy = objectFactory.newInstance(DefaultVersionMappingStrategy.class);
             configureDefaultConfigurationsUsedWhenMappingToResolvedVersions(versionMappingStrategy);

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -610,8 +610,8 @@ $append
         }
 
         and:
-        outputContains """Project :a:core has the same (groupId, artifactId) as :b:core. It has been assigned an automatic artifact id of a-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
-Project :b:core has the same (groupId, artifactId) as :a:core. It has been assigned an automatic artifact id of b-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
+        outputContains """Project :a:core has the same (groupId, artifactId) as :b:core. It has been assigned a synthetic artifactId of a-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
+Project :b:core has the same (groupId, artifactId) as :a:core. It has been assigned a synthetic artifactId of b-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
 """
     }
 
@@ -688,8 +688,8 @@ Project :b:core has the same (groupId, artifactId) as :a:core. It has been assig
         }
 
         and:
-        outputDoesNotContain """Project :a:core has the same (groupId, artifactId) as :b:core. It has been assigned an automatic artifact id of a-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
-Project :b:core has the same (groupId, artifactId) as :a:core. It has been assigned an automatic artifact id of b-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
+        outputDoesNotContain """Project :a:core has the same (groupId, artifactId) as :b:core. It has been assigned a synthetic artifactId of a-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
+Project :b:core has the same (groupId, artifactId) as :a:core. It has been assigned a synthetic artifactId of b-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
 """
     }
 
@@ -766,8 +766,8 @@ Project :b:core has the same (groupId, artifactId) as :a:core. It has been assig
         }
 
         and:
-        outputDoesNotContain """Project :a:core has the same (groupId, artifactId) as :b:core. It has been assigned an automatic artifact id of a-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
-Project :b:core has the same (groupId, artifactId) as :a:core. It has been assigned an automatic artifact id of b-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
+        outputDoesNotContain """Project :a:core has the same (groupId, artifactId) as :b:core. It has been assigned a synthetic artifactId of a-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
+Project :b:core has the same (groupId, artifactId) as :a:core. It has been assigned a synthetic artifactId of b-core as a workaround, but you should set both the groupId and artifactId of the publication to be safe.
 """
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -305,7 +305,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
                         .append(project.getPath())
                         .append(" has the same (groupId, artifactId) as ")
                         .append(projectsWithSameId.stream().map(Project::getPath).collect(Collectors.joining(" and ")))
-                        .append(". It has been assigned an automatic artifact id of ")
+                        .append(". It has been assigned a synthetic artifactId of ")
                         .append(projectBackedModule.getName())
                         .append(" as a workaround, but you should set both the groupId and artifactId of the publication to be safe.");
                     logger.warn(sb.toString());


### PR DESCRIPTION
### Context

Before this commit, during dependency resolution, a synthetic
module version identifier was generated by project, using the
group and name of the project. However, it's possible for a
project in gradle to have the same name as another in the
same build, leading to duplicates. In this case the projects
were mixed together and lead to a circular dependency.

This commit fixes the problem by making sure we generate
distinct module version identifiers for such projects, by
using the full project path as the name instead of the short
name.

This also makes it possible to publish valid publications
when using the maven or ivy publish plugins. However, we detect
this problem early and warn the user that they should overwrite
the project identity in this case.

<!--- The issue this PR addresses -->
Fixes #847 
