### PR TITLE
Remove JNI headers on incremental compilation

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -219,7 +219,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         buildFile << """
             allprojects {
                 apply plugin: 'java'
-    
+
                 repositories {
                    maven { url '$mavenRepo.uri' }
                 }
@@ -230,7 +230,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
             dependencies {
                 implementation project(':b')
             }
-            
+
             task checkClasspath {
                 doLast {
                     def compileClasspath = compileJava.classpath.files*.name
@@ -405,13 +405,13 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         settingsFile << "include 'a', 'b'"
         file('a/build.gradle') << """
             apply plugin: 'java'
-            
+
             dependencies {
                 implementation project(':b')
             }
-            
+
             task processDependency {
-                def lazyInputs = configurations.runtimeClasspath.incoming.artifactView { 
+                def lazyInputs = configurations.runtimeClasspath.incoming.artifactView {
                     attributes{ attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME)) }
                     attributes{ attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.${token})) }
                 }.files
@@ -446,7 +446,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         def buildFileWithDependencies = { String... dependencies ->
             buildFile.text = """
                 apply plugin: 'java'
-                                  
+
                 ${mavenCentralRepository()}
 
                 dependencies {
@@ -521,7 +521,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
     def "compile classpath snapshotting should warn when jar on classpath is malformed"() {
         buildFile << '''
             apply plugin: 'java'
-            
+
             dependencies {
                implementation files('foo.jar')
             }
@@ -543,7 +543,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
     def "compile classpath snapshotting on Java 8 and earlier should warn when jar on classpath has non-utf8 characters in filenames"() {
         buildFile << '''
             apply plugin: 'java'
-            
+
             dependencies {
                implementation files('broken-utf8.jar')
             }
@@ -566,19 +566,19 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
     def "compile classpath snapshotting should warn when jar on classpath contains malformed class file"() {
         buildFile << '''
             apply plugin: 'java'
-            
+
             task fooJar(type:Jar) {
                 archiveFileName = 'foo.jar'
                 from file('foo.class')
             }
-            
+
             dependencies {
                implementation files(fooJar.archiveFile)
             }
-            
+
             compileJava.dependsOn(fooJar)
-            
-            
+
+
         '''
         file('foo.class') << 'this is clearly not a well formed class file'
         file('src/main/java/Hello.java') << 'public class Hello {}'
@@ -596,11 +596,11 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
     def "compile classpath snapshotting should warn when class on classpath is malformed"() {
         buildFile << '''
             apply plugin: 'java'
-            
+
             dependencies {
                implementation files('classes')
             }
-            
+
         '''
         file('classes/foo.class') << 'this is clearly not a well formed class file'
         file('src/main/java/Hello.java') << 'public class Hello {}'
@@ -624,7 +624,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
 
         buildFile << '''
             apply plugin: 'java'
-            
+
             dependencies {
                implementation project(':b')
             }
@@ -650,7 +650,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
 
         file('src/main/java/org/gradle/test/MyTest.java').text = """
             package org.gradle.test;
-            
+
             class MyTest {}
         """
 
@@ -678,7 +678,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         file("src/main/java/module-info.java") << 'module example { exports io.example; }'
         file("src/main/java/io/example/Example.java") << '''
             package io.example;
-            
+
             public class Example {}
         '''
 
@@ -699,7 +699,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
             plugins {
                 id 'java'
             }
-            
+
             compileJava {
                 options.compilerArgs = ['--module-source-path', files('src/main/java', 'src/main/moreJava').asPath]
             }
@@ -712,15 +712,15 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         '''
         file("src/main/java/example/io/example/Example.java") << '''
             package io.example;
-            
+
             import io.another.BaseExample;
-            
+
             public class Example extends BaseExample {}
         '''
         file("src/main/moreJava/another/module-info.java") << 'module another { exports io.another; }'
         file("src/main/moreJava/another/io/another/BaseExample.java") << '''
             package io.another;
-            
+
             public class BaseExample {}
         '''
 
@@ -743,7 +743,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
             plugins {
                 id 'java'
             }
-            
+
             compileJava {
                 options.compilerArgs = ['--module-source-path', files('src/main/java', 'src/main/moreJava').asPath]
                 options.sourcepath = files('src/main/ignoredJava')
@@ -757,21 +757,21 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         '''
         file("src/main/java/example/io/example/Example.java") << '''
             package io.example;
-            
+
             import io.another.BaseExample;
-            
+
             public class Example extends BaseExample {}
         '''
         file("src/main/moreJava/another/module-info.java") << 'module another { exports io.another; }'
         file("src/main/moreJava/another/io/another/BaseExample.java") << '''
             package io.another;
-            
+
             public class BaseExample {}
         '''
         file("src/main/ignoredJava/ignored/module-info.java") << 'module ignored { exports io.ignored; }'
         file("src/main/ignoredJava/ignored/io/ignored/IgnoredExample.java") << '''
             package io.ignored;
-            
+
             public class IgnoredExample {}
         '''
 
@@ -792,7 +792,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
     def "fails when sourcepath is set on compilerArgs"() {
         buildFile << '''
             apply plugin: 'java'
-            
+
             compileJava {
                 options.compilerArgs = ['-sourcepath', files('src/main/java').asPath]
             }
@@ -809,7 +809,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
     def "fails when processorpath is set on compilerArgs"() {
         buildFile << '''
             apply plugin: 'java'
-            
+
             compileJava {
                 options.compilerArgs = ['-processorpath', files('src/main/java').asPath]
             }
@@ -849,13 +849,13 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         def jdk8bootClasspath = TextUtil.escapeString(jdk8.jre.homeDir.absolutePath) + "/lib/rt.jar"
         buildFile << """
             apply plugin: 'java'
-            
+
             compileJava {
                 if (project.hasProperty("java7")) {
                     options.bootstrapClasspath = files("$jdk7bootClasspath")
                 } else if (project.hasProperty("java8")) {
                     options.bootstrapClasspath = files("$jdk8bootClasspath")
-                } 
+                }
                 options.fork = true
             }
         """
@@ -932,19 +932,26 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
             apply plugin: 'java'
             compileJava.options.headerOutputDirectory = file("build/headers/java/main")
         """
-        def header = file('src/main/java/Foo.java') << """
+        def header = file('src/main/java/my/org/Foo.java') << """
+            package my.org;
+
             public class Foo {
                 public native void foo();
             }
         """
+        def generatedHeader = file("build/headers/java/main/my_org_Foo.h")
+
+        when:
         succeeds "compileJava"
+        then:
+        generatedHeader.isFile()
 
         when:
         header.delete()
         succeeds "compileJava"
 
         then:
-        !file("build/headers/java/main/Foo.h").exists()
+        !generatedHeader.exists()
     }
 
     @Issue("https://github.com/gradle/gradle/issues/11017")
@@ -955,11 +962,11 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         """
         file("src/main/java/com/example/Main.java") << """
             package com.example;
-            
+
             import com.example.cvs.Test;
-            
+
             public class Main {
-            
+
               public static void main(String[] args) {
                 System.out.println(new Test());
               }
@@ -967,7 +974,7 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         """
         file("src/main/java/com/example/cvs/Test.java") << """
             package com.example.cvs;
-            
+
             public class Test {
             }
         """

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/JavaRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/JavaRecompilationSpecProvider.java
@@ -153,12 +153,13 @@ public class JavaRecompilationSpecProvider extends AbstractRecompilationSpecProv
     private void prepareJavaPatterns(Collection<String> staleClasses, PatternSet filesToDelete, PatternSet sourceToCompile) {
         for (String staleClass : staleClasses) {
             String path = staleClass.replaceAll("\\.", "/");
+            String headerPath = staleClass.replaceAll("\\.", "_");
             filesToDelete.include(path.concat(".class"));
             filesToDelete.include(path.concat(".java"));
-            filesToDelete.include(path.concat(".h"));
+            filesToDelete.include(headerPath.concat(".h"));
             filesToDelete.include(path.concat("$*.class"));
             filesToDelete.include(path.concat("$*.java"));
-            filesToDelete.include(path.concat("$*.h"));
+            filesToDelete.include(headerPath.concat("_*.h"));
 
             sourceToCompile.include(path.concat(".java"));
             sourceToCompile.include(path.concat("$*.java"));


### PR DESCRIPTION
The removal only worked for top-level classes in the
default package.

Fixes #12084