### PR TITLE
Use implementation instead of compile

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
@@ -29,13 +29,13 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         settingsFile << "include 'upstream', 'downstream'"
         buildFile << """
             subprojects {
-                apply plugin: 'java'
+                apply plugin: 'java-library'
                 ${mavenCentralRepository()}
             }
 
             project(':downstream') {
                 dependencies {
-                    compile project(":upstream")
+                    implementation project(":upstream")
                 }
             }
         """
@@ -141,7 +141,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         def extraProjectNames = (0..100).collect { "project$it" }
         extraProjectNames.each {
             settingsFile << "\n include '$it' \n"
-            buildFile << "\n project(':$it') { dependencies { compile project(':upstream') } } \n"
+            buildFile << "\n project(':$it') { dependencies { implementation project(':upstream') } } \n"
             file("${it}/src/main/java/Thing${it}.java").createFile() << """
                 class Thing${it} extends Upstream {}
             """


### PR DESCRIPTION
in `MultiProjectContinuousIntegrationTest`, so no deprecation message is emitted.