### PR TITLE
Let instant execution honor the build layout

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -17,6 +17,7 @@ package org.gradle.util;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.IoActions;
 import org.gradle.util.internal.LimitedDescription;
@@ -33,6 +34,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -315,5 +317,39 @@ public class GFileUtils {
         if (!dir.mkdir() && !dir.isDirectory()) {
             throw new UncheckedIOException(String.format("Failed to create directory '%s'", dir));
         }
+    }
+
+    /**
+     * Returns the path of target relative to base.
+     *
+     * @param target target file or directory
+     * @param base base directory
+     * @return the path of target relative to base.
+     */
+    public static String relativePathOf(File target, File base) {
+        String separatorChars = "/" + File.separator;
+        List<String> basePath = splitAbsolutePathOf(base, separatorChars);
+        List<String> targetPath = new ArrayList<String>(splitAbsolutePathOf(target, separatorChars));
+
+        // Find and remove common prefix
+        int maxDepth = Math.min(basePath.size(), targetPath.size());
+        int prefixLen = 0;
+        while (prefixLen < maxDepth && basePath.get(prefixLen).equals(targetPath.get(prefixLen))) {
+            prefixLen++;
+        }
+        basePath = basePath.subList(prefixLen, basePath.size());
+        targetPath = targetPath.subList(prefixLen, targetPath.size());
+
+        for (int i = 0; i < basePath.size(); i++) {
+            targetPath.add(0, "..");
+        }
+        if (targetPath.isEmpty()) {
+            return ".";
+        }
+        return CollectionUtils.join(File.separator, targetPath);
+    }
+
+    private static List<String> splitAbsolutePathOf(File baseDir, String separatorChars) {
+        return Arrays.asList(StringUtils.split(baseDir.getAbsolutePath(), separatorChars));
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -404,7 +404,6 @@ class SomeTask extends DefaultTask {
         fixture.assertProjectsConfigured(":", ":a")
     }
 
-    @ToBeFixedForInstantExecution
     def "does not configure all projects when excluded task path is not qualified and is exact match for task in default project"() {
         settingsFile << "include 'a', 'a:child', 'b', 'b:child', 'c'"
         file('a').mkdirs()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -94,6 +94,7 @@ class ConfigurationOnDemandIntegrationTest extends AbstractIntegrationSpec {
         !output.contains("Configuration on demand is incubating")
     }
 
+    @ToBeFixedForInstantExecution
     def "follows java project dependencies"() {
         settingsFile << "include 'api', 'impl', 'util'"
         buildFile << "allprojects { apply plugin: 'java-library' } "
@@ -403,6 +404,7 @@ class SomeTask extends DefaultTask {
         fixture.assertProjectsConfigured(":", ":a")
     }
 
+    @ToBeFixedForInstantExecution
     def "does not configure all projects when excluded task path is not qualified and is exact match for task in default project"() {
         settingsFile << "include 'a', 'a:child', 'b', 'b:child', 'c'"
         file('a').mkdirs()
@@ -439,6 +441,7 @@ allprojects {
         fixture.assertProjectsConfigured(":", ":b", ":a")
     }
 
+    @ToBeFixedForInstantExecution
     def "does not configure all projects when excluded task path is not qualified and an exact match for task has already been seen in some sub-project of default project"() {
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
         file('c').mkdirs()
@@ -467,6 +470,7 @@ project(':b') {
         fixture.assertProjectsConfigured(":", ":c", ':c:child')
     }
 
+    @ToBeFixedForInstantExecution
     def "configures all subprojects of default project when excluded task path is not qualified and an exact match not found in default project"() {
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
         file('c').mkdirs()
@@ -493,6 +497,7 @@ allprojects {
         fixture.assertProjectsConfigured(":", ":c", ':c:child')
     }
 
+    @ToBeFixedForInstantExecution
     def "configures all subprojects of default projects when excluded task path is not qualified and uses camel case matching"() {
         settingsFile << "include 'a', 'b', 'b:child', 'c'"
         file('b').mkdirs()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -440,7 +440,6 @@ allprojects {
         fixture.assertProjectsConfigured(":", ":b", ":a")
     }
 
-    @ToBeFixedForInstantExecution
     def "does not configure all projects when excluded task path is not qualified and an exact match for task has already been seen in some sub-project of default project"() {
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
         file('c').mkdirs()
@@ -469,7 +468,6 @@ project(':b') {
         fixture.assertProjectsConfigured(":", ":c", ':c:child')
     }
 
-    @ToBeFixedForInstantExecution
     def "configures all subprojects of default project when excluded task path is not qualified and an exact match not found in default project"() {
         settingsFile << "include 'a', 'b', 'c', 'c:child'"
         file('c').mkdirs()
@@ -496,7 +494,6 @@ allprojects {
         fixture.assertProjectsConfigured(":", ":c", ':c:child')
     }
 
-    @ToBeFixedForInstantExecution
     def "configures all subprojects of default projects when excluded task path is not qualified and uses camel case matching"() {
         settingsFile << "include 'a', 'b', 'b:child', 'c'"
         file('b').mkdirs()

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -30,7 +30,6 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
     @SuppressWarnings("GroovyUnusedDeclaration")
     final operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
 
-    @ToBeFixedForInstantExecution
     def "requested and filtered tasks are exposed"() {
         settingsFile << """
         include "a"

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractBaseDirFileResolver.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractBaseDirFileResolver.java
@@ -16,16 +16,12 @@
 
 package org.gradle.api.internal.file;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
-import org.gradle.util.CollectionUtils;
+import org.gradle.util.GFileUtils;
 import org.gradle.util.GUtil;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public abstract class AbstractBaseDirFileResolver extends AbstractFileResolver {
     public AbstractBaseDirFileResolver(Factory<PatternSet> patternSetFactory) {
@@ -36,27 +32,7 @@ public abstract class AbstractBaseDirFileResolver extends AbstractFileResolver {
 
     @Override
     public String resolveAsRelativePath(Object path) {
-        List<String> basePath = Arrays.asList(StringUtils.split(getBaseDir().getAbsolutePath(), "/" + File.separator));
-        File targetFile = resolve(path);
-        List<String> targetPath = new ArrayList<String>(Arrays.asList(StringUtils.split(targetFile.getAbsolutePath(),
-                "/" + File.separator)));
-
-        // Find and remove common prefix
-        int maxDepth = Math.min(basePath.size(), targetPath.size());
-        int prefixLen = 0;
-        while (prefixLen < maxDepth && basePath.get(prefixLen).equals(targetPath.get(prefixLen))) {
-            prefixLen++;
-        }
-        basePath = basePath.subList(prefixLen, basePath.size());
-        targetPath = targetPath.subList(prefixLen, targetPath.size());
-
-        for (int i = 0; i < basePath.size(); i++) {
-            targetPath.add(0, "..");
-        }
-        if (targetPath.isEmpty()) {
-            return ".";
-        }
-        return CollectionUtils.join(File.separator, targetPath);
+        return GFileUtils.relativePathOf(resolve(path), getBaseDir());
     }
 
     @Override

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -894,5 +894,4 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         outputContains("thisTask = true")
         outputContains("bean.owner = true")
     }
-
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -894,4 +894,38 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         outputContains("thisTask = true")
         outputContains("bean.owner = true")
     }
+
+    def "reuses cache when build is started from a different subdirectory"() {
+        given:
+        settingsFile << """
+            include 'a', 'b'
+        """
+        buildScript """
+            task ok
+        """
+        def a = testDirectory.createDir('a')
+        def b = testDirectory.createDir('b')
+        def instantExecution = newInstantExecutionFixture()
+
+        when:
+        inDirectory a
+        instantRun ':ok'
+
+        then:
+        instantExecution.assertStateStored()
+
+        when:
+        inDirectory b
+        instantRun ':ok'
+
+        then:
+        instantExecution.assertStateLoaded()
+
+        when:
+        inDirectory a
+        instantRun ':ok'
+
+        then:
+        instantExecution.assertStateLoaded()
+    }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -895,37 +895,4 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         outputContains("bean.owner = true")
     }
 
-    def "reuses cache when build is started from a different subdirectory"() {
-        given:
-        settingsFile << """
-            include 'a', 'b'
-        """
-        buildScript """
-            task ok
-        """
-        def a = testDirectory.createDir('a')
-        def b = testDirectory.createDir('b')
-        def instantExecution = newInstantExecutionFixture()
-
-        when:
-        inDirectory a
-        instantRun ':ok'
-
-        then:
-        instantExecution.assertStateStored()
-
-        when:
-        inDirectory b
-        instantRun ':ok'
-
-        then:
-        instantExecution.assertStateLoaded()
-
-        when:
-        inDirectory a
-        instantRun ':ok'
-
-        then:
-        instantExecution.assertStateLoaded()
-    }
 }

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionMultiProjectIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionMultiProjectIntegrationTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+class InstantExecutionMultiProjectIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+
+    def "reuses cache for absolute task invocation from subproject dir across dirs"() {
+        given:
+        settingsFile << """
+            include 'a', 'b'
+        """
+        buildScript """
+            task ok
+        """
+        def a = createDir('a')
+        def b = createDir('b')
+        def instantExecution = newInstantExecutionFixture()
+
+        when:
+        inDirectory a
+        instantRun ':ok'
+
+        then:
+        instantExecution.assertStateStored()
+
+        when:
+        inDirectory b
+        instantRun ':ok'
+
+        then:
+        instantExecution.assertStateLoaded()
+
+        when:
+        inDirectory a
+        instantRun ':ok'
+
+        then:
+        instantExecution.assertStateLoaded()
+    }
+
+    def "reuses cache for relative task invocation from subproject dir"() {
+        given:
+        settingsFile << """
+            include 'a', 'b'
+        """
+        buildScript """
+            allprojects {
+                task ok
+            }
+        """
+        def a = createDir('a')
+        def b = createDir('b')
+        def instantExecution = newInstantExecutionFixture()
+
+        when:
+        inDirectory testDirectory
+        instantRun 'ok'
+
+        then:
+        result.assertTasksExecuted(':ok', ':a:ok', ':b:ok')
+        instantExecution.assertStateStored()
+
+        when:
+        inDirectory a
+        instantRun 'ok'
+
+        then:
+        result.assertTasksExecuted(':a:ok')
+        instantExecution.assertStateStored()
+
+        when:
+        inDirectory b
+        instantRun 'ok'
+
+        then:
+        result.assertTasksExecuted(':b:ok')
+        instantExecution.assertStateStored()
+
+        when:
+        inDirectory a
+        instantRun 'ok'
+
+        then:
+        result.assertTasksExecuted(':a:ok')
+        instantExecution.assertStateLoaded()
+
+        when:
+        inDirectory b
+        instantRun 'ok'
+
+        then:
+        result.assertTasksExecuted(':b:ok')
+        instantExecution.assertStateLoaded()
+
+        when:
+        inDirectory testDirectory
+        instantRun 'ok'
+
+        then:
+        result.assertTasksExecuted(':ok', ':a:ok', ':b:ok')
+        instantExecution.assertStateLoaded()
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -493,10 +493,13 @@ class DefaultInstantExecution internal constructor(
 
     private
     fun instantExecutionCacheKey() = startParameter.run {
+        // The following characters are not valid in task names
+        // and can be used as separators: /, \, :, <, >, ", ?, *, |
+        // except we also accept qualified task names with :, so colon is out.
         val cacheKey = StringBuilder()
         requestedTaskNames.joinTo(cacheKey, separator = "/")
         if (excludedTaskNames.isNotEmpty()) {
-            excludedTaskNames.joinTo(cacheKey, prefix = "-", separator = "/")
+            excludedTaskNames.joinTo(cacheKey, prefix = "<", separator = "/")
         }
         val taskNames = requestedTaskNames.asSequence() + excludedTaskNames.asSequence()
         val hasRelativeTaskName = taskNames.any { !it.startsWith(':') }
@@ -505,7 +508,7 @@ class DefaultInstantExecution internal constructor(
             // sub-project according to `invocationDir` we need to include
             // the relative invocation dir information in the key.
             relativeChildPathOrNull(invocationDir, rootDirectory)?.let { relativeSubDir ->
-                cacheKey.append('@')
+                cacheKey.append('*')
                 cacheKey.append(relativeSubDir)
             }
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -501,7 +501,7 @@ class DefaultInstantExecution internal constructor(
             absoluteTasksOnly -> tasksPart
             else -> {
                 // Because unqualified task names are resolved relative to the enclosing
-                // subproject according to `invocationDir` we need to include
+                // sub-project according to `invocationDir` we need to include
                 // the relative invocation dir information in the key.
                 relativeChildPathOrNull(invocationDir, rootDirectory)?.let { subDirPart ->
                     "$subDirPart:$tasksPart"
@@ -512,7 +512,7 @@ class DefaultInstantExecution internal constructor(
 
     /**
      * Returns the path of [target] relative to [base] if
-     * [target] is a child of [base] and `null` otherwise.
+     * [target] is a child of [base] or `null` otherwise.
      */
     private
     fun relativeChildPathOrNull(target: File, base: File): String? =

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -498,7 +498,7 @@ class DefaultInstantExecution internal constructor(
 
     private
     fun absoluteFile(path: String) =
-        File(startParameter.rootDir, path).absoluteFile
+        File(startParameter.rootDirectory, path).absoluteFile
 
     private
     val reportOutputDir by unsafeLazy {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -276,7 +276,7 @@ class DefaultInstantExecution internal constructor(
                 }
             }
             else -> {
-                val valueSource = instantiateValueSourceOf(this)
+                val valueSource = instantiateValueSource()
                 if (value.get() != valueSource.obtain()) {
                     "a build logic input has changed"
                 } else {
@@ -287,14 +287,12 @@ class DefaultInstantExecution internal constructor(
     }
 
     private
-    fun instantiateValueSourceOf(obtainedValue: ObtainedValue): ValueSource<Any, ValueSourceParameters> =
-        obtainedValue.run {
-            (valueSourceProviderFactory as DefaultValueSourceProviderFactory).instantiateValueSource(
-                valueSourceType,
-                valueSourceParametersType,
-                valueSourceParameters
-            )
-        }
+    fun ObtainedValue.instantiateValueSource(): ValueSource<Any, ValueSourceParameters> =
+        (valueSourceProviderFactory as DefaultValueSourceProviderFactory).instantiateValueSource(
+            valueSourceType,
+            valueSourceParametersType,
+            valueSourceParameters
+        )
 
     private
     fun attachBuildLogicInputsCollector() {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -493,7 +493,9 @@ class DefaultInstantExecution internal constructor(
 
     private
     fun instantExecutionCacheKey() = startParameter.run {
-        val tasksPart = requestedTaskNames.joinToString("/")
+        val requested = requestedTaskNames.joinToString("/")
+        val excluded = excludedTaskNames.joinToString("/")
+        val tasksPart = "$requested-$excluded"
         val absoluteTasksOnly = requestedTaskNames.all { it.startsWith(':') }
         when {
             absoluteTasksOnly -> tasksPart

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -235,7 +235,7 @@ class InstantExecutionHost internal constructor(
 
     private
     val rootDir
-        get() = startParameter.rootDir
+        get() = startParameter.rootDirectory
 
     private
     val coreScope: ClassLoaderScope

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionPropertiesLoader.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionPropertiesLoader.kt
@@ -31,7 +31,7 @@ class InstantExecutionPropertiesLoader(
 
     fun loadProperties() {
         require(!hasLoaded)
-        propertiesLoader.loadProperties(startParameter.rootDir)
+        propertiesLoader.loadProperties(startParameter.rootDirectory)
         loaded = true
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -29,6 +29,9 @@ class InstantExecutionStartParameter(
     val rootDirectory: File
         get() = buildLayout.rootDirectory
 
+    val invocationDir: File
+        get() = startParameter.currentDir
+
     val isRefreshDependencies
         get() = startParameter.isRefreshDependencies
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -17,13 +17,17 @@
 package org.gradle.instantexecution.initialization
 
 import org.gradle.StartParameter
+import org.gradle.initialization.layout.BuildLayout
 import java.io.File
 
 
-class InstantExecutionStartParameter(private val startParameter: StartParameter) {
+class InstantExecutionStartParameter(
+    private val buildLayout: BuildLayout,
+    private val startParameter: StartParameter
+) {
 
-    val rootDir: File
-        get() = startParameter.currentDir
+    val rootDirectory: File
+        get() = buildLayout.rootDirectory
 
     val isRefreshDependencies
         get() = startParameter.isRefreshDependencies

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -39,6 +39,9 @@ class InstantExecutionStartParameter(
         startParameter.taskNames
     }
 
+    val excludedTaskNames: Set<String>
+        get() = startParameter.excludedTaskNames
+
     fun systemPropertyArg(propertyName: String): String? =
         startParameter.systemPropertiesArgs[propertyName]
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IncrementalJavaProjectBuildIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IncrementalJavaProjectBuildIntegrationTest.groovy
@@ -38,7 +38,7 @@ class IncrementalJavaProjectBuildIntegrationTest extends AbstractIntegrationTest
     }
 
     @Test
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     public void doesNotRebuildJarIfSourceHasNotChanged() {
         // Use own home dir so we don't blast the shared one when we run with -C rebuild
         executer.requireOwnGradleUserHomeDir()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -48,9 +48,9 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         file('dest').assertHasDescendants(
-                'dir1/file1.txt',
-                'dir2/subdir/file2.txt',
-                'dir2/file3.txt'
+            'dir1/file1.txt',
+            'dir2/subdir/file2.txt',
+            'dir2/file3.txt'
         )
         !file('dest/someOtherEmptyDir').exists()
         file('dest/emptyDir').exists()
@@ -244,7 +244,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         defaultSourceFileTree()
         file('dest').create {
             some {
-                '.git' { }
+                '.git' {}
             }
             out {
                 '.git' {
@@ -279,8 +279,8 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         given:
         defaultSourceFileTree()
         file('dest').create {
-            preservedDir { }
-            nonPreservedDir { }
+            preservedDir {}
+            nonPreservedDir {}
         }
 
         buildScript '''
@@ -566,7 +566,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     project.sync {
                         from files('source')
-                        from fileTree('source2') { exclude '**/ignore/**' } 
+                        from fileTree('source2') { exclude '**/ignore/**' }
                         from configurations.compile
                         into 'dest'
                         include { fte -> fte.relativePath.segments.length < 3 && (fte.file.directory || fte.file.name.contains('f')) }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests
 
 import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -428,7 +428,6 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/9586")
-    @ToBeFixedForInstantExecution
     def "change in case of input folder will sync properly"() {
         given:
         def uppercaseDir = file('DIR')

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -160,7 +160,6 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("a", "b", "c")
     }
 
-    @ToBeFixedForInstantExecution
     def excludesTasksWhenExcludePatternSpecified() {
         settingsFile << "include 'sub'"
         buildFile << """

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -217,7 +217,6 @@ task someTask(dependsOn: [someDep, someOtherDep])
         executer.withTasks("someTask").withArguments("-x", ":sODep").run().assertTasksExecuted(":someDep", ":someTask")
     }
 
-    @ToBeFixedForInstantExecution
     def 'can combine exclude task filters'() {
         buildFile << """
 task someDep

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -205,7 +205,6 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file('sub')).withTasks('c').withArguments('-x', 'a').run().assertTasksExecuted(':a', ':sub:b', ':sub:c')
     }
 
-    @ToBeFixedForInstantExecution
     def 'can use camel-case matching to exclude tasks'() {
         buildFile << """
 task someDep

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -68,6 +68,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3540")
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     def "hash set output files marks task up-to-date"() {
         buildFile << """
             class MyTask extends DefaultTask {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -424,7 +424,7 @@ class AbstractIntegrationSpec extends Specification {
         return zip
     }
 
-    def createDir(String name, @DelegatesTo(value = TestWorkspaceBuilder.class, strategy = Closure.DELEGATE_FIRST) Closure cl) {
+    def createDir(String name, @DelegatesTo(value = TestWorkspaceBuilder.class, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         TestFile root = file(name)
         root.create(cl)
     }


### PR DESCRIPTION
And reuse the instant execution cache even when the build is invoked from a project subdirectory.