### PR TITLE
Add Hibernate jpamodelgen to list of annotation processors

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -762,6 +762,10 @@ Many popular annotation processors support incremental annotation processing (se
 | link:https://github.com/airbnb/epoxy/issues/423[Open issue]
 | N/A
 
+| link:https://docs.jboss.org/hibernate/orm/5.4/topical/html_single/metamodelgen/MetamodelGenerator.html[JPA Static Metamodel Generator]
+| link:https://github.com/hibernate/hibernate-orm/releases/tag/5.4.11[5.4.11]
+| N/A
+
 |===
 
 [[sec:java_compile_avoidance]]


### PR DESCRIPTION
Signed-off-by: SamDeBlock <6572609+SamDeBlock@users.noreply.github.com>

<!--- The issue this PR addresses -->
Fixes: Small documentation update.

### Context
Updates java plugin documentation to include hibernate jpamodelgen to list of annotation processors.
See https://hibernate.atlassian.net/browse/HHH-13390 for relevant hibernate issue.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
