### PR TITLE
sign also -SNAPSHOT versions

### DIFF
--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -105,18 +105,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     }
 
     private void signArtifact(final PublicationArtifact publicationArtifact) {
-        if (publicationArtifactCanBeSigned(publicationArtifact)) {
-            addSignature(new Signature(publicationArtifact, publicationArtifact::getFile, null, null, this, this));
-        } else {
-            addSignature(new InvalidSignature(publicationArtifact, publicationArtifact::getFile, this));
-        }
-    }
-
-    private boolean publicationArtifactCanBeSigned(PublicationArtifact publicationArtifact) {
-        if (publicationArtifact.getFile().getName().equals("module.json")) {
-            return !String.valueOf(getProject().getVersion()).endsWith("-SNAPSHOT");
-        }
-        return true;
+        addSignature(new Signature(publicationArtifact, publicationArtifact::getFile, null, null, this, this));
     }
 
     /**


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #11387

### Context
I don't see a reason why a SNAPSHOT build should not be signed

### Contributor Checklist
did the adjustments via Web-GUI thus tests are missing. Just want to kick-start a fix for #11387. Totally fine if you close this PR as long as you create a new one with tests :wink: 

- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
