### PR TITLE
Fix: LongCommandLineDetectionUtil.java - support for Mac OSX

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/util/LongCommandLineDetectionUtil.java
@@ -23,6 +23,8 @@ import java.util.List;
 public class LongCommandLineDetectionUtil {
     // See http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
     public static final int MAX_COMMAND_LINE_LENGTH_WINDOWS = 32767;
+    // Derived from default when running getconf ARG_MAX in OSX
+    public static final int MAX_COMMAND_LINE_LENGTH_OSX = 262144;
     public static final int MAX_COMMAND_LINE_LENGTH_NIX = 2097152;
     private static final String WINDOWS_LONG_COMMAND_EXCEPTION_MESSAGE = "The filename or extension is too long";
     private static final String NIX_LONG_COMMAND_EXCEPTION_MESSAGE = "error=7, Argument list too long";
@@ -34,7 +36,9 @@ public class LongCommandLineDetectionUtil {
 
     private static int getMaxCommandLineLength() {
         int defaultMax = MAX_COMMAND_LINE_LENGTH_NIX;
-        if (OperatingSystem.current().isWindows()) {
+        if (OperatingSystem.current().isMacOsX()) {
+            defaultMax = MAX_COMMAND_LINE_LENGTH_OSX;
+        } else if (OperatingSystem.current().isWindows()) {
             defaultMax = MAX_COMMAND_LINE_LENGTH_WINDOWS;
         }
         // in chars

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecWithLongCommandLineIntegrationTest.groovy
@@ -44,7 +44,7 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
                 classpath extraClasspath
                 main "driver.Driver"
             }
-            
+
             task runWithJavaExec {
                 dependsOn sourceSets.main.runtimeClasspath
                 doLast {
@@ -66,7 +66,7 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
         def veryLongCommandLineArgs = getLongArgs()
         buildFile << """
             extraClasspath.from('${veryLongFileNames.join("','")}')
-            
+
             run.args '${veryLongCommandLineArgs.join("','")}'
         """
 
@@ -159,7 +159,8 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
     private static List<String> getLongArgs() {
         final int maxIndividualArgLength = 65530
 
-        int maxCommandLength = OperatingSystem.current().windows ? LongCommandLineDetectionUtil.MAX_COMMAND_LINE_LENGTH_WINDOWS : LongCommandLineDetectionUtil.MAX_COMMAND_LINE_LENGTH_NIX
+
+        int maxCommandLength = getMaxArgs()
         List<String> result = new ArrayList<>()
         while (maxCommandLength > 0) {
             result.add('a' * maxIndividualArgLength)
@@ -167,5 +168,19 @@ class JavaExecWithLongCommandLineIntegrationTest extends AbstractIntegrationSpec
         }
 
         return result
+    }
+
+    private static int getMaxArgs() {
+        switch(OperatingSystem.current()) {
+            case OperatingSystem.WINDOWS:
+                return LongCommandLineDetectionUtil.MAX_COMMAND_LINE_LENGTH_WINDOWS
+                break
+            case OperatingSystem.MAC_OS:
+                return LongCommandLineDetectionUtil.MAX_COMMAND_LINE_LENGTH_OSX
+                break
+            default:
+                return LongCommandLineDetectionUtil.MAX_COMMAND_LINE_LENGTH_NIX
+                break
+        }
     }
 }


### PR DESCRIPTION
This addresses https://github.com/gradle/gradle/issues/11907

### Context
#10544 and #11620 introduced support for pathing jar on Windows//Unix/OSX. However, Mac OS is not working as expected.

Doing some debugging I found that my command line length is 306934 and the max is set to 2097152

Looking at the default `ARG_MAX` in `limits.h`, I found that is 262144 which differs from the default value on Linux distributions

This adds support for case where OS is MacOs

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
