### PR TITLE
Normalize META-INF manifest attributes and properties files

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/normalization/MetaInfNormalization.java
+++ b/subprojects/core-api/src/main/java/org/gradle/normalization/MetaInfNormalization.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.normalization;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Configuration of manifest normalization.
+ *
+ * @since 6.5
+ */
+public interface MetaInfNormalization {
+    /**
+     * Ignore all files and subdirectories in the {@code META-INF} directory within archives.
+     *
+     * @since 6.5
+     */
+    @Incubating
+    void ignoreCompletely();
+
+    /**
+     * Ignore the {@code META-INF/MANIFEST.MF} file within archives.
+     *
+     * @since 6.5
+     */
+    @Incubating
+    void ignoreManifest();
+
+    /**
+     * Ignore attributes in {@code META-INF/MANIFEST.MF} within archives matching {@code name}. {@code name} is matched case-insensitively with the manifest attribute name.
+     *
+     * @since 6.5
+     */
+    @Incubating
+    void ignoreAttribute(String name);
+
+    /**
+     * Ignore keys in properties files stored in {@code META-INF} within archives matching {@code name}. {@code name} is matched case-sensitively with the property key.
+     *
+     * @since 6.5
+     */
+    @Incubating
+    void ignoreProperty(String name);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/normalization/RuntimeClasspathNormalization.java
+++ b/subprojects/core-api/src/main/java/org/gradle/normalization/RuntimeClasspathNormalization.java
@@ -17,6 +17,7 @@
 package org.gradle.normalization;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -36,5 +37,6 @@ public interface RuntimeClasspathNormalization extends InputNormalization {
      *
      * @since 6.5
      */
+    @Incubating
     void metaInf(Action<? super MetaInfNormalization> configuration);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/normalization/RuntimeClasspathNormalization.java
+++ b/subprojects/core-api/src/main/java/org/gradle/normalization/RuntimeClasspathNormalization.java
@@ -16,6 +16,7 @@
 
 package org.gradle.normalization;
 
+import org.gradle.api.Action;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -29,4 +30,11 @@ public interface RuntimeClasspathNormalization extends InputNormalization {
      * Ignore resources in classpath entries matching {@code pattern}.
      */
     void ignore(String pattern);
+
+    /**
+     * Configures the normalization strategy for the {@code META-INF} directory in archives.
+     *
+     * @since 6.5
+     */
+    void metaInf(Action<? super MetaInfNormalization> configuration);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -79,6 +79,48 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
     }
 
     @ToBeFixedForInstantExecution
+    def "can ignore manifest attributes on runtime classpath"() {
+        def project = new ProjectWithRuntimeClasspathNormalization(true).withManifestAttributesIgnored()
+
+        when:
+        succeeds project.customTask
+        then:
+        executedAndNotSkipped(project.customTask)
+
+        when:
+        succeeds project.customTask
+        then:
+        skipped(project.customTask)
+
+        when:
+        project.jarManifest.replaceContents("Manifest-Version: 1.0\nImplementation-Version: 1.0.1")
+        succeeds project.customTask
+        then:
+        skipped(project.customTask)
+    }
+
+    @ToBeFixedForInstantExecution
+    def "can ignore manifest properties on runtime classpath"() {
+        def project = new ProjectWithRuntimeClasspathNormalization(true).withManifestPropertiesIgnored()
+
+        when:
+        succeeds project.customTask
+        then:
+        executedAndNotSkipped(project.customTask)
+
+        when:
+        succeeds project.customTask
+        then:
+        skipped(project.customTask)
+
+        when:
+        project.jarManifestProperties.replaceContents("implementation-version=1.0.1")
+        succeeds project.customTask
+        then:
+        skipped(project.customTask)
+    }
+
+    @ToBeFixedForInstantExecution
     def "can configure ignore rules per project (using runtime API: #useRuntimeApi)"() {
         def projectWithIgnores = new ProjectWithRuntimeClasspathNormalization('a', useRuntimeApi).withFilesIgnored()
         def projectWithoutIgnores = new ProjectWithRuntimeClasspathNormalization('b', useRuntimeApi)
@@ -105,7 +147,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
     @UnsupportedWithInstantExecution(because = "Task.getProject() during execution")
     def "runtime classpath normalization cannot be changed after first usage (using runtime API: #useRuntimeApi)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(useRuntimeApi)
-        project.buildFile << """ 
+        project.buildFile << """
             task configureNormalization() {
                 dependsOn '${project.customTask}'
                 doLast {
@@ -136,6 +178,8 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         TestResource ignoredResourceInNestedJar
         TestResource notIgnoredResourceInJar
         TestResource notIgnoredResourceInNestedJar
+        TestResource jarManifest
+        TestResource jarManifestProperties
         TestFile libraryJar
         TestFile nestedJar
         private TestFile libraryJarContents
@@ -162,6 +206,8 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
                 notIgnoredResourceInNestedJar = new TestResource(file('some/package/not-ignored.txt') << "This should not be ignored", this.&createJar)
             }
             libraryJarContents = root.file('libraryContents').create {
+                jarManifest = new TestResource(file('META-INF/MANIFEST.MF') << "Manifest-Version: 1.0\nImplementation-Version: 1.0.0", this.&createJar)
+                jarManifestProperties = new TestResource(file('META-INF/build-info.properties') << "implementation-version=1.0.0", this.&createJar)
                 ignoredResourceInJar = new TestResource(file('some/package/ignored.txt') << "This should be ignored", this.&createJar)
                 notIgnoredResourceInJar = new TestResource(file('some/package/not-ignored.txt') << "This should not be ignored", this.&createJar)
                 nestedJar = file('nested.jar')
@@ -191,12 +237,12 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
                     class CustomTask extends DefaultTask {
                         @OutputFile File outputFile = new File(temporaryDir, "output.txt")
                         @Classpath FileCollection classpath = project.layout.files("classpath/dirEntry", "library.jar")
-    
+
                         @TaskAction void generate() {
                             outputFile.text = "done"
-                        } 
+                        }
                     }
-                    
+
                     task customTask(type: CustomTask)
                 """
             }
@@ -224,6 +270,32 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
             return this
         }
 
+        ProjectWithRuntimeClasspathNormalization withManifestAttributesIgnored() {
+            root.file('build.gradle') << """
+                normalization {
+                    runtimeClasspath {
+                        metaInf {
+                            ignoreAttribute "Implementation-Version"
+                        }
+                    }
+                }
+            """.stripIndent()
+            return this
+        }
+
+        ProjectWithRuntimeClasspathNormalization withManifestPropertiesIgnored() {
+            root.file('build.gradle') << """
+                normalization {
+                    runtimeClasspath {
+                        metaInf {
+                            ignoreProperty "implementation-version"
+                        }
+                    }
+                }
+            """.stripIndent()
+            return this
+        }
+
         String getCustomTask() {
             return "${projectName ? ":${projectName}" : ''}:customTask"
         }
@@ -236,6 +308,13 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         TestResource(TestFile backingFile, Closure finalizedBy = {}) {
             this.backingFile = backingFile
             this.finalizedBy = finalizedBy
+        }
+
+        void replaceContents(String contents) {
+            backingFile.withWriter { w ->
+                w << contents
+            }
+            finalizedBy()
         }
 
         void changeContents() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceEntryFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceEntryFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.internal.hash.Hasher;
+
+public class IgnoringResourceEntryFilter implements ResourceEntryFilter {
+    private final ImmutableSet<String> ignores;
+
+    public IgnoringResourceEntryFilter(ImmutableSet<String> ignores) {
+        this.ignores = ignores;
+    }
+
+    @Override
+    public boolean shouldBeIgnored(String value) {
+        return ignores.contains(value);
+    }
+
+    @Override
+    public void appendConfigurationToHasher(Hasher hasher) {
+        hasher.putString(getClass().getName());
+        for (String ignore : ignores) {
+            hasher.putString(ignore);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceEntryFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceEntryFilter.java
@@ -27,8 +27,8 @@ public class IgnoringResourceEntryFilter implements ResourceEntryFilter {
     }
 
     @Override
-    public boolean shouldBeIgnored(String value) {
-        return ignores.contains(value);
+    public boolean shouldBeIgnored(String entry) {
+        return ignores.contains(entry);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/PropertyResourceBundleCharsetBackport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/PropertyResourceBundleCharsetBackport.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Backport of PropertyResourceBundleCharset to retain Java 8 compatibility.
+ *
+ * Unchanged except the classname to avoid confusion and member variables that don't meed Gradle codestyle rules.
+ */
+
+//package sun.util;
+
+package org.gradle.api.internal.changedetection.state;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * A Charset implementation for reading PropertyResourceBundle, in order
+ * for loading properties files. This first tries to load the properties
+ * file with UTF-8 encoding). If it fails, then load the file with ISO-8859-1
+ */
+public class PropertyResourceBundleCharsetBackport extends Charset {
+
+    private boolean strictUTF8 = false;
+
+    public PropertyResourceBundleCharsetBackport(boolean strictUTF8) {
+        this(PropertyResourceBundleCharsetBackport.class.getCanonicalName(), null);
+        this.strictUTF8 = strictUTF8;
+    }
+
+    public PropertyResourceBundleCharsetBackport(String canonicalName, String[] aliases) {
+        super(canonicalName, aliases);
+    }
+
+    @Override
+    public boolean contains(Charset cs) {
+        return false;
+    }
+
+    @Override
+    public CharsetDecoder newDecoder() {
+        return new PropertiesFileDecoder(this, 1.0f, 1.0f);
+    }
+
+    @Override
+    public CharsetEncoder newEncoder() {
+        throw new UnsupportedOperationException("Encoding is not supported");
+    }
+
+    private final class PropertiesFileDecoder extends CharsetDecoder {
+
+        private CharsetDecoder utf8 = StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT); // Backport: was cdUTF_8
+        private CharsetDecoder iso88591 = null; // Backport: was cdISO_8859_1
+
+        protected PropertiesFileDecoder(Charset cs,
+                                        float averageCharsPerByte, float maxCharsPerByte) {
+            super(cs, averageCharsPerByte, maxCharsPerByte);
+        }
+
+        protected CoderResult decodeLoop(ByteBuffer in, CharBuffer out) {
+            if (Objects.nonNull(iso88591)) {
+                return iso88591.decode(in, out, false);
+            }
+            in.mark();
+            out.mark();
+
+            CoderResult cr = utf8.decode(in, out, false);
+            if (cr.isUnderflow() || cr.isOverflow() ||
+                PropertyResourceBundleCharsetBackport.this.strictUTF8) {
+                return cr;
+            }
+
+            // Invalid or unmappable UTF-8 sequence detected.
+            // Switching to the ISO 8859-1 decorder.
+            assert cr.isMalformed() || cr.isUnmappable();
+            in.reset();
+            out.reset();
+            iso88591 = StandardCharsets.ISO_8859_1.newDecoder();
+            return iso88591.decode(in, out, false);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceEntryFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceEntryFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+import org.gradle.internal.hash.Hasher;
+
+/**
+ * A resource entry filter supporting exact matches of values.
+ */
+public interface ResourceEntryFilter extends ConfigurableNormalizer {
+    ResourceEntryFilter FILTER_NOTHING = new ResourceEntryFilter() {
+        @Override
+        public boolean shouldBeIgnored(String value) {
+            return false;
+        }
+
+        @Override
+        public void appendConfigurationToHasher(Hasher hasher) {
+            hasher.putString(getClass().getName());
+        }
+    };
+
+    boolean shouldBeIgnored(String value);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceEntryFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ResourceEntryFilter.java
@@ -24,7 +24,7 @@ import org.gradle.internal.hash.Hasher;
 public interface ResourceEntryFilter extends ConfigurableNormalizer {
     ResourceEntryFilter FILTER_NOTHING = new ResourceEntryFilter() {
         @Override
-        public boolean shouldBeIgnored(String value) {
+        public boolean shouldBeIgnored(String entry) {
             return false;
         }
 
@@ -34,5 +34,5 @@ public interface ResourceEntryFilter extends ConfigurableNormalizer {
         }
     };
 
-    boolean shouldBeIgnored(String value);
+    boolean shouldBeIgnored(String entry);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.compress.utils.Lists;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.file.archive.FileZipInput;
 import org.gradle.api.internal.file.archive.StreamZipInput;
 import org.gradle.api.internal.file.archive.ZipEntry;
@@ -114,7 +115,7 @@ public class ZipHasher implements RegularFileHasher, ConfigurableNormalizer {
             Hasher hasher = Hashing.newHasher();
             FingerprintHashingStrategy.SORT.appendToHasher(hasher, fingerprints);
             return hasher.hash();
-        } catch (Exception e) {
+        } catch (IOException | UncheckedIOException e) {
             return hashMalformedZip(zipFileSnapshot, e);
         }
     }
@@ -171,7 +172,7 @@ public class ZipHasher implements RegularFileHasher, ConfigurableNormalizer {
             if (hash != null) {
                 fingerprints.add(new DefaultFileSystemLocationFingerprint(fullName, FileType.RegularFile, hash));
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             LOGGER.warn("Could not load fingerprint " + rootParentName + ". Falling back to regular fingerprinting", e);
             ZipEntry manifestZipEntry = new ZipEntry() {
                 @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -44,6 +44,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -244,7 +245,7 @@ public class ZipHasher implements RegularFileHasher, ConfigurableNormalizer {
     private HashCode hashProperties(byte[] entryBytes) throws IOException {
         Hasher hasher = Hashing.newHasher();
         Properties properties = new Properties();
-        properties.load(new ByteArrayInputStream(entryBytes));
+        properties.load(new InputStreamReader(new ByteArrayInputStream(entryBytes), new PropertyResourceBundleCharsetBackport(false)));
         Map<String, String> entries = Maps.fromProperties(properties);
         entries
             .entrySet()

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -192,7 +192,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         return new DefaultClasspathFingerprinter(
             resourceSnapshotterCacheService,
             fileCollectionSnapshotter,
-            inputNormalizationHandler.getRuntimeClasspath().getResourceFilter(),
+            inputNormalizationHandler.getRuntimeClasspath().getResourceFilters(),
             stringInterner
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/ClasspathResourceFilters.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/ClasspathResourceFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.normalization.internal;
+package org.gradle.internal.fingerprint.classpath;
 
-import org.gradle.normalization.RuntimeClasspathNormalization;
+import org.gradle.api.internal.changedetection.state.ResourceFilter;
 
-public interface RuntimeClasspathNormalizationInternal extends RuntimeClasspathNormalization {
-    RuntimeClasspathResourceFilters getResourceFilters();
+public interface ClasspathResourceFilters {
+    public static ClasspathResourceFilters NONE = () -> ResourceFilter.FILTER_NOTHING;
+
+    ResourceFilter getResourceFilter();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinter.java
@@ -17,25 +17,25 @@
 package org.gradle.internal.fingerprint.classpath.impl;
 
 import org.gradle.api.internal.cache.StringInterner;
-import org.gradle.api.internal.changedetection.state.ResourceFilter;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.RuntimeClasspathResourceHasher;
 import org.gradle.api.tasks.ClasspathNormalizer;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
+import org.gradle.internal.fingerprint.classpath.ClasspathResourceFilters;
 import org.gradle.internal.fingerprint.impl.AbstractFileCollectionFingerprinter;
 
 public class DefaultClasspathFingerprinter extends AbstractFileCollectionFingerprinter implements ClasspathFingerprinter {
     public DefaultClasspathFingerprinter(
         ResourceSnapshotterCacheService cacheService,
         FileCollectionSnapshotter fileCollectionSnapshotter,
-        ResourceFilter classpathResourceFilter,
+        ClasspathResourceFilters classpathResourceFilters,
         StringInterner stringInterner
     ) {
         super(
             ClasspathFingerprintingStrategy.runtimeClasspath(
-                classpathResourceFilter,
+                classpathResourceFilters,
                 new RuntimeClasspathResourceHasher(),
                 cacheService,
                 stringInterner

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.changedetection.state.CachingFileHasher;
 import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache;
 import org.gradle.api.internal.changedetection.state.DefaultResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.GlobalScopeFileTimeStampInspector;
-import org.gradle.api.internal.changedetection.state.ResourceFilter;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.SplitFileHasher;
 import org.gradle.api.internal.changedetection.state.SplitResourceSnapshotterCacheService;
@@ -49,6 +48,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
+import org.gradle.internal.fingerprint.classpath.ClasspathResourceFilters;
 import org.gradle.internal.fingerprint.classpath.CompileClasspathFingerprinter;
 import org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter;
 import org.gradle.internal.fingerprint.classpath.impl.DefaultCompileClasspathFingerprinter;
@@ -227,7 +227,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
         }
 
         ClasspathFingerprinter createClasspathFingerprinter(ResourceSnapshotterCacheService resourceSnapshotterCacheService, FileCollectionSnapshotter fileCollectionSnapshotter, StringInterner stringInterner) {
-            return new DefaultClasspathFingerprinter(resourceSnapshotterCacheService, fileCollectionSnapshotter, ResourceFilter.FILTER_NOTHING, stringInterner);
+            return new DefaultClasspathFingerprinter(resourceSnapshotterCacheService, fileCollectionSnapshotter, ClasspathResourceFilters.NONE, stringInterner);
         }
 
         ClasspathHasher createClasspathHasher(ClasspathFingerprinter fingerprinter, FileCollectionFactory fileCollectionFactory) {

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultRuntimeClasspathNormalization.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultRuntimeClasspathNormalization.java
@@ -17,28 +17,106 @@
 package org.gradle.normalization.internal;
 
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Action;
 import org.gradle.api.GradleException;
+import org.gradle.api.internal.changedetection.state.IgnoringResourceEntryFilter;
 import org.gradle.api.internal.changedetection.state.IgnoringResourceFilter;
+import org.gradle.api.internal.changedetection.state.ResourceEntryFilter;
 import org.gradle.api.internal.changedetection.state.ResourceFilter;
+import org.gradle.normalization.MetaInfNormalization;
+
+import java.util.Locale;
 
 public class DefaultRuntimeClasspathNormalization implements RuntimeClasspathNormalizationInternal {
     private final ImmutableSet.Builder<String> ignoresBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<String> attributeIgnoresBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<String> propertiesIgnoresBuilder = ImmutableSet.builder();
+    private final MetaInfNormalization metaInfNormalization = new RuntimeMetaInfNormalization();
+
+    private boolean evaluated = false;
     private ResourceFilter resourceFilter;
+    private ResourceEntryFilter attributeResourceFilter;
+    private ResourceEntryFilter propertyResourceFilter;
 
     @Override
     public void ignore(String pattern) {
-        if (resourceFilter != null) {
-            throw new GradleException("Cannot configure runtime classpath normalization after execution started.");
-        }
+        checkNotEvaluated();
         ignoresBuilder.add(pattern);
     }
 
     @Override
-    public ResourceFilter getResourceFilter() {
-        if (resourceFilter == null) {
-            ImmutableSet<String> ignores = ignoresBuilder.build();
-            resourceFilter = ignores.isEmpty() ? ResourceFilter.FILTER_NOTHING : new IgnoringResourceFilter(ignores);
+    public void metaInf(Action<? super MetaInfNormalization> configuration) {
+        configuration.execute(metaInfNormalization);
+    }
+
+    @Override
+    public RuntimeClasspathResourceFilters getResourceFilters() {
+        resourceFilter = maybeCreateFilter(resourceFilter, ignoresBuilder);
+        attributeResourceFilter = maybeCreateEntryFilter(attributeResourceFilter, attributeIgnoresBuilder);
+        propertyResourceFilter = maybeCreateEntryFilter(propertyResourceFilter, propertiesIgnoresBuilder);
+        return new RuntimeClasspathResourceFilters() {
+            @Override
+            public ResourceFilter getResourceFilter() {
+                return resourceFilter;
+            }
+
+            @Override
+            public ResourceEntryFilter getManifestAttributeEntryFilter() {
+                return attributeResourceFilter;
+            }
+
+            @Override
+            public ResourceEntryFilter getManifestPropertyEntryFilter() {
+                return propertyResourceFilter;
+            }
+        };
+    }
+
+    private void checkNotEvaluated() {
+        if (evaluated) {
+            throw new GradleException("Cannot configure runtime classpath normalization after execution started.");
         }
-        return resourceFilter;
+    }
+
+    private ResourceFilter maybeCreateFilter(ResourceFilter existingFilter, ImmutableSet.Builder<String> ignoresBuilder) {
+        evaluated = true;
+        if (existingFilter == null) {
+            ImmutableSet<String> ignores = ignoresBuilder.build();
+            return ignores.isEmpty() ? ResourceFilter.FILTER_NOTHING : new IgnoringResourceFilter(ignores);
+        }
+        return existingFilter;
+    }
+
+    private ResourceEntryFilter maybeCreateEntryFilter(ResourceEntryFilter existingEntryFilter, ImmutableSet.Builder<String> ignoresBuilder) {
+        evaluated = true;
+        if (existingEntryFilter == null) {
+            ImmutableSet<String> ignores = ignoresBuilder.build();
+            return ignores.isEmpty() ? ResourceEntryFilter.FILTER_NOTHING : new IgnoringResourceEntryFilter(ignores);
+        }
+        return existingEntryFilter;
+    }
+
+    public class RuntimeMetaInfNormalization implements MetaInfNormalization {
+        @Override
+        public void ignoreCompletely() {
+            ignore("META-INF/*");
+        }
+
+        @Override
+        public void ignoreManifest() {
+            ignore("META-INF/MANIFEST.MF");
+        }
+
+        @Override
+        public void ignoreAttribute(String name) {
+            checkNotEvaluated();
+            attributeIgnoresBuilder.add(name.toLowerCase(Locale.ROOT));
+        }
+
+        @Override
+        public void ignoreProperty(String name) {
+            checkNotEvaluated();
+            propertiesIgnoresBuilder.add(name);
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/RuntimeClasspathResourceFilters.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/RuntimeClasspathResourceFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 
 package org.gradle.normalization.internal;
 
-import org.gradle.normalization.RuntimeClasspathNormalization;
+import org.gradle.api.internal.changedetection.state.ResourceEntryFilter;
+import org.gradle.internal.fingerprint.classpath.ClasspathResourceFilters;
 
-public interface RuntimeClasspathNormalizationInternal extends RuntimeClasspathNormalization {
-    RuntimeClasspathResourceFilters getResourceFilters();
+public interface RuntimeClasspathResourceFilters extends ClasspathResourceFilters {
+    ResourceEntryFilter getManifestAttributeEntryFilter();
+
+    ResourceEntryFilter getManifestPropertyEntryFilter();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.FileMetadata
 import org.gradle.internal.snapshot.RegularFileSnapshot
@@ -24,12 +25,20 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+
 class ZipHasherTest extends Specification {
 
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
-    ZipHasher zipHasher = new ZipHasher(new RuntimeClasspathResourceHasher(), ResourceFilter.FILTER_NOTHING)
+    ResourceEntryFilter manifestResourceFilter = new IgnoringResourceEntryFilter(ImmutableSet.copyOf("created-by"))
+    ResourceEntryFilter propertyResourceFilter = new IgnoringResourceEntryFilter(ImmutableSet.copyOf("created-by"))
+    ZipHasher zipHasher = new ZipHasher(new RuntimeClasspathResourceHasher(), ResourceFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING)
+    ZipHasher ignoringZipHasher = new ZipHasher(new RuntimeClasspathResourceHasher(), ResourceFilter.FILTER_NOTHING, manifestResourceFilter, propertyResourceFilter)
 
     def "adding an empty jar inside another jar changes the hashcode"() {
         given:
@@ -71,6 +80,197 @@ class ZipHasherTest extends Specification {
 
         expect:
         hash1 != hash2
+    }
+
+    def "changing manifest attributes changes the hashcode"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        createJarWithAttributes(jarfile, ["Implementation-Version": "1.0.0"])
+
+        def jarfile2 = tmpDir.file("test2.jar")
+        createJarWithAttributes(jarfile2, ["Implementation-Version": "1.0.1"])
+
+        def hash1 = zipHasher.hash(snapshot(jarfile))
+        def hash2 = zipHasher.hash(snapshot(jarfile2))
+
+        expect:
+        hash1 != hash2
+    }
+
+    def "manifest attributes are ignored"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        createJarWithAttributes(jarfile, ["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+
+        def hash1 = zipHasher.hash(snapshot(jarfile))
+        def hash2 = ignoringZipHasher.hash(snapshot(jarfile))
+
+        expect:
+        hash1 != hash2
+    }
+
+    def "manifest attributes are case insensitive"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        createJarWithAttributes(jarfile, ["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+
+        def jarfile2 = tmpDir.file("test2.jar")
+        createJarWithAttributes(jarfile2, ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+
+        when:
+
+        def hash1 = zipHasher.hash(snapshot(jarfile))
+        def hash2 = zipHasher.hash(snapshot(jarfile2))
+
+        then:
+        hash1 == hash2
+
+        when:
+        def hash3 = ignoringZipHasher.hash(snapshot(jarfile))
+        def hash4 = ignoringZipHasher.hash(snapshot(jarfile2))
+
+        then:
+        hash3 == hash4
+    }
+
+    def "manifest attributes are section order insensitive"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        def manifest = new Manifest()
+        def attributes = manifest.getMainAttributes()
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+        attributes.put(new Attributes.Name("Created-By"), "1.8.0_232-b18 (Azul Systems, Inc.)")
+        attributes.put(Attributes.Name.IMPLEMENTATION_VERSION, "1.0")
+
+        def apiAttributes = new Attributes()
+        apiAttributes.putValue("Sealed", "true")
+        def baseAttributes = new Attributes()
+        baseAttributes.putValue("Sealed", "true")
+
+        manifest.entries.put("org/gradle/api", apiAttributes)
+        manifest.entries.put("org/gradle/base", baseAttributes)
+
+        JarOutputStream jarOutput = new JarOutputStream(jarfile.newOutputStream(), manifest);
+        jarOutput.close()
+
+        def jarfile2 = tmpDir.file("test2.jar")
+        manifest = new Manifest()
+        attributes = manifest.getMainAttributes()
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+        attributes.put(Attributes.Name.IMPLEMENTATION_VERSION, "1.0")
+        attributes.put(new Attributes.Name("Created-By"), "1.8.0_232-b18 (Azul Systems, Inc.)")
+
+        manifest.entries.put("org/gradle/base", baseAttributes)
+        manifest.entries.put("org/gradle/api", apiAttributes)
+
+        jarOutput = new JarOutputStream(jarfile2.newOutputStream(), manifest);
+        jarOutput.close()
+
+        def hash1 = zipHasher.hash(snapshot(jarfile))
+        def hash2 = zipHasher.hash(snapshot(jarfile2))
+
+        expect:
+        hash1 == hash2
+    }
+
+    def "manifest section is ignored if all attributes are ignored"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        def manifest = new Manifest()
+        def attributes = manifest.getMainAttributes()
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+
+        def apiAttributes = new Attributes()
+        apiAttributes.putValue("Created-By", "1.8.0_232-b18 (Azul Systems, Inc.)")
+        def baseAttributes = new Attributes()
+        baseAttributes.putValue("Created-By", "1.8.0_232-b18 (Azul Systems, Inc.)")
+
+        manifest.entries.put("org/gradle/api", apiAttributes)
+        manifest.entries.put("org/gradle/base", baseAttributes)
+
+        JarOutputStream jarOutput = new JarOutputStream(jarfile.newOutputStream(), manifest);
+        jarOutput.close()
+
+        def jarfile2 = tmpDir.file("test2.jar")
+        createJarWithAttributes(jarfile2, [:])
+
+        def hash1 = ignoringZipHasher.hash(snapshot(jarfile))
+        def hash2 = ignoringZipHasher.hash(snapshot(jarfile2))
+
+        expect:
+        hash1 == hash2
+    }
+
+    def "changing manifest properties changes the hashcode"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        createJarWithBuildInfo(jarfile, ["implementation-version": "1.0.0"])
+
+        def jarfile2 = tmpDir.file("test2.jar")
+        createJarWithBuildInfo(jarfile2, ["implementation-version": "1.0.1"])
+
+        def hash1 = ignoringZipHasher.hash(snapshot(jarfile))
+        def hash2 = ignoringZipHasher.hash(snapshot(jarfile2))
+
+        expect:
+        hash1 != hash2
+    }
+
+    def "manifest properties are case sensitive"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        createJarWithBuildInfo(jarfile, ["Created-By": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+
+        def jarfile2 = tmpDir.file("test2.jar")
+        createJarWithBuildInfo(jarfile2, ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)"])
+
+        def hash1 = zipHasher.hash(snapshot(jarfile))
+        def hash2 = zipHasher.hash(snapshot(jarfile2))
+
+        expect:
+        hash1 != hash2
+    }
+
+    def "manifest properties are normalized and ignored"() {
+        given:
+        def jarfile = tmpDir.file("test.jar")
+        createJarWithBuildInfo(jarfile, ["created-by": "1.8.0_232-b18 (Azul Systems, Inc.)", "foo": "true"], "Build information 1.0")
+
+        def jarfile2 = tmpDir.file("test2.jar")
+        createJarWithBuildInfo(jarfile2, ["created-by": "1.8.0_232-b15 (Azul Systems, Inc.)", "foo": "true"], "Build information 1.1")
+
+        def hash1 = ignoringZipHasher.hash(snapshot(jarfile))
+        def hash2 = ignoringZipHasher.hash(snapshot(jarfile2))
+
+        expect:
+        hash1 == hash2
+    }
+
+    def createJarWithAttributes(TestFile jarfile, Map<String, String> attributes) {
+        def manifest = new Manifest()
+        def mainAttributes = manifest.getMainAttributes()
+        mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+        attributes.each { name, value ->
+            mainAttributes.put(new Attributes.Name(name), value)
+        }
+        new JarOutputStream(jarfile.newOutputStream(), manifest).close()
+    }
+
+    def createJarWithBuildInfo(TestFile jarfile, Map<String, String> props, String comments = "Build information") {
+        def manifest = new Manifest()
+        def attributes = manifest.getMainAttributes()
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+
+        def properties = new Properties()
+        props.each { name, value ->
+            properties.put(name, value)
+        }
+
+        def jarOutput = new JarOutputStream(jarfile.newOutputStream(), manifest);
+        def jarEntry = new JarEntry("META-INF/build-info.properties")
+        jarOutput.putNextEntry(jarEntry)
+        properties.store(jarOutput, comments)
+        jarOutput.close()
     }
 
     private static RegularFileSnapshot snapshot(TestFile file) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.internal.fingerprint.classpath.impl
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.changedetection.state.DefaultResourceSnapshotterCacheService
-import org.gradle.api.internal.changedetection.state.ResourceFilter
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
+import org.gradle.internal.fingerprint.classpath.ClasspathResourceFilters
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.serialize.HashCodeSerializer
@@ -48,7 +48,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
     def fingerprinter = new DefaultClasspathFingerprinter(
         cacheService,
         fileCollectionSnapshotter,
-        ResourceFilter.FILTER_NOTHING,
+        ClasspathResourceFilters.NONE,
         stringInterner)
 
     def "directories and missing files are ignored"() {

--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -1160,6 +1160,37 @@ If adding such a file to your jar files is something you do for all of the proje
 The effect of this configuration would be that changes to `build-info.properties` would be ignored for up-to-date checks and <<build_cache.adoc#build_cache,build cache>> key calculations.
 Note that this will not change the runtime behavior of the `test` task — i.e. any test is still able to load `build-info.properties` and the runtime classpath is still the same as before.
 
+===== Java `META-INF` normalization
+
+For files in the `META-INF` directory of jar archives it's not always possible to ignore files completely due to their runtime impact.
+
+Manifests and properties files within `META-INF` are normalized to ignore comments, whitespace and order differences. Manifest attribute names are compared case-and-order insensitively. Properties file keys are order insensitive.
+
+.Ignore `META-INF` manifest attributes
+====
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/groovy",files="build.gradle[tags=ignore-metainf-attribute]"]
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/kotlin",files="build.gradle.kts[tags=ignore-metainf-attribute]"]
+====
+
+.Ignore `META-INF` property keys
+====
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/groovy",files="build.gradle[tags=ignore-metainf-property]"]
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/kotlin",files="build.gradle.kts[tags=ignore-metainf-property]"]
+====
+
+.Ignore `META-INF/MANIFEST.MF`
+====
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/groovy",files="build.gradle[tags=ignore-metainf-manifest]"]
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/kotlin",files="build.gradle.kts[tags=ignore-metainf-manifest]"]
+====
+
+.Ignore all files and directories inside `META-INF`
+====
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/groovy",files="build.gradle[tags=ignore-manifest-completely]"]
+include::sample[dir="snippets/userguide/tasks/inputNormalizationMetaInf/kotlin",files="build.gradle.kts[tags=ignore-manifest-completely]"]
+====
+
+
 [[sec:stale_task_outputs]]
 === Stale task outputs
 

--- a/subprojects/docs/src/snippets/tasks/inputNormalization/runtimeClasspathManifestNormalization.sample.conf
+++ b/subprojects/docs/src/snippets/tasks/inputNormalization/runtimeClasspathManifestNormalization.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: tasks
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: tasks
+}]

--- a/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/groovy/build.gradle
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+}
+
+// tag::ignore-metainf-attribute[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute("Implementation-Version")
+        }
+    }
+}
+// end::ignore-metainf-attribute[]
+
+// tag::ignore-metainf-properties[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreProperty("app.version")
+        }
+    }
+}
+// end::ignore-metainf-manifest[]
+
+// tag::ignore-metainf-manifest[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreManifest()
+        }
+    }
+}
+// end::ignore-metainf-completely[]
+
+// tag::ignore-metainf-completely[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreCompletely()
+        }
+    }
+}
+// end::ignore-metainf-completely[]

--- a/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'input-normalization-manifest'

--- a/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/kotlin/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    java
+}
+
+// tag::ignore-metainf-attribute[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute("Implementation-Version")
+        }
+    }
+}
+// end::ignore-metainf-attribute[]
+
+// tag::ignore-metainf-properties[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreProperty("app.version")
+        }
+    }
+}
+// end::ignore-metainf-manifest[]
+
+// tag::ignore-metainf-manifest[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreManifest()
+        }
+    }
+}
+// end::ignore-metainf-completely[]
+
+// tag::ignore-metainf-completely[]
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreCompletely()
+        }
+    }
+}
+// end::ignore-metainf-completely[]

--- a/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "input-normalization-manifest"

--- a/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/runtimeClasspathNormalization.sample.conf
+++ b/subprojects/docs/src/snippets/tasks/inputNormalizationMetaInf/runtimeClasspathNormalization.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: tasks
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: tasks
+}]


### PR DESCRIPTION
### Context

It's common for `META-INF` to contain changing attributes in `MANIFEST.MF` and properties files, and the current normalization method cannot be used either due to their impact on runtime behaviour, or non-stable filenames (for instance `<module-name>.properties`, so this makes their normalization a feature. 

In addition to allowing attributes to be ignored by key, for changing attributes such as `Created-By` (typically includes the exact JDK version), keys are sorted for comparison allowing keys to be order insensitive. Comments, whitespace and line-endings are also ignored by virtue of comparing the parsed representation of the files.

This specifically addresses the use case called out here:

https://guides.gradle.org/using-build-cache/#stable_task_inputs

And our info plugin that exposes build information in the manifest and `<module-name>.properties` files:

https://github.com/nebula-plugins/gradle-info-plugin

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
