### PR TITLE
Better Test Parallelization By Duration-Based Sorting

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RunSortedBySizeTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RunSortedBySizeTestClassProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.processors;
+
+import org.gradle.api.internal.tasks.testing.TestClassProcessor;
+import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
+import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This processor uses test class duration information to resort test classes by
+ * duration in descending order before passing them on for processing.
+ *
+ * Tests processed without duration information are at the end behind known classes.
+ * If no durations at all are known beforehand, this will not change the test order.
+ */
+public class RunSortedBySizeTestClassProcessor implements TestClassProcessor {
+    private final TestClassProcessor delegate;
+    private final Map<String, Long> durationByTestClassName;
+
+    private final List<TestClassRunInfo> knownTestClasses = new ArrayList<TestClassRunInfo>();
+    private final List<TestClassRunInfo> unknownTestClasses = new ArrayList<TestClassRunInfo>();
+
+    public RunSortedBySizeTestClassProcessor(Map<String, Long> durationByTestClassName, TestClassProcessor delegate) {
+        this.durationByTestClassName = durationByTestClassName;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void startProcessing(TestResultProcessor resultProcessor) {
+        delegate.startProcessing(resultProcessor);
+    }
+
+    @Override
+    public void processTestClass(TestClassRunInfo testClass) {
+        if (durationByTestClassName.containsKey(testClass.getTestClassName())) {
+            knownTestClasses.add(testClass);
+        } else {
+            unknownTestClasses.add(testClass);
+        }
+    }
+
+    @Override
+    public void stop() {
+        // sort and process known classes first
+        Collections.sort(knownTestClasses, new Comparator<TestClassRunInfo>() {
+            @Override
+            public int compare(TestClassRunInfo t1, TestClassRunInfo t2) {
+                // Reverse the argument order for descending sort order:
+                return durationByTestClassName.get(t2.getTestClassName())
+                    .compareTo(durationByTestClassName.get(t1.getTestClassName()));
+            }
+        });
+        for (TestClassRunInfo testClassRunInfo : knownTestClasses) {
+            delegate.processTestClass(testClassRunInfo);
+        }
+        for (TestClassRunInfo testClassRunInfo : unknownTestClasses) {
+            delegate.processTestClass(testClassRunInfo);
+        }
+        delegate.stop();
+    }
+
+    @Override
+    public void stopNow() {
+        delegate.stopNow();
+    }
+}

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/RunSortedBySizeTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/RunSortedBySizeTestClassProcessorTest.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.processors
+
+import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo
+import org.gradle.api.internal.tasks.testing.TestClassProcessor
+import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import spock.lang.Specification
+
+class RunSortedBySizeTestClassProcessorTest extends Specification {
+    TestClassProcessor delegate = Mock()
+    TestResultProcessor testResultProcessor = Mock()
+    RunSortedBySizeTestClassProcessor processor
+
+    def 'test classes should be processed by size'() {
+        given:
+        processor = new RunSortedBySizeTestClassProcessor(['Class3': 2L, 'Class2': 8L, 'Class1': 12L ] as Map, delegate)
+
+        when:
+        processor.startProcessing(testResultProcessor)
+        ['Class3', 'Class2', 'Class1'].each { processor.processTestClass(new DefaultTestClassRunInfo(it)) }
+        processor.stop()
+
+        then:
+        1 * delegate.startProcessing(testResultProcessor)
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class1'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class2'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class3'))
+        then:
+        1 * delegate.stop()
+    }
+
+    def 'test classes of same size should be processed by incoming'() {
+        given:
+        processor = new RunSortedBySizeTestClassProcessor(['Class3': 2L, 'Class2': 2L, 'Class1': 12L ] as Map, delegate)
+
+        when:
+        processor.startProcessing(testResultProcessor)
+        ['Class3', 'Class2', 'Class1'].each { processor.processTestClass(new DefaultTestClassRunInfo(it)) }
+        processor.stop()
+
+        then:
+        1 * delegate.startProcessing(testResultProcessor)
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class1'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class3'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class2'))
+        then:
+        1 * delegate.stop()
+    }
+
+    def 'test classes without size information should be added at the end'() {
+        given:
+        processor = new RunSortedBySizeTestClassProcessor(['Class1': 8L, 'Class2': 2L ] as Map, delegate)
+
+        when:
+        processor.startProcessing(testResultProcessor)
+        ['ClassWithoutSize1', 'Class2', 'ClassWithoutSize2','Class1'].each { processor.processTestClass(new DefaultTestClassRunInfo(it)) }
+        processor.stop()
+
+        then:
+        1 * delegate.startProcessing(testResultProcessor)
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class1'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class2'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('ClassWithoutSize1'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('ClassWithoutSize2'))
+        then:
+        1 * delegate.stop()
+    }
+
+    def 'processing order should not change without size information'() {
+        given:
+        processor = new RunSortedBySizeTestClassProcessor([:] as Map, delegate)
+
+        when:
+        processor.startProcessing(testResultProcessor)
+        ['Class1', 'Class2', 'Class3', 'Class4'].each { processor.processTestClass(new DefaultTestClassRunInfo(it)) }
+        processor.stop()
+
+        then:
+        1 * delegate.startProcessing(testResultProcessor)
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class1'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class2'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class3'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class4'))
+        then:
+        1 * delegate.stop()
+    }
+}

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/UniqueTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/UniqueTestClassProcessorTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.processors
+
+import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo
+import org.gradle.api.internal.tasks.testing.TestClassProcessor
+import org.gradle.api.internal.tasks.testing.TestResultProcessor
+import spock.lang.Specification
+
+class UniqueTestClassProcessorTest extends Specification {
+    TestClassProcessor delegate = Mock()
+    TestResultProcessor testResultProcessor = Mock()
+    UniqueTestClassProcessor processor
+
+    def 'of duplicate test classes only the first should be processed'() {
+        given:
+        processor = new UniqueTestClassProcessor(delegate)
+
+        when:
+        processor.startProcessing(testResultProcessor)
+        ['Class1', 'Class2', 'Class1', 'Class3'].each { processor.processTestClass(new DefaultTestClassRunInfo(it)) }
+        processor.stop()
+
+        then:
+        1 * delegate.startProcessing(testResultProcessor)
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class1'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class2'))
+        then:
+        1 * delegate.processTestClass(new DefaultTestClassRunInfo('Class3'))
+        then:
+        1 * delegate.stop()
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/RunTestsSortedByDurationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/RunTestsSortedByDurationIntegrationTest.groovy
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.junit
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.hamcrest.CoreMatchers
+import spock.lang.Unroll
+
+import static groovy.util.GroovyCollections.combinations
+
+class RunTestsSortedByDurationIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final Map<Integer, Integer> TESTS_WITH_DURATION = [1: 10, 2: 20, 3: 40, 4: 60]
+    private static final String FAILING_TESTS_PROPERTY = "failing.tests.indices"
+    private static final List<List<Integer>> FAILING_TESTS_INDICES = combinations(TESTS_WITH_DURATION.keySet(), TESTS_WITH_DURATION.keySet()).findAll { i, j -> j > i }
+
+    def setup() {
+        buildFile << """
+            apply plugin: 'java'
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                testImplementation 'junit:junit:4.12'
+            }
+        """
+
+        TESTS_WITH_DURATION.each { testIndex, duration ->
+            testFile(testIndex) << """
+                import org.junit.Test;
+                import java.util.Arrays;
+                public class ${testClassName(testIndex)} {
+                    @Test
+                    public void takingTimeTest() throws Exception {
+                        System.out.println("Test index " + ${testIndex});
+                        Thread.sleep(${duration});
+                        String indices = System.getProperty("${FAILING_TESTS_PROPERTY}");
+                        if(indices != null && Arrays.asList(indices.split(",")).contains("${testIndex}")) {
+                            throw new RuntimeException();
+                        }
+                    }
+                }
+            """.stripIndent()
+        }
+    }
+
+    @Unroll
+    def 'subsequent execution runs succeeding tests by duration, then unknown test #unknownTestIndex'() {
+
+        when:
+        testFile(unknownTestIndex).delete()
+        succeeds('test')
+
+        then:
+        def knownTestIndices = TESTS_WITH_DURATION.keySet() - unknownTestIndex
+        testsSucceed(knownTestIndices)
+
+        when:
+        TESTS_WITH_DURATION.keySet().each {
+            testFile(it).text = """
+                import org.junit.Test;
+                public class ${testClassName(it)} {
+                    @Test
+                    public void takingTimeTest() {
+                        System.out.println("Test index " + ${it});
+                    }
+                }
+            """.stripIndent()
+        }
+        succeeds('test', '--info')
+
+        then:
+        testsAreRunInOrder(sortedByDuration(knownTestIndices) + unknownTestIndex)
+
+        where:
+        unknownTestIndex << TESTS_WITH_DURATION.keySet()
+    }
+
+
+    @Unroll
+    def 'subsequent execution runs failing tests #failingTestsIndices by duration, then succeeding test '() {
+
+        given:
+        letTestsFail(failingTestsIndices)
+
+        when:
+        fails('test')
+
+        then:
+        testFailed(failingTestsIndices)
+
+        when:
+        TESTS_WITH_DURATION.keySet().each {
+            testFile(it).text = """
+                import org.junit.Test;
+                public class ${testClassName(it)} {
+                    @Test
+                    public void takingTimeTest() {
+                        System.out.println("Test index " + ${it});
+                    }
+                }
+            """.stripIndent()
+        }
+        succeeds('test', '--info')
+
+        then:
+        def succeedingTestIndices = TESTS_WITH_DURATION.keySet() - failingTestsIndices
+        testsAreRunInOrder(sortedByDuration(failingTestsIndices) + sortedByDuration(succeedingTestIndices))
+
+        where:
+        failingTestsIndices << FAILING_TESTS_INDICES
+    }
+
+    def sortedByDuration(testIndices) {
+        testIndices.sort(false, { -TESTS_WITH_DURATION.get(it) })
+    }
+
+    def letTestsFail(indices) {
+        buildFile << """
+        test {
+            systemProperty('${FAILING_TESTS_PROPERTY}', '${indices.join(",")}')
+        }
+        """
+    }
+
+    void testsAreRunInOrder(List<Integer> testIndices) {
+        List<String> lines = output.readLines()
+        int nextIndex = 0
+        for (String line in lines) {
+            if (nextIndex < testIndices.size && line.contains("Test index ${testIndices[nextIndex]}")) {
+                nextIndex++
+            } else if (line.contains("Test index")) {
+                assert false: "Got ${line.strip()}, expected ${testIndices[nextIndex]}"
+            }
+        }
+
+        assert nextIndex == testIndices.size
+    }
+
+    void testsSucceed(Set<Integer> testIndices) {
+        new DefaultTestExecutionResult(testDirectory).assertTestClassesExecuted(testIndices.collect { testClassName(it) } as String[])
+    }
+
+    void testFailed(indices) {
+        indices.each {
+            new DefaultTestExecutionResult(testDirectory)
+                .testClass("${testClassName(it)}").assertTestFailed('takingTimeTest', CoreMatchers.anything())
+        }
+    }
+
+    File testFile(int testIndex) {
+        file("src/test/java/${testClassName(testIndex)}.java")
+    }
+
+    String testClassName(int testIndex) {
+        "TestWithDuration_${testIndex}"
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -24,6 +24,7 @@ import org.gradle.util.Path;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 @UsedByScanPlugin("test-distribution")
@@ -40,15 +41,16 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final JavaForkOptions javaForkOptions;
     private final int maxParallelForks;
     private final Set<String> previousFailedTestClasses;
+    private final Map<String, Long> previousTestClassDurations;
 
     /**
      * Required by test-retry-gradle-plugin <= 1.1.3
      */
     public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
-        this(testFramework, classpath, Collections.<File>emptyList(), candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses);
+        this(testFramework, classpath, Collections.<File>emptyList(), candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses, Collections.<String, Long>emptyMap());
     }
 
-    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
+    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses, Map<String, Long> previousTestClassDurations) {
         this.testFramework = testFramework;
         this.classpath = classpath;
         this.modulePath = modulePath;
@@ -61,6 +63,7 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         this.javaForkOptions = javaForkOptions;
         this.maxParallelForks = maxParallelForks;
         this.previousFailedTestClasses = previousFailedTestClasses;
+        this.previousTestClassDurations = previousTestClassDurations;
     }
 
     public TestFramework getTestFramework() {
@@ -116,5 +119,9 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
 
     public Set<String> getPreviousFailedTestClasses() {
         return previousFailedTestClasses;
+    }
+
+    public Map<String, Long> getPreviousTestClassDurations() {
+        return previousTestClassDurations;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -31,7 +31,9 @@ import org.gradle.api.internal.tasks.testing.processors.MaxNParallelTestClassPro
 import org.gradle.api.internal.tasks.testing.processors.PatternMatchTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.processors.RestartEveryNTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.processors.RunPreviousFailedFirstTestClassProcessor;
+import org.gradle.api.internal.tasks.testing.processors.RunSortedBySizeTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.processors.TestMainAction;
+import org.gradle.api.internal.tasks.testing.processors.UniqueTestClassProcessor;
 import org.gradle.api.internal.tasks.testing.worker.ForkingTestClassProcessor;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -100,9 +102,11 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
             }
         };
         processor =
-            new PatternMatchTestClassProcessor(testFilter,
-                new RunPreviousFailedFirstTestClassProcessor(testExecutionSpec.getPreviousFailedTestClasses(),
-                    new MaxNParallelTestClassProcessor(getMaxParallelForks(testExecutionSpec), reforkingProcessorFactory, actorFactory)));
+            new UniqueTestClassProcessor(
+                new PatternMatchTestClassProcessor(testFilter,
+                    new RunSortedBySizeTestClassProcessor(testExecutionSpec.getPreviousTestClassDurations(),
+                        new RunPreviousFailedFirstTestClassProcessor(testExecutionSpec.getPreviousFailedTestClasses(),
+                            new MaxNParallelTestClassProcessor(getMaxParallelForks(testExecutionSpec), reforkingProcessorFactory, actorFactory)))));
 
         final FileTree testClassFiles = testExecutionSpec.getCandidateClassFiles();
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -86,7 +86,7 @@ import org.gradle.util.ConfigureUtil;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -641,7 +641,12 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         boolean testIsModule = javaModuleDetector.isModule(modularity.getInferModulePath().get(), getTestClassesDirs());
         FileCollection classpath = javaModuleDetector.inferClasspath(testIsModule, stableClasspath);
         FileCollection modulePath = javaModuleDetector.inferModulePath(testIsModule, stableClasspath);
-        return new JvmTestExecutionSpec(getTestFramework(), classpath, modulePath, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses());
+
+        Set<String> previousFailedTestClasses = new HashSet<String>();
+        Map<String, Long> previousTestClassDurations = new HashMap<String, Long>();
+        initializePreviousTestClassInformation(previousFailedTestClasses, previousTestClassDurations);
+
+        return new JvmTestExecutionSpec(getTestFramework(), classpath, modulePath, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), previousFailedTestClasses, previousTestClassDurations);
     }
 
     private void validateToolchainConfiguration() {
@@ -650,22 +655,24 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         }
     }
 
-    private Set<String> getPreviousFailedTestClasses() {
+    /**
+     * Fills the argument collections with information about previous test runs.
+     */
+    private void initializePreviousTestClassInformation(final Set<String> previousFailedTestClasses, final Map<String, Long> previousTestClassDurations) {
         TestResultSerializer serializer = new TestResultSerializer(getBinResultsDir());
-        if (serializer.isHasResults()) {
-            final Set<String> previousFailedTestClasses = new HashSet<String>();
-            serializer.read(new Action<TestClassResult>() {
-                @Override
-                public void execute(TestClassResult testClassResult) {
-                    if (testClassResult.getFailuresCount() > 0) {
-                        previousFailedTestClasses.add(testClassResult.getClassName());
-                    }
-                }
-            });
-            return previousFailedTestClasses;
-        } else {
-            return Collections.emptySet();
+        if (!serializer.isHasResults()) {
+            return;
         }
+
+        serializer.read(new Action<TestClassResult>() {
+            @Override
+            public void execute(TestClassResult testClassResult) {
+                if (testClassResult.getFailuresCount() > 0) {
+                    previousFailedTestClasses.add(testClassResult.getClassName());
+                }
+                previousTestClassDurations.put(testClassResult.getClassName(), testClassResult.getDuration());
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #2669 for one class of scenarios.

### Context
<!--- Why do you believe many users will benefit from this change? -->
On the issue discussion page, a number of people have asked for an improvement in the parallel test scheduling, and even others who are not aware of it might be positively affected through shorter execution times.

The fix proposed here is to collect the test class runtime information from the previous test execution, and execute the tests sorted by duration, from longest to shortest. The actual change is small and seems to carry little danger (or even none?), and the central part of it (sorting test classes by size before allocation) has been proposed by the Gradle team themselves in the linked issue  #2669. I have combined it with a small (but noticeable) improvement of the vanilla round robin scheduling. 

This change should have no impact when there is no size information available. Tests without known size information are run before tests sorted by duration; the rationale is that these are potentially "new" and hence more interesting tests.

As before, previously failing tests would still be run first.

The main scenario in which the sorting will be beneficial is one where duration information is available for most or many of the tests, e.g., reruns of test suites on not-swept workspaces. In an interactive setting, where you might be running `gradle test --tests xyz`, this will be of limited use. (But again, do no harm as compared to current behaviour.)

<!--- Link to relevant issues or forum discussions here -->
I have briefly examined the statistics of the current scheduling and the proposed improvement in a Juypter notebook: https://github.com/hansi-b/Long-Poles/blob/master/LongPoleTests.ipynb

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
  - Added integration test to demonstrate/ensure ordering of tests.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing 
  - Updated related javadocs.
  - Unsure if this should be documented explicitly, e.g., in `src/docs/userguide/jvm/java_testing.adoc`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
