### PR TITLE
Take field annotation into account for conflicting ignore annotations

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1392,7 +1392,6 @@ task generate(type: TransformerTask) {
         outputFile.text == 'second'
     }
 
-    @ToBeImplemented
     @Issue("https://github.com/gradle/gradle/issues/11805")
     def "Groovy property annotated as @Internal with differently annotated getter emits warning about conflicting annotations"() {
         def inputFile = file("input.txt")
@@ -1425,21 +1424,24 @@ task generate(type: TransformerTask) {
         """
 
         when:
+        executer.expectDeprecationWarning()
         run "custom"
         then:
         executedAndNotSkipped ":custom"
+        outputContains("Property 'classpath' annotated with @Internal should not be also annotated with @InputFiles, @Classpath. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.")
 
         when:
+        executer.expectDeprecationWarning()
         run "custom"
         then:
         skipped ":custom"
 
         when:
+        executer.expectDeprecationWarning()
         inputFile.text = "changed"
         run "custom"
 
         then:
-        // FIXME This should execute instead of being skipped, or emit a warning
         skipped ":custom"
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -257,7 +257,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification {
         assertProperties TypeWithIgnoredPropertyWithOtherAnnotations, [
             ignoredProperty: [(TYPE): Ignored]
         ], [
-            "Property 'ignoredProperty' getter 'getIgnoredProperty()' annotated with @Ignored should not be also annotated with @Color."
+            "Property 'ignoredProperty' annotated with @Ignored should not be also annotated with @Color."
         ]
     }
 
@@ -272,7 +272,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification {
         assertProperties TypeWithIgnoredPropertyWithMultipleIgnoreAnnotations, [
             twiceIgnoredProperty: [(TYPE): Ignored]
         ], [
-            "Property 'twiceIgnoredProperty' getter 'getTwiceIgnoredProperty()' annotated with @Ignored should not be also annotated with @Ignored2."
+            "Property 'twiceIgnoredProperty' annotated with @Ignored should not be also annotated with @Ignored2."
         ]
     }
 
@@ -280,6 +280,26 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification {
         interface TypeWithIgnoredPropertyWithMultipleIgnoreAnnotations {
             @Ignored @Ignored2
             String getTwiceIgnoredProperty()
+        }
+
+    def "warns when field is ignored but there is another annotation on the getter"() {
+        expect:
+        assertProperties TypeWithIgnoredFieldAndGetterInput, [
+            ignoredByField: [(TYPE): Ignored]
+        ], [
+            "Property 'ignoredByField' annotated with @Ignored should not be also annotated with @Small."
+        ]
+    }
+
+        @SuppressWarnings("unused")
+        static class TypeWithIgnoredFieldAndGetterInput {
+            @Ignored
+            private String ignoredByField;
+
+            @Small
+            String getIgnoredByField() {
+                return ignoredByField
+            }
         }
 
     def "superclass properties are present in subclass"() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -763,7 +763,7 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
 
         expect:
         assertValidationFailsWith(
-            "Type 'MyTask': property 'oldProperty' getter 'getOldProperty()' annotated with @ReplacedBy should not be also annotated with @Input.": WARNING,
+            "Type 'MyTask': property 'oldProperty' annotated with @ReplacedBy should not be also annotated with @Input.": WARNING,
         )
     }
 


### PR DESCRIPTION
When a field is annotated with `@Ignore` and the getter is annotated
with another ignore annotation or another input annotation, then
the user should be warned about the conflict.

Fixes #11805.