### PR TITLE
Fix issue with capability and virtual platforms

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -61,9 +61,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
             ModuleIdentifier rootId = null;
             final List<NodeState> candidatesForConflict = Lists.newArrayListWithCapacity(nodes.size());
             for (NodeState ns : nodes) {
-                // TODO: CC the special casing of virtual platform should go away if we can implement
-                // disambiguation of variants for a _single_ component
-                if (ns.isSelected() && !ns.isAttachedToVirtualPlatform()) {
+                if (ns.isSelected()) {
                     candidatesForConflict.add(ns);
                     if (ns.isRoot()) {
                         rootId = ns.getComponent().getId().getModule();


### PR DESCRIPTION
As the engine now properly supports disambiguating variants of the same
module, it is no longer needed to ignore virtual platform references
when dealing with capabilities conflicts.
