### PR TITLE
Polishing shared readonly dependency cache

### DIFF
--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/TwoStageModuleMetadataCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/TwoStageModuleMetadataCacheTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.modulecache
+
+import org.gradle.util.BuildCommencedTimeProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TwoStageModuleMetadataCacheTest extends Specification {
+    def timeProvider = Stub(BuildCommencedTimeProvider)
+    def readCache = Mock(AbstractModuleMetadataCache)
+    def writeCache = Mock(AbstractModuleMetadataCache)
+    def key = Stub(ModuleComponentAtRepositoryKey)
+    def entry = Stub(ModuleMetadataCacheEntry)
+    def metadata = Stub(ModuleMetadataCache.CachedMetadata)
+
+    @Subject
+    def twoStageCache = new TwoStageModuleMetadataCache(timeProvider, readCache, writeCache)
+
+    def "storing delegates to write cache"() {
+        when:
+        twoStageCache.store(key, entry, metadata)
+
+        then:
+        1 * writeCache.store(key, entry, metadata)
+        0 * readCache._
+    }
+
+    def "reading from write cache then read cache"() {
+        when:
+        twoStageCache.get(key)
+
+        then:
+        1 * writeCache.get(key) >> null
+        1 * readCache.get(key)
+
+        when:
+        twoStageCache.get(key)
+
+        then:
+        1 * writeCache.get(key) >> metadata
+        0 * readCache._
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/TwoStageArtifactsCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/TwoStageArtifactsCacheTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts
+
+import org.gradle.util.BuildCommencedTimeProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TwoStageArtifactsCacheTest extends Specification {
+    def timeProvider = Stub(BuildCommencedTimeProvider)
+    def readCache = Mock(AbstractArtifactsCache)
+    def writeCache = Mock(AbstractArtifactsCache)
+    def key = Stub(ArtifactsAtRepositoryKey)
+
+    @Subject
+    TwoStageArtifactsCache twoStageArtifactsCache = new TwoStageArtifactsCache(timeProvider, readCache, writeCache)
+
+    def "reads first in write cache then in read cache"() {
+        when:
+        twoStageArtifactsCache.get(key)
+
+        then:
+        1 * writeCache.get(key) >> null
+        1 * readCache.get(key) >> Stub(AbstractArtifactsCache.ModuleArtifactsCacheEntry)
+
+        when:
+        twoStageArtifactsCache.get(key)
+
+        then:
+        1 * writeCache.get(key) >> Stub(AbstractArtifactsCache.ModuleArtifactsCacheEntry)
+        0 * readCache.get(key)
+    }
+
+    def "writes are delegated to the writable cache"() {
+        def entry = Stub(AbstractArtifactsCache.ModuleArtifactsCacheEntry)
+        when:
+        twoStageArtifactsCache.store(key, entry)
+
+        then:
+        writeCache.store(key, entry)
+        0 * readCache.store(key, entry)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/TwoStageModuleArtifactCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/TwoStageModuleArtifactCacheTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts
+
+import org.gradle.internal.hash.HashCode
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.nio.file.Path
+
+class TwoStageModuleArtifactCacheTest extends Specification {
+    Path readOnlyPath = Stub(Path)
+    File artifact = Stub(File)
+    HashCode hashCode = Stub(HashCode)
+    def key = Stub(ArtifactAtRepositoryKey)
+
+    def readCache = Mock(ModuleArtifactCache)
+    def writeCache = Mock(ModuleArtifactCache)
+
+    @Subject
+    def twoStageCache = new TwoStageModuleArtifactCache(readOnlyPath, readCache, writeCache)
+
+    def "storing delegates to the write index"() {
+        when:
+        twoStageCache.store(key, artifact, hashCode)
+
+        then:
+        1 * writeCache.store(key, artifact, hashCode)
+        0 * readCache._
+    }
+
+    def "store missing delegates to the write index"() {
+        when:
+        twoStageCache.storeMissing(key, ["abc"], hashCode)
+
+        then:
+        1 * writeCache.storeMissing(key, ["abc"], hashCode)
+        0 * readCache._
+    }
+
+    def "lookup searches the write index then delegates to the read index"() {
+        when:
+        twoStageCache.lookup(key)
+
+        then:
+        1 * writeCache.lookup(key) >> null
+        1 * readCache.lookup(key)
+
+        when:
+        twoStageCache.lookup(key)
+
+        then:
+        1 * writeCache.lookup(key) >> Stub(CachedArtifact)
+        0 * readCache._
+    }
+
+    def "clearing delegates to the writable cache"() {
+        when:
+        twoStageCache.clear(key)
+
+        then:
+        1 * writeCache.clear(key)
+        0 * readCache._
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/TwoStageModuleVersionsCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/TwoStageModuleVersionsCacheTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions
+
+import org.gradle.util.BuildCommencedTimeProvider
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TwoStageModuleVersionsCacheTest extends Specification {
+    def timeProvider = Stub(BuildCommencedTimeProvider)
+    def readCache = Mock(AbstractModuleVersionsCache)
+    def writeCache = Mock(AbstractModuleVersionsCache)
+    def key = Stub(ModuleAtRepositoryKey)
+    def entry = Stub(ModuleVersionsCacheEntry)
+
+    @Subject
+    def twoStageCache = new TwoStageModuleVersionsCache(timeProvider, readCache, writeCache)
+
+    def "writing delegates to write cache"() {
+        when:
+        twoStageCache.store(key, entry)
+
+        then:
+        1 * writeCache.store(key, entry)
+        0 * readCache._
+    }
+
+    def "reading aggregates read and write caches"() {
+        def r1 = new ModuleVersionsCacheEntry(["1.0", "1.1"] as Set, 0L)
+        def r2 = new ModuleVersionsCacheEntry(["1.2", "1.3"]  as Set, 123L)
+
+        when:
+        def result = twoStageCache.get(key)
+
+        then:
+        1 * readCache.get(key) >> {
+            r1
+        }
+        1 * writeCache.get(key) >> {
+            r2
+        }
+        result.moduleVersionListing == ["1.0", "1.1", "1.2", "1.3"] as Set
+        result.createTimestamp == 123L
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/filestore/TwoStageArtifactIdentifierFileStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/filestore/TwoStageArtifactIdentifierFileStoreTest.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.filestore
+
+import org.gradle.api.Action
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
+import org.gradle.internal.resource.local.FileAccessTracker
+import org.gradle.internal.resource.local.LocallyAvailableExternalResource
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TwoStageArtifactIdentifierFileStoreTest extends Specification {
+    def readStore = Mock(ArtifactIdentifierFileStore)
+    def writeStore = Mock(ArtifactIdentifierFileStore)
+    def key = Stub(ModuleComponentArtifactIdentifier)
+    def file = Stub(File)
+    def action = Stub(Action)
+
+    @Subject
+    def twoStageStore = new TwoStageArtifactIdentifierFileStore(readStore, writeStore)
+
+    def "storing an artifact uses the writable store"() {
+        when:
+        twoStageStore.move(key, file)
+
+        then:
+        1 * writeStore.move(key, file)
+        0 * readStore.move(_, _)
+
+        when:
+        twoStageStore.add(key, action)
+
+        then:
+        1 * writeStore.add(key, action)
+        0 * readStore.add(key, action)
+    }
+
+    def "searches in both read and write stores"() {
+        setup:
+        def r1 = Stub(LocallyAvailableExternalResource)
+        def r2 = Stub(LocallyAvailableExternalResource)
+        def r3 = Stub(LocallyAvailableExternalResource)
+        1 * writeStore.search(key) >> {
+            [r1] as Set
+        }
+        1 * readStore.search(key) >> {
+            [r2, r3] as Set
+        }
+
+        when:
+        def result = twoStageStore.search(key)
+
+        then:
+        result == [r1, r2, r3] as Set
+    }
+
+    def "whereIs falls back to the read store"() {
+        def missing = Stub(File) {
+            exists() >> false
+        }
+        def found = Stub(File)
+
+        1 * writeStore.whereIs(key, "checksum") >> { missing }
+        1 * readStore.whereIs(key, "checksum") >> { found }
+
+        expect:
+        twoStageStore.whereIs(key, "checksum") == found
+    }
+
+    def "whereIs uses file found in write store"() {
+        def found = Stub(File) {
+            exists() >> true
+        }
+
+        1 * writeStore.whereIs(key, "checksum") >> { found }
+
+        expect:
+        twoStageStore.whereIs(key, "checksum") == found
+    }
+
+    def "file access tracker delegates to both trackers"() {
+        def fat1 = Mock(FileAccessTracker)
+        def fat2 = Mock(FileAccessTracker)
+
+        when:
+        twoStageStore.getFileAccessTracker().markAccessed(file)
+
+        then:
+        1 * readStore.getFileAccessTracker() >> fat1
+        1 * writeStore.getFileAccessTracker() >> fat2
+        1 * fat1.markAccessed(file)
+        1 * fat2.markAccessed(file)
+
+        when:
+        twoStageStore.getFileAccessTracker().markAccessed([file])
+
+        then:
+        1 * readStore.getFileAccessTracker() >> fat1
+        1 * writeStore.getFileAccessTracker() >> fat2
+        1 * fat1.markAccessed([file])
+        1 * fat2.markAccessed([file])
+    }
+
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/TwoStageByUrlCachedExternalResourceIndexTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/TwoStageByUrlCachedExternalResourceIndexTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.cached
+
+import org.gradle.internal.resource.metadata.ExternalResourceMetaData
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.nio.file.Path
+
+class TwoStageByUrlCachedExternalResourceIndexTest extends Specification {
+    Path readOnlyPath = Stub(Path)
+    File artifact = Stub(File)
+    ExternalResourceMetaData metadata = Stub(ExternalResourceMetaData)
+
+    CachedExternalResourceIndex<String> readIndex = Mock(CachedExternalResourceIndex)
+    CachedExternalResourceIndex<String> writeIndex = Mock(CachedExternalResourceIndex)
+
+    @Subject
+    TwoStageByUrlCachedExternalResourceIndex twoStageIndex = new TwoStageByUrlCachedExternalResourceIndex(readOnlyPath, readIndex, writeIndex)
+
+    def "storing delegates to the write index"() {
+        when:
+        twoStageIndex.store("key", artifact, metadata)
+
+        then:
+        1 * writeIndex.store("key", artifact, metadata)
+        0 * readIndex._
+    }
+
+    def "store missing delegates to the write index"() {
+        when:
+        twoStageIndex.storeMissing("key")
+
+        then:
+        1 * writeIndex.storeMissing("key")
+        0 * readIndex._
+    }
+
+    def "lookup searches the write index then delegates to the read index"() {
+        when:
+        twoStageIndex.lookup("key")
+
+        then:
+        1 * writeIndex.lookup("key") >> null
+        1 * readIndex.lookup("key")
+
+        when:
+        twoStageIndex.lookup("other")
+
+        then:
+        1 * writeIndex.lookup("other") >> Stub(CachedExternalResource)
+        0 * readIndex._
+    }
+
+    def "clearing delegates to the writable cache"() {
+        when:
+        twoStageIndex.clear("key")
+
+        then:
+        1 * writeIndex.clear("key")
+        0 * readIndex._
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/TwoStageExternalResourceFileStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/TwoStageExternalResourceFileStoreTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.cached
+
+import org.gradle.api.Action
+import org.gradle.internal.resource.local.FileAccessTracker
+import org.gradle.internal.resource.local.LocallyAvailableResource
+import spock.lang.Specification
+import spock.lang.Subject
+
+class TwoStageExternalResourceFileStoreTest extends Specification {
+    def readStore = Mock(ExternalResourceFileStore)
+    def writeStore = Mock(ExternalResourceFileStore)
+
+    String key = "key"
+    def file = Stub(File)
+    def action = Stub(Action)
+
+    @Subject
+    TwoStageExternalResourceFileStore twoStageStore = new TwoStageExternalResourceFileStore(readStore, writeStore)
+
+    def "storing an artifact uses the writable store"() {
+        when:
+        twoStageStore.move(key, file)
+
+        then:
+        1 * writeStore.move(key, file)
+        0 * readStore.move(_, _)
+
+        when:
+        twoStageStore.add(key, action)
+
+        then:
+        1 * writeStore.add(key, action)
+        0 * readStore.add(key, action)
+    }
+
+    def "searches in both read and write stores"() {
+        setup:
+        def r1 = Stub(LocallyAvailableResource)
+        def r2 = Stub(LocallyAvailableResource)
+        def r3 = Stub(LocallyAvailableResource)
+        1 * writeStore.search(key) >> {
+            [r1] as Set
+        }
+        1 * readStore.search(key) >> {
+            [r2, r3] as Set
+        }
+
+        when:
+        def result = twoStageStore.search(key)
+
+        then:
+        result == [r1, r2, r3] as Set
+    }
+
+    def "file access tracker delegates to both trackers"() {
+        def fat1 = Mock(FileAccessTracker)
+        def fat2 = Mock(FileAccessTracker)
+
+        when:
+        twoStageStore.getFileAccessTracker().markAccessed(file)
+
+        then:
+        1 * readStore.getFileAccessTracker() >> fat1
+        1 * writeStore.getFileAccessTracker() >> fat2
+        1 * fat1.markAccessed(file)
+        1 * fat2.markAccessed(file)
+
+        when:
+        twoStageStore.getFileAccessTracker().markAccessed([file])
+
+        then:
+        1 * readStore.getFileAccessTracker() >> fat1
+        1 * writeStore.getFileAccessTracker() >> fat2
+        1 * fat1.markAccessed([file])
+        1 * fat2.markAccessed([file])
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -42,7 +42,7 @@ A lot of the work on this feature is, in particular, available to previous versi
 <a name="shared-dependency-cache"></a>
 ## Shared dependency cache
 
-Improving on [relocatable dependency caches introduced in the previous release](https://docs.gradle.org/6.1.1/release-notes.html#ephemeral-ci:-reuse-gradle's-dependency-cache), Gradle 6.2 now offers the ability to **share** a dependency cache between multiple instances.
+Improving on [relocatable dependency caches introduced in the previous release](https://docs.gradle.org/6.1.1/release-notes.html#ephemeral-ci:-reuse-gradle's-dependency-cache), Gradle 6.2 now offers the ability to **share** a dependency cache between multiple Gradle instances.
 In the context of ephemeral builds on disposable containers, this makes it possible to have a single, shared, directory between containers which contains most, if not all, the dependencies required by all builds:
 
 - each container will have access to the shared read-only dependency cache, avoiding redundant downloads between builds

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -239,7 +239,7 @@ To help with this scenario, Gradle provides a couple of options:
 - <<sub:shared-readonly-cache,sharing a read-only dependency cache>> between multiple containers
 
 [[sub:cache_copy]]
-=== Copy and reuse the cache
+=== Copying and reusing the cache
 
 The dependency cache, both the file and metadata parts, are fully encoded using relative paths.
 This means that it is perfectly possible to copy a cache around and see Gradle benefit from it.


### PR DESCRIPTION
Follow up to code review of shared read-only dependency cache