### PR TITLE
Apply the idea plugin to all subprojects

### DIFF
--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -117,6 +117,9 @@ open class IdePlugin : Plugin<Project> {
     private
     fun Project.configureIdeaForRootProject() {
         apply(plugin = "org.jetbrains.gradle.plugin.idea-ext")
+        allprojects {
+            apply(plugin = "idea")
+        }
         tasks.named("idea") {
             doFirst {
                 throw RuntimeException("To import in IntelliJ, please follow the instructions here: https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md#intellij")


### PR DESCRIPTION
Running IDEA sync doesn't apply the `idea` plugin early enough anymore,
so we need to apply it now to all subprojects in order for the
customizations we have to take effect.

This should fix the problem that the integration test source sets are not marked as test source sets anymore. Note that https://youtrack.jetbrains.com/issue/IDEA-219200 needs to be fixed as well if the sources have been marked as production sources at any point in time.

See https://gradle.slack.com/archives/CDH5M7FAT/p1579004267033200.