### PR TITLE
Don't use `Task output caching` when talking about the build cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
@@ -242,7 +242,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         executer.withBuildCacheEnabled()
         succeeds("customTask")
         then:
-        outputContains("Task output caching is enabled, but no build caches are configured or enabled.")
+        outputContains("Using the build cache is enabled, but no build caches are configured or enabled.")
 
         and:
         localBuildCache.empty

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
@@ -107,7 +107,7 @@ public final class BuildCacheControllerFactory {
                 ));
 
                 if (!localEnabled && !remoteEnabled) {
-                    LOGGER.warn("Task output caching is enabled, but no build caches are configured or enabled.");
+                    LOGGER.warn("Using the build cache is enabled, but no build caches are configured or enabled.");
                     return NoOpBuildCacheController.INSTANCE;
                 } else {
                     BuildCacheServicesConfiguration config = toConfiguration(


### PR DESCRIPTION
The message whether the build cache is available mentions
task output caching, though that is never enabled. Only
the build cache can be enabled by e.g. `--build-cache`.

Fixes #11866