### PR TITLE
Ignore failing test with vfs retention enabled

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -31,6 +32,7 @@ import static org.gradle.work.ChangeType.MODIFIED
 
 @Unroll
 @Requires(TestPrecondition.SYMLINKS)
+@ToBeFixedForVfsRetention("https://github.com/gradle/gradle/issues/11851")
 class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
 
     def "#desc can handle symlinks"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
@@ -20,7 +20,10 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
-import static org.gradle.api.tasks.PathSensitivity.*
+import static org.gradle.api.tasks.PathSensitivity.ABSOLUTE
+import static org.gradle.api.tasks.PathSensitivity.NAME_ONLY
+import static org.gradle.api.tasks.PathSensitivity.NONE
+import static org.gradle.api.tasks.PathSensitivity.RELATIVE
 
 @Unroll
 abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegrationSpec {
@@ -165,7 +168,7 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
         """
         buildFile << """
             task test(type: PathSensitiveTask) {
-                outputFile = file("output.txt")
+                outputFile = file("build/output.txt")
             }
         """
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedPathSensitivityIntegrationTest.groovy
@@ -24,11 +24,7 @@ import spock.lang.Unroll
 class CachedPathSensitivityIntegrationTest extends AbstractPathSensitivityIntegrationSpec implements DirectoryBuildCacheFixture {
     def setup() {
         buildFile << """
-            task clean {
-                doLast {
-                    delete(tasks*.outputs*.files)
-                }
-            }
+            apply plugin: 'base'
         """
     }
 
@@ -54,23 +50,22 @@ class CachedPathSensitivityIntegrationTest extends AbstractPathSensitivityIntegr
         buildFile << """
             task producer {
                 outputs.cacheIf { true }
-                outputs.file("outputs/producer.txt")
+                outputs.file("build/outputs/producer.txt")
                 doLast {
-                    mkdir("outputs")
-                    file("outputs/producer.txt").text = "alma"
+                    file("build/outputs/producer.txt").text = "alma"
                 }
             }
-            
+
             task consumer {
                 dependsOn producer
                 outputs.cacheIf { true }
-                inputs.file("outputs/producer.txt")
+                inputs.file("build/outputs/producer.txt")
                     .withPropertyName("producer")
                     .withPathSensitivity(PathSensitivity.$pathSensitivity)
-                outputs.file("outputs/consumer.txt")
+                outputs.file("build/outputs/consumer.txt")
                     .withPropertyName("consumer")
                 doLast {
-                    file("outputs/consumer.txt").text = file("outputs/producer.txt").text
+                    file("build/outputs/consumer.txt").text = file("build/outputs/producer.txt").text
                 }
             }
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ConcurrentBuildsIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ConcurrentBuildsIncrementalBuildIntegrationTest.groovy
@@ -32,6 +32,7 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
@@ -86,6 +87,7 @@ public class TransformerTask extends DefaultTask {
 '''
     }
 
+    @ToBeFixedForVfsRetention("https://github.com/gradle/gradle/issues/11837")
     def "task history is shared between multiple build processes"() {
         prepareTransformTask()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -25,6 +26,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 @Requires(TestPrecondition.SYMLINKS)
+@ToBeFixedForVfsRetention("https://github.com/gradle/gradle/issues/11851")
 class IncrementalBuildSymlinkHandlingIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
@@ -25,6 +25,7 @@ import spock.lang.Unroll
 class BuildScanEndOfBuildNotifierIntegrationTest extends AbstractIntegrationSpec {
 
     private static final VFS_RETENTION_OUTPUT = '''(Watching \\d* (directory hierarchies to track changes between builds in \\d* directories|directories to track changes between builds)
+Spent \\d+ ms registering watches for file system events
 )?'''
 
     def setup() {
@@ -37,7 +38,7 @@ class BuildScanEndOfBuildNotifierIntegrationTest extends AbstractIntegrationSpec
         when:
         buildFile << """
             notifier.notify {
-                println "failure is null: \${it.failure == null}" 
+                println "failure is null: \${it.failure == null}"
             }
             // user logic registered _after_ listener registered
             gradle.buildFinished {
@@ -62,7 +63,7 @@ ${VFS_RETENTION_OUTPUT}\$""")
         buildFile << """
             task t { doFirst { throw new Exception("!") } }
             notifier.notify {
-                println "failure message: \${it.failure.cause.message}" 
+                println "failure message: \${it.failure.cause.message}"
                 System.err.println "notified"
             }
             // user logic registered _after_ listener registered
@@ -99,10 +100,10 @@ notified
         """
         buildFile << """
             notifier.notify {
-                println "failure message: \${it.failure.cause.message}" 
+                println "failure message: \${it.failure.cause.message}"
             }
-            task t { 
-                dependsOn gradle.includedBuild("child").task(":t") 
+            task t {
+                dependsOn gradle.includedBuild("child").task(":t")
                 doLast { }
             }
         """

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionIntegrationTest.groovy
@@ -76,15 +76,22 @@ class InstantExecutionIntegrationTest extends AbstractInstantExecutionIntegratio
     def "instant execution for help on empty project"() {
         given:
         instantRun "help"
-        def firstRunOutput = result.normalizedOutput.replace('Calculating task graph as no instant execution cache is available for tasks: help', '')
+        def firstRunOutput = result.normalizedOutput
+            .replaceAll(/Calculating task graph as no instant execution cache is available for tasks: help\n/, '')
+            .replaceAll(/Watching \d+ (directory hierarchies to track changes between builds in \d+ directories|directories to track changes between builds)\n/, '')
+            .replaceAll(/Spent \d+ ms registering watches for file system events\n/, '')
 
         when:
         instantRun "help"
+        def secondRunOutput = result.normalizedOutput
+            .replaceAll(/Reusing instant execution cache. This is not guaranteed to work in any way.\n/, '')
+            .replaceAll(/Received \d+ file system events since last build\n/, '')
+            .replaceAll(/Spent \d+ ms processing file system events since last build\n/, '')
+            .replaceAll(/Watching \d+ (directory hierarchies to track changes between builds in \d+ directories|directories to track changes between builds)\n/, '')
+            .replaceAll(/Spent \d+ ms registering watches for file system events\n/, '')
 
         then:
-        firstRunOutput == result.normalizedOutput
-            .replace('Reusing instant execution cache. This is not guaranteed to work in any way.', '')
-            .replaceAll('Received \\d* file system events since last build\n', '')
+        firstRunOutput == secondRunOutput
     }
 
     def "restores some details of the project structure"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SubstIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SubstIntegrationTest.groovy
@@ -16,11 +16,13 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
 
 @Requires(TestPrecondition.WINDOWS)
+@ToBeFixedForVfsRetention("https://github.com/gradle/gradle/issues/12135")
 class SubstIntegrationTest extends AbstractIntegrationSpec {
     def "up to date check works from filesystem's root - intput folder to output file"() {
         def drive = 'X:'
@@ -32,18 +34,18 @@ class SubstIntegrationTest extends AbstractIntegrationSpec {
         def outputFile = file("output.txt")
 
         def taskName = 'inputFromFilesystemRoot'
-        def script = /*language=Groovy*/ """
+        def script = """
             class InputDirectoryContentToOutputFileAction extends DefaultTask {
                 @InputDirectory File inputDirectory
                 @OutputFile File output
-                
+
                 @TaskAction def execute() {
                     output.text = inputDirectory.list().join()
                 }
             }
-            
+
             task ${taskName}(type: InputDirectoryContentToOutputFileAction) {
-                inputDirectory = new File("${drive}\\\\") 
+                inputDirectory = new File("${drive}\\\\")
                 output = file("${TextUtil.escapeString(outputFile.absolutePath)}")
             }
         """
@@ -69,18 +71,18 @@ class SubstIntegrationTest extends AbstractIntegrationSpec {
         def outputDirectory = new File(drive)
 
         def taskName = 'outputFromFilesystemRoot'
-        def script = /*language=Groovy*/ """
+        def script = """
             class InputFileToOutputDirectoryCopyAction extends DefaultTask {
                 @InputFile File input
                 @OutputDirectory File outputDirectory
-                
+
                 @TaskAction def execute() {
                     new File(outputDirectory, "${inputFileName}") << input.text
                 }
             }
-            
+
             task ${taskName}(type: InputFileToOutputDirectoryCopyAction) {
-                input = file("${TextUtil.escapeString(inputFile.absolutePath)}") 
+                input = file("${TextUtil.escapeString(inputFile.absolutePath)}")
                 outputDirectory = new File("${drive}\\\\")
             }
         """

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetention.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetention.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures;
+
+import org.spockframework.runtime.extension.ExtensionAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtensionAnnotation(ToBeFixedForVfsRetentionExtension.class)
+public @interface ToBeFixedForVfsRetention {
+    /**
+     * The reason why the test doesn't work.
+     */
+    String value();
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetentionExtension.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForVfsRetentionExtension.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures;
+
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter;
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension;
+import org.spockframework.runtime.model.FeatureInfo;
+import org.spockframework.runtime.model.ISkippable;
+import org.spockframework.runtime.model.SpecInfo;
+
+public class ToBeFixedForVfsRetentionExtension extends AbstractAnnotationDrivenExtension<ToBeFixedForVfsRetention> {
+    @Override
+    public void visitSpecAnnotation(ToBeFixedForVfsRetention annotation, SpecInfo spec) {
+        doVisit(spec);
+    }
+
+    @Override
+    public void visitFeatureAnnotation(ToBeFixedForVfsRetention annotation, FeatureInfo feature) {
+        doVisit(feature);
+    }
+
+    private void doVisit(ISkippable skippable) {
+        if (GradleContextualExecuter.isVfsRetention()) {
+            skippable.setSkipped(true);
+        }
+    }
+}

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/AbstractPrecompiledScriptPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/AbstractPrecompiledScriptPluginTest.kt
@@ -27,6 +27,11 @@ open class AbstractPrecompiledScriptPluginTest : AbstractPluginTest() {
     @Before
     fun setupPluginTest() {
         requireGradleDistributionOnEmbeddedExecuter()
+        executer.beforeExecute {
+            // Ignore stacktraces when the Kotlin daemon fails
+            // See https://github.com/gradle/gradle-private/issues/2936
+            it.withStackTraceChecksDisabled()
+        }
     }
 
     protected

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadWaitingIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/continuous/PlayContinuousBuildReloadWaitingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.play.integtest.continuous
 
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 
 /**
  * Test that app requests block while a build is in progress when using `--continuous`.
@@ -109,6 +110,7 @@ class PlayContinuousBuildReloadWaitingIntegrationTest extends AbstractPlayReload
     }
 
     @ToBeFixedForInstantExecution
+    @ToBeFixedForVfsRetention("https://github.com/gradle/gradle/issues/12136")
     def "wait for changes to be built when a request comes in during initial app startup and there are pending changes"() {
         given:
         // prebuild so the build doesn't timeout waiting for rebuild signal

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BuildSrcPluginIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.ToBeFixedForVfsRetention
 import spock.lang.Issue
 
 class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
@@ -127,12 +128,13 @@ class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Could not compile build file '$buildFile.canonicalPath'.")
     }
 
+    @ToBeFixedForVfsRetention("https://github.com/gradle/gradle/issues/11837")
     def "build uses jar from buildSrc"() {
         writeBuildSrcPlugin("buildSrc", "MyPlugin")
         buildFile << """
             apply plugin: MyPlugin
             // nuke buildSrc classes so we can't use them
-            project.delete(file("buildSrc/build/classes")) 
+            project.delete(file("buildSrc/build/classes"))
         """
         when:
         succeeds("myTaskMyPlugin")
@@ -140,6 +142,7 @@ class BuildSrcPluginIntegrationTest extends AbstractIntegrationSpec {
         outputContains("From MyPlugin")
     }
 
+    @ToBeFixedForVfsRetention("https://github.com/gradle/gradle/issues/11837")
     def "build uses jars from multi-project buildSrc"() {
         writeBuildSrcPlugin("buildSrc", "MyPlugin")
         writeBuildSrcPlugin("buildSrc/subproject", "MyPluginSub")


### PR DESCRIPTION
Allow to easily ignore test which fail when vfs retention is enabled.

Fixes #12134.