### PR TITLE
Improve serialization of `PatternSet` instances to the instant execution cache

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/IntersectionPatternSet.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/util/internal/IntersectionPatternSet.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.util.internal;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.FileTreeElement;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
+import org.gradle.api.tasks.util.PatternSet;
+
+public class IntersectionPatternSet extends PatternSet {
+
+    private final PatternSet other;
+
+    public IntersectionPatternSet(PatternSet other) {
+        super(other);
+        this.other = other;
+    }
+
+    public PatternSet getOther() {
+        return other;
+    }
+
+    @Override
+    public Spec<FileTreeElement> getAsSpec() {
+        return Specs.intersect(super.getAsSpec(), other.getAsSpec());
+    }
+
+    @Override
+    public Object addToAntBuilder(Object node, String childNodeName) {
+        return PatternSetAntBuilderDelegate.and(node, new Action<Object>() {
+            @Override
+            public void execute(Object andNode) {
+                org.gradle.api.tasks.util.internal.IntersectionPatternSet.super.addToAntBuilder(andNode, null);
+                other.addToAntBuilder(andNode, null);
+            }
+        });
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return other.isEmpty() && super.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        org.gradle.api.tasks.util.internal.IntersectionPatternSet that = (org.gradle.api.tasks.util.internal.IntersectionPatternSet) o;
+
+        return other != null ? other.equals(that.other) : that.other == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (other != null ? other.hashCode() : 0);
+        return result;
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -217,6 +217,7 @@ class Codecs(
         bind(FileTreeCodec(directoryFileTreeFactory))
         bind(ConfigurableFileCollectionCodec(fileCollectionFactory))
         bind(FileCollectionCodec(fileCollectionFactory))
+        bind(IntersectPatternSetCodec)
         bind(PatternSetCodec)
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PatternSetCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/PatternSetCodec.kt
@@ -17,6 +17,7 @@
 package org.gradle.instantexecution.serialization.codecs
 
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.api.tasks.util.internal.IntersectionPatternSet
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
@@ -37,4 +38,21 @@ object PatternSetCodec : Codec<PatternSet> {
             setIncludes(readStrings())
             setExcludes(readStrings())
         }
+}
+
+
+object IntersectPatternSetCodec : Codec<IntersectionPatternSet> {
+    override suspend fun WriteContext.encode(value: IntersectionPatternSet) {
+        write(value.other)
+        writeStrings(value.includes)
+        writeStrings(value.excludes)
+    }
+
+    override suspend fun ReadContext.decode(): IntersectionPatternSet? {
+        val other = read() as PatternSet
+        return IntersectionPatternSet(other).apply {
+            setIncludes(readStrings())
+            setExcludes(readStrings())
+        }
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -161,7 +161,7 @@ public class JavaCompile extends AbstractCompile {
         Compiler<JavaCompileSpec> compiler;
         if (!compileOptions.isIncremental()) {
             spec = createSpec();
-            spec.setSourceFiles(getSource());
+            spec.setSourceFiles(getStableSources());
             compiler = createCompiler(spec);
         } else {
             spec = createSpec();


### PR DESCRIPTION

### Context

This fixes an issue where the Java compilation task for a source set would attempt to compile non-Java source files found in the source set.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
