### PR TITLE
Monitor file handle leaking on windows

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -15,6 +15,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.ProjectFeatures
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import model.CIBuildModel
 import model.StageNames
 
@@ -110,6 +111,32 @@ fun BaseGradleBuildType.gradleRunnerStep(model: CIBuildModel, gradleTasks: Strin
 }
 
 private
+fun BuildType.attachFileLeakDetector() {
+    steps {
+        script {
+            name = "ATTACH_FILE_LEAK_DETECTOR"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = """
+            "%windows.java11.openjdk.64bit%\bin\java" gradle/AttachAgentToDaemon.java
+        """.trimIndent()
+        }
+    }
+}
+
+private
+fun BuildType.dumpOpenFiles() {
+    steps {
+        script {
+            name = "DUMP_OPEN_FILES"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = """
+            "%windows.java11.openjdk.64bit%\bin\java" gradle\DumpOpenFiles.java
+        """.trimIndent()
+        }
+    }
+}
+
+private
 fun BaseGradleBuildType.gradleRerunnerStep(model: CIBuildModel, gradleTasks: String, os: Os = Os.linux, extraParameters: String = "", daemon: Boolean = true) {
     val buildScanTags = model.buildScanTags + listOfNotNull(stage?.id)
     val cleanedExtraParameters = extraParameters
@@ -158,6 +185,9 @@ fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTas
 
     buildType.steps {
         extraSteps()
+        if (os == Os.windows) {
+            buildType.attachFileLeakDetector()
+        }
         checkCleanM2(os)
         verifyTestFilesCleanup(daemon, os)
     }
@@ -187,7 +217,15 @@ fun applyTestDefaults(
         preSteps()
     }
 
+    if (os == Os.windows) {
+        buildType.attachFileLeakDetector()
+    }
+
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
+
+    if (os == Os.windows) {
+        buildType.dumpOpenFiles()
+    }
     buildType.killProcessStepIfNecessary("KILL_PROCESSES_STARTED_BY_GRADLE", os)
     buildType.gradleRerunnerStep(model, gradleTasks, os, extraParameters, daemon)
     buildType.killProcessStepIfNecessary("KILL_PROCESSES_STARTED_BY_GRADLE_RERUN", os)

--- a/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
@@ -97,7 +97,9 @@ class ApplyDefaultConfigurationTest {
         applyTestDefaults(buildModel, buildType, "myTask", os = Os.windows, extraParameters = extraParameters, daemon = daemon)
 
         assertEquals(listOf(
+            "ATTACH_FILE_LEAK_DETECTOR",
             "GRADLE_RUNNER",
+            "DUMP_OPEN_FILES",
             "KILL_PROCESSES_STARTED_BY_GRADLE",
             "GRADLE_RERUNNER",
             "KILL_PROCESSES_STARTED_BY_GRADLE_RERUN",

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -345,14 +345,14 @@ class CIConfigIntegrationTests {
         val p = RootProject(m, SubProjectBucketProvider(m))
         assertTrue(p.subProjects.size == 2)
 
-        val buildStepsWithCache = (p.subProjectsOrder[0] as StageProject)
-            .subProjects[0].buildTypes.map { ((it as FunctionalTest).steps.items[0] as GradleBuildStep) }
+        val buildStepsWithCache: List<GradleBuildStep> = (p.subProjectsOrder[0] as StageProject)
+            .subProjects[0].buildTypes.map { ((it as FunctionalTest).steps.items.first { it is GradleBuildStep } as GradleBuildStep) }
         buildStepsWithCache.forEach {
             assertTrue(it.gradleParams!!.contains("--build-cache"))
         }
 
         val buildStepsWithoutCache = (p.subProjectsOrder[1] as StageProject)
-            .subProjects[0].buildTypes.map { ((it as FunctionalTest).steps.items[0] as GradleBuildStep) }
+            .subProjects[0].buildTypes.map { ((it as FunctionalTest).steps.items.first { it is GradleBuildStep } as GradleBuildStep) }
         buildStepsWithoutCache.forEach {
             assertFalse(it.gradleParams!!.contains("--build-cache"))
         }

--- a/gradle/AttachAgentToDaemon.java
+++ b/gradle/AttachAgentToDaemon.java
@@ -1,0 +1,33 @@
+import java.time.format.*;
+import java.time.*;
+import java.io.*;
+import java.nio.file.*;
+import java.net.*;
+import java.util.*;
+
+public class AttachAgentToDaemon {
+    private static final File AGENT_JAR_FILE = new File("C:\\tcagent1\\file-leak-detector-1.14-SNAPSHOT-gradle.jar");
+
+    public static void main(String[] args) throws Exception {
+        if (!AGENT_JAR_FILE.isFile()) {
+            System.err.println(AGENT_JAR_FILE.getAbsolutePath() + " not found, skip.");
+            return;
+        }
+
+        Properties gradleProperties = new Properties();
+        gradleProperties.load(new FileInputStream(new File("gradle.properties")));
+
+        String oldJvmArgs = (String) Optional.ofNullable(gradleProperties.get("org.gradle.jvmargs")).orElseThrow(IllegalStateException::new);
+        String newJvmArgs = String.format("-javaagent:%s=gradleRootDir=%s,excludes=%s %s", AGENT_JAR_FILE.getAbsolutePath(), new File(".").getCanonicalPath(), getGradleUserHomeDir(), oldJvmArgs);
+
+        System.out.println("New jvm args: " + newJvmArgs);
+
+        gradleProperties.put("org.gradle.jvmargs", newJvmArgs);
+        gradleProperties.store(new FileOutputStream(new File("gradle.properties")), "");
+        gradleProperties.store(new FileOutputStream(new File("buildSrc/gradle.properties")), "");
+    }
+
+    private static String getGradleUserHomeDir() {
+        return new File(System.getProperty("user.home"), ".gradle").getAbsolutePath();
+    }
+}

--- a/gradle/DumpOpenFiles.java
+++ b/gradle/DumpOpenFiles.java
@@ -1,0 +1,29 @@
+import java.time.format.*;
+import java.time.*;
+import java.io.*;
+import java.nio.file.*;
+import java.net.*;
+import java.util.*;
+
+public class DumpOpenFiles {
+    public static void main(String[] args) throws Exception {
+        String url = "http://localhost:" + parsePort() + "/dump";
+        System.out.println("Sending request to " + url);
+        try (BufferedReader response = new BufferedReader(new InputStreamReader(new URL(url).openStream()))) {
+            String line = null;
+            while ((line = response.readLine()) != null) {
+                System.out.println(line);
+            }
+        }
+    }
+
+    private static String parsePort() throws Exception {
+        if (new File("port.txt").isFile()) {
+            return Files.readAllLines(new File("port.txt").toPath()).get(0).trim();
+        } else {
+            System.err.println("Port not found, skip");
+            System.exit(0);
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
### Context 

We've been bitten by file leaking for a long time. This PR uses [the custom fork](https://github.com/blindpirate/file-leak-detector/) with some changes:

- Original file leak detector only supports printing open file handles at shutdown time, but for Gradle daemon this doesn't work. We want to print all open file handles at the end of every build. We achieve this goal by setting up a tiny http server inside the daemon JVM and sending HTTP requests to notify it.

So the whole monitor process is:

- Replace `gradle.properties` with `gradle.windows.properties`, which has the javaagent JVM startup parameter.
- The agent looks for an available port to listen, then prints the port number to `port.txt` file.
- After each build, a script runs `java gradle/DumpOpenFiles.java`, which reads the port number and sends HTTP request to daemon. The generated file handle dump file will be at the project directory for further investigation if any file leaking happens.