### PR TITLE
Publish build-cache-packaging as public library

### DIFF
--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -17,6 +17,7 @@ import org.gradle.gradlebuild.unittestandcompile.ModuleType
 
 plugins {
     `java-library`
+    gradlebuild.`publish-public-libraries`
     gradlebuild.classycle
 }
 
@@ -31,11 +32,9 @@ dependencies {
     implementation(project(":files"))
     implementation(project(":snapshots"))
 
-    implementation(library("slf4j_api"))
-    implementation(library("guava"))
-    implementation(library("inject"))
-    implementation(library("commons_compress"))
-    implementation(library("commons_io"))
+    implementation(library("guava")) { version { require(libraryVersion("guava")) } }
+    implementation(library("commons_compress")) { version { require(libraryVersion("commons_compress")) } }
+    implementation(library("commons_io")) { version { require(libraryVersion("commons_io")) } }
 
     testImplementation(project(":processServices"))
     testImplementation(project(":fileCollections"))


### PR DESCRIPTION
Since published libraries can not depend on the distribution platform
versions for external dependencies have to be redeclared. See also #10861.
Some unnecessary dependencies have been removed.

Part of https://github.com/gradle/gradle-private/issues/2417
