### PR TITLE
Pass executable setting to Scala Compiler

### DIFF
--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -85,6 +85,10 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
         ScalaForkOptions scalaOptions = spec.getScalaCompileOptions().getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, scalaOptions));
         javaForkOptions.setWorkingDir(daemonWorkingDir);
+        String javaExecutable = javaOptions.getExecutable();
+        if (javaExecutable != null) {
+            javaForkOptions.setExecutable(javaExecutable);
+        }
 
         ClassPath compilerClasspath = classPathRegistry.getClassPath("SCALA-COMPILER").plus(DefaultClassPath.of(zincClasspath));
 

--- a/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DaemonScalaCompilerTest.groovy
+++ b/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DaemonScalaCompilerTest.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.scala
+
+import org.gradle.api.internal.ClassPathRegistry
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.tasks.compile.MinimalJavaCompileOptions
+import org.gradle.api.tasks.compile.BaseForkOptions
+import org.gradle.api.tasks.compile.ForkOptions
+import org.gradle.api.tasks.scala.ScalaForkOptions
+import org.gradle.initialization.ClassLoaderRegistry
+import org.gradle.internal.classloader.FilteringClassLoader
+import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.language.scala.tasks.BaseScalaCompileOptions
+import org.gradle.process.internal.JavaForkOptionsFactory
+import org.gradle.process.internal.JavaForkOptionsInternal
+import org.gradle.workers.internal.ActionExecutionSpecFactory
+import org.gradle.workers.internal.WorkerDaemonFactory
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class DaemonScalaCompilerTest extends Specification {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+    def workingDirectory = new File(".").absoluteFile
+    def delegateClass = ZincScalaCompilerFacade.class
+    def delegateParameters = [] as Object[]
+    def workerDaemonFactory = Mock(WorkerDaemonFactory)
+    ScalaJavaJointCompileSpec spec = Mock(ScalaJavaJointCompileSpec)
+    def javaCompileOptions = Mock(MinimalJavaCompileOptions)
+    def scalaCompileOptions = Mock(BaseScalaCompileOptions)
+    def javaForkOptions = Mock(ForkOptions)
+    def scalaForkOptions = Mock(ScalaForkOptions)
+    def forkOptionsFactory = new TestForkOptionsFactory(TestFiles.execFactory())
+    def classpathRegistry = Mock(ClassPathRegistry)
+    def classLoaderRegistry = Mock(ClassLoaderRegistry)
+    def actionExecutionSpecFactory = Mock(ActionExecutionSpecFactory)
+
+    def setup(){
+        _ * spec.getCompileOptions() >> javaCompileOptions
+        _ * spec.getScalaCompileOptions() >> scalaCompileOptions
+        _ * javaCompileOptions.getForkOptions() >> javaForkOptions
+        _ * scalaCompileOptions.getForkOptions() >> scalaForkOptions
+        _ * javaForkOptions.jvmArgs >> []
+        _ * scalaForkOptions.jvmArgs >> []
+        _ * classpathRegistry.getClassPath(_) >> new DefaultClassPath()
+        _ * classLoaderRegistry.gradleApiFilterSpec >> Mock(FilteringClassLoader.Spec)
+    }
+
+    def "passes compile classpath to daemon options"() {
+        given:
+        def classpath = someClasspath()
+        def compiler = new DaemonScalaCompiler(workingDirectory, delegateClass, delegateParameters, workerDaemonFactory, classpath,
+            forkOptionsFactory, classpathRegistry, classLoaderRegistry, actionExecutionSpecFactory)
+        when:
+        def daemonForkOptions = compiler.toDaemonForkOptions(spec)
+        then:
+        daemonForkOptions.getClassLoaderStructure().spec.classpath == someClasspath().collect { it.toURI().toURL() }
+    }
+
+    def "applies fork settings to daemon options"(){
+        given:
+        def compiler = new DaemonScalaCompiler(workingDirectory, delegateClass, delegateParameters, workerDaemonFactory, someClasspath(), forkOptionsFactory, classpathRegistry, classLoaderRegistry, actionExecutionSpecFactory)
+        when:
+        1 * javaForkOptions.getMemoryInitialSize() >> "256m"
+        1 * javaForkOptions.getMemoryMaximumSize() >> "512m"
+        then:
+        def daemonForkOptions = compiler.toDaemonForkOptions(spec)
+        daemonForkOptions.javaForkOptions.getMinHeapSize() == "256m"
+        daemonForkOptions.javaForkOptions.getMaxHeapSize() == "512m"
+    }
+
+    def "applies scala fork settings to daemon options"(){
+        given:
+        def compiler = new DaemonScalaCompiler(workingDirectory, delegateClass, delegateParameters, workerDaemonFactory, someClasspath(), forkOptionsFactory, classpathRegistry, classLoaderRegistry, actionExecutionSpecFactory)
+        when:
+        1 * scalaForkOptions.getMemoryInitialSize() >> "256m"
+        1 * scalaForkOptions.getMemoryMaximumSize() >> "512m"
+        then:
+        def daemonForkOptions = compiler.toDaemonForkOptions(spec)
+        daemonForkOptions.javaForkOptions.getMinHeapSize() == "256m"
+        daemonForkOptions.javaForkOptions.getMaxHeapSize() == "512m"
+    }
+
+    def "sets executable on daemon options"(){
+        given:
+        def compiler = new DaemonScalaCompiler(workingDirectory, delegateClass, delegateParameters, workerDaemonFactory, someClasspath(), forkOptionsFactory, classpathRegistry, classLoaderRegistry, actionExecutionSpecFactory)
+        when:
+        1 * javaForkOptions.getExecutable() >> "custom/java"
+        then:
+        def daemonForkOptions = compiler.toDaemonForkOptions(spec)
+        daemonForkOptions.javaForkOptions.getExecutable() == "custom/java"
+    }
+
+    def someClasspath() {
+        [new File("foo"), new File("bar")]
+    }
+
+    class TestForkOptionsFactory implements JavaForkOptionsFactory {
+        private final JavaForkOptionsFactory delegate
+
+        TestForkOptionsFactory(JavaForkOptionsFactory delegate) {
+            this.delegate = delegate
+        }
+
+        @Override
+        JavaForkOptionsInternal newDecoratedJavaForkOptions() {
+            return newJavaForkOptions()
+        }
+
+        @Override
+        JavaForkOptionsInternal newJavaForkOptions() {
+            def forkOptions = delegate.newJavaForkOptions()
+            forkOptions.setWorkingDir(temporaryFolder.root)
+            return forkOptions
+        }
+
+        @Override
+        JavaForkOptionsInternal immutableCopy(JavaForkOptionsInternal options) {
+            return delegate.immutableCopy(options)
+        }
+    }
+}

--- a/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DaemonScalaCompilerTest.groovy
+++ b/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DaemonScalaCompilerTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.scala
 import org.gradle.api.internal.ClassPathRegistry
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.tasks.compile.MinimalJavaCompileOptions
-import org.gradle.api.tasks.compile.BaseForkOptions
 import org.gradle.api.tasks.compile.ForkOptions
 import org.gradle.api.tasks.scala.ScalaForkOptions
 import org.gradle.initialization.ClassLoaderRegistry

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCrossCompilationIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCrossCompilationIntegrationTest.groovy
@@ -27,7 +27,7 @@ import org.junit.Assume
 
 import static org.gradle.util.TestPrecondition.SUPPORTS_TARGETING_JAVA6
 
-@TargetVersions(["1.6", "1.7", "1.8"])
+@TargetVersions(["1.6", "1.7", "1.8", "9", "10", "11"])
 class ScalaCrossCompilationIntegrationTest extends MultiVersionIntegrationSpec {
     JavaVersion getJavaVersion() {
         JavaVersion.toVersion(MultiVersionIntegrationSpec.version)

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -28,7 +28,9 @@ import org.junit.Assume
 import org.junit.Rule
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
+import static org.gradle.util.TextUtil.escapeString
 import static org.gradle.util.TextUtil.normaliseFileSeparators
+import static org.hamcrest.core.IsNull.notNullValue
 
 @TargetCoverage({ScalaCoverage.DEFAULT})
 class ZincScalaCompilerIntegrationTest extends MultiVersionIntegrationSpec {
@@ -145,10 +147,10 @@ compileScala.scalaCompileOptions.failOnError = false
     }
 
     def "respects fork options settings and executable"() {
-        def differentJvm = AvailableJavaHomes.differentJdkWithValidJre
-        Assume.assumeNotNull(differentJvm)
+        def differentJvm = AvailableJavaHomes.differentJdk
+        Assume.assumeThat(differentJvm, notNullValue())
         def differentJavaExecutablePath = normaliseFileSeparators(differentJvm.javaExecutable.absolutePath)
-        def differentJavaExecutableCanonicalPath = normaliseFileSeparators(differentJvm.javaExecutable.canonicalPath)
+        def differentJavaExecutableCanonicalPath = escapeString(differentJvm.javaExecutable.canonicalPath)
 
         file("build.gradle") << """
             import org.gradle.workers.internal.WorkerDaemonClientsManager


### PR DESCRIPTION
JDK8 is the only supported java runtime to execute some versions of the
scala compiler on, which means that any gradle project using a newer
JDK version cannot compile scala code for older versions of scala
unless the executable for the scala compile task is respected.

This PR copies the executable setting from the java fork options on the
scala compile specification to the fork options used to launch the
compile daemon process.

Signed-off-by: James Baiera <james.baiera@gmail.com>

<!--- The issue this PR addresses -->
Fixes #10685

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
