### PR TITLE
Ignore dev builds of native platform for dependency verification

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -9,7 +9,7 @@
          <trust group="gradle" name="gradle"/>
          <!-- TAPI tests use a lot of different versions of the Tooling API -->
          <trust group="org.gradle" name="gradle-tooling-api"/>
-         <trust group="net[.]rubygrapefruit" name="native-platform.*" version=".*snapshot.*" regex="true"/>
+         <trust group="net[.]rubygrapefruit" name="native-platform.*" version=".*(-snapshot-.*|-dev)" regex="true"/>
          <trust file=".*-javadoc[.]jar" regex="true"/>
          <trust file=".*-sources[.]jar" regex="true"/>
       </trusted-artifacts>


### PR DESCRIPTION
So it is easier to test local changes.