### PR TITLE
[Spike] More fine-grained artifact type definition API

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeDefinition.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeDefinition.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.artifacts.type;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasAttributes;
 
@@ -62,6 +64,37 @@ public interface ArtifactTypeDefinition extends HasAttributes, Named {
      * @since 5.3
      */
     String DIRECTORY_TYPE = "directory";
+
+    /**
+     * Define a file name extension to which this type definition applies.
+     * This overrides the default where the name of the type defintion is considered as extension.
+     *
+     * @param extension extension to which this definition applies
+     *
+     * @since 6.3
+     */
+    @Incubating
+    void forFileNameExtension(String extension);
+
+    /**
+     * Add a module id. If module ids are defined, this type definition only applies to artifacts
+     * which are part of the indicated modules.
+     *
+     * @param group module group
+     * @param name module name
+     *
+     * @since 6.3
+     */
+    @Incubating
+    void forModule(String group, String name);
+
+    /**
+     * Returns the set of module identifiers for which this definition applies. Empty, if it applies to all artifacts matching the configured file name extension(s).
+     *
+     * @since 6.3
+     */
+    @Incubating
+    Set<ModuleIdentifier> getModuleIdentifiers();
 
     /**
      * Returns the set of file name extensions that should be mapped to this artifact type. Defaults to the name of this type.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -96,7 +96,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
         ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builder();
 
         // Apply any artifact type mappings to the attributes of the variant
-        ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant);
+        ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant, ownerId.getModule());
 
         for (ComponentArtifactMetadata artifact : artifacts) {
             IvyArtifactName artifactName = artifact.getName();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/ArtifactTypeRegistry.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.type;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Factory;
@@ -24,7 +25,7 @@ import org.gradle.internal.component.model.VariantResolveMetadata;
 import java.io.File;
 
 public interface ArtifactTypeRegistry extends Factory<ArtifactTypeContainer> {
-    ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant);
+    ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant, ModuleIdentifier moduleIdentifier);
 
     ImmutableAttributes mapAttributesFor(File file);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeContainer.java
@@ -17,11 +17,14 @@
 package org.gradle.api.internal.artifacts.type;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -43,6 +46,8 @@ public class DefaultArtifactTypeContainer extends AbstractValidatingNamedDomainO
     public static class DefaultArtifactTypeDefinition implements ArtifactTypeDefinition {
         private final String name;
         private final AttributeContainer attributes;
+        private Set<String> fileNameExtensions;
+        private Set<ModuleIdentifier> moduleIdentifiers;
 
         public DefaultArtifactTypeDefinition(String name, ImmutableAttributesFactory attributesFactory) {
             this.name = name;
@@ -50,8 +55,35 @@ public class DefaultArtifactTypeContainer extends AbstractValidatingNamedDomainO
         }
 
         @Override
+        public void forFileNameExtension(String extension) {
+            if (fileNameExtensions == null) {
+                fileNameExtensions = Sets.newHashSet();
+            }
+            fileNameExtensions.add(extension);
+        }
+
+        @Override
+        public void forModule(String group, String name) {
+            if (moduleIdentifiers == null) {
+                moduleIdentifiers = Sets.newHashSet();
+            }
+            moduleIdentifiers.add(DefaultModuleIdentifier.newId(group, name));
+        }
+
+        @Override
+        public Set<ModuleIdentifier> getModuleIdentifiers() {
+            if (moduleIdentifiers == null) {
+                return ImmutableSet.of();
+            }
+            return ImmutableSet.copyOf(moduleIdentifiers);
+        }
+
+        @Override
         public Set<String> getFileNameExtensions() {
-            return ImmutableSet.of(name);
+            if (fileNameExtensions == null) {
+                return ImmutableSet.of(name);
+            }
+            return ImmutableSet.copyOf(fileNameExtensions);
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
+import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.transform.VariantSelector
@@ -28,6 +29,7 @@ import spock.lang.Specification
 
 class DefaultArtifactSetTest extends Specification {
     def componentId = Stub(ComponentIdentifier)
+    def moduleId = Stub(ModuleVersionIdentifier)
     def exclusions = Stub(ModuleExclusions)
     def schema = Stub(AttributesSchemaInternal)
     def artifactTypeRegistry = Stub(ArtifactTypeRegistry)
@@ -42,9 +44,9 @@ class DefaultArtifactSetTest extends Specification {
         def variant2 = Stub(VariantResolveMetadata)
 
         given:
-        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
+        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, moduleId, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
+        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, moduleId, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
+        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, moduleId, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
         expect:
         artifacts1.select({false}, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
@@ -59,9 +61,9 @@ class DefaultArtifactSetTest extends Specification {
         def selector = Stub(VariantSelector)
 
         given:
-        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
+        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, moduleId, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
+        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, moduleId, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
+        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, moduleId, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
         selector.select(_) >> resolvedVariant1
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -58,7 +58,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         variant.attributes >> attrs
 
         expect:
-        registry.mapAttributesFor(variant) == attrs
+        registry.mapAttributesFor(variant, null) == attrs
     }
 
     def "does not apply any mapping when variant has no artifacts"() {
@@ -70,7 +70,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         variant.artifacts >> ImmutableList.of()
 
         expect:
-        registry.mapAttributesFor(variant) == attrs
+        registry.mapAttributesFor(variant, null) == attrs
     }
 
     def "adds artifactType attribute but does not apply any mapping when no matching artifact type"() {
@@ -90,7 +90,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("aar")
 
         expect:
-        registry.mapAttributesFor(variant) == attrsPlusFormat
+        registry.mapAttributesFor(variant, null) == attrsPlusFormat
     }
 
     def "applies mapping when no attributes defined for matching type"() {
@@ -110,7 +110,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("jar")
 
         expect:
-        registry.mapAttributesFor(variant) == attrsPlusFormat
+        registry.mapAttributesFor(variant, null) == attrsPlusFormat
     }
 
     def "applies mapping to matching artifact type"() {
@@ -130,7 +130,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("jar").attributes.attribute(Attribute.of("custom", String), "123")
 
         expect:
-        registry.mapAttributesFor(variant) == attrsPlusFormat
+        registry.mapAttributesFor(variant, null) == attrsPlusFormat
     }
 
     def "does not apply mapping when multiple artifacts with different types"() {
@@ -155,7 +155,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
         registry.create().create("zip").attributes.attribute(Attribute.of("custom", String), "234")
 
         expect:
-        registry.mapAttributesFor(variant) == attrs
+        registry.mapAttributesFor(variant, null) == attrs
     }
 
     def "maps only artifactType attribute for arbitrary files when no extensions are registered"() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.internal;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.BuildIdentifier;
@@ -153,7 +154,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             }
 
             @Override
-            public ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant) {
+            public ImmutableAttributes mapAttributesFor(VariantResolveMetadata variant, ModuleIdentifier moduleIdentifier) {
                 return variant.getAttributes().asImmutable();
             }
 


### PR DESCRIPTION
A suggestion to improve the specification of attributes that only apply on the **artifact level** . That is, to control artifact transforms without influencing variant matching itself.