### PR TITLE
Use unique transform names for Gradle API sources

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
@@ -148,10 +148,19 @@ public class DefaultGradleApiSourcesResolver implements GradleApiSourcesResolver
         Map<String, String> sourceDependency = new HashMap<>();
         sourceDependency.put("group", "gradle");
         sourceDependency.put("name", "gradle");
-        sourceDependency.put("version", gradleVersion().getVersion());
+        sourceDependency.put("version", dependencyVersion());
         sourceDependency.put("classifier", "src");
         sourceDependency.put("ext", "zip");
         return project.getDependencies().create(sourceDependency);
+    }
+
+    private String dependencyVersion() {
+        GradleVersion version = gradleVersion();
+        if (version.isSnapshot()) {
+            return String.format("(6.1.1, %s]", version.getVersion());
+        } else {
+            return version.getVersion();
+        }
     }
 
     private static String repositoryNameFor(GradleVersion gradleVersion) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
@@ -54,8 +54,8 @@ public class DefaultGradleApiSourcesResolver implements GradleApiSourcesResolver
     private final Project project;
 
     private final String zipType = "zip";
-    private final String unzippedDistributionType = "unzipped-distribution";
-    private final String sourceDirectory = "src-directory";
+    private final String unzippedDistributionType = "gradle-src-unzip";
+    private final String sourceDirectory = "gradle-src-dir";
 
     public DefaultGradleApiSourcesResolver(Project project) {
         this.project = project;

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/KotlinIdeaModelBuildAction.java
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/KotlinIdeaModelBuildAction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.idea.IdeaProject;
+import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel;
+
+public class KotlinIdeaModelBuildAction implements BuildAction<Object> {
+
+    @Override
+    public Object execute(BuildController controller) {
+        controller.getModel(KotlinDslScriptsModel.class);
+        controller.getModel(IdeaProject.class);
+        return null;
+    }
+}

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -73,8 +73,6 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
 
     def "can configure Kotlin DSL project with gradleApi() dependency via tooling API"() {
         given:
-        toolingApi.requireIsolatedToolingApi()
-
         buildKotlinFile << """
         plugins {
             java

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.time.CountdownTimer
 import org.gradle.internal.time.Time
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.tooling.BuildActionFailureException
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.GradleProject
@@ -89,10 +88,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
         when:
         def stdOut = new ByteArrayOutputStream()
         toolingApi.withConnection { ProjectConnection connection ->
-            connection.action(new KotlinIdeaModelBuildAction())
-                .addArguments("--info")
-                .setStandardOutput(stdOut)
-                .run()
+            connection.action(new KotlinIdeaModelBuildAction()).setStandardOutput(stdOut).run()
         }
 
         then:

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -88,6 +88,9 @@ dependencies {
     testImplementation(testFixtures(project(":workers")))
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))
+    integTestRuntimeOnly(project(":kotlinDsl"))
+    integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
+    integTestRuntimeOnly(project(":kotlinDslToolingBuilders"))
 }
 
 gradlebuildJava {

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     integTestRuntimeOnly(project(":kotlinDsl"))
     integTestRuntimeOnly(project(":kotlinDslProviderPlugins"))
     integTestRuntimeOnly(project(":kotlinDslToolingBuilders"))
+    integTestRuntimeOnly(project(":apiMetadata"))
 }
 
 gradlebuildJava {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/12178

Otherwise it clashes with [KotlinDSL transforms](https://github.com/gradle/gradle/blob/364a3181db2929c9a9dc29072ccceed9d956ec8a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt#L42-L43) when using latest IDEA Kotlin plugin - version `1.3.70-eap-184-IJ2019.3-1`