### PR TITLE
Download groovy-all sources when using gradleTestKit dependency

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.GRADLE_API;
+import static org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.GRADLE_TEST_KIT;
 import static org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.LOCAL_GROOVY;
 
 /**
@@ -236,7 +237,7 @@ public class IdeDependencySet {
         private boolean isLocalGroovyDependency(ResolvedArtifactResult artifact) {
             String artifactFileName = artifact.getFile().getName();
             String componentIdentifier = artifact.getId().getComponentIdentifier().getDisplayName();
-            return (componentIdentifier.equals(GRADLE_API.displayName) || componentIdentifier.equals(LOCAL_GROOVY.displayName))
+            return (componentIdentifier.equals(GRADLE_API.displayName) || componentIdentifier.equals(GRADLE_TEST_KIT.displayName) || componentIdentifier.equals(LOCAL_GROOVY.displayName))
                 && artifactFileName.startsWith("groovy-all-");
         }
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/1003

`groovy-all` sources were being downloaded only when using `localGroovy()` explicitly or when using `gradleApi()` dependency.
This change will make Gradle download `groovy-all` sources when using `gradleTestKit()` dependency as well.