### PR TITLE
Mark Gradle properties that influence `project.version` as build logic inputs

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
@@ -54,9 +54,9 @@ fun Project.setBuildVersion() {
         logger.logStartParameter(gradle.startParameter)
     }
 
-    val finalRelease: Any? by project
-    val rcNumber: String? by project
-    val milestoneNumber: String? by project
+    val finalRelease = gradleProperty("finalRelease").orNull
+    val rcNumber = gradleProperty("rcNumber").orNull
+    val milestoneNumber = gradleProperty("milestoneNumber").orNull
     if ((finalRelease != null && rcNumber != null) ||
         (finalRelease != null && milestoneNumber != null) ||
         (rcNumber != null && milestoneNumber != null)) {
@@ -66,7 +66,7 @@ fun Project.setBuildVersion() {
         )
     }
 
-    val versionQualifier: String? by project
+    val versionQualifier = gradleProperty("versionQualifier").orNull
     val isSnapshot = finalRelease == null && rcNumber == null && milestoneNumber == null
     val isFinalRelease = finalRelease != null
     val baseVersion = rootProject.trimmedContentsOfFile("version.txt")
@@ -181,7 +181,6 @@ fun Project.buildTimestamp(): Provider<String> =
             )
             buildTimestampFromGradleProperty.set(
                 gradleProperty("buildTimestamp")
-                    .uncheckedCast<Provider<String>>()
             )
             runningOnCi.set(
                 providers.environmentVariable(CI_ENVIRONMENT_VARIABLE)
@@ -302,10 +301,9 @@ val Project.buildTypes
     get() = extensions.getByName<NamedDomainObjectContainer<BuildType>>("buildTypes")
 
 
-// TODO: move to ProviderFactory and make it a build logic input
 private
-fun Project.gradleProperty(propertyName: String): Provider<Any> =
-    provider { findProperty(propertyName) }
+fun Project.gradleProperty(propertyName: String): Provider<String> =
+    providers.gradleProperty(propertyName)
 
 
 /**


### PR DESCRIPTION
By accessing them via `providers.gradleProperty(...)`.
