### PR TITLE
Correctly create symlink on Windows 10

### DIFF
--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/WindowsSymbolicLinkDeleterTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/WindowsSymbolicLinkDeleterTest.groovy
@@ -19,12 +19,10 @@ package org.gradle.internal.file.impl
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
 import static org.gradle.util.WindowsSymbolicLinkUtil.createWindowsSymbolicLink
 
 @Requires(TestPrecondition.WINDOWS)
-@IgnoreIf({ System.getProperty("os.version") == "10.0" })
 class WindowsSymbolicLinkDeleterTest extends AbstractSymlinkDeleterTest {
     @Override
     protected void createSymbolicLink(File link, TestFile target) {

--- a/subprojects/native/src/testFixtures/groovy/org/gradle/util/WindowsSymbolicLinkUtil.groovy
+++ b/subprojects/native/src/testFixtures/groovy/org/gradle/util/WindowsSymbolicLinkUtil.groovy
@@ -20,7 +20,8 @@ import com.sun.security.auth.module.NTSystem
 
 class WindowsSymbolicLinkUtil {
     static void createWindowsSymbolicLink(File link, File target) {
-        assert ["cmd", "/C", "mklink", "/D", link, target].execute().waitFor() == 0
+        def extraOptions = target.isDirectory() ? ["/D"] : []
+        assert ["cmd", "/C", "mklink", *extraOptions, link, target].execute().waitFor() == 0
     }
 
     static void createWindowsJunction(File link, File target) {


### PR DESCRIPTION
It looks like Windows 10 enforces the correct use of the `/D` parameter for `mklink` when creating a symlink. So only pass the `/D` parameter when the target is actually a directory.


Fixes https://github.com/gradle/gradle-private/issues/2903