### PR TITLE
Add javadoc to deprecation builder public methods

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -30,6 +30,22 @@ import static org.gradle.internal.deprecation.Messages.thisIsScheduledToBeRemove
 import static org.gradle.internal.deprecation.Messages.thisWillBecomeAnError;
 import static org.gradle.internal.deprecation.Messages.xHasBeenDeprecated;
 
+
+/**
+ * Provides entry points for constructing and emitting deprecation messages.
+ * The basic deprecation message structure is "Summary. RemovalDetails. Context. Advice. Documentation."
+ *
+ * The deprecateX methods in this class return a builder that guides creation of the deprecation message.
+ * Summary and RemovalDetails parts are populated by the deprecateX methods in this class.
+ * Context can be added in free text using {@link DeprecationMessageBuilder#withContext(String)}.
+ * Advice is constructed contextually using {@link DeprecationMessageBuilder.WithReplacement#replaceWith(Object)} methods based on the thing being deprecated. Alternatively, it can be populated using {@link DeprecationMessageBuilder#withAdvice(String)}.
+ * Documentation reference is added using one of:
+ *  - {@link DeprecationMessageBuilder#withUpgradeGuideSection(int, String)}
+ *  - {@link DeprecationMessageBuilder#withDslReference(Class, String)}
+ *  - {@link DeprecationMessageBuilder#withUserManual(String, String)}
+ *
+ *  In order for the deprecation message to be emitted, terminal operation {@link DeprecationMessageBuilder.WithDocumentation#nagUser()} has to be called after one of the documentation providing methods.
+ */
 @ThreadSafe
 public class DeprecationLogger {
 
@@ -60,6 +76,8 @@ public class DeprecationLogger {
     }
 
     /**
+     * This is a rather generic deprecation entry point - consider using a more specific deprecation method and only resort to this one if there is no fit.
+     *
      * Output: ${feature} has been deprecated. This is scheduled to be removed in Gradle X.
      */
     @CheckReturnValue
@@ -75,6 +93,9 @@ public class DeprecationLogger {
     }
 
     /**
+     * Indirect usage means that stack trace at the time the deprecation is logged does not indicate the call site.
+     * This directs GE to not display unhelpful stacktraces with the deprecation.
+     *
      * Output: ${feature} has been deprecated. This is scheduled to be removed in Gradle X.
      */
     @CheckReturnValue
@@ -85,6 +106,7 @@ public class DeprecationLogger {
     }
 
     /**
+     *
      * Output: ${feature} has been deprecated. This is scheduled to be removed in Gradle X.
      */
     @CheckReturnValue

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -50,25 +50,41 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
         return (T) this;
     }
 
+    /**
+     * Allows proceeding to terminal {@link WithDocumentation#nagUser()} operation without including any documentation reference.
+     * Consider using one of the documentation providing methods instead.
+     */
     public WithDocumentation undocumented() {
         return new WithDocumentation(this);
     }
 
+    /**
+     * Output: See USER_MANUAL_URL for more details.
+     */
     public WithDocumentation withUserManual(String documentationId) {
         this.documentation = Documentation.userManual(documentationId);
         return new WithDocumentation(this);
     }
 
+    /**
+     * Output: See USER_MANUAL_URL for more details.
+     */
     public WithDocumentation withUserManual(String documentationId, String section) {
         this.documentation = Documentation.userManual(documentationId, section);
         return new WithDocumentation(this);
     }
 
+    /**
+     * Output: See DSL_REFERENCE_URL for more details.
+     */
     public WithDocumentation withDslReference(Class<?> targetClass, String property) {
         this.documentation = Documentation.dslReference(targetClass, property);
         return new WithDocumentation(this);
     }
 
+    /**
+     * Output: Consult the upgrading guide for further information: UPGRADE_GUIDE_URL
+     */
     public WithDocumentation withUpgradeGuideSection(int majorVersion, String upgradeGuideSection) {
         this.documentation = Documentation.upgradeGuide(majorVersion, upgradeGuideSection);
         return new WithDocumentation(this);
@@ -105,10 +121,13 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
     public static class WithDocumentation {
         private final DeprecationMessageBuilder<?> builder;
 
-        public WithDocumentation(DeprecationMessageBuilder<?> builder) {
+        WithDocumentation(DeprecationMessageBuilder<?> builder) {
             this.builder = builder;
         }
 
+        /**
+         * Terminal operation. Emits the deprecation message.
+         */
         public void nagUser() {
             DeprecationLogger.nagUserWith(builder, WithDocumentation.class);
         }
@@ -122,6 +141,16 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
             this.subject = subject;
         }
 
+        /**
+         * Constructs advice message based on the context.
+         *
+         * deprecateProperty: Please use the ${replacement} property instead.
+         * deprecateMethod/deprecateInvocation: Please use the ${replacement} method instead.
+         * deprecatePlugin: Please use the ${replacement} plugin instead.
+         * deprecateTask: Please use the ${replacement} task instead.
+         * deprecateInternalApi: Please use ${replacement} instead.
+         * deprecateNamedParameter: Please use the ${replacement} named parameter instead.
+         */
         @SuppressWarnings("unchecked")
         public SELF replaceWith(T replacement) {
             this.replacement = replacement;
@@ -178,6 +207,9 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
             this.property = property;
         }
 
+        /**
+         * Output: See DSL_REFERENCE_URL for more details.
+         */
         public WithDocumentation withDslReference() {
             setDocumentation(Documentation.dslReference(propertyClass, property));
             return new WithDocumentation(this);
@@ -333,6 +365,9 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
             return externalReplacement ? String.format("Consider using the %s plugin instead.", replacement) : String.format("Please use the %s plugin instead.", replacement);
         }
 
+        /**
+         * Advice output: Consider using the ${replacement} plugin instead.
+         */
         public DeprecatePlugin replaceWithExternalPlugin(String replacement) {
             this.externalReplacement = true;
             return replaceWith(replacement);


### PR DESCRIPTION
Added javadoc to the public methods of DeprecationLogger and DeprecationMessageBuilder where I felt more explanation would be useful.