### PR TITLE
Some fixes to allow a clean build of `binZip` with instant execution enabled

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
@@ -121,7 +121,7 @@ fun Project.registerBuildReceiptTask(
             this.baseVersion.set(baseVersion)
             this.isSnapshot.set(isSnapshot)
             this.buildTimestampFrom(buildTimestamp)
-            this.commitId.set(determineCommitId.flatMap { it.determinedCommitId })
+            this.commitId.set(determineCommitId.get().determinedCommitId)
             this.destinationDir = rootProject.buildDir
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1252,13 +1252,12 @@ task generate(type: TransformerTask) {
     }
 
     @Issue('https://github.com/gradle/gradle/issues/1224')
-    @ToBeFixedForInstantExecution
     def 'can change input properties dynamically'() {
         given:
         file('inputDir1').createDir()
         file('inputDir2').createDir()
         buildFile << '''
-    class MyTask extends DefaultTask{
+    class MyTask extends DefaultTask {
         @TaskAction
         void processFiles(IncrementalTaskInputs inputs) {
             inputs.outOfDate { }

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -15,6 +15,7 @@ tasks {
 
 dependencies {
     implementation(project(":baseServices"))
+    implementation(project(":baseServicesGroovy"))
     implementation(project(":messaging"))
     implementation(project(":logging"))
     implementation(project(":coreApi"))

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionParallelTaskExecutionIntegrationTest.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+import spock.lang.IgnoreIf
+
+class InstantExecutionParallelTaskExecutionIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+
+    // Don't run in parallel mode, as the expectation for the setup build are incorrect and running in parallel
+    // does not really make any difference to the coverage
+    @IgnoreIf({ GradleContextualExecuter.parallel})
+    def "runs tasks in different projects in parallel by default"() {
+        server.start()
+
+        given:
+        settingsFile << """
+            include 'a', 'b', 'c'
+        """
+        buildFile << """
+            class SlowTask extends DefaultTask {
+                @TaskAction
+                def go() {
+                    ${server.callFromBuildUsingExpression("project.name")}
+                }
+            }
+
+            subprojects {
+                tasks.create('slow', SlowTask)
+            }
+            project(':a') {
+                tasks.slow.dependsOn(project(':b').tasks.slow, project(':c').tasks.slow)
+            }
+        """
+
+        when:
+        server.expectConcurrent("b")
+        server.expectConcurrent("c")
+        server.expectConcurrent("a")
+        instantRun "a:slow"
+
+        then:
+        noExceptionThrown()
+
+        when:
+        server.expectConcurrent("b", "c")
+        server.expectConcurrent("a")
+        instantRun "a:slow"
+
+        then:
+        noExceptionThrown()
+    }
+
+    // Don't run in parallel mode, as the expectation for the setup build are incorrect
+    // It could potentially be worth running this in parallel mode to demonstrate the difference between
+    // parallel and instant execution
+    @IgnoreIf({ GradleContextualExecuter.parallel})
+    def "runs tasks in same project in parallel by default"() {
+        server.start()
+
+        given:
+        buildFile << """
+            class SlowTask extends DefaultTask {
+                @TaskAction
+                def go() {
+                    ${server.callFromBuildUsingExpression("name")}
+                }
+            }
+            tasks.create('b', SlowTask)
+            tasks.create('c', SlowTask)
+            tasks.create('a', SlowTask) {
+                dependsOn('b', 'c')
+            }
+        """
+
+        when:
+        // TODO - should run from the IE cache in this initial build as well, so tasks can run in parallel
+        server.expectConcurrent("b")
+        server.expectConcurrent("c")
+        server.expectConcurrent("a")
+        instantRun "a"
+
+        then:
+        noExceptionThrown()
+
+        when:
+        server.expectConcurrent("b", "c")
+        server.expectConcurrent("a")
+        instantRun "a"
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleVerboseRenderingFunctionalTest.groovy
@@ -16,13 +16,12 @@
 
 package org.gradle.internal.logging.console.taskgrouping
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
 abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractConsoleVerboseBasicFunctionalTest {
 
-    @ToBeFixedForInstantExecution
     def 'up-to-date task result can be rendered'() {
         given:
         buildFile << '''
@@ -55,7 +54,7 @@ abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractCon
         """
         buildFile << """
             task allTasks
-            
+
             12.times { i ->
                 project(":project\${i}") {
                     task "slowTask\${i}" {
@@ -63,7 +62,7 @@ abstract class AbstractConsoleVerboseRenderingFunctionalTest extends AbstractCon
                             sleep 2000 + (1000*(i%2))
                         }
                     }
-                    
+
                     rootProject.allTasks.dependsOn ":project\${i}:slowTask\${i}"
                 }
             }


### PR DESCRIPTION

### Context

This PR contains a minor fix for serialization of task state to the instant execution cache, and some workarounds for issues (https://github.com/gradle/instant-execution/issues/184 and https://github.com/gradle/instant-execution/issues/183).

The result is that `gradle binZip` now works when run after `gradle clean` when instant execution is enabled.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
