### PR TITLE
Add documentation for discontinued methods since 6.0.0

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -306,7 +306,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     public StartParameter useEmptySettings() {
         DeprecationLogger.deprecateMethod(StartParameter.class, "useEmptySettings()")
-            .undocumented()
+            .withUpgradeGuideSection(6, "discontinued_methods")
             .nagUser();
         doUseEmptySettings();
         return this;
@@ -325,7 +325,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     public boolean isUseEmptySettings() {
         DeprecationLogger.deprecateMethod(StartParameter.class, "isUseEmptySettings()")
-            .undocumented()
+            .withUpgradeGuideSection(6, "discontinued_methods")
             .nagUser();
         return useEmptySettings;
     }

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -64,10 +64,12 @@ println("thread pool size = " + consumer.threadPoolSize.get())
 Querying the value of `consumer.threadPoolSize` will produce a deprecation warning if done prior to `producer` completing, as the output file has not yet been generated.
 
 ==== Discontinued methods
-The following methods have been discontinued and should no longer be used. Using them will fail with an error in Gradle 7.0.
+The following methods have been discontinued and should no longer be used. They will be removed in Gradle 7.0.
 
 - `BasePluginConvention.setProject(ProjectInternal)`
 - `BasePluginConvention.getProject()`
+- `StartParameter.useEmptySettings()`
+- `StartParameter.isUseEmptySettings()`
 
 [[upgrading_jvm_plugins]]
 ==== Alternative JVM plugins (a.k.a "Software Model")

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -63,6 +63,12 @@ println("thread pool size = " + consumer.threadPoolSize.get())
 
 Querying the value of `consumer.threadPoolSize` will produce a deprecation warning if done prior to `producer` completing, as the output file has not yet been generated.
 
+==== Discontinued methods
+The following methods have been discontinued and should no longer be used. Using them will fail with an error in Gradle 7.0.
+
+- `BasePluginConvention.setProject(ProjectInternal)`
+- `BasePluginConvention.getProject()`
+
 [[upgrading_jvm_plugins]]
 ==== Alternative JVM plugins (a.k.a "Software Model")
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
@@ -84,13 +84,17 @@ public class DefaultBasePluginConvention extends BasePluginConvention implements
 
     @Override
     public ProjectInternal getProject() {
-        DeprecationLogger.deprecateMethod(BasePluginConvention.class, "getProject()").undocumented().nagUser();
+        DeprecationLogger.deprecateMethod(BasePluginConvention.class, "getProject()")
+            .withUpgradeGuideSection(6, "discontinued_methods")
+            .nagUser();
         return project;
     }
 
     @Override
     public void setProject(ProjectInternal project) {
-        DeprecationLogger.deprecateMethod(BasePluginConvention.class, "setProject()").undocumented().nagUser();
+        DeprecationLogger.deprecateMethod(BasePluginConvention.class, "setProject()")
+            .withUpgradeGuideSection(6, "discontinued_methods")
+            .nagUser();
         this.project = project;
     }
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/11828

Add documentation for discontinued methods in `DefaultBasePluginConvention` and `StartParameter`.