### PR TITLE
Add test for nested bean from Kotlin Closure

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.Issue
 
 @Requires([TestPrecondition.KOTLIN_SCRIPT])
 @LeaksFileHandles
@@ -103,6 +104,7 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractPlu
     }
 
     @ToBeFixedForInstantExecution
+    @Issue("https://github.com/gradle/gradle/issues/11703")
     def "nested bean from closure can be used with the build cache"() {
         def project1 = file("project1").createDir()
         def project2 = file("project2").createDir()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -17,15 +17,17 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractPluginIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.KotlinDslTestUtil
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 @Requires([TestPrecondition.KOTLIN_SCRIPT])
 @LeaksFileHandles
-class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractPluginIntegrationTest {
+class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractPluginIntegrationTest implements DirectoryBuildCacheFixture {
 
     @Override
     protected String getDefaultBuildFileName() {
@@ -57,7 +59,7 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractPlu
         buildFile.text = """
             tasks.create<TaskWithNestedAction>("myTask") {
                 action = Action { writeText("changed") }
-            }                      
+            }
         """
         run 'myTask', '--info'
         then:
@@ -100,28 +102,66 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractPlu
         output.contains "Implementation of input property 'action' has changed for task ':myTask'"
     }
 
-    private void setupTaskWithNestedAction(String actionType, String actionInvocation) {
-        file('buildSrc/settings.gradle.kts') << ""
-        file('buildSrc/build.gradle.kts') << KotlinDslTestUtil.kotlinDslBuildSrcScript
-        file("buildSrc/src/main/kotlin/TaskWithNestedAction.kt") << """
-            import org.gradle.api.DefaultTask
-            import org.gradle.api.tasks.Nested
-            import org.gradle.api.tasks.OutputFile
-            import org.gradle.api.tasks.TaskAction
-            import java.io.File
-            
-            open class TaskWithNestedAction : DefaultTask() {
-                @get: Nested
-                lateinit var action: ${actionType}
-            
-                @get: OutputFile
-                var outputFile: File = File(temporaryDir, "output.txt")
-            
-                @TaskAction
-                fun generate() {
-                    action${actionInvocation}(outputFile)
+    @ToBeFixedForInstantExecution
+    def "nested bean from closure can be used with the build cache"() {
+        def project1 = file("project1").createDir()
+        def project2 = file("project2").createDir()
+        [project1, project2].each { projectDir ->
+            def buildFile = projectDir.file("build.gradle.kts")
+            setupTaskWithNestedAction('(File) -> Unit', '', projectDir)
+            buildFile << """
+                apply(plugin = "base")
+
+                tasks.create<TaskWithNestedAction>("myTask") {
+                    outputs.cacheIf { true }
+                    action = { it.writeText("hello") }
                 }
-            }
-        """
+                """
+            buildFile.makeOlder()
+            projectDir.file("settings.gradle") << localCacheConfiguration()
+        }
+
+        when:
+        executer.inDirectory(project1)
+        withBuildCache().run 'myTask'
+
+        then:
+        executedAndNotSkipped(':myTask')
+        project1.file('build/tmp/myTask/output.txt').text == "hello"
+
+        when:
+        executer.inDirectory(project2)
+        withBuildCache().run 'myTask'
+
+        then:
+        skipped(':myTask')
+        project2.file('build/tmp/myTask/output.txt').text == "hello"
+    }
+
+    private void setupTaskWithNestedAction(String actionType, String actionInvocation, TestFile projectDir = temporaryFolder.testDirectory) {
+        projectDir.with {
+            file('buildSrc/settings.gradle.kts') << ""
+            file('buildSrc/build.gradle.kts') << KotlinDslTestUtil.kotlinDslBuildSrcScript
+            file("buildSrc/src/main/kotlin/TaskWithNestedAction.kt") << """
+                import org.gradle.api.DefaultTask
+                import org.gradle.api.tasks.Nested
+                import org.gradle.api.tasks.OutputFile
+                import org.gradle.api.tasks.TaskAction
+                import java.io.File
+
+                open class TaskWithNestedAction : DefaultTask() {
+                    @get: Nested
+                    lateinit var action: ${actionType}
+
+                    @get: OutputFile
+                    var outputFile: File = File(temporaryDir, "output.txt")
+
+                    @TaskAction
+                    fun generate() {
+                        action${actionInvocation}(outputFile)
+                    }
+                }
+            """
+        }
     }
 }


### PR DESCRIPTION
For Groovy build scripts, the resulting class seems
to be non-relocatable, since the class name contains
an absolute path: #11703.

For Kotlin build scripts, that doesn't seem to be a problem,
as the test demonstrates.