### PR TITLE
Partially implemented Git-VCS auth (Username/Password)

### DIFF
--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -217,6 +217,23 @@ class GitVersionControlSystemSpec extends Specification {
         e.cause.cause.message.contains('URI not supported: https://notarepo.invalid')
     }
 
+    def 'error if repo is not a git repo with credentials'() {
+        given:
+        def target = tmpDir.file('versionDir')
+        repoSpec.url = 'https://username:123@notarepo.invalid'
+
+        when:
+        gitVcs.populate(target, repoHead, repoSpec)
+
+        then:
+        GradleException e = thrown()
+        e.message.contains('Could not clone from https://username:123@notarepo.invalid in')
+        e.cause != null
+        e.cause.message.contains('Exception caught during execution of fetch command')
+        e.cause.cause != null
+        e.cause.cause.message.contains('URI not supported: https://username@notarepo.invalid')
+    }
+
     def 'treats tags as the available versions and ignores other references'() {
         given:
         def versions = gitVcs.getAvailableVersions(repoSpec)


### PR DESCRIPTION
### Context
The feature supports partially the authentication to private Repositories due to Username / Password URI.
The Authentication with identity file is still missing. So this Feature is only implemented partially.
Issue #8245

Signed-off-by: Maximilian Quickmann <m.quickmann@gmx.de>

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

The two leaving checks are, because i cannot provide a private Repository with credentials.
The only changes happen to the source are including a UsernamePasswordCredentialProvider
and adding a Unit test for URI's containing username:password.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
