### PR TITLE
Set category attribute to 'library' for compile and runtime classpath

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -101,7 +101,9 @@ allprojects {
 
 dependencies {
     subprojects.forEach {
-        runtimeOnly(project(it.path))
+        if (it.name != "buildPlatform") {
+            runtimeOnly(project(it.path))
+        }
     }
 }
 

--- a/buildSrc/subprojects/binary-compatibility/binary-compatibility.gradle.kts
+++ b/buildSrc/subprojects/binary-compatibility/binary-compatibility.gradle.kts
@@ -1,7 +1,6 @@
 dependencies {
     api("me.champeau.gradle:japicmp-gradle-plugin:0.2.9")
 
-    implementation(project(":buildPlatform"))
     implementation(project(":kotlinDsl"))
 
     implementation("com.google.code.gson:gson:2.8.2")

--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -2,8 +2,6 @@ dependencies {
     api("com.google.guava:guava")
     api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")
 
-    implementation(project(":buildPlatform"))
-
     implementation("org.asciidoctor:asciidoctorj:1.5.8.1")
     implementation("commons-lang:commons-lang:2.6")
     implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16")

--- a/buildSrc/subprojects/buildquality/buildquality.gradle.kts
+++ b/buildSrc/subprojects/buildquality/buildquality.gradle.kts
@@ -1,6 +1,5 @@
 dependencies {
     implementation(project(":binaryCompatibility"))
-    implementation(project(":buildPlatform"))
     implementation(project(":cleanup"))
     implementation(project(":configuration"))
     implementation(project(":docs"))

--- a/buildSrc/subprojects/docs/docs.gradle.kts
+++ b/buildSrc/subprojects/docs/docs.gradle.kts
@@ -1,5 +1,4 @@
 dependencies {
-    implementation(project(":buildPlatform"))
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
     implementation(project(":versioning"))

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1729,6 +1729,7 @@ org:leaf2:1.0
 project :
    variant "runtimeClasspath" [
       org.gradle.usage               = java-runtime
+      org.gradle.category            = library
       org.gradle.libraryelements     = jar
       org.gradle.dependency.bundling = external
       org.gradle.jvm.version         = $jvmVersion
@@ -1737,7 +1738,7 @@ project :
       org.gradle.usage               = java-runtime
       org.gradle.libraryelements     = jar
       org.gradle.dependency.bundling = external
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
       org.gradle.jvm.version         = $jvmVersion
    ]
 
@@ -1788,7 +1789,7 @@ org:leaf2:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
       org.gradle.libraryelements     = jar
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -1843,7 +1844,7 @@ project :impl
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
       org.gradle.jvm.version         = $jvmVersion
    ]
 
@@ -1896,7 +1897,7 @@ org:leaf4:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -1935,7 +1936,7 @@ org:leaf1:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -1956,7 +1957,7 @@ org:leaf2:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2018,7 +2019,7 @@ project :api
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -2037,7 +2038,7 @@ project :some:deeply:nested
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -2055,7 +2056,7 @@ project :some:deeply:nested
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
       org.gradle.dependency.bundling = external
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -2107,7 +2108,7 @@ org:leaf3:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2215,7 +2216,7 @@ foo:foo:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2272,7 +2273,7 @@ org:foo -> $selected
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2326,7 +2327,7 @@ org:foo -> $selected
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2377,7 +2378,7 @@ org:foo:${displayVersion} -> $selected
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2434,7 +2435,7 @@ org:foo:[1.1,1.3] -> 1.3
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2451,7 +2452,7 @@ org:foo:1.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2512,7 +2513,7 @@ org:bar:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2530,7 +2531,7 @@ org:foo:1.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2576,7 +2577,7 @@ org:leaf:1.0 (by constraint)
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2629,7 +2630,7 @@ org.test:leaf:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2813,7 +2814,7 @@ org:foo:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2869,7 +2870,7 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2936,7 +2937,7 @@ org:foo:1.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2945,12 +2946,14 @@ org:foo:1.0
    Selection reasons:
       - Rejection : version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
+          - Attribute 'org.gradle.category' didn't match. Requested 'library', was: not found
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
           - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.libraryelements' didn't match. Requested 'classes', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
+          - Attribute 'org.gradle.category' didn't match. Requested 'library', was: not found
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
           - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.libraryelements' didn't match. Requested 'classes', was: not found
@@ -3014,7 +3017,7 @@ planet:mercury:1.0.2
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -3046,7 +3049,7 @@ planet:venus:2.0.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -3078,7 +3081,7 @@ planet:pluto:1.0.0
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -36,7 +36,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
         settingsFile << "include 'a', 'b', 'c'"
         file('a/build.gradle') << '''
             apply plugin: 'java-library'
-            
+
             dependencies {
                 api project(':b')
                 implementation project(':c')
@@ -56,7 +56,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
    variant "$expectedVariant" [
       $expectedAttributes
       org.gradle.dependency.bundling = external
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -74,7 +74,7 @@ project :$expectedProject
         mavenRepo.with {
             def leaf = module('org.test', 'leaf', '1.0')
                 .withModuleMetadata()
-                .variant('api', ['org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.test': 'published attribute'])
+                .variant('api', ['org.gradle.usage': 'java-api', 'org.gradle.category': 'library', 'org.gradle.libraryelements': 'jar', 'org.gradle.test': 'published attribute'])
                 .publish()
             module('org.test', 'a', '1.0')
                 .dependsOn(leaf)
@@ -84,15 +84,15 @@ project :$expectedProject
 
         file("build.gradle") << """
             apply plugin: 'java-library'
-            
+
             repositories {
                maven { url "${mavenRepo.uri}" }
             }
-            
+
             dependencies {
                 implementation 'org.test:a:1.0'
             }
-            
+
             configurations.compileClasspath.attributes.attribute(Attribute.of('org.gradle.blah', String), 'something')
         """
 
@@ -103,6 +103,7 @@ project :$expectedProject
         outputContains """org.test:leaf:1.0
    variant "api" [
       org.gradle.usage               = java-api
+      org.gradle.category            = library
       org.gradle.libraryelements     = jar (compatible with: classes)
       org.gradle.test                = published attribute (not requested)
       org.gradle.status              = release (not requested)
@@ -243,7 +244,7 @@ org:leaf:1.0
             dependencies.attributesSchema.attribute(CUSTOM_ATTRIBUTE)
             def configValue = objects.named(CustomAttributeType.class, 'conf_value')
             def dependencyValue = objects.named(CustomAttributeType.class, 'dep_value')
-            
+
             repositories {
                 maven { url "${mavenRepo.uri}" }
             }
@@ -271,7 +272,7 @@ org:leaf:1.0
                     }
                 }
             }
-            
+
             interface CustomAttributeType extends Named {}
         """
 

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/runtimeClasspath.out
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/runtimeClasspath.out
@@ -4,7 +4,7 @@ mysql:mysql-connector-java:8.0.14
    variant "runtime" [
       org.gradle.status             = release (not requested)
       org.gradle.usage              = java-runtime
-      org.gradle.category = library (not requested)
+      org.gradle.category = library
    ]
 
 mysql:mysql-connector-java:8.0.14

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/runtimeClasspath.out
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/runtimeClasspath.out
@@ -5,7 +5,7 @@ org.mongodb:bson:3.9.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
       org.gradle.libraryelements     = jar
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -24,7 +24,7 @@ org.mongodb:mongodb-driver-core:3.9.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
       org.gradle.libraryelements     = jar
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -41,7 +41,7 @@ org.mongodb:mongodb-driver-sync:3.9.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
       org.gradle.libraryelements     = jar
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/runtimeClasspath.out
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/runtimeClasspath.out
@@ -5,7 +5,7 @@ mysql:mysql-connector-java:8.0.14
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
       org.gradle.libraryelements     = jar
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/failRuntimeClasspathResolve.out
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/failRuntimeClasspathResolve.out
@@ -4,50 +4,28 @@ Execution failed for task ':failRuntimeClasspathResolve'.
      Required by:
          project :
       > Cannot choose between the following variants of org.lwjgl:lwjgl:3.2.3:
-          - enforced-platform-runtime
           - natives-windows-runtime
           - natives-windows-x86-runtime
-          - platform-runtime
         All of them match the consumer attributes:
-          - Variant 'enforced-platform-runtime' capability org.lwjgl:lwjgl-derived-enforced-platform:3.2.3:
-              - Unmatched attributes:
-                  - Found org.gradle.category 'enforced-platform' but wasn't required.
-                  - Required org.gradle.dependency.bundling 'external' but no value provided.
-                  - Required org.gradle.jvm.version '11' but no value provided.
-                  - Required org.gradle.libraryelements 'jar' but no value provided.
-                  - Required org.gradle.native.operatingSystem 'windows' but no value provided.
-                  - Found org.gradle.status 'release' but wasn't required.
-              - Compatible attribute:
-                  - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.
           - Variant 'natives-windows-runtime' capability org.lwjgl:lwjgl:3.2.3:
               - Unmatched attributes:
-                  - Found org.gradle.category 'library' but wasn't required.
                   - Required org.gradle.dependency.bundling 'external' but no value provided.
                   - Required org.gradle.jvm.version '11' but no value provided.
                   - Found org.gradle.native.architecture 'x86-64' but wasn't required.
                   - Found org.gradle.status 'release' but wasn't required.
               - Compatible attributes:
+                  - Required org.gradle.category 'library' and found compatible value 'library'.
                   - Required org.gradle.libraryelements 'jar' and found compatible value 'jar'.
                   - Required org.gradle.native.operatingSystem 'windows' and found compatible value 'windows'.
                   - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.
           - Variant 'natives-windows-x86-runtime' capability org.lwjgl:lwjgl:3.2.3:
               - Unmatched attributes:
-                  - Found org.gradle.category 'library' but wasn't required.
                   - Required org.gradle.dependency.bundling 'external' but no value provided.
                   - Required org.gradle.jvm.version '11' but no value provided.
                   - Found org.gradle.native.architecture 'x86' but wasn't required.
                   - Found org.gradle.status 'release' but wasn't required.
               - Compatible attributes:
+                  - Required org.gradle.category 'library' and found compatible value 'library'.
                   - Required org.gradle.libraryelements 'jar' and found compatible value 'jar'.
                   - Required org.gradle.native.operatingSystem 'windows' and found compatible value 'windows'.
-                  - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.
-          - Variant 'platform-runtime' capability org.lwjgl:lwjgl-derived-platform:3.2.3:
-              - Unmatched attributes:
-                  - Found org.gradle.category 'platform' but wasn't required.
-                  - Required org.gradle.dependency.bundling 'external' but no value provided.
-                  - Required org.gradle.jvm.version '11' but no value provided.
-                  - Required org.gradle.libraryelements 'jar' but no value provided.
-                  - Required org.gradle.native.operatingSystem 'windows' but no value provided.
-                  - Found org.gradle.status 'release' but wasn't required.
-              - Compatible attribute:
                   - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
@@ -3,7 +3,7 @@ org.ow2.asm:asm:7.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
@@ -22,7 +22,7 @@ org.slf4j:slf4j-log4j12:1.6.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReportReplaced.out
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReportReplaced.out
@@ -3,7 +3,7 @@ org.slf4j:log4j-over-slf4j:1.7.10
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -24,7 +24,7 @@ org.slf4j:slf4j-log4j12:1.6.1
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
       org.gradle.libraryelements     = jar (compatible with: classes)
-      org.gradle.category            = library (not requested)
+      org.gradle.category            = library
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -32,7 +32,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
             allprojects {
                 apply plugin: 'java-library'
             }
-            
+
             dependencies {
                 api project(':producer')
             }
@@ -61,7 +61,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Incompatible attribute:
           - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Other attributes:
-          - Found org.gradle.category 'library' but wasn't required.
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
@@ -69,7 +69,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Incompatible attribute:
           - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Other attributes:
-          - Found org.gradle.category 'library' but wasn't required.
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.''')
@@ -81,7 +81,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
             // avoid test noise so that typically version 8 is not selected when running on JDK 8
             configurations.apiElements.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 1000)
             configurations.runtimeElements.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 1000)
-            
+
             [6, 7, 9].each { v ->
                 configurations {
                     "apiElementsJdk\${v}" {
@@ -154,7 +154,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Incompatible attribute:
           - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Other attributes:
-          - Found org.gradle.category 'library' but wasn't required.
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
@@ -162,7 +162,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Incompatible attribute:
           - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Other attributes:
-          - Found org.gradle.category 'library' but wasn't required.
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime'.""")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
@@ -31,11 +31,11 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
         """
         buildFile << """
             apply plugin: 'java-library'
-            
+
             repositories {
                 maven { url '${mavenHttpRepo.uri}' }
             }
-            
+
             dependencies {
                 api 'org:producer:1.0'
             }
@@ -50,31 +50,37 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
                 .variant("apiElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 6,
+                'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("apiElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 7,
+                'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("apiElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 9,
+                'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-api'], { artifact('producer-1.0-jdk9.jar') })
                 .variant("runtimeElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 6,
+                'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("runtimeElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 7,
+                'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("runtimeElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
                 'org.gradle.jvm.version': 9,
+                'org.gradle.category': 'library',
                 'org.gradle.libraryelements': 'jar',
                 'org.gradle.usage': 'java-runtime'], { artifact('producer-1.0-jdk9.jar') })
                 .publish()
@@ -98,6 +104,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Other attributes:
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
@@ -106,6 +113,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Other attributes:
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
@@ -114,6 +122,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Other attributes:
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
@@ -122,6 +131,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Other attributes:
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
@@ -130,6 +140,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Other attributes:
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
@@ -138,6 +149,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
       - Incompatible attribute:
           - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Other attributes:
+          - Required org.gradle.category 'library' and found compatible value 'library'.
           - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
           - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
           - Found org.gradle.status 'release' but wasn't required.
@@ -165,6 +177,7 @@ class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDe
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': selected,
                             'org.gradle.usage': 'java-api',
+                            'org.gradle.category': 'library',
                             'org.gradle.libraryelements': 'jar',
                             'org.gradle.status': 'release'
                     ])

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.SourceDirectorySet;
@@ -292,6 +293,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setDescription("Compile classpath for " + sourceSetName + ".");
         compileClasspathConfiguration.setCanBeConsumed(false);
         compileClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
+        compileClasspathConfiguration.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         compileClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, javaClasspathPackaging? LibraryElements.JAR : LibraryElements.CLASSES));
         compileClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         compileClasspathConfiguration.beforeLocking(configureDefaultTargetPlatform);
@@ -315,6 +317,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         runtimeClasspathConfiguration.setDescription("Runtime classpath of " + sourceSetName + ".");
         runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration, implementationConfiguration);
         runtimeClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        runtimeClasspathConfiguration.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         runtimeClasspathConfiguration.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.JAR));
         runtimeClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
         runtimeClasspathConfiguration.beforeLocking(configureDefaultTargetPlatform);


### PR DESCRIPTION
If we do not do this Gradle may attempt to match variants of other categories, like platform or documentation, if the category=library variants to not fit (in which case Gradle should fail).

No setting this was an oversight. We set `libraryelements` to a value (jar), which implies `category=library`.
