### PR TITLE
Get `--scan` to work with instant execution again

### DIFF
--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -47,6 +47,32 @@ import javax.inject.Inject
 
 class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegrationTest {
 
+    def "--scan works"() {
+        given:
+        settingsKotlinFile << '''
+            plugins {
+                `gradle-enterprise`
+            }
+
+            gradleEnterprise.buildScan {
+                termsOfServiceUrl = "https://gradle.com/terms-of-service"
+                termsOfServiceAgree = "yes"
+            }
+        '''
+
+        when:
+        instantRun "help", "--scan", "-Dscan.dump"
+
+        then:
+        postBuildOutputContains("Build scan written to")
+
+        when:
+        instantRun "help", "--scan", "-Dscan.dump"
+
+        then:
+        postBuildOutputContains("Build scan written to")
+    }
+
     def "instant execution for help on empty project"() {
         given:
         instantRun "help"

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -207,7 +207,6 @@ class DefaultInstantExecution internal constructor(
         readRelevantProjects(build)
 
         build.registerProjects()
-        build.autoApplyPlugins()
 
         initProjectProvider(build::getProject)
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
@@ -29,8 +29,6 @@ interface InstantExecutionBuild {
 
     fun getProject(path: String): ProjectInternal
 
-    fun autoApplyPlugins()
-
     fun registerProjects()
 
     fun scheduleNodes(nodes: Collection<Node>)


### PR DESCRIPTION
By making the `Settings` object initialization in instant execution more similar to how it works in classic execution:

- instantiate `Settings` object during `SettingsPreparer` execution
- move `SettingsProcessor` execution to happen in the context of `SettingsPreparer`
- create a separate ClassLoaderScope for `Settings` so it can receive plugins
- always apply auto-applied plugin requests during `SettingsProcess` execution

This commit also removes the system property propagation hack as it's no longer needed.