### PR TITLE
Restore dropped coverage for instant execution on Santa Tracker

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.scan.config.fixtures.GradleEnterprisePluginSettingsFi
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.internal.ToolingApiGradleExecutor
 import org.junit.Rule
@@ -49,7 +50,15 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
     }
 
     protected BuildResult buildLocation(File projectDir, String agpVersion) {
-        def runner = runner("assembleDebug", "-DagpVersion=$agpVersion")
+        return runnerForLocation(projectDir, agpVersion, "assembleDebug").build()
+    }
+
+    protected BuildResult cleanLocation(File projectDir, String agpVersion) {
+        return runnerForLocation(projectDir, agpVersion, "clean").build()
+    }
+
+    private GradleRunner runnerForLocation(File projectDir, String agpVersion, String... tasks) {
+        def runner = runner(*[["-DagpVersion=$agpVersion"], tasks].flatten())
             .withProjectDir(projectDir)
             .withTestKitDir(homeDir)
             .forwardOutput()
@@ -57,7 +66,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
             def init = AGP_VERSIONS.createAgpNightlyRepositoryInitScript()
             runner.withArguments([runner.arguments, ['-I', init.canonicalPath]].flatten())
         }
-        runner.build()
+        return runner
     }
 
     protected static boolean verify(BuildResult result, Map<String, TaskOutcome> outcomes) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerJavaCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerJavaCachingSmokeTest.groovy
@@ -43,13 +43,19 @@ class AndroidSantaTrackerJavaCachingSmokeTest extends AbstractAndroidSantaTracke
         setupCopyOfSantaTracker(originalDir, 'Java', agpVersion)
         setupCopyOfSantaTracker(relocatedDir, 'Java', agpVersion)
 
-        when:
+        when: 'clean build'
         buildLocation(originalDir, agpVersion)
 
         then:
         assertInstantExecutionStateStored()
 
-        when:
+        when: 'up-to-date build, reusing instant execution cache when enabled'
+        buildLocation(originalDir, agpVersion)
+
+        then:
+        assertInstantExecutionStateLoaded()
+
+        when: 'clean cached build'
         BuildResult relocatedResult = buildLocation(relocatedDir, agpVersion)
 
         then:
@@ -60,6 +66,13 @@ class AndroidSantaTrackerJavaCachingSmokeTest extends AbstractAndroidSantaTracke
             ? EXPECTED_RESULTS_3_6
             : EXPECTED_RESULTS
         verify(relocatedResult, expectedResults)
+
+        when: 'clean cached build, reusing instant execution cache when enabled'
+        cleanLocation(relocatedDir, agpVersion)
+        buildLocation(relocatedDir, agpVersion)
+
+        then:
+        assertInstantExecutionStateLoaded()
 
         where:
         agpVersion << TESTED_AGP_VERSIONS

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerKotlinCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerKotlinCachingSmokeTest.groovy
@@ -43,13 +43,19 @@ class AndroidSantaTrackerKotlinCachingSmokeTest extends AbstractAndroidSantaTrac
         setupCopyOfSantaTracker(originalDir, 'Kotlin', agpVersion)
         setupCopyOfSantaTracker(relocatedDir, 'Kotlin', agpVersion)
 
-        when:
+        when: 'clean build'
         buildLocation(originalDir, agpVersion)
 
         then:
         assertInstantExecutionStateStored()
 
-        when:
+        when: 'up-to-date build, reusing instant execution cache when enabled'
+        buildLocation(originalDir, agpVersion)
+
+        then:
+        assertInstantExecutionStateLoaded()
+
+        when: 'clean cached build'
         BuildResult relocatedResult = buildLocation(relocatedDir, agpVersion)
 
         then:
@@ -60,6 +66,13 @@ class AndroidSantaTrackerKotlinCachingSmokeTest extends AbstractAndroidSantaTrac
             ? EXPECTED_RESULTS_3_6
             : EXPECTED_RESULTS
         verify(relocatedResult, expectedResults)
+
+        when: 'clean cached build, reusing instant execution cache when enabled'
+        cleanLocation(relocatedDir, agpVersion)
+        buildLocation(relocatedDir, agpVersion)
+
+        then:
+        assertInstantExecutionStateLoaded()
 
         where:
         agpVersion << TESTED_AGP_VERSIONS


### PR DESCRIPTION
Java & Kotlin
up-to-date builds
clean builds

This is a follow up to https://github.com/gradle/gradle/pull/11951