### PR TITLE
Add file collection fingerprinting logging

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -33,6 +33,7 @@ import java.util.List;
  */
 @NonNullApi
 public abstract class AbstractFileCollectionFingerprinter implements FileCollectionFingerprinter {
+
     private final FileCollectionSnapshotter fileCollectionSnapshotter;
     private final FingerprintingStrategy fingerprintingStrategy;
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/caching/impl/LoggingCachingStateBuilder.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/caching/impl/LoggingCachingStateBuilder.java
@@ -55,7 +55,7 @@ public class LoggingCachingStateBuilder extends DefaultCachingStateBuilder {
     @Override
     public void withInputFilePropertyFingerprints(Map<String, CurrentFileCollectionFingerprint> fingerprints) {
         fingerprints.forEach((propertyName, fingerprint) -> {
-            LOGGER.warn("Appending input file fingerprints for '{}' to build cache key: {}", propertyName, fingerprint.getHash());
+            LOGGER.warn("Appending input file fingerprints for '{}' to build cache key: {} - {}", propertyName, fingerprint.getHash(), fingerprint);
         });
         super.withInputFilePropertyFingerprints(fingerprints);
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
@@ -30,7 +30,9 @@ import org.gradle.internal.snapshot.CompleteFileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotVisitor;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DefaultCurrentFileCollectionFingerprint implements CurrentFileCollectionFingerprint {
 
@@ -117,5 +119,15 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
         for (FileSystemSnapshot root : roots) {
             root.accept(visitor);
         }
+    }
+
+    @Override
+    public String toString() {
+        Map<Boolean, List<Map.Entry<String, FileSystemLocationFingerprint>>> collect = fingerprints.entrySet()
+            .stream()
+            .collect(Collectors.partitioningBy(entry -> entry.getValue() instanceof IgnoredPathFileSystemLocationFingerprint));
+        List<Map.Entry<String, FileSystemLocationFingerprint>> includedFingerprints = collect.get(false);
+        List<Map.Entry<String, FileSystemLocationFingerprint>> ignoredFingerprints = collect.get(true);
+        return identifier + "{fingerprints=" + includedFingerprints + ", ignoredFingerprints=" + ignoredFingerprints + "}";
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
@@ -73,6 +73,6 @@ public class EmptyCurrentFileCollectionFingerprint implements CurrentFileCollect
 
     @Override
     public String toString() {
-        return "EMPTY{" + identifier + "}";
+        return identifier + "{EMPTY}";
     }
 }


### PR DESCRIPTION
### Context
I found it difficult to debug unstable task inputs without resorting to the debugger, so this adds file collection fingerprinting debug logging to make troubleshooting easier:

```
2020-01-21T14:08:31.168-0800 [DEBUG] [org.gradle.internal.fingerprint.classpath.impl.DefaultCompileClasspathFingerprinter] Fingerprinted input files for task ':buildSrc:compileGroovy' property 'classpath', fingerprint: COMPILE_CLASSPATH{/Users/dannyt/.gradle/caches/6.2-20200121220757+0000/generated-gradle-jars/gradle-api-6.2-20200121220757+0000.jar=IGNORED / 4663eb6aef8dcd9eb3523976542f255e, /Users/dannyt/Projects/gradle-source-build/lib/groovy-all-1.3-2.5.8.jar=IGNORED / f278c72a75845b466cd7d787b73044cc, /Users/dannyt/Projects/gradle-source-build/lib/kotlin-stdlib-1.3.61.jar=IGNORED / 5b17dff5b9e5ef86cec461baf8b54c96, /Users/dannyt/Projects/gradle-source-build/lib/kotlin-stdlib-common-1.3.61.jar=IGNORED / b4ffe6c04c447ca2bf8e1659ba078d13, /Users/dannyt/Projects/gradle-source-build/lib/kotlin-stdlib-jdk8-1.3.61.jar=IGNORED / a70b06fc24c92d091bbb9be149062887, /Users/dannyt/Projects/gradle-source-build/lib/kotlin-stdlib-jdk7-1.3.61.jar=IGNORED / 34cbc8e11311fb2a0d6d9bbd95099b34, /Users/dannyt/Projects/gradle-source-build/lib/kotlin-reflect-1.3.61.jar=IGNORED / 973b26dfabcf679d91e337ba4fa7dfa0, /Users/dannyt/Projects/gradle-source-build/lib/gradle-installation-beacon-6.2.jar=IGNORED / d6fd80b5c8e98dda755304764edbc6aa}
2020-01-21T14:08:31.170-0800 [DEBUG] [org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter] Fingerprinted input files for task ':buildSrc:compileGroovy' property 'groovyClasspath', fingerprint: CLASSPATH{/Users/dannyt/Projects/gradle-source-build/lib/groovy-all-1.3-2.5.8.jar=IGNORED / 650af15673e02d85fe353cc064fd139d}
2020-01-21T14:08:31.170-0800 [DEBUG] [org.gradle.internal.fingerprint.impl.IgnoredPathFileCollectionFingerprinter] Fingerprinted input files for task ':buildSrc:compileGroovy' property 'groovyOptions.configurationScript', fingerprint: IGNORED_PATH{EMPTY}
2020-01-21T14:08:31.171-0800 [DEBUG] [org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter] Fingerprinted input files for task ':buildSrc:compileGroovy' property 'options.annotationProcessorPath', fingerprint: CLASSPATH{EMPTY}
2020-01-21T14:08:31.171-0800 [DEBUG] [org.gradle.internal.fingerprint.classpath.impl.DefaultCompileClasspathFingerprinter] Fingerprinted input files for task ':buildSrc:compileGroovy' property 'options.bootstrapClasspath', fingerprint: COMPILE_CLASSPATH{EMPTY}
2020-01-21T14:08:31.171-0800 [DEBUG] [org.gradle.internal.fingerprint.impl.RelativePathFileCollectionFingerprinter] Fingerprinted input files for task ':buildSrc:compileGroovy' property 'options.sourcepath', fingerprint: RELATIVE_PATH{EMPTY}
```

Relates to https://github.com/gradle/gradle/pull/11937.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
