### PR TITLE
Use the correct project directory to resolve files after loading from instant execution cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -244,7 +244,7 @@ class TaskDependencyInferenceIntegrationTest extends AbstractIntegrationSpec imp
         result.assertTasksExecuted(":b", ":c")
     }
 
-    def "dependency declared using orElse provider whose original value is missing and  alternative value is constant does not imply task dependency"() {
+    def "dependency declared using orElse provider whose original value is missing and alternative value is constant does not imply task dependency"() {
         taskTypeWithOutputFileProperty()
         buildFile << """
             def taskA = tasks.create("a", FileProducer) {
@@ -824,7 +824,7 @@ The following types/formats are supported:
 
     def "input property with value of mapped task output implies dependency on the task"() {
         taskTypeWithOutputFileProperty()
-        taskTypeWithInputProperty()
+        taskTypeWithIntInputProperty()
         buildFile << """
             def task = tasks.create("a", FileProducer) {
                 output = file("file.txt")
@@ -866,7 +866,7 @@ The following types/formats are supported:
 
     def "input property with value of mapped task output location does not imply dependency on the task"() {
         taskTypeWithOutputFileProperty()
-        taskTypeWithInputProperty()
+        taskTypeWithIntInputProperty()
         buildFile << """
             def task = tasks.create("a", FileProducer) {
                 output = file("file.txt")
@@ -887,7 +887,7 @@ The following types/formats are supported:
     }
 
     def "input property can have value of mapped output property of same task"() {
-        taskTypeWithInputProperty()
+        taskTypeWithIntInputProperty()
         buildFile << """
             tasks.register("b", InputTask) {
                 inValue = outFile.locationOnly.map { it.asFile.name.length() }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -32,15 +32,16 @@ trait TasksWithInputsAndOutputs {
                 @OutputFile
                 final RegularFileProperty output = project.objects.fileProperty()
                 @Input
-                String content = "content" // set to empty string to delete file
-            
+                final Property<String> content = project.objects.property(String).convention("content") // set to empty string to delete file
+
                 @TaskAction
                 def go() {
                     def file = output.get().asFile
-                    if (content.empty) {
+                    def text = this.content.get()
+                    if (text.empty) {
                         file.delete()
                     } else {
-                        file.text = content
+                        file.text = text
                     }
                 }
             }
@@ -54,7 +55,7 @@ trait TasksWithInputsAndOutputs {
                 abstract val output: RegularFileProperty
                 @get:Input
                 var content = "content" // set to empty string to delete file
-            
+
                 @TaskAction
                 fun go() {
                     val file = output.get().asFile
@@ -77,7 +78,7 @@ trait TasksWithInputsAndOutputs {
                 final ListProperty<String> names = project.objects.listProperty(String)
                 @Input
                 String content = "content" // set to empty string to delete directory
-            
+
                 @TaskAction
                 def go() {
                     def dir = output.get().asFile
@@ -128,7 +129,7 @@ trait TasksWithInputsAndOutputs {
         """
     }
 
-    def taskTypeWithInputProperty() {
+    def taskTypeWithIntInputProperty() {
         buildFile << """
             class InputTask extends DefaultTask {
                 @Input

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -50,7 +50,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         """
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     def "transform is applied to each file once per build"() {
         given:
         buildFile << declareAttributes() << multiProjectWithJarSizeTransform() << withJarTasks() << withLibJarDependency("lib3.jar")
@@ -311,7 +311,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         output.count("Transforming artifact lib2.jar (project :lib) with MakeGreen") == 2
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     def "each file is transformed once per set of configuration parameters"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << withLibJarDependency("lib3.jar") << """
@@ -414,7 +414,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         output.count("Transformed") == 0
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     def "can use custom type that does not implement equals() for transform configuration"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << """
@@ -518,7 +518,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     def "can use configuration parameter of type #type"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << """
@@ -608,7 +608,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         "Named"        | "objects.named(Named, 'abc')"
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     def "each file is transformed once per transform class"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << withLibJarDependency("lib3.jar") << """
@@ -816,7 +816,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         output.count("Transformed") == 0
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     def "transform is executed in different workspace for different file produced in chain"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << duplicatorTransform << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -39,11 +39,11 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             project(':b') {
                 tasks.producer.doLast { throw new RuntimeException('broken') }
             }
-            
+
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -81,7 +81,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact ${annotation}
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -196,7 +196,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact ${annotation}
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     if (input.exists()) {
@@ -313,7 +313,6 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         "@PathSensitive(PathSensitivity.NAME_ONLY)" | "@PathSensitive(PathSensitivity.NAME_ONLY)"
     }
 
-    @ToBeFixedForInstantExecution
     def "re-runs transform when input artifact file changes from file to missing"() {
         settingsFile << "include 'a', 'b', 'c'"
         setupBuildWithColorTransformAction()
@@ -324,11 +323,11 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
+
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     if (input.exists()) {
@@ -359,7 +358,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         outputContains("result = [b.jar.green, c.jar.green]")
 
         when:
-        succeeds(":a:resolve", "-PbProduceNothing")
+        succeeds(":a:resolve", "-PbContent=")
 
         then: // file is missing, should run
         result.assertTasksNotSkipped(":b:producer", ":a:resolve")
@@ -385,13 +384,13 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':b')
                 }
             }
-            
+
             @CacheableTransform
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -426,13 +425,13 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
+
             @CacheableTransform
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -509,13 +508,13 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
+
             @CacheableTransform
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -602,13 +601,13 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
+
             @CacheableTransform
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -692,7 +691,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -783,7 +782,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -869,8 +868,8 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
         buildFile << """
             repositories {
-                maven { 
-                    url = '${mavenRepo.uri}' 
+                maven {
+                    url = '${mavenRepo.uri}'
                     metadataSources { gradleMetadata() }
                 }
             }
@@ -882,12 +881,12 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
                 implementation 'group2:lib2:1.0'
             }
-            
+
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -957,8 +956,8 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
         buildFile << """
             repositories {
-                maven { 
-                    url = '${mavenRepo.uri}' 
+                maven {
+                    url = '${mavenRepo.uri}'
                     metadataSources { gradleMetadata() }
                 }
             }
@@ -970,12 +969,12 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
                 implementation 'group2:lib2:1.0'
             }
-            
+
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -1039,11 +1038,11 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
+
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact @${annotation}
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -1140,12 +1139,12 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
+
             @CacheableTransform
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact @${annotation}
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
@@ -1240,18 +1239,18 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':b')
                     implementation project(':c')
                 }
-                
+
                 normalization {
                     runtimeClasspath {
                         ignore("ignored.txt")
                     }
                 }
             }
-            
+
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact @Classpath
                 abstract Provider<FileSystemLocation> getInputArtifact()
-                
+
                 void transform(TransformOutputs outputs) {
                     def input = inputArtifact.get().asFile
                     println "processing \${input.name}"

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -356,24 +356,19 @@ allprojects { p ->
          * ${project.name}OutputDir - changes the build directory of the given project.
          * ${project.name}FileName - changes the output file name.
          * ${project.name}ProduceNothing - deletes the output file instead of writing to it.
-         * ${project.name}Content - changes the text to write to the output file.
+         * ${project.name}Content - changes the text to write to the output file, set to empty string to delete the output file.
          */
         void produceFiles() {
             producerTaskClassName = "FileProducer"
             producerConfig = """
                 output = layout.buildDir.file("\${project.name}.jar")
-                content = project.name
+                content.convention(providers.gradleProperty("\${project.name}Content").orElse(project.name))
             """.stripIndent()
             producerConfigOverrides = """
                 if (project.hasProperty("\${project.name}OutputDir")) {
                     buildDir = project.file(project.property("\${project.name}OutputDir"))
                 }
                 tasks.withType(FileProducer) {
-                    if (project.hasProperty("\${project.name}ProduceNothing")) {
-                        content = ""
-                    } else if (project.hasProperty("\${project.name}Content")) {
-                        content = project.property("\${project.name}Content")
-                    }
                     if (project.hasProperty("\${project.name}FileName")) {
                         output = layout.buildDir.file(project.property("\${project.name}FileName"))
                     }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FilePropertyTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FilePropertyTest.groovy
@@ -38,12 +38,12 @@ class FilePropertyTest extends FileSystemPropertySpec<RegularFile> {
 
     @Override
     RegularFile someOtherValue2() {
-        return baseDir.file("other1").get()
+        return baseDir.file("other2").get()
     }
 
     @Override
     RegularFile someOtherValue3() {
-        return baseDir.file("other1").get()
+        return baseDir.file("other3").get()
     }
 
     @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
@@ -28,11 +28,7 @@ abstract class FileSystemPropertySpec<T extends FileSystemLocation> extends Prop
     def resolver = TestFiles.resolver(tmpDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     def factory = new DefaultFilePropertyFactory(resolver, fileCollectionFactory)
-    def baseDir = factory.newDirectoryProperty()
-
-    def setup() {
-        baseDir.set(tmpDir.testDirectory)
-    }
+    def baseDir = factory.newDirectoryProperty().fileValue(tmpDir.testDirectory)
 
     def "can set value using absolute file"() {
         given:

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -92,6 +92,14 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
 
         settingsFile << """
             rootProject.name = 'thing'
+            include 'a', 'b', 'c'
+            include 'a:b'
+            project(':a:b').projectDir = file('custom')
+            gradle.rootProject {
+                allprojects {
+                    task thing
+                }
+            }
         """
 
         when:
@@ -100,6 +108,8 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         then:
         def event = fixture.first(LoadProjectsBuildOperationType)
         event.result.rootProject.name == 'thing'
+        event.result.rootProject.path == ':'
+        event.result.rootProject.children.size() == 3 // All projects are created when storing
 
         when:
         instantRun "help"
@@ -107,6 +117,59 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
         then:
         def event2 = fixture.first(LoadProjectsBuildOperationType)
         event2.result.rootProject.name == 'thing'
+        event2.result.rootProject.path == ':'
+        event2.result.rootProject.projectDir == testDirectory.absolutePath
+        event2.result.rootProject.children.empty // None of the child projects are created when loading, as they have no tasks scheduled
+
+        when:
+        instantRun ":a:thing"
+
+        then:
+        def event3 = fixture.first(LoadProjectsBuildOperationType)
+        event3.result.rootProject.name == 'thing'
+        event3.result.rootProject.children.size() == 3 // All projects are created when storing
+
+        when:
+        instantRun ":a:thing"
+
+        then:
+        def event4 = fixture.first(LoadProjectsBuildOperationType)
+        event4.result.rootProject.name == 'thing'
+        event4.result.rootProject.path == ':'
+        event4.result.rootProject.projectDir == testDirectory.absolutePath
+        event4.result.rootProject.children.size() == 1 // Only project a is created when loading
+        def project1 = event4.result.rootProject.children.first()
+        project1.name == 'a'
+        project1.path == ':a'
+        project1.projectDir == file('a').absolutePath
+        project1.children.empty
+
+        when:
+        instantRun ":a:b:thing"
+
+        then:
+        def event5 = fixture.first(LoadProjectsBuildOperationType)
+        event5.result.rootProject.name == 'thing'
+        event5.result.rootProject.children.size() == 3 // All projects are created when storing
+
+        when:
+        instantRun ":a:b:thing"
+
+        then:
+        def event6 = fixture.first(LoadProjectsBuildOperationType)
+        event6.result.rootProject.name == 'thing'
+        event6.result.rootProject.path == ':'
+        event6.result.rootProject.projectDir == testDirectory.absolutePath
+        event6.result.rootProject.children.size() == 1
+        def project3 = event6.result.rootProject.children.first()
+        project3.name == 'a'
+        project3.path == ':a'
+        project3.projectDir == file('a').absolutePath
+        project3.children.size() == 1
+        def project4 = project3.children.first()
+        project4.name == 'b'
+        project4.path == ':a:b'
+        project4.projectDir == file('custom').absolutePath
     }
 
     def "does not configure build when task graph is already cached for requested tasks"() {

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionTaskWiringIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.TasksWithInputsAndOutputs
 class InstantExecutionTaskWiringIntegrationTest extends AbstractInstantExecutionIntegrationTest implements TasksWithInputsAndOutputs {
     def "task input property can consume the mapped output of another task"() {
         taskTypeWithInputFileProperty()
-        taskTypeWithInputProperty()
+        taskTypeWithIntInputProperty()
 
         buildFile << """
             task producer(type: InputFileTask) {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
@@ -19,13 +19,14 @@ package org.gradle.instantexecution
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.execution.plan.Node
+import java.io.File
 
 
 interface InstantExecutionBuild {
 
     val gradle: GradleInternal
 
-    fun createProject(path: String)
+    fun createProject(path: String, dir: File)
 
     fun getProject(path: String): ProjectInternal
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -200,15 +200,16 @@ class Codecs(
 
     private
     fun BindingsBuilder.providerTypes(filePropertyFactory: FilePropertyFactory, buildServiceRegistry: BuildServiceRegistryInternal, valueSourceProviderFactory: ValueSourceProviderFactory) {
-        bind(ListPropertyCodec)
-        bind(SetPropertyCodec)
-        bind(MapPropertyCodec)
-        bind(DirectoryPropertyCodec(filePropertyFactory))
-        bind(RegularFilePropertyCodec(filePropertyFactory))
-        bind(PropertyCodec)
+        val nestedCodec = FixedValueReplacingProviderCodec(valueSourceProviderFactory, buildServiceRegistry)
+        bind(ListPropertyCodec(nestedCodec))
+        bind(SetPropertyCodec(nestedCodec))
+        bind(MapPropertyCodec(nestedCodec))
+        bind(DirectoryPropertyCodec(filePropertyFactory, nestedCodec))
+        bind(RegularFilePropertyCodec(filePropertyFactory, nestedCodec))
+        bind(PropertyCodec(nestedCodec))
         bind(BuildServiceProviderCodec(buildServiceRegistry))
         bind(ValueSourceProviderCodec(valueSourceProviderFactory))
-        bind(ProviderCodec)
+        bind(ProviderCodec(nestedCodec))
     }
 
     private

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/InstantExecutionTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/InstantExecutionTest.kt
@@ -16,7 +16,8 @@
 
 package org.gradle.instantexecution
 
-import org.gradle.util.Path.path
+import com.nhaarman.mockitokotlin2.mock
+import org.gradle.api.Project
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -26,23 +27,30 @@ class InstantExecutionTest {
 
     @Test
     fun `mind the gaps`() {
+        val root = project(null)
+        val a = project(root)
+        val a_b = project(a)
+        val a_c = project(a)
+        val d = project(root)
+        val d_e = project(d)
+        val d_e_f = project(d_e)
         assertThat(
             fillTheGapsOf(
-                sortedSetOf(
-                    path(":a:b"),
-                    path(":a:c"),
-                    path(":d:e:f")
+                listOf(
+                    a_b,
+                    a_c,
+                    d_e_f
                 )
             ),
             equalTo(
                 listOf(
-                    path(":"),
-                    path(":a"),
-                    path(":a:b"),
-                    path(":a:c"),
-                    path(":d"),
-                    path(":d:e"),
-                    path(":d:e:f")
+                    root,
+                    a,
+                    a_b,
+                    a_c,
+                    d,
+                    d_e,
+                    d_e_f
                 )
             )
         )
@@ -50,23 +58,33 @@ class InstantExecutionTest {
 
     @Test
     fun `don't mind no gaps`() {
+        val root = project(null)
+        val a = project(root)
+        val a_b = project(a)
+        val a_c = project(a)
         assertThat(
             fillTheGapsOf(
-                sortedSetOf(
-                    path(":"),
-                    path(":a"),
-                    path(":a:b"),
-                    path(":a:c")
+                listOf(
+                    root,
+                    a,
+                    a_b,
+                    a_c
                 )
             ),
             equalTo(
                 listOf(
-                    path(":"),
-                    path(":a"),
-                    path(":a:b"),
-                    path(":a:c")
+                    root,
+                    a,
+                    a_b,
+                    a_c
                 )
             )
         )
+    }
+
+    fun project(parent: Project?): Project {
+        return mock {
+            on(mock.parent).thenReturn(parent)
+        }
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.integtests
 
 import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -395,6 +396,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         ins.close()
     }
 
+    @ToBeFixedForInstantExecution
     @Issue("https://github.com/gradle/gradle/issues/9586")
     def "change in case of input file will sync properly"() {
         given:
@@ -425,6 +427,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
+    @ToBeFixedForInstantExecution(skip = ToBeFixedForInstantExecution.Skip.FLAKY)
     @Issue("https://github.com/gradle/gradle/issues/9586")
     def "change in case of input folder will sync properly"() {
         given:

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.Action;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.internal.properties.GradleProperties;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
@@ -171,6 +172,12 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
 
         public P getParameters() {
             return parameters;
+        }
+
+        @Override
+        public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
+            // For now, assume value is never calculated from a task output
+            return true;
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -37,11 +37,18 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
 
     @Override
     public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        if (provider.isPresent()) {
+        if (provider.isValueProducedByTask() || provider.isPresent()) {
+            // either the provider value will be used, or we don't know yet
             return provider.maybeVisitBuildDependencies(context);
         } else {
-            return super.maybeVisitBuildDependencies(context);
+            // provider value will not be used, so there are no dependencies
+            return true;
         }
+    }
+
+    @Override
+    public boolean isValueProducedByTask() {
+        return provider.isValueProducedByTask();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -36,12 +36,21 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Override
+    public boolean isValueProducedByTask() {
+        // TODO - this isn't quite right. The value isn't produced by a task when left always has a value and its value is not produced by a task
+        return left.isValueProducedByTask() || right.isValueProducedByTask();
+    }
+
+    @Override
     public boolean maybeVisitBuildDependencies(TaskDependencyResolveContext context) {
-        if (left.isPresent()) {
-            return left.maybeVisitBuildDependencies(context);
-        } else {
-            return right.maybeVisitBuildDependencies(context);
+        if (left.isValueProducedByTask() && !left.maybeVisitBuildDependencies(context)) {
+            return false;
         }
+        if (!left.isValueProducedByTask() && left.isPresent()) {
+            return left.maybeVisitBuildDependencies(context);
+        }
+        // TODO - this isn't quite right. We shouldn't build right's inputs when left always has a value, but that value is produced by a task
+        return right.maybeVisitBuildDependencies(context);
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -44,7 +44,7 @@ public interface ValueSupplier {
     /**
      * Returns true when the <em>value</em> of this supplier is produced by a task. The <em>value</em> is the object returned the query methods.
      * This is distinct from the <em>content</em>, which is the state of the value or the thing that the value points to. For example, for a file property, the file path
-     * represents the value of the property, and the contents of the file on the file system represents the content of the property.
+     * represents the value of the property, and the content of the file on the file system represents the content of the property.
      *
      * <p>Note that a task producing the value of this supplier is not necessarily the same as a task producing the <em>content</em> of
      * the value of this supplier.

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/ProviderSpec.groovy
@@ -45,6 +45,11 @@ abstract class ProviderSpec<T> extends Specification {
         return "this provider"
     }
 
+    def setup() {
+        def values = [someValue(), someOtherValue(), someOtherValue2(), someOtherValue3()]
+        assert values.unique(false) == values
+    }
+
     def "can query value when it has as value"() {
         given:
         def provider = providerWithValue(someValue())


### PR DESCRIPTION

### Context

Serialize some missing details so that the correct project directory is associated with each project, and the correct project hierarchy is recreated, on load. This fixes some issues uncovered by the `gradle/gradle` build, and causes the output of an artifact transform applied to a project output to be reused on the first load from the cache (previously, the incorrect workspace was used on load, meaning the transform was rerun on the first load, and then reused from that incorrect location on subsequent loads).

Also generalize `Provider` serialization so that a mapped value supplier referenced by a task, but not used at configuration time, does not cause the cache to be invalidated on each build invocation.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
