### PR TITLE
Add accessors for sourced attributes within metadata rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
@@ -18,6 +18,8 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
+
 /**
  * Describes a dependency declared in a resolved component's metadata, which typically originates from
  * a component descriptor (Gradle metadata file, Ivy file, Maven POM). This interface can be used to adjust
@@ -53,5 +55,23 @@ public interface DirectDependencyMetadata extends DependencyMetadata<DirectDepen
      */
     @Incubating
     boolean isEndorsingStrictVersions();
+
+    /**
+     * Returns the classifier for the dependency if available via the original Maven POM.
+     *
+     * @since 6.3
+     */
+    @Incubating
+    @Nullable
+    String getClassifier();
+
+    /**
+     * Returns the Maven POM type for the dependency if available.
+     *
+     * @since 6.3
+     */
+    @Incubating
+    @Nullable
+    String getType();
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
@@ -18,7 +18,7 @@ package org.gradle.api.artifacts;
 
 import org.gradle.api.Incubating;
 
-import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Describes a dependency declared in a resolved component's metadata, which typically originates from
@@ -57,21 +57,12 @@ public interface DirectDependencyMetadata extends DependencyMetadata<DirectDepen
     boolean isEndorsingStrictVersions();
 
     /**
-     * Returns the classifier for the dependency if available via the original Maven POM.
+     * Returns additional artifact information associated with the dependency that is used to select artifacts in the targeted module.
+     * For example, a classifier or type defined in POM metadata or a complete artifact name defined in Ivy metadata.
      *
      * @since 6.3
      */
     @Incubating
-    @Nullable
-    String getClassifier();
-
-    /**
-     * Returns the Maven POM type for the dependency if available.
-     *
-     * @since 6.3
-     */
-    @Incubating
-    @Nullable
-    String getType();
+    List<DependencyArtifact> getArtifactSelectors();
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -129,13 +129,9 @@ dependencies {
 
         then:
         succeeds 'resolve'
-        if (isGradleMetadataPublished()) {
-            outputContains("selectorSize:0")
-        } else {
-            outputContains("selectorSize:1")
-            outputContains("classifier:classy")
-            outputContains("type:jar")
-        }
+        outputContains("selectorSize:1")
+        outputContains("classifier:classy")
+        outputContains("type:jar")
     }
 
     def "added dependency has no artifact selectors"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
@@ -63,10 +63,10 @@ public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataA
 
     private Optional<IvyArtifactName> getIvyArtifact() {
         ModuleDependencyMetadata originalMetadata = getOriginalMetadata();
-        if(originalMetadata instanceof ConfigurationBoundExternalDependencyMetadata) {
+        if (originalMetadata instanceof ConfigurationBoundExternalDependencyMetadata) {
             ConfigurationBoundExternalDependencyMetadata externalMetadata = (ConfigurationBoundExternalDependencyMetadata) originalMetadata;
             ExternalDependencyDescriptor descriptor = externalMetadata.getDependencyDescriptor();
-            if(descriptor instanceof MavenDependencyDescriptor) {
+            if (descriptor instanceof MavenDependencyDescriptor) {
                 return Optional.ofNullable(((MavenDependencyDescriptor) descriptor).getDependencyArtifact());
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
@@ -18,9 +18,15 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
+import org.gradle.internal.component.external.model.ExternalDependencyDescriptor;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
+import org.gradle.internal.component.model.IvyArtifactName;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataAdapter<DirectDependencyMetadata> implements DirectDependencyMetadata {
 
@@ -42,4 +48,29 @@ public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataA
     public boolean isEndorsingStrictVersions() {
         return getOriginalMetadata().isEndorsingStrictVersions();
     }
+
+    @Nullable
+    @Override
+    public String getClassifier() {
+        return getIvyArtifact().map(IvyArtifactName::getClassifier).orElse(null);
+    }
+
+    @Nullable
+    @Override
+    public String getType() {
+        return getIvyArtifact().map(IvyArtifactName::getType).orElse(null);
+    }
+
+    private Optional<IvyArtifactName> getIvyArtifact() {
+        ModuleDependencyMetadata originalMetadata = getOriginalMetadata();
+        if(originalMetadata instanceof ConfigurationBoundExternalDependencyMetadata) {
+            ConfigurationBoundExternalDependencyMetadata externalMetadata = (ConfigurationBoundExternalDependencyMetadata) originalMetadata;
+            ExternalDependencyDescriptor descriptor = externalMetadata.getDependencyDescriptor();
+            if(descriptor instanceof MavenDependencyDescriptor) {
+                return Optional.ofNullable(((MavenDependencyDescriptor) descriptor).getDependencyArtifact());
+            }
+        }
+        return Optional.empty();
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
 import org.gradle.internal.component.external.model.ExternalDependencyDescriptor;
+import org.gradle.internal.component.external.model.GradleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
@@ -73,6 +74,16 @@ public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataA
             if (descriptor instanceof IvyDependencyDescriptor) {
                 return fromIvyDescriptor((IvyDependencyDescriptor) descriptor);
             }
+        } else if (originalMetadata instanceof GradleDependencyMetadata){
+            return fromGradleMetadata((GradleDependencyMetadata) originalMetadata);
+        }
+        return Collections.emptyList();
+    }
+
+    private List<IvyArtifactName> fromGradleMetadata(GradleDependencyMetadata metadata) {
+        IvyArtifactName artifact = metadata.getDependencyArtifact();
+        if(artifact != null) {
+            return Collections.singletonList(artifact);
         }
         return Collections.emptyList();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImpl.java
@@ -18,9 +18,11 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 
 import org.gradle.api.artifacts.DirectDependencyMetadata;
 
+import javax.annotation.Nullable;
+
 public class DirectDependencyMetadataImpl extends AbstractDependencyImpl<DirectDependencyMetadata> implements DirectDependencyMetadata {
 
-    boolean endorsing = false;
+    private boolean endorsing = false;
 
     public DirectDependencyMetadataImpl(String group, String name, String version) {
         super(group, name, version);
@@ -40,4 +42,17 @@ public class DirectDependencyMetadataImpl extends AbstractDependencyImpl<DirectD
     public boolean isEndorsingStrictVersions() {
         return endorsing;
     }
+
+    @Nullable
+    @Override
+    public String getClassifier() {
+        throw new UnsupportedOperationException("Classifier is not available for newly added dependencies");
+    }
+
+    @Nullable
+    @Override
+    public String getType() {
+        throw new UnsupportedOperationException("Type is not available for newly added dependencies");
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImpl.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImpl.java
@@ -16,9 +16,11 @@
 
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
+import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
 
-import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
 
 public class DirectDependencyMetadataImpl extends AbstractDependencyImpl<DirectDependencyMetadata> implements DirectDependencyMetadata {
 
@@ -43,16 +45,9 @@ public class DirectDependencyMetadataImpl extends AbstractDependencyImpl<DirectD
         return endorsing;
     }
 
-    @Nullable
     @Override
-    public String getClassifier() {
-        throw new UnsupportedOperationException("Classifier is not available for newly added dependencies");
-    }
-
-    @Nullable
-    @Override
-    public String getType() {
-        throw new UnsupportedOperationException("Type is not available for newly added dependencies");
+    public List<DependencyArtifact> getArtifactSelectors() {
+        return Collections.emptyList();
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -91,15 +91,6 @@ abstract class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].selector.version == "1.0"
     }
 
-    def "added dependency has no maven metadata"() {
-        when:
-        adapter.add "org.gradle.test:module1:1.0"
-
-        then:
-        println dependenciesMetadata[0].selector
-        println dependenciesMetadata[0].selector.class
-    }
-
     def "remove is propagated to the underlying dependency list"() {
         given:
         fillDependencyList(1)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -91,6 +91,15 @@ abstract class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].selector.version == "1.0"
     }
 
+    def "added dependency has no maven metadata"() {
+        when:
+        adapter.add "org.gradle.test:module1:1.0"
+
+        then:
+        println dependenciesMetadata[0].selector
+        println dependenciesMetadata[0].selector.class
+    }
+
     def "remove is propagated to the underlying dependency list"() {
         given:
         fillDependencyList(1)
@@ -206,6 +215,15 @@ abstract class DependenciesMetadataAdapterTest extends Specification {
         then:
         dependenciesMetadata.size() == 1
         dependenciesMetadata[0].isEndorsingStrictVersions()
+    }
+
+    def "modified dependency has no maven pom attributes"() {
+        when:
+        adapter.add "org.gradle.test:module1:1.0"
+
+        then:
+        adapter.get(0).classifier == null
+        adapter.get(0).type == null
     }
 
     private fillDependencyList(int size) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -217,13 +217,12 @@ abstract class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata[0].isEndorsingStrictVersions()
     }
 
-    def "modified dependency has no maven pom attributes"() {
+    def "modified dependency has no artifact selectors"() {
         when:
         adapter.add "org.gradle.test:module1:1.0"
 
         then:
-        adapter.get(0).classifier == null
-        adapter.get(0).type == null
+        adapter.get(0).artifactSelectors == []
     }
 
     private fillDependencyList(int size) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImplTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImplTest.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.resolver
+
+import spock.lang.Specification
+
+class DirectDependencyMetadataImplTest extends Specification {
+    def "endoreStrictVersion is off by default"() {
+        given:
+        def metadata = new DirectDependencyMetadataImpl("g", "a", "v")
+
+        expect:
+        metadata.endorsingStrictVersions == false
+    }
+
+    def "can toggle endoreStrictVersion"() {
+        given:
+        def metadata = new DirectDependencyMetadataImpl("g", "a", "v")
+
+        when:
+        metadata.endorseStrictVersions()
+
+        then:
+        metadata.endorsingStrictVersions
+    }
+
+    def "can reset endoreStrictVersion"() {
+        given:
+        def metadata = new DirectDependencyMetadataImpl("g", "a", "v")
+
+        when:
+        metadata.endorseStrictVersions()
+        metadata.doNotEndorseStrictVersions()
+
+        then:
+        metadata.endorsingStrictVersions == false
+    }
+
+    def "classifier is not available for newly added dependencies"() {
+        given:
+        def metadata = new DirectDependencyMetadataImpl("g", "a", "v")
+
+        when:
+        metadata.classifier
+
+        then:
+        def e = thrown(UnsupportedOperationException)
+        e.message == "Classifier is not available for newly added dependencies"
+    }
+
+    def "type is not available for newly added dependencies"() {
+        given:
+        def metadata = new DirectDependencyMetadataImpl("g", "a", "v")
+
+        when:
+        metadata.type
+
+        then:
+        def e = thrown(UnsupportedOperationException)
+        e.message == "Type is not available for newly added dependencies"
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImplTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataImplTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories.resolver
 
+
 import spock.lang.Specification
 
 class DirectDependencyMetadataImplTest extends Specification {
@@ -50,28 +51,15 @@ class DirectDependencyMetadataImplTest extends Specification {
         metadata.endorsingStrictVersions == false
     }
 
-    def "classifier is not available for newly added dependencies"() {
+    def "no selectors for newly added dependencies"() {
         given:
         def metadata = new DirectDependencyMetadataImpl("g", "a", "v")
 
         when:
-        metadata.classifier
+        def selectors = metadata.artifactSelectors
 
         then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "Classifier is not available for newly added dependencies"
-    }
-
-    def "type is not available for newly added dependencies"() {
-        given:
-        def metadata = new DirectDependencyMetadataImpl("g", "a", "v")
-
-        when:
-        metadata.type
-
-        then:
-        def e = thrown(UnsupportedOperationException)
-        e.message == "Type is not available for newly added dependencies"
+        selectors == []
     }
 
 }


### PR DESCRIPTION
If a component metadata rule needs to rewrite dependencies
based on either the original maven pom classifier or type,
these are now exposed on the dependencies within the metadata
rule.

Fixes #11975

Signed-off-by: Benjamin Muskalla <bmuskalla@gradle.com>

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [x] Recognize contributor in release notes
