### PR TITLE
Remove @ToBeFixedForInstantExecution from a passing test

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/GradleBuildScriptExecutionFromSubDirIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/GradleBuildScriptExecutionFromSubDirIntegTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class GradleBuildScriptExecutionFromSubDirIntegTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "shouldn't create a gradle directory within the invocation directory"() {
         buildFile << """
             tasks.register("checkDir") {


### PR DESCRIPTION
`GradleBuildScriptExecutionFromSubDirIntegTest` looks to be passing consistently with instant execution enabled.