### PR TITLE
Move method back to ProjectExtensions

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -26,23 +26,9 @@
             ]
         },
         {
-            "type": "org.gradle.kotlin.dsl.ProjectExtensionsKt",
-            "member": "Method org.gradle.kotlin.dsl.ProjectExtensionsKt.repositories(org.gradle.api.initialization.dsl.ScriptHandler,kotlin.jvm.functions.Function1)",
-            "acceptation": "Extension method moved to org.gradle.kotlin.dsl.ScriptHandlerExtensions",
-            "changes": [
-                "Method has been removed"
-            ]
-        },
-        {
             "type": "org.gradle.kotlin.dsl.ScriptHandlerExtensionsKt",
             "member": "Class org.gradle.kotlin.dsl.ScriptHandlerExtensionsKt",
             "acceptation": "Dedicated type for ScriptHandler extensions",
-            "changes": []
-        },
-        {
-            "type": "org.gradle.kotlin.dsl.ScriptHandlerExtensionsKt",
-            "member": "Method org.gradle.kotlin.dsl.ScriptHandlerExtensionsKt.repositories(org.gradle.api.initialization.dsl.ScriptHandler,kotlin.jvm.functions.Function1)",
-            "acceptation": "Extension method moved from org.gradle.kotlin.dsl.ProjectExtensions",
             "changes": []
         },
         {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ProjectExtensions.kt
@@ -25,6 +25,8 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 
+import org.gradle.api.initialization.dsl.ScriptHandler
+
 import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDependency
 import org.gradle.api.internal.file.FileCollectionInternal
 
@@ -142,6 +144,13 @@ fun <T : Task> Project.task(name: String, type: KClass<T>, configuration: T.() -
  * @param configuration the configuration block.
  */
 fun Project.repositories(configuration: RepositoryHandler.() -> Unit) =
+    repositories.configuration()
+
+
+/**
+ * Configures the repositories for the script dependencies.
+ */
+fun ScriptHandler.repositories(configuration: RepositoryHandler.() -> Unit) =
     repositories.configuration()
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerExtensions.kt
@@ -18,15 +18,7 @@ package org.gradle.kotlin.dsl
 
 import org.gradle.api.Incubating
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler
-import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.initialization.dsl.ScriptHandler
-
-
-/**
- * Configures the repositories for the script dependencies.
- */
-fun ScriptHandler.repositories(configuration: RepositoryHandler.() -> Unit) =
-    repositories.configuration()
 
 
 /**


### PR DESCRIPTION
The move of the method was a mistake as it breaks usage of this method
in plugins or pre-compiled script plugins.