### PR TITLE
Let Santa Tracker performance tests use managed AGP versions

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
@@ -16,9 +16,7 @@
 
 package org.gradle.integtests.fixtures.versions
 
-import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.internal.Factory
-import org.gradle.test.fixtures.file.TestFile
 
 
 /**
@@ -53,26 +51,8 @@ class AndroidGradlePluginVersions {
         }
     """
 
-    static void usingAgpVersion(GradleExecuter executer, TestFile buildFile, String agpVersion) {
-        println "> Using AGP version ${agpVersion}"
-        buildFile.text = replaceAgpVersion(buildFile.text, agpVersion)
-        executer.beforeExecute {
-            withArgument(OVERRIDE_VERSION_CHECK)
-        }
-        if (isAgpNightly(agpVersion)) {
-            usingAgpNightlyRepository(executer)
-        }
-    }
-
     static boolean isAgpNightly(String agpVersion) {
         return agpVersion.contains("-") && agpVersion.substring(agpVersion.indexOf("-") + 1).matches("^[0-9].*")
-    }
-
-    static void usingAgpNightlyRepository(GradleExecuter executer) {
-        def init = createAgpNightlyRepositoryInitScript()
-        executer.beforeExecute {
-            usingInitScript(init)
-        }
     }
 
     static File createAgpNightlyRepositoryInitScript() {
@@ -80,16 +60,6 @@ class AndroidGradlePluginVersions {
         mirrors.deleteOnExit()
         mirrors << AGP_NIGHTLY_REPOSITORY_INIT_SCRIPT
         return mirrors
-    }
-
-    static void replaceAgpVersion(File script, String agpVersion) {
-        script.text = replaceAgpVersion(script.text, agpVersion)
-    }
-
-    static String replaceAgpVersion(String scriptText, String agpVersion) {
-        def regex = "(['\"]com.android.tools.build:gradle:).+(['\"])"
-        scriptText.readLines().any { it.matches(".*${regex}.*") }
-        return scriptText.replaceAll(regex, "${'$'}1$agpVersion${'$'}2")
     }
 
     private final Factory<Properties> propertiesFactory

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
@@ -82,7 +82,11 @@ class AndroidGradlePluginVersions {
         return mirrors
     }
 
-    private static String replaceAgpVersion(String scriptText, String agpVersion) {
+    static void replaceAgpVersion(File script, String agpVersion) {
+        script.text = replaceAgpVersion(script.text, agpVersion)
+    }
+
+    static String replaceAgpVersion(String scriptText, String agpVersion) {
         def regex = "(['\"]com.android.tools.build:gradle:).+(['\"])"
         scriptText.readLines().any { it.matches(".*${regex}.*") }
         return scriptText.replaceAll(regex, "${'$'}1$agpVersion${'$'}2")
@@ -115,6 +119,10 @@ class AndroidGradlePluginVersions {
         assert lowerBound.matches("^[0-9]+\\.[0-9]+\$")
         def withBound = (latests + lowerBound).sort()
         return withBound.subList(withBound.indexOf(lowerBound) + 1, withBound.size())
+    }
+
+    String getLatestOfMinor(String lowerBound) {
+        return getLatestsFromMinor(lowerBound).first()
     }
 
     List<String> getLatestsFromMinorPlusNightly(String lowerBound) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -81,20 +81,20 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
     @Override
     void configure(GradleProfilerCrossVersionPerformanceTestRunner runner) {
         super.configure(runner)
-        runner.gradleOpts += [ENABLE_AGP_IDE_MODE_ARG]
+        runner.gradleOpts.add(ENABLE_AGP_IDE_MODE_ARG)
     }
 
     @Override
     void configure(GradleBuildExperimentSpec.GradleBuilder builder) {
         super.configure(builder)
         builder.invocation {
-            gradleOptions += [ENABLE_AGP_IDE_MODE_ARG]
+            gradleOptions.add(ENABLE_AGP_IDE_MODE_ARG)
         }
     }
 
 
     void configureForLatestAgpVersionOfMinor(GradleProfilerCrossVersionPerformanceTestRunner runner, String lowerBound) {
-        runner.gradleOpts += ["-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}"]
+        runner.gradleOpts.add("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
     }
 
     void configureForAbiChange(GradleProfilerCrossVersionPerformanceTestRunner runner) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -60,6 +60,7 @@ class AndroidTestProject {
 class IncrementalAndroidTestProject extends AndroidTestProject {
 
     private static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
+    private static final String ENABLE_AGP_IDE_MODE_ARG = "-Pandroid.injected.invoked.from.ide=true"
 
     static final SANTA_TRACKER_KOTLIN = new IncrementalAndroidTestProject(
         templateName: 'santaTrackerAndroidBuild',
@@ -77,6 +78,21 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
 
     String pathToChange
     String taskToRunForChange
+
+    @Override
+    void configure(GradleProfilerCrossVersionPerformanceTestRunner runner) {
+        super.configure(runner)
+        runner.gradleOpts += [ENABLE_AGP_IDE_MODE_ARG]
+    }
+
+    @Override
+    void configure(GradleBuildExperimentSpec.GradleBuilder builder) {
+        super.configure(builder)
+        builder.invocation {
+            gradleOptions += [ENABLE_AGP_IDE_MODE_ARG]
+        }
+    }
+
 
     void configureForLatestAgpVersionOfMinor(GradleProfilerCrossVersionPerformanceTestRunner runner, String lowerBound) {
         runner.addBuildMutator { invocationSettings ->

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -19,7 +19,6 @@ package org.gradle.performance.regression.android
 import org.gradle.integtests.fixtures.versions.AndroidGradlePluginVersions
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
 import org.gradle.performance.fixture.GradleProfilerCrossVersionPerformanceTestRunner
-import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
 import org.gradle.profiler.mutations.ApplyAbiChangeToJavaSourceFileMutator
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
@@ -95,17 +94,7 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
 
 
     void configureForLatestAgpVersionOfMinor(GradleProfilerCrossVersionPerformanceTestRunner runner, String lowerBound) {
-        runner.addBuildMutator { invocationSettings ->
-            new BuildMutator() {
-                @Override
-                void beforeScenario() {
-                    AGP_VERSIONS.replaceAgpVersion(
-                        new File(invocationSettings.projectDir, "build.gradle"),
-                        AGP_VERSIONS.getLatestOfMinor(lowerBound)
-                    )
-                }
-            }
-        }
+        runner.gradleOpts += ["-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}"]
     }
 
     void configureForAbiChange(GradleProfilerCrossVersionPerformanceTestRunner runner) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -16,13 +16,16 @@
 
 package org.gradle.performance.regression.android
 
+import org.gradle.integtests.fixtures.versions.AndroidGradlePluginVersions
 import org.gradle.performance.fixture.GradleBuildExperimentSpec
 import org.gradle.performance.fixture.GradleProfilerCrossVersionPerformanceTestRunner
+import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
 import org.gradle.profiler.mutations.ApplyAbiChangeToJavaSourceFileMutator
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 
 class AndroidTestProject {
+
     static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild',
         memory: '5g',
@@ -55,6 +58,9 @@ class AndroidTestProject {
 }
 
 class IncrementalAndroidTestProject extends AndroidTestProject {
+
+    private static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
+
     static final SANTA_TRACKER_KOTLIN = new IncrementalAndroidTestProject(
         templateName: 'santaTrackerAndroidBuild',
         memory: '1g',
@@ -71,6 +77,20 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
 
     String pathToChange
     String taskToRunForChange
+
+    void configureForLatestAgpVersionOfMinor(GradleProfilerCrossVersionPerformanceTestRunner runner, String lowerBound) {
+        runner.addBuildMutator { invocationSettings ->
+            new BuildMutator() {
+                @Override
+                void beforeScenario() {
+                    AGP_VERSIONS.replaceAgpVersion(
+                        new File(invocationSettings.projectDir, "build.gradle"),
+                        AGP_VERSIONS.getLatestOfMinor(lowerBound)
+                    )
+                }
+            }
+        }
+    }
 
     void configureForAbiChange(GradleProfilerCrossVersionPerformanceTestRunner runner) {
         configure(runner)

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -92,7 +92,6 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
         }
     }
 
-
     void configureForLatestAgpVersionOfMinor(GradleProfilerCrossVersionPerformanceTestRunner runner, String lowerBound) {
         runner.gradleOpts.add("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
     }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -81,14 +81,14 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
     @Override
     void configure(GradleProfilerCrossVersionPerformanceTestRunner runner) {
         super.configure(runner)
-        runner.gradleOpts.add(ENABLE_AGP_IDE_MODE_ARG)
+        runner.args.add(ENABLE_AGP_IDE_MODE_ARG)
     }
 
     @Override
     void configure(GradleBuildExperimentSpec.GradleBuilder builder) {
         super.configure(builder)
         builder.invocation {
-            gradleOptions.add(ENABLE_AGP_IDE_MODE_ARG)
+            args.add(ENABLE_AGP_IDE_MODE_ARG)
         }
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -93,7 +93,7 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
     }
 
     void configureForLatestAgpVersionOfMinor(GradleProfilerCrossVersionPerformanceTestRunner runner, String lowerBound) {
-        runner.gradleOpts.add("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
+        runner.args.add("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
     }
 
     void configureForAbiChange(GradleProfilerCrossVersionPerformanceTestRunner runner) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidTestProject.groovy
@@ -96,6 +96,10 @@ class IncrementalAndroidTestProject extends AndroidTestProject {
         runner.args.add("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
     }
 
+    void configureForLatestAgpVersionOfMinor(GradleBuildExperimentSpec.GradleBuilder builder, String lowerBound) {
+        builder.invocation.args("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
+    }
+
     void configureForAbiChange(GradleProfilerCrossVersionPerformanceTestRunner runner) {
         configure(runner)
         runner.tasksToRun = [taskToRunForChange]

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -36,7 +36,7 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     def "faster incremental build on #testProject (build comparison)"() {
         given:
         runner.testGroup = "incremental android changes"
-        def agpVersionMinor = "4.0"
+        def agpTargetVersion = "4.0"
 
         and:
         // Kotlin is not supported for instant execution
@@ -55,14 +55,14 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
         optimizations.each { name, Set<Optimization> enabledOptimizations ->
             runner.buildSpec {
                 testProject.configureForNonAbiChange(it)
-                testProject.configureForLatestAgpVersionOfMinor(it, agpVersionMinor)
+                testProject.configureForLatestAgpVersionOfMinor(it, agpTargetVersion)
                 passChangedFile(it, testProject)
                 invocation.args(*enabledOptimizations*.argument)
                 displayName("non abi change (${name})")
             }
             runner.buildSpec {
                 testProject.configureForAbiChange(it)
-                testProject.configureForLatestAgpVersionOfMinor(it, agpVersionMinor)
+                testProject.configureForLatestAgpVersionOfMinor(it, agpTargetVersion)
                 passChangedFile(it, testProject)
                 invocation.args(*enabledOptimizations*.argument)
                 displayName("abi change (${name})")

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/FasterIncrementalAndroidBuildsPerformanceTest.groovy
@@ -36,7 +36,9 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
     def "faster incremental build on #testProject (build comparison)"() {
         given:
         runner.testGroup = "incremental android changes"
+        def agpVersionMinor = "4.0"
 
+        and:
         // Kotlin is not supported for instant execution
         def optimizations = testProject == SANTA_TRACKER_KOTLIN
             ? [
@@ -53,12 +55,14 @@ class FasterIncrementalAndroidBuildsPerformanceTest extends AbstractCrossBuildPe
         optimizations.each { name, Set<Optimization> enabledOptimizations ->
             runner.buildSpec {
                 testProject.configureForNonAbiChange(it)
+                testProject.configureForLatestAgpVersionOfMinor(it, agpVersionMinor)
                 passChangedFile(it, testProject)
                 invocation.args(*enabledOptimizations*.argument)
                 displayName("non abi change (${name})")
             }
             runner.buildSpec {
                 testProject.configureForAbiChange(it)
+                testProject.configureForLatestAgpVersionOfMinor(it, agpVersionMinor)
                 passChangedFile(it, testProject)
                 invocation.args(*enabledOptimizations*.argument)
                 displayName("abi change (${name})")

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -32,6 +32,8 @@ import static org.gradle.performance.regression.android.IncrementalAndroidTestPr
 
 class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
 
+    private static final String SANTA_AGP_VERSION_MINOR = "3.6"
+
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
         runner.targetVersions = ["6.2-20200108160029+0000"]
@@ -49,6 +51,11 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
         applyEnterprisePlugin()
+
+        and:
+        if (testProject == SANTA_TRACKER_KOTLIN) {
+            testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+        }
 
         when:
         def result = runner.run()
@@ -81,6 +88,11 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
             new ClearArtifactTransformCacheMutator(invocationSettings.getGradleUserHome(), AbstractCleanupMutator.CleanupSchedule.BUILD)
         }
         applyEnterprisePlugin()
+
+        and:
+        if (testProject == SANTA_TRACKER_KOTLIN) {
+            testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_LOWER_BOUND)
+        }
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.performance.regression.android.IncrementalAndroidTestPr
 
 class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProfilerPerformanceTest {
 
-    private static final String SANTA_AGP_VERSION_MINOR = "3.6"
+    private static final String SANTA_AGP_TARGET_VERSION = "3.6"
 
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
@@ -56,7 +56,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
 
         and:
         if (testProject == SANTA_TRACKER_KOTLIN) {
-            (testProject as IncrementalAndroidTestProject).configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+            (testProject as IncrementalAndroidTestProject).configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_TARGET_VERSION)
         }
 
         when:
@@ -93,7 +93,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
 
         and:
         if (testProject == SANTA_TRACKER_KOTLIN) {
-            (testProject as IncrementalAndroidTestProject).configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+            (testProject as IncrementalAndroidTestProject).configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_TARGET_VERSION)
         }
 
         when:
@@ -113,7 +113,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
     def "abi change on #testProject"() {
         given:
         testProject.configureForAbiChange(runner)
-        testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+        testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_TARGET_VERSION)
         runner.args.add('-Dorg.gradle.parallel=true')
         applyEnterprisePlugin()
 
@@ -131,7 +131,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
     def "non-abi change on #testProject"() {
         given:
         testProject.configureForNonAbiChange(runner)
-        testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+        testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_TARGET_VERSION)
         runner.args.add('-Dorg.gradle.parallel=true')
         applyEnterprisePlugin()
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -47,14 +47,16 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         given:
         testProject.configure(runner)
         runner.tasksToRun = tasks.split(' ')
-        runner.args = parallel ? ['-Dorg.gradle.parallel=true'] : []
+        if (parallel) {
+            runner.args.add('-Dorg.gradle.parallel=true')
+        }
         runner.warmUpRuns = warmUpRuns
         runner.runs = runs
         applyEnterprisePlugin()
 
         and:
         if (testProject == SANTA_TRACKER_KOTLIN) {
-            testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+            (testProject as IncrementalAndroidTestProject).configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
         }
 
         when:
@@ -80,7 +82,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
         given:
         testProject.configure(runner)
         runner.tasksToRun = tasks.split(' ')
-        runner.args = ['-Dorg.gradle.parallel=true']
+        runner.args.add('-Dorg.gradle.parallel=true')
         runner.warmUpRuns = warmUpRuns
         runner.cleanTasks = ["clean"]
         runner.runs = runs
@@ -91,7 +93,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
 
         and:
         if (testProject == SANTA_TRACKER_KOTLIN) {
-            testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_LOWER_BOUND)
+            (testProject as IncrementalAndroidTestProject).configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
         }
 
         when:
@@ -111,7 +113,8 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
     def "abi change on #testProject"() {
         given:
         testProject.configureForAbiChange(runner)
-        runner.args = ['-Dorg.gradle.parallel=true']
+        testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+        runner.args.add('-Dorg.gradle.parallel=true')
         applyEnterprisePlugin()
 
         when:
@@ -128,7 +131,8 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionGradleProf
     def "non-abi change on #testProject"() {
         given:
         testProject.configureForNonAbiChange(runner)
-        runner.args = ['-Dorg.gradle.parallel=true']
+        testProject.configureForLatestAgpVersionOfMinor(runner, SANTA_AGP_VERSION_MINOR)
+        runner.args.add('-Dorg.gradle.parallel=true')
         applyEnterprisePlugin()
 
         when:

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -360,7 +360,7 @@ tasks.register("largeAndroidBuild", RemoteProject) {
 tasks.register("santaTrackerAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
     // Pinned from branch agp-3.6.0
-    ref = '3bbbd895de38efafd0dd1789454d4e4cb72d46d5'
+    ref = '65479d5a244a64afef79d86b4bbc81d8908d2434'
     doLast {
         addGoogleServicesJson(outputDirectory)
     }
@@ -369,7 +369,7 @@ tasks.register("santaTrackerAndroidBuild", RemoteProject) {
 tasks.register("santaTrackerAndroidJavaBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
     // Pinned from branch agp-3.6.0-java
-    ref = '174705275e434adc843e8e9b28106a5e3ffd6733'
+    ref = '5fff06e2496cc762b34031f6dd28467041ae8453'
     doLast {
         addGoogleServicesJson(outputDirectory)
     }

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -123,13 +123,13 @@ tasks {
     register<RemoteProject>("santaTrackerKotlin") {
         remoteUri.set(santaGitUri)
         // Pinned from branch agp-3.6.0
-        ref.set("3bbbd895de38efafd0dd1789454d4e4cb72d46d5")
+        ref.set("65479d5a244a64afef79d86b4bbc81d8908d2434")
     }
 
     register<RemoteProject>("santaTrackerJava") {
         remoteUri.set(santaGitUri)
         // Pinned from branch agp-3.6.0-java
-        ref.set("174705275e434adc843e8e9b28106a5e3ffd6733")
+        ref.set("5fff06e2496cc762b34031f6dd28467041ae8453")
     }
 
     register<RemoteProject>("gradleBuildCurrent") {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -46,14 +46,10 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
     protected void setupCopyOfSantaTracker(TestFile targetDir, String flavour, String agpVersion = null) {
         copyRemoteProject("santaTracker${flavour.capitalize()}", targetDir)
         GradleEnterprisePluginSettingsFixture.applyEnterprisePlugin(targetDir.file("settings.gradle"))
-        if (agpVersion != null) {
-            def buildFile = targetDir.file("build.gradle")
-            buildFile.text = AGP_VERSIONS.replaceAgpVersion(buildFile.text, agpVersion)
-        }
     }
 
     protected BuildResult buildLocation(File projectDir, String agpVersion) {
-        def runner = runner("assembleDebug")
+        def runner = runner("assembleDebug", "-DagpVersion=$agpVersion")
             .withProjectDir(projectDir)
             .withTestKitDir(homeDir)
             .forwardOutput()


### PR DESCRIPTION
This is a follow up to #11951 addressing the remaining places where Santa Tracker based Android tests aren't specifying the AGP version under test.