### PR TITLE
Isolate TAPI tests from the Gradle build itself

### DIFF
--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
     "latestReleaseSnapshot": {
-        "version": "6.1.1-20200124111952+0000",
-        "buildTime": "20200124111952+0000"
+        "version": "6.1.1-20200123000143+0000",
+        "buildTime": "20200123000143+0000"
     },
     "latestRc": {
         "version": "6.1-rc-3",

--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
     "latestReleaseSnapshot": {
-        "version": "6.1.1-20200123000143+0000",
-        "buildTime": "20200123000143+0000"
+        "version": "6.1.1-20200124111952+0000",
+        "buildTime": "20200124111952+0000"
     },
     "latestRc": {
         "version": "6.1-rc-3",

--- a/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderIntegrationTest.groovy
@@ -19,10 +19,19 @@ package org.gradle.testfixtures
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
+import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 
 class ProjectBuilderIntegrationTest extends AbstractIntegrationSpec {
+    @Rule SetSystemProperties systemProperties
     @Rule HttpServer server
+
+    def setup() {
+        System.setProperty("user.dir", temporaryFolder.testDirectory.absolutePath)
+        file("settings.gradle") << """
+            rootProject.name = 'test'
+        """
+    }
 
     def "can resolve remote dependencies"() {
         def repo = new MavenHttpRepository(server, mavenRepo)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -25,11 +25,11 @@ import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext
 import org.gradle.execution.ProjectExecutionServices
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.SetSystemProperties
 import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
-
 /**
  * An abstract class for writing tests using ProjectBuilder.
  * The fixture automatically takes care of deleting files creating in the temporary project directory used by the Project instance.
@@ -46,12 +46,16 @@ abstract class AbstractProjectBuilderSpec extends Specification {
     // @CleanupTestDirectory annotation.
     @Rule
     final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+
+    @Rule SetSystemProperties systemProperties
+
     ProjectInternal project
     ProjectExecutionServices executionServices
 
     def setup() {
         project = TestUtil.createRootProject(temporaryFolder.testDirectory)
         executionServices = new ProjectExecutionServices(project)
+        System.setProperty("user.dir", temporaryFolder.testDirectory.absolutePath)
     }
 
     void execute(Task task) {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.plugins.ide.internal.tooling.eclipse
 
-
 import org.gradle.api.Project
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry
 import org.gradle.api.internal.composite.CompositeBuildContext
@@ -50,6 +49,9 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
         child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
         child3 = ProjectBuilder.builder().withName("child3").withParent(project).build()
+        new File(project.projectDir, "settings.gradle") << """
+            rootProject.name = 'test'
+        """
 
         def libsDir = new File(project.projectDir, "libs")
         libsDir.mkdirs()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -259,6 +259,8 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
             .collect(Collectors.joining(" "));
         File cpJar = new File(getDefaultTmpDir(), "daemon-classpath-manifest-" + HashUtil.createCompactMD5(cpString) + ".jar");
         if (!cpJar.isFile()) {
+            // Make sure the parent exists or the jar creation might fail
+            cpJar.getParentFile().mkdirs();
             Manifest manifest = new Manifest();
             manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
             manifest.getMainAttributes().put(Attributes.Name.CLASS_PATH, cpString);

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -25,7 +25,6 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
-import org.gradle.util.TextUtil
 
 import java.lang.reflect.Proxy
 
@@ -34,22 +33,10 @@ import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.junit.Assert.assertThat
 
+
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
-    String currentWorkingDir
-
-    def setup() {
-        // we change the working directory because of a bug in 6.1.x where the verification
-        // file is fetched from the working directory instead of the project directory,
-        // which causes the verification file of Gradle itself being used to verify the build
-        // under test
-        currentWorkingDir = System.getProperty("user.dir")
-    }
-
-    def cleanup() {
-        System.setProperty("user.dir", currentWorkingDir)
-    }
 
     def "can fetch model for the scripts of a build"() {
 
@@ -64,7 +51,6 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCro
 
         and:
         assertModelMatchesBuildSpec(model, spec)
-
     }
 
     def "can fetch model for the scripts of a build in lenient mode"() {
@@ -236,13 +222,6 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCro
         def bJar = withEmptyJar("classes_b.jar")
         def precompiledJar = withEmptyJar("classes_b_precompiled.jar")
 
-        def patchBuild = ""
-        def baseVersion = targetDist.version.baseVersion.version
-        if (baseVersion in ["6.1", "6.1.1"]) {
-            // see comment on top of the test class, changing working directory
-            patchBuild = """System.setProperty("user.dir", "${TextUtil.escapeString(temporaryFolder.testDirectory.absolutePath)}")"""
-        }
-
         def some = withFile("some.gradle.kts", """
             buildscript {
                 dependencies {
@@ -256,7 +235,6 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCro
                     classpath(files("${escapeString(settingsJar)}"))
                 }
             }
-            $patchBuild
             apply(from = "some.gradle.kts")
             include("a", "b")
         """)

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/SetWorkingDirectoryAction.java
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/SetWorkingDirectoryAction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.fixture;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+
+public class SetWorkingDirectoryAction implements BuildAction {
+    private final String workingDirectory;
+
+    public SetWorkingDirectoryAction(String workingDirectory) {
+        this.workingDirectory = workingDirectory;
+    }
+
+    @Override
+    public Object execute(BuildController controller) {
+        System.setProperty("user.dir", workingDirectory);
+        return workingDirectory;
+    }
+}

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -203,11 +203,23 @@ class ToolingApi implements TestRule {
             }
         }
 
+        isolateFromGradleOwnBuild(connector)
+
         connector.useGradleUserHomeDir(new File(gradleUserHomeDir.path))
         connectorConfigurers.each {
             connector.with(it)
         }
         return connector
+    }
+
+    private void isolateFromGradleOwnBuild(DefaultGradleConnector connector) {
+        // override the `user.dir` property in order to isolate tests from the Gradle directory
+        def connection = connector.connect()
+        try {
+            connection.action(new SetWorkingDirectoryAction(testWorkDirProvider.testDirectory.absolutePath))
+        } finally {
+            connection.close()
+        }
     }
 
     boolean isUseClasspathImplementation() {
@@ -265,4 +277,5 @@ class ToolingApi implements TestRule {
             }
         }
     }
+
 }

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -94,6 +94,12 @@ abstract class ToolingApiSpecification extends Specification {
         VERSION.get()
     }
 
+    def setup() {
+        // this is to avoid the working directory to be the Gradle directory itself
+        // which causes isolation problems for tests. This one is for _embedded_ mode
+        System.setProperty("user.dir", temporaryFolder.testDirectory.absolutePath)
+    }
+
     DaemonsFixture getDaemonsFixture() {
         toolingApi.daemons
     }


### PR DESCRIPTION
### Context

See commits.
