### PR TITLE
Add more attributes to the runtime api

### DIFF
--- a/subprojects/runtime-api-info/runtime-api-info.gradle.kts
+++ b/subprojects/runtime-api-info/runtime-api-info.gradle.kts
@@ -23,14 +23,22 @@ configurations {
         isVisible = false
         isCanBeResolved = true
         isCanBeConsumed = false
-        attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attributes.attribute(Attribute.of("org.gradle.api", String::class.java), "runtime")
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
+            attribute(Attribute.of("org.gradle.api", String::class.java), "runtime")
+        }
     }
     create("testKitPackages") {
         isVisible = false
         isCanBeResolved = true
         isCanBeConsumed = false
-        attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
+        }
     }
 }
 


### PR DESCRIPTION
So that the tasks work even when the dependencies
are project dependencies brought in by a composite
build.

This allows running with native platform in a composite build.