### PR TITLE
Publish build-cache-base as public library

### DIFF
--- a/subprojects/build-cache-base/build-cache-base.gradle.kts
+++ b/subprojects/build-cache-base/build-cache-base.gradle.kts
@@ -19,12 +19,13 @@ plugins {
     `java-library`
     gradlebuild.`strict-compile`
     gradlebuild.classycle
+    gradlebuild.`publish-public-libraries`
 }
 
 dependencies {
     implementation(project(":baseAnnotations"))
     implementation(project(":files"))
-    implementation(library("slf4j_api"))
+    implementation(library("slf4j_api")) { version { require(libraryVersion("slf4j_api")) } }
 }
 
 gradlebuildJava {

--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -25,16 +25,15 @@ description = "Package build cache results"
 
 dependencies {
     api(project(":buildCacheBase"))
-
-    implementation(project(":baseServices"))
-    implementation(project(":coreApi"))
-    implementation(project(":buildCache"))
-    implementation(project(":files"))
-    implementation(project(":snapshots"))
+    api(project(":snapshots"))
+    api(project(":hashing"))
+    api(project(":files"))
 
     implementation(library("guava")) { version { require(libraryVersion("guava")) } }
     implementation(library("commons_compress")) { version { require(libraryVersion("commons_compress")) } }
     implementation(library("commons_io")) { version { require(libraryVersion("commons_io")) } }
+
+    compileOnly(project(":baseAnnotations"))
 
     testImplementation(project(":processServices"))
     testImplementation(project(":fileCollections"))

--- a/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
+++ b/subprojects/build-cache-packaging/build-cache-packaging.gradle.kts
@@ -29,11 +29,11 @@ dependencies {
     api(project(":hashing"))
     api(project(":files"))
 
+    implementation(project(":baseAnnotations"))
+
     implementation(library("guava")) { version { require(libraryVersion("guava")) } }
     implementation(library("commons_compress")) { version { require(libraryVersion("commons_compress")) } }
     implementation(library("commons_io")) { version { require(libraryVersion("commons_io")) } }
-
-    compileOnly(project(":baseAnnotations"))
 
     testImplementation(project(":processServices"))
     testImplementation(project(":fileCollections"))

--- a/subprojects/snapshots/snapshots.gradle.kts
+++ b/subprojects/snapshots/snapshots.gradle.kts
@@ -24,10 +24,12 @@ plugins {
 description = "Tools to take immutable, comparable snapshots of files and other things"
 
 dependencies {
-    implementation(library("guava")) { version { require(libraryVersion("guava")) } }
-    implementation(project(":files"))
-    implementation(project(":hashing"))
+    api(project(":files"))
+    api(project(":hashing"))
+
     implementation(project(":baseAnnotations"))
+
+    implementation(library("guava")) { version { require(libraryVersion("guava")) } }
     implementation(library("slf4j_api")) { version { require(libraryVersion("slf4j_api")) } }
 
     testImplementation(project(":processServices"))


### PR DESCRIPTION
Last changes necessary in order to reuse `build-cache-packaging`.

Part of https://github.com/gradle/gradle-private/issues/2417