### PR TITLE
Allow war task to be made cacheable with runtime api

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/WarTaskIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/WarTaskIntegrationTest.groovy
@@ -309,6 +309,7 @@ task war(type: War) {
         succeeds "war"
     }
 
+    @ToBeFixedForInstantExecution
     def "can make war task cacheable with runtime api"() {
         given:
         def webXml = file('web.xml') << '<web/>'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/WarTaskIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/WarTaskIntegrationTest.groovy
@@ -308,4 +308,45 @@ task war(type: War) {
         then:
         succeeds "war"
     }
+
+    def "can make war task cacheable with runtime api"() {
+        given:
+        def webXml = file('web.xml') << '<web/>'
+        createDir('web-inf') {
+            webinf1 {
+                file 'file1.txt'
+            }
+        }
+        and:
+        buildFile << """
+            apply plugin: "base"
+            
+            task war(type: War) {
+                webInf {
+                    from 'web-inf'
+                }
+                webXml = file('web.xml')
+                destinationDirectory = buildDir
+                archiveFileName = 'test.war'
+                outputs.cacheIf { true }
+            }
+        """
+
+        when:
+        withBuildCache().run "clean", "war"
+
+        then:
+        def war = new JarTestFixture(file('build/test.war'))
+        war.assertContainsFile('META-INF/MANIFEST.MF')
+        war.assertContainsFile('WEB-INF/web.xml')
+        war.assertContainsFile('WEB-INF/webinf1/file1.txt')
+
+        war.assertFileContent('WEB-INF/web.xml', webXml.text)
+
+        when:
+        withBuildCache().run "clean", "war"
+
+        then:
+        skipped ":war"
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -66,29 +66,19 @@ public class WarPlugin implements Plugin<Project> {
         project.getTasks().withType(War.class).configureEach(new Action<War>() {
             @Override
             public void execute(War task) {
-                task.from(new Callable() {
-                    @Override
-                    public Object call() throws Exception {
-                        return pluginConvention.getWebAppDir();
-                    }
+                task.from((Callable) () -> pluginConvention.getWebAppDir());
+                task.dependsOn((Callable) () -> project.getConvention()
+                    .getPlugin(JavaPluginConvention.class)
+                    .getSourceSets()
+                    .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                    .getRuntimeClasspath());
+                task.classpath((Callable) () -> {
+                    FileCollection runtimeClasspath = project.getConvention().getPlugin(JavaPluginConvention.class)
+                            .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
+                    Configuration providedRuntime = project.getConfigurations().getByName(
+                            PROVIDED_RUNTIME_CONFIGURATION_NAME);
+                    return runtimeClasspath.minus(providedRuntime);
                 });
-                task.dependsOn(new Callable() {
-                    @Override
-                    public Object call() throws Exception {
-                        return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(
-                                SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
-                    }
-                });
-                task.classpath(new Object[] {new Callable() {
-                    @Override
-                    public Object call() throws Exception {
-                        FileCollection runtimeClasspath = project.getConvention().getPlugin(JavaPluginConvention.class)
-                                .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath();
-                        Configuration providedRuntime = project.getConfigurations().getByName(
-                                PROVIDED_RUNTIME_CONFIGURATION_NAME);
-                        return runtimeClasspath.minus(providedRuntime);
-                    }
-                }});
             }
         });
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -19,7 +19,9 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
+import org.gradle.api.internal.file.copy.RenamingCopyAction;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
@@ -59,10 +61,11 @@ public class War extends Jar {
             FileCollection classpath = getClasspath();
             return classpath != null ? classpath.filter(File::isFile) : Collections.<File>emptyList();
         }));
-        webInf.into("", spec -> {
-            spec.from((Callable<File>) War.this::getWebXml);
-            spec.rename(name -> "web.xml");
-        });
+
+        CopySpecInternal renameSpec = webInf.addChild();
+        renameSpec.into("");
+        renameSpec.from((Callable<File>) War.this::getWebXml);
+        renameSpec.appendCachingSafeCopyAction(new RenamingCopyAction(name -> "web.xml"));
     }
 
     @Internal


### PR DESCRIPTION
By default, the `War` task is not cacheable, but we want to support allowing users to make it cacheable when that makes sense.  Unfortunately, there was a rename being added in the constructor for `War` that marks the task as not-cacheable in any scenario, so even if the user used the runtime api to mark the task as cacheable, it still would not cache.

This changes the rename to be added as a "cache safe" action, so the `War` task can be marked cacheable as long as the user doesn't add anything else to the task's copy spec that would disable caching again.

Fixes #12117.

