### PR TITLE
@RequiredFeature can be used as a repeated annotation

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -31,7 +31,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InstantExecutionRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecOperations
@@ -189,9 +188,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         outputContains("service: closed with value 12")
     }
 
-    @RequiredFeatures(
-        [@RequiredFeature(feature = "org.gradle.unsafe.instant-execution", value = "false")]
-    )
+    @RequiredFeature(feature = "org.gradle.unsafe.instant-execution", value = "false")
     @UnsupportedWithInstantExecution
     def "service can be used at configuration and execution time"() {
         serviceImplementation()
@@ -239,9 +236,7 @@ class BuildServiceIntegrationTest extends AbstractIntegrationSpec {
         outputContains("service: closed with value 11")
     }
 
-    @RequiredFeatures(
-        [@RequiredFeature(feature = "org.gradle.unsafe.instant-execution", value = "true")]
-    )
+    @RequiredFeature(feature = "org.gradle.unsafe.instant-execution", value = "true")
     def "service used at configuration and execution time can be used with instant execution"() {
         serviceImplementation()
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 
 class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
 
@@ -25,9 +24,7 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
         gradleMetadataPublished
     }
 
-    @RequiredFeatures(
-        [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="false")]
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="false")
     void "published dependency constraint is ignored when Gradle module metadata is not available"() {
         given:
         repository {
@@ -404,9 +401,8 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
         }
     }
 
-    @RequiredFeatures(
-        [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")]
-    )
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
     void "deferred selector still resolved when constraint disappears"() {
         repository {
             'org:bar:1.0'()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -18,13 +18,10 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import spock.lang.Issue
 import spock.lang.Unroll
 
-@RequiredFeatures(
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
     def "should not downgrade dependency version when an external transitive dependency has strict version"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.ivy.IvyModule
 import spock.lang.IgnoreIf
@@ -526,9 +525,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "should fail if 1st-level version disagrees with transitive strict version"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -16,10 +16,9 @@
 
 package org.gradle.integtests.resolve.alignment
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 
 class AlignmentIntegrationTest extends AbstractAlignmentSpec {
@@ -341,10 +340,9 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
     }
 
-    @RequiredFeatures([
-        // Platforms cannot be published with plain Ivy
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+
+    // Platforms cannot be published with plain Ivy
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "can align thanks to a published platform"() {
         repository {
             path 'databind:2.7.9 -> core:2.7.9'
@@ -669,10 +667,9 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         }
     }
 
-    @RequiredFeatures([
-        // Platforms cannot be published with plain Ivy
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+
+    // Platforms cannot be published with plain Ivy
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "can belong to 2 different published platforms"() {
         given:
         repository {
@@ -775,10 +772,8 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         }
     }
 
-    @RequiredFeatures([
-        // Platforms cannot be published with plain Ivy
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+    // Platforms cannot be published with plain Ivy
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "belonging to both a virtual and a published platforms resolves with alignment"() {
         given:
         repository {
@@ -864,11 +859,9 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         }
     }
 
-    @RequiredFeatures([
-        // We only need to test one flavor
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+    // We only need to test one flavor
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @ToBeFixedForInstantExecution
     def "virtual platform missing modules are cached across builds"() {
         // Disable daemon, so that the second run executes with the file cache
@@ -931,10 +924,8 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         }
     }
 
-    @RequiredFeatures([
-        // Platforms cannot be published with plain Ivy
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+    // Platforms cannot be published with plain Ivy
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @ToBeFixedForInstantExecution
     def "published platform can be found in a different repository"() {
         // Disable daemon, so that the second run executes with the file cache
@@ -1088,9 +1079,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
 
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "virtual platform constraints shouldn't be transitive"() {
         repository {
             "org:member1:1.1" {
@@ -1167,11 +1156,9 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         }
     }
 
-    @RequiredFeatures([
-        // We only need to test one flavor
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+    // We only need to test one flavor
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "should manage to realign through two conflicts"() {
         repository {
             path 'start:start:1.0 -> foo:1.0'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.alignment
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.publish.RemoteRepositorySpec
 import spock.lang.IgnoreIf
@@ -573,9 +572,7 @@ include 'other'
         succeeds ':checkDeps'
     }
 
-    @RequiredFeatures([
-            @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def 'forced platform turning selector state to force after being selected and deselected'() {
         repository {
             ['1.0', '2.0'].each {
@@ -808,9 +805,8 @@ include 'other'
     }
 
 
-    @RequiredFeatures([
-            @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @Unroll("can constrain a virtual platforms components by adding the platform itself via a constraint")
     def "can constrain a virtual platforms components by adding the platform itself via a constraint"() {
         repository {
@@ -857,9 +853,7 @@ include 'other'
     }
 
     @Unroll("can force a published platform version by forcing the platform itself via a dependency")
-    @RequiredFeatures([
-            @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "can force a published platform version by forcing the platform itself via a dependency"() {
         repository {
             ['2.7.9', '2.9.4', '2.9.4.1'].each { v ->
@@ -933,9 +927,7 @@ include 'other'
         ].permutations()*.join("\n")
     }
 
-    @RequiredFeatures([
-            @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "cannot force a published platform version by forcing the platform itself via a constraint"() {
         // This fails. Users can use enforcedPlatform() dependencies instead - see test above.
         // The ability to define enforcedPlatform() constraints only exists to allow the enforcing of virtual platforms.
@@ -976,9 +968,7 @@ include 'other'
         failureCauseContains("Inconsistency between attributes of a constraint and a dependency, on attribute 'org.gradle.category' : dependency requires 'platform' while constraint required 'enforced-platform'")
     }
 
-    @RequiredFeatures([
-            @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @Issue("nebula-plugins/gradle-nebula-integration#51")
     @Unroll("force to higher patch version should bring the rest of aligned group up (notation=#forceNotation)")
     def "force to higher patch version should bring the rest of aligned group up"() {
@@ -1034,9 +1024,7 @@ include 'other'
         ]
     }
 
-    @RequiredFeatures([
-            @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @Issue("nebula-plugins/gradle-nebula-integration#51")
     @Unroll("force to lower patch version should bring the rest of aligned group up (notation=#forceNotation)")
     def "force to lower patch version should bring the rest of aligned group up"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.alignment
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.publish.RemoteRepositorySpec
 import org.gradle.test.fixtures.server.http.MavenHttpModule
@@ -279,9 +278,7 @@ include 'other'
         succeeds ':checkDeps'
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @Issue("nebula-plugins/gradle-nebula-integration#51")
     def "force to higher patch version should bring the rest of aligned group up"() {
         given:
@@ -325,9 +322,8 @@ include 'other'
 
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-    ])
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @Issue("nebula-plugins/gradle-nebula-integration#51")
     def "force to lower patch version should bring the rest of aligned group up"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
@@ -16,25 +16,23 @@
 
 package org.gradle.integtests.resolve.attributes
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes
-import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.ClassNode
 
 class ClasspathDependenciesAttributesIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def pluginBuilder = new PluginBuilder(file('plugin'))
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @ToBeFixedForInstantExecution
     def 'module metadata fetched through a settings useModule properly derives variants and subsequent project use of the dependency has access to derived variants'() {
         given:
@@ -101,10 +99,9 @@ task printDeps {
         outputContains 'test-plugin applied'
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @ToBeFixedForInstantExecution
     def 'module metadata fetched through a settings useModule properly uses Java ecosystem'() {
         given:
@@ -205,10 +202,8 @@ buildscript {
         succeeds()
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def 'show that settings classpath respects attributes and thus will use the default java-runtime value'() {
         given:
         def jarFile = file('build/lib/foo.jar')
@@ -225,11 +220,11 @@ buildscript {
     configurations.classpath {
         attributes.attribute(Usage.USAGE_ATTRIBUTE, services.get(ObjectFactory).named(Usage, Usage.JAVA_API))
     }
-    
+
     dependencies {
         classpath 'org:bar:1.0'
     }
-}    
+}
     Class.forName('org.gradle.MyClass')
 """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ComponentAttributesDynamicVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ComponentAttributesDynamicVersionIntegrationTest.groovy
@@ -18,13 +18,10 @@ package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
-@RequiredFeatures(
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     @Unroll("#outcome if component-level attribute is #requested")
@@ -40,7 +37,7 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
             configurations {
                 conf.attributes.attribute(quality, '$requested')
             }
-            
+
             dependencies {
                 attributesSchema {
                     attribute(quality)
@@ -101,7 +98,7 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
             configurations {
                 conf.attributes.attribute(quality, 'qa')
             }
-            
+
             dependencies {
                 attributesSchema {
                     attribute(quality)
@@ -166,7 +163,7 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
                 // configuration-level already has its own test
                 conf.attributes.attribute(quality, 'boo')
             }
-            
+
             dependencies {
                 attributesSchema {
                     attribute(quality)
@@ -225,7 +222,7 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
             configurations {
                 conf.attributes.attribute(color, 'green')
             }
-            
+
             dependencies {
                 attributesSchema {
                     attribute(color)
@@ -279,7 +276,7 @@ Versions rejected by attribute matching:
                 conf.attributes.attribute(color, 'green')
                 conf.attributes.attribute(shape, 'circle')
             }
-            
+
             dependencies {
                 attributesSchema {
                     attribute(color)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -106,9 +105,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         outputDoesNotContain("Cannot set attributes for constraint \"org:test:1.0\": it was probably created by a plugin using internal APIs")
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects variant #expectedVariant using custom attribute value #attributeValue")
     def "attribute value is used during selection"() {
         given:
@@ -157,9 +155,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "Fails resolution because dependency attributes and constraint attributes conflict"() {
         given:
         repository {
@@ -202,9 +198,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         failure.assertHasCause("""Inconsistency between attributes of a constraint and a dependency, on attribute 'custom' : dependency requires 'c1' while constraint required 'c2'""")
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects variant #expectedVariant using typed attribute value #attributeValue")
     @Issue("gradle/gradle#5232")
     def "can declare typed attributes without failing serialization"() {
@@ -222,10 +216,10 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         buildFile << """
             interface Lifecycle extends Named {}
-            
+
             def LIFECYCLE_ATTRIBUTE = Attribute.of('lifecycle', Lifecycle)
             dependencies.attributesSchema.attribute(LIFECYCLE_ATTRIBUTE)
-            
+
             dependencies {
                 conf('org:test:1.0') {
                     attributes {
@@ -262,9 +256,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', lifecycle: 'c2']
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Issue("gradle/gradle#5232")
     def "Serializes and reads back failed resolution when failure comes from an unmatched typed attribute"() {
         given:
@@ -276,10 +268,10 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         buildFile << """
             interface Lifecycle extends Named {}
-            
+
             def LIFECYCLE_ATTRIBUTE = Attribute.of('lifecycle', Lifecycle)
             dependencies.attributesSchema.attribute(LIFECYCLE_ATTRIBUTE)
-            
+
             dependencies {
                 conf('org:test:[1.0,)') {
                     attributes {
@@ -287,7 +279,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                     }
                 }
             }
-            
+
             configurations.conf.incoming.afterResolve {
                 // afterResolve will trigger the problem when reading
                 it.resolutionResult.allComponents {
@@ -314,9 +306,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         outputContains("Success for project :")
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "Merges consumer configuration attributes with dependency attributes"() {
         given:
         repository {
@@ -361,9 +351,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         }
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "Fails resolution because consumer configuration attributes and dependency attributes conflict"() {
         given:
         repository {
@@ -417,9 +405,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
           - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.""")
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects variant #expectedVariant using custom attribute value #dependencyValue overriding configuration attribute #configurationValue")
     def "dependency attribute value overrides configuration attribute"() {
         given:
@@ -470,9 +456,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects variant #expectedVariant using custom attribute value #dependencyValue overriding configuration attribute #configurationValue using dependency constraint")
     def "dependency attribute value overrides configuration attribute using dependency constraint"() {
         given:
@@ -530,9 +514,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "Fails resolution because consumer configuration attributes and constraint attributes conflict"() {
         given:
         repository {
@@ -589,9 +571,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
           - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.""")
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects variant #expectedVariant using dependency attribute value #attributeValue set in a metadata rule")
     def "attribute value set by metadata rule is used during selection"() {
         given:
@@ -721,9 +701,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects variant #expectedVariant using transitive dependency attribute value #attributeValue set in a metadata rule")
     def "attribute value set by metadata rule on transitive dependency is used during selection"() {
         given:
@@ -870,9 +848,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects direct=#expectedDirectVariant, transitive=[#expectedTransitiveVariantA, #expectedTransitiveVariantB], leaf=#expectedLeafVariant making sure dependency attribute value doesn't leak to transitives")
     def "Attribute value on dependency only affects selection of this dependency (using component metadata rules)"() {
         given:
@@ -928,11 +904,11 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                     withModule('org:directA', ModifyDependencyRule) {
                         params(CUSTOM_ATTRIBUTE)
                         params('$transitiveAttributeValueA')
-                    } 
+                    }
                     withModule('org:directB', ModifyDependencyRule) {
                         params(CUSTOM_ATTRIBUTE)
                         params('$transitiveAttributeValueB')
-                    }                    
+                    }
                 }
                 conf('org:directA:1.0')
                 conf('org:directB:1.0')
@@ -994,9 +970,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         'c2'                        | 'c1'                      | 'c2'                      | 'runtime'             | 'api'                      | 'runtime'                  | 'runtime'
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll("Selects direct=#expectedDirectVariant, transitive=[#expectedTransitiveVariantA, #expectedTransitiveVariantB], leaf=#expectedLeafVariant making sure dependency attribute value doesn't leak to transitives (using published metadata)")
     def "Attribute value on dependency only affects selection of this dependency (using published metadata)"() {
         given:
@@ -1030,7 +1004,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         buildFile << """
             configurations.conf.attributes.attribute(CUSTOM_ATTRIBUTE, '$configurationAttributeValue')
 
-            dependencies {                
+            dependencies {
                 conf('org:directA:1.0')
                 conf('org:directB:1.0')
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -18,15 +18,13 @@ package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
-@RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-)
+
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def setup() {
@@ -237,8 +235,8 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                     }
                 }
             }
-            
-                        
+
+
             configurations.conf.resolutionStrategy.capabilitiesResolution.all { selectHighestVersion() }
         """
 
@@ -762,10 +760,10 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                     }
                 }
             }
-            
+
             dependencies {
                 conf('org:test:1.0')
-                
+
                 registerTransform {
                     artifactTransform(FooToBar.class)
                     from.attribute(Attribute.of("usage", String), "api")
@@ -774,7 +772,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                     to.attribute(Attribute.of("format", String), "bar")
                 }
             }
-            
+
             class FooToBar extends ArtifactTransform {
                 public List<File> transform(File fooFile) {
                     return java.util.Collections.singletonList(fooFile)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
@@ -16,20 +16,16 @@
 
 package org.gradle.integtests.resolve.bundling
 
-
+import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
-import org.gradle.api.attributes.Bundling
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Unroll
 
-@RequiredFeatures(
-        [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def setup() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
@@ -19,14 +19,12 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
 class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDependencyResolveTest {
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll
     def "reasonable error message when a user rule throws an exception (#rule)"() {
         given:
@@ -50,7 +48,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
                 conf 'org:testA:1.0'
                 conf 'org:testB:1.0'
             }
-            
+
             // fix the conflict between modules providing the same capability using resolution rules
             configurations.all {
                 resolutionStrategy {
@@ -84,9 +82,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll
     def "can express preference for capabilities declared in published modules (#rule)"() {
         given:
@@ -110,7 +106,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
                 conf 'org:testA:1.0'
                 conf 'org:testB:1.0'
             }
-            
+
             // fix the conflict between modules providing the same capability using resolution rules
             configurations.all {
                 resolutionStrategy {
@@ -151,9 +147,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
         ]
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "can express preference for a certain variant with capabilities declared in published modules"() {
         given:
         repository {
@@ -177,7 +171,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
                     }
                 }
             }
-            
+
             // fix the conflict between variants of module providing the same capability using resolution rules
             configurations.all {
                 resolutionStrategy {
@@ -207,9 +201,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
         }
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "expressing a preference for a variant with capabilities declared in a published modules does not evict unrelated variants"() {
         given:
         repository {
@@ -241,7 +233,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
                     }
                 }
             }
-            
+
             // fix the conflict between variants of module providing the same capability using resolution rules
             configurations.all {
                 resolutionStrategy {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -252,9 +251,7 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
    Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(conf)]""")
     }
 
-    @RequiredFeatures(
-        [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")]
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
     def "can remove a published capability"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Unroll
@@ -62,12 +61,12 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             dependencies {
                conf "cglib:cglib-nodep:3.2.5"
                conf "cglib:cglib:3.2.5"
-            
+
                components {
                   withModule('cglib:cglib-nodep', CapabilityRule)
                }
             }
-            
+
             configurations.all {
                 resolutionStrategy {
                     dependencySubstitution {
@@ -166,10 +165,10 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             dependencies {
                conf "org:a:1.0"
                conf "org:b:1.0"
-            
+
                components {
                   withModule('org.apache:groovy-all', CapabilityRule)
-               }               
+               }
 
                // solution
                configurations.all {
@@ -288,10 +287,10 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             dependencies {
                conf "org:a:1.0"
                conf "org:b:1.0"
-            
+
                components {
                   withModule('org.apache:groovy-all', CapabilityRule)
-                  
+
                   // solution
                   configurations.all {
                       resolutionStrategy {
@@ -300,7 +299,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                           }
                       }
                   }
-               } 
+               }
             }
         """
 
@@ -370,9 +369,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
      *
      * This test also makes sure that the order in which dependencies are seen in the graph do not matter.
      */
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll
     def "published module can declare relocation (first in graph = #first, second in graph = #second, failOnVersionConflict=#failOnVersionConflict)"() {
         given:
@@ -392,7 +389,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                conf "$first"
                conf "$second"
             }
-            
+
             if ($failOnVersionConflict) {
                configurations.conf.resolutionStrategy.failOnVersionConflict()
             }
@@ -440,9 +437,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
      * as we visit the graph. But using a module substitution rule, we can fix the problem.
      */
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll
     def "can express preference for capabilities declared in published modules (#description)"() {
         given:
@@ -466,7 +461,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 conf 'org:testA:1.0'
                 conf 'org:testB:1.0'
             }
-            
+
             // fix the conflict between modules providing the same capability
             configurations.all {
                 resolutionStrategy {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -18,13 +18,10 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
-@RequiredFeatures(
-    [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def "can consume published capabilities"() {
@@ -82,7 +79,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
                conf "cglib:cglib-nodep:3.2.4"
                conf "cglib:cglib:3.2.5"
             }
-            
+
             configurations.conf.resolutionStrategy.capabilitiesResolution.$rule
         """
 
@@ -128,7 +125,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
 
         buildFile << """
             apply plugin: 'java-library'
-            
+
             configurations.api.outgoing {
                 capability 'org:capability:1.0'
             }
@@ -136,7 +133,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
             dependencies {
                 conf 'org:test:1.0'
             }
-            
+
             configurations {
                 conf.extendsFrom(api)
             }
@@ -237,7 +234,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
                 conf 'org:testC:1.0'
                 conf 'org:testD:1.0'
             }
-            
+
             configurations.conf.resolutionStrategy.capabilitiesResolution.all { selectHighestVersion() }
         """
 
@@ -317,7 +314,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
                 conf 'org:testC:1.0'
                 conf 'org:testD:1.0'
             }
-            
+
             configurations.conf.resolutionStrategy.capabilitiesResolution.withCapability('org:cap') {
                 select candidates.find { it.id.module == "$expected" }
                 because "prefers module ${expected}"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilityRequestsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilityRequestsIntegrationTest.groovy
@@ -18,12 +18,9 @@ package org.gradle.integtests.resolve.capabilities
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
-@RequiredFeatures(
-    [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class PublishedCapabilityRequestsIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def "capability request without versions can be consumed"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -18,12 +18,9 @@ package org.gradle.integtests.resolve.features
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
-@RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def "can select a variant providing a different capability"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
@@ -18,15 +18,12 @@ package org.gradle.integtests.resolve.http
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.HttpRepository
 
 class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "can resolve with only gradle metadata"() {
         buildFile << """
             repositories.all {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesProcessingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesProcessingIntegTest.groovy
@@ -16,10 +16,9 @@
 
 package org.gradle.integtests.resolve.ivy
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.ivy.IvyModule
 import org.gradle.test.fixtures.maven.MavenModule
 
@@ -99,12 +98,10 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
         checkDependencies()
     }
 
-    @RequiredFeatures([
-        // this test doesn't make sense with Gradle metadata
-        @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="false"),
-        // only test one combination
-        @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy")]
-    )
+    // this test doesn't make sense with Gradle metadata
+    @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="false")
+    // only test one combination
+    @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy")
     def "maven module is not affected by rule requiring ivy module descriptor input"() {
         def mavenModule = mavenRepo.module("org.utils", "api", "1.1").publishWithChangedContent()
 
@@ -149,10 +146,8 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
         file("libs/api-1.1.jar").assertIsCopyOf(mavenModule.artifactFile)
     }
 
-    @RequiredFeatures([
-        // Gradle metadata doesn't support parents
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="false")]
-    )
+    // Gradle metadata doesn't support parents
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="false")
     def "parent is not affected by selection rules" () {
         given:
         repository {
@@ -227,10 +222,8 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
         succeeds "resolveConf"
     }
 
-    @RequiredFeatures(
-        // because of the IvyModuleDescriptor rule
-        @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy")
-    )
+    // because of the IvyModuleDescriptor rule
+    @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy")
     @ToBeFixedForInstantExecution
     def "component metadata is requested only once for rules that do require it" () {
         buildFile << """
@@ -281,12 +274,10 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
         checkDependencies()
     }
 
-    @RequiredFeatures([
-        // because of the IvyModuleDescriptor rule
-        @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy"),
-        // because of branch
-        @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="false")
-    ])
+    // because of the IvyModuleDescriptor rule
+    @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy")
+    // because of branch
+    @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="false")
     @ToBeFixedForInstantExecution
     def "changed component metadata becomes visible when module is refreshed" () {
 
@@ -392,7 +383,7 @@ class ComponentSelectionRulesProcessingIntegTest extends AbstractComponentSelect
     def "copies selection rules when configuration is copied" () {
         buildFile << """
             configurations {
-                notCopy 
+                notCopy
             }
 
             dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -17,17 +17,13 @@ package org.gradle.integtests.resolve.ivy
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
-@RequiredFeatures([
-    // this test is specific to Ivy
-    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy"),
-]
-)
+// this test is specific to Ivy
+@RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy")
 @IgnoreIf({ GradleContextualExecuter.parallel })
 class IvyDynamicRevisionResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
@@ -17,12 +17,10 @@ package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
-@RequiredFeatures(
-    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-)
+
+@RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
 class MavenDependencyResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     String getRootProjectName() { 'testproject' }
@@ -193,10 +191,8 @@ dependencies {
         failure.assertHasCause("Artifact name must not be null!")
     }
 
-    @RequiredFeatures(
-        // only available with Maven metadata: Gradle metadata does not support "optional"
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
-    )
+    // only available with Maven metadata: Gradle metadata does not support "optional"
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
     def "does not include optional dependencies of maven module"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.maven.MavenModule
@@ -26,9 +25,7 @@ import org.gradle.test.fixtures.server.http.MavenHttpModule
 import spock.lang.Issue
 import spock.lang.Unroll
 
-@RequiredFeatures(
-    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
 class MavenSnapshotResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     @Override
@@ -984,11 +981,8 @@ Required by:
 """)
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    ]
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll
     def "can resolve unique and non-unique snapshots using Gradle Module Metadata (redirection = #redirection, metadata sources=#metadataSources)"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
@@ -18,17 +18,14 @@ package org.gradle.integtests.resolve.override
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
 /**
  * There is more test coverage for 'dependency artifacts' in ArtifactDependenciesIntegrationTest (old test setup).
  */
-@RequiredFeatures(
-    // This test bypasses all metadata using 'artifact()' metadata sources. It is sufficient to test with one metadata setup.
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-)
+// This test bypasses all metadata using 'artifact()' metadata sources. It is sufficient to test with one metadata setup.
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def "can combine artifact notation and constraints"() {
@@ -49,7 +46,7 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
             }
             dependencies {
                 conf('org:foo@distribution-tgz')
-              
+
                 constraints {
                    conf('org:foo:1.0')
                 }
@@ -151,10 +148,10 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         buildFile << """
             dependencies {
                 conf 'org:foo:$otherVersion'
-                conf module('org:foo:1.0') { 
+                conf module('org:foo:1.0') {
                     // no dependencies
                 }
-            } 
+            }
 
         """
 
@@ -196,13 +193,13 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         buildFile << """
             dependencies {
                 conf 'org:foo:1.1'
-                conf module('org:foo:[1.0,1.1]') { 
+                conf module('org:foo:[1.0,1.1]') {
                     // no dependencies
                 }
-                conf module('org:foo:1.0') { 
+                conf module('org:foo:1.0') {
                     // no dependencies
                 }
-            } 
+            }
         """
 
         when:
@@ -235,12 +232,12 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
                 conf
             }
             dependencies {
-                conf module('org:foo:1.0') { 
+                conf module('org:foo:1.0') {
                 }
                 conf module('org:foo:1.0') {
                     dependency("org:baz:1.0")
                 }
-            } 
+            }
         """
 
         when:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
@@ -17,21 +17,16 @@
 package org.gradle.integtests.resolve.platforms
 
 import org.gradle.api.JavaVersion
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 import static org.gradle.util.TextUtil.escapeString
 
-@RequiredFeatures(
-    [
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value="maven"),
-    ]
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
+@RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value="maven")
 class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
     @ToBeFixedForInstantExecution
     def "publishes a platform with native alignment"() {
@@ -45,14 +40,14 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
             plugins {
                 id 'java-platform'
             }
-            
+
             dependencies {
                 constraints {
                     api(project(":core")) { because "platform alignment" }
                     api(project(":lib")) { because "platform alignment" }
                 }
             }
-            
+
             publishing {
                 publications {
                     maven(MavenPublication) {
@@ -69,7 +64,7 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                 api(platform(project(":platform")))
                 api(project(":lib"))
             }
-            
+
             publishing {
                 publications {
                     maven(MavenPublication) {
@@ -86,7 +81,7 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
             dependencies {
                 api(platform(project(":platform")))
             }
-            
+
             publishing {
                 publications {
                     maven(MavenPublication) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/reproducibility/FailOnChangingVersionsResolveIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.reproducibility
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -95,9 +94,7 @@ class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDepende
         failure.assertHasCause("Could not resolve org:testB:1.0: Resolution strategy disallows usage of changing versions")
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @Unroll
     def "can deny a direct snapshot dependency (unique = #unique)"() {
         buildFile << """
@@ -131,9 +128,7 @@ class FailOnChangingVersionsResolveIntegrationTest extends AbstractModuleDepende
         unique << [true, false]
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     @Unroll
     def "can deny a transitive snapshot dependency (unique = #unique)"() {
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.rules
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.server.http.IvyHttpModule
 import spock.lang.Unroll
@@ -51,7 +50,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
                     }
                 }
             }
-            
+
             dependencies {
                 attributesSchema {
                     attribute(quality)
@@ -97,9 +96,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
         mutation << ['not added', 'added']
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll
     def "variant attributes take precedence over component attributes (component level = #componentLevel)"() {
         given:
@@ -180,7 +177,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
                    attributes.attribute(quality, 'qa')
                 }
             }
-            
+
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
@@ -232,9 +229,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
 
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @Unroll
     def "published component metadata can be overwritten (fix applied = #fixApplied)"() {
         given:
@@ -245,11 +240,11 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
         }
         buildFile << """
             def quality = Attribute.of("quality", String)
-            
+
             configurations {
                 conf.attributes.attribute(quality, 'qa')
             }
-            
+
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
@@ -316,12 +311,12 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
         }
         buildFile << """
             def quality = Attribute.of("quality", String)
-            
+
             configurations {
                 conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
                 conf.attributes.attribute(quality, 'qa')
             }
-            
+
             class AttributeRule implements ComponentMetadataRule {
                 Attribute targetAttribute
 
@@ -410,7 +405,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
                    attributes.attribute(org.gradle.api.internal.project.ProjectInternal.STATUS_ATTRIBUTE, '$status')
                 }
             }
-            
+
             class StatusRule implements ComponentMetadataRule {
                 public void execute(ComponentMetadataContext context) {
                     if (${!GradleMetadataResolveRunner.useIvy()}) {
@@ -424,7 +419,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
                     }
                 }
             }
-            
+
             dependencies {
                 conf 'org:test:[1,)'
                 components {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -16,10 +16,9 @@
 
 package org.gradle.integtests.resolve.rules
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class ComponentMetadataRulesCachingIntegrationTest extends AbstractModuleDependencyResolveTest implements ComponentMetadataRulesSupport {
@@ -270,9 +269,7 @@ dependencies {
         outputDoesNotContain('Attribute rule executed')
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     @ToBeFixedForInstantExecution
     def 'can cache rules setting custom type attributes'() {
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -15,10 +15,10 @@
  */
 package org.gradle.integtests.resolve.rules
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Issue
 
@@ -74,104 +74,6 @@ dependencies {
         when:
         repositoryInteractions {
             'org.test:projectA:1.0' {
-                allowAll()
-            }
-        }
-
-        then:
-        succeeds 'resolve'
-    }
-
-    def "rule can use artifactSelector to check sourced metadata"() {
-        repository {
-            'org.test:projectA:1.0' {
-                dependsOn group: 'org.test', artifact: 'projectB', version: '1.0', 'classifier': 'classy'
-            }
-            'org.test:projectB:1.0' {
-                withModule {
-                    undeclaredArtifact(type: 'jar', classifier: 'classy')
-                }
-            }
-        }
-        buildFile << """
-
-class AssertingRule implements ComponentMetadataRule {
-
-    void execute(ComponentMetadataContext context) {
-        context.details.allVariants {
-            withDependencies {
-                it.each { dep ->
-                    println "selectorSize:" + dep.artifactSelectors.size
-                    println "classifier:" + dep.artifactSelectors[0]?.classifier
-                    println "type:" + dep.artifactSelectors[0]?.type
-                }
-            }
-        }
-    }
-}
-
-dependencies {
-    components {
-        all(AssertingRule)
-    }
-}
-"""
-
-        when:
-        repositoryInteractions {
-            'org.test:projectA:1.0' {
-                allowAll()
-            }
-            'org.test:projectB:1.0' {
-                allowAll()
-            }
-        }
-
-        then:
-        succeeds 'resolve'
-        outputContains("selectorSize:1")
-        outputContains("classifier:classy")
-        outputContains("type:jar")
-    }
-
-    def "added dependency has no artifact selectors"() {
-        repository {
-            'org.test:projectA:1.0' {
-            }
-            'org.test:projectB:1.0' {
-                withModule {
-                    undeclaredArtifact(type: 'jar', classifier: 'classy')
-                }
-            }
-        }
-        buildFile << """
-
-class AssertingRule implements ComponentMetadataRule {
-
-    void execute(ComponentMetadataContext context) {
-        context.details.allVariants {
-            withDependencies {
-                add("org.test:projectB:1.0") {
-                    artifactSelectors == []
-                }
-            }
-        }
-    }
-}
-
-dependencies {
-    components {
-        all(AssertingRule)
-    }
-}
-"""
-
-        when:
-        repositoryInteractions {
-            'org.test:projectA:1.0' {
-                allowAll()
-            }
-            'org.test:projectB:1.0' {
                 allowAll()
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -15,10 +15,9 @@
  */
 package org.gradle.integtests.resolve.rules
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import spock.lang.Unroll
@@ -456,9 +455,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         keyword << ["prefer", "require", "strictly"]
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "can set version on dependency constraint"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvySpecificComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvySpecificComponentMetadataRulesIntegrationTest.groovy
@@ -17,19 +17,16 @@
 package org.gradle.integtests.resolve.rules
 
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.encoding.Identifier
 import spock.lang.Unroll
 
-@RequiredFeatures([
-    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy"),
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
-])
+@RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy")
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
 class IvySpecificComponentMetadataRulesIntegrationTest extends AbstractModuleDependencyResolveTest implements ComponentMetadataRulesSupport {
 
     def setup() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.rules
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -52,7 +51,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
             def formatAttribute = Attribute.of('format', String)
 
             configurations { $variantToTest { attributes { attribute(formatAttribute, 'custom') } } }
-            
+
             dependencies {
                 $variantToTest group: 'org.test', name: 'moduleA', version: '1.0' ${publishedModulesHaveAttributes ? "" : ", configuration: '$variantToTest'"}
             }
@@ -72,7 +71,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                 }
 
                 void execute(ComponentMetadataContext context) {
-                    context.details.withVariant("$variantToTest") { 
+                    context.details.withVariant("$variantToTest") {
                         attributes {
                             attribute(attribute, "custom")
                         }
@@ -133,7 +132,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                 }
 
                 void execute(ComponentMetadataContext context) {
-                    context.details.withVariant("$transitiveSelectedVariant") { 
+                    context.details.withVariant("$transitiveSelectedVariant") {
                         attributes {
                             attribute(attribute, "custom")
                         }
@@ -233,7 +232,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                 }
 
                 void execute(ComponentMetadataContext context) {
-                    context.details.withVariant("$variantToTest") { 
+                    context.details.withVariant("$variantToTest") {
                         attributes {
                             // defines the 'format' attribute with value 'custom' on all variants
                             // which will be inherited by artifacts
@@ -315,7 +314,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
             dependencies {
                 components {
                     withModule('org.test:moduleB') {
-                        withVariant("$variantToTest") { 
+                        withVariant("$variantToTest") {
                             attributes {
                                 if (++cpt == $invalidCount) {
                                     throw new IllegalStateException("rule should only be applied once on variant $variantToTest")
@@ -371,7 +370,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                 }
 
                 void execute(ComponentMetadataContext context) {
-                    context.details.withVariant('$selectedVariant') { 
+                    context.details.withVariant('$selectedVariant') {
                         attributes {
                             attribute(attribute, "select")
                         }
@@ -441,10 +440,8 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
         selectedVariant << ['customVariant1', 'customVariant2']
     }
 
-    @RequiredFeatures(
-        // published attributes are only available in Gradle metadata
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    // published attributes are only available in Gradle metadata
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "published variant metadata can be overwritten"() {
         given:
         repository {
@@ -459,7 +456,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
         }
         buildFile << """
             def quality = Attribute.of("quality", String)
-            
+
             class AttributeRule implements ComponentMetadataRule {
                 Attribute attribute
 
@@ -480,7 +477,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
             configurations {
                 ${variantToTest}.attributes.attribute(quality, 'qa')
             }
-            
+
             dependencies {
                 attributesSchema {
                     attribute(quality)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.rules
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
@@ -237,9 +236,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         failure.assertHasCause "$baseType 'this-does-not-exist' not defined in module org.test:moduleA:1.0"
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def "can add variants containing metadata as artifacts using lenient rules"() {
         given:
         repository {
@@ -341,9 +338,7 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         }
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "capabilities of base are preserved"() {
         given:
         repository {
@@ -434,10 +429,8 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         failure.assertHasCause("Cannot add file moduleA-1.0-extraFeature.jar (url: ../somewhere/some.jar) because it is already defined (url: moduleA-1.0-extraFeature.jar)")
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "ivy")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
     @Unroll
     def "can add variants for ivy - #usageAttribute"() {
         // through this, we opt-into variant aware dependency management for a pure ivy module
@@ -514,10 +507,8 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         'java-runtime' | 'runtimeElements'
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
-    ])
+    @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
     @Unroll
     def "do #not opt-out of maven artifact discovery when #not adding files to a variant (#extension artifact)"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
@@ -15,15 +15,12 @@
  */
 package org.gradle.integtests.resolve.strict
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
-@RequiredFeatures([
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def setup() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.strict
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class StrictVersionConstraintsFeatureInteractionIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -87,9 +86,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
         }
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
     def "can turn strict constraint into normal constraint by using a component metadata rule"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.resolve.strict
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
@@ -231,9 +230,7 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         }
     }
 
-    @RequiredFeatures(
-        @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
-    )
+    @RequiredFeature(feature=GradleMetadataResolveRunner.GRADLE_METADATA, value="true")
     def "conflicting version constraints fail resolution"() {
         given:
         repository {
@@ -503,9 +500,7 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         }
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "original version constraint is not ignored if there is another parent"() {
         given:
         repository {
@@ -553,9 +548,7 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
    Constraint path ':test:unspecified' --> 'org:x1:1.0' --> 'org:foo:{strictly 1.0}'"""
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
-    )
+    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     def "can reintroduce a strict version on the root level"() { // similar to test above, but reintroduces strict version in build script
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -17,19 +17,16 @@ package org.gradle.integtests.resolve.strict
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Ignore
 import spock.lang.Unroll
 
+import static org.gradle.integtests.resolve.strict.StrictVersionsInPlatformCentricDevelopmentIntegrationTest.PlatformType.ENFORCED_PLATFORM
+import static org.gradle.integtests.resolve.strict.StrictVersionsInPlatformCentricDevelopmentIntegrationTest.PlatformType.LEGACY_PLATFORM
 import static org.gradle.integtests.resolve.strict.StrictVersionsInPlatformCentricDevelopmentIntegrationTest.PlatformType.MODULE
 import static org.gradle.integtests.resolve.strict.StrictVersionsInPlatformCentricDevelopmentIntegrationTest.PlatformType.PLATFORM
-import static org.gradle.integtests.resolve.strict.StrictVersionsInPlatformCentricDevelopmentIntegrationTest.PlatformType.LEGACY_PLATFORM
-import static org.gradle.integtests.resolve.strict.StrictVersionsInPlatformCentricDevelopmentIntegrationTest.PlatformType.ENFORCED_PLATFORM
 
-@RequiredFeatures([
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")]
-)
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     enum PlatformType {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerIntegrationTest.groovy
@@ -16,17 +16,14 @@
 
 package org.gradle.integtests.resolve.suppliers
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import spock.lang.Unroll
 
-@RequiredFeatures([
-    // we only need to check without Gradle metadata, it doesn't matter
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
-])
+// we only need to check without Gradle metadata, it doesn't matter
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
 class CustomVersionListerIntegrationTest extends AbstractModuleDependencyResolveTest {
     void "can list versions without hitting repository"() {
         withLister([testA: [1, 2, 3]])
@@ -312,10 +309,10 @@ $listing
         buildFile << """
             class BrokenLister implements ComponentMetadataVersionLister {
                 private final boolean breakBuild
-                
+
                 @javax.inject.Inject
                 BrokenLister(boolean breakBuild) { this.breakBuild = breakBuild }
-            
+
                 void execute(ComponentMetadataListerDetails details) {
                     if (breakBuild) { throw new RuntimeException("oh noes!") }
                 }
@@ -331,7 +328,7 @@ $listing
             class MyLister implements ComponentMetadataVersionLister {
 
                 final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
                 @javax.inject.Inject
                 MyLister(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerWithSupplierIntegrationTest.groovy
@@ -19,13 +19,10 @@ package org.gradle.integtests.resolve.suppliers
 import groovy.json.JsonBuilder
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
-@RequiredFeatures([
-    // we only need to check without Gradle metadata, it doesn't matter
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
-])
+// we only need to check without Gradle metadata, it doesn't matter
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false")
 class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDependencyResolveTest {
     private final static String TEST_A_METADATA = new JsonBuilder(
         [
@@ -64,12 +61,12 @@ class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDepen
         }
         buildFile << """
             def customAttr = Attribute.of('custom', String)
-            
+
             dependencies {
                 conf "org:testA:latest.release"
                 conf "org:testB:latest.release"
             }
-            
+
             configurations.conf.attributes.attribute(customAttr, 'bar')
         """
 
@@ -115,12 +112,12 @@ class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDepen
         }
         buildFile << """
             def customAttr = Attribute.of('custom', String)
-            
+
             dependencies {
                 conf "org:testA:latest.release"
                 conf "org:testB:latest.release"
             }
-            
+
             configurations.conf.attributes.attribute(customAttr, 'bar')
         """
 
@@ -160,7 +157,7 @@ class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDepen
             class MyLister implements ComponentMetadataVersionLister {
 
                 final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
                 @javax.inject.Inject
                 MyLister(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
 
@@ -175,11 +172,11 @@ class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDepen
                     }
                 }
             }
-            
+
             class MySupplier implements ComponentMetadataSupplier {
 
                 final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
                 @javax.inject.Inject
                 MySupplier(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
 
@@ -215,7 +212,7 @@ class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDepen
             class MyLister implements ComponentMetadataVersionLister {
 
                 final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
                 @javax.inject.Inject
                 MyLister(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
 
@@ -230,11 +227,11 @@ class CustomVersionListerWithSupplierIntegrationTest extends AbstractModuleDepen
                     }
                 }
             }
-            
+
             class MySupplier implements ComponentMetadataSupplier {
 
                 final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
                 @javax.inject.Inject
                 MySupplier(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -16,10 +16,9 @@
 package org.gradle.integtests.resolve.suppliers
 
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.cache.CachingIntegrationFixture
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.HttpModule
@@ -347,12 +346,12 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
           }
           class MP implements ComponentMetadataSupplier {
             final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
             @Inject
             MP(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
-          
+
             static String filename = 'status.txt'
-          
+
             void execute(ComponentMetadataSupplierDetails details) {
                 def id = details.id
                 repositoryResourceAccessor.withResource("\${id.group}/\${id.module}/\${id.version}/\${filename}") {
@@ -463,7 +462,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
 
             @Inject
             MP(String status) { this.status = status }
-            
+
             void execute(ComponentMetadataSupplierDetails details) {
                 if (details.id.version == "2.2") {
                     details.result.status = status
@@ -565,7 +564,7 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
             MP() {
                 throw new RuntimeException("broken")
             }
-          
+
             void execute(ComponentMetadataSupplierDetails details) {
             }
           }
@@ -594,14 +593,13 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
         failure.assertHasCause('broken')
     }
 
-    @RequiredFeatures([
-        @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy")
-    ])
+
+    @RequiredFeature(feature=GradleMetadataResolveRunner.REPOSITORY_TYPE, value="ivy")
     def "custom metadata provider doesn't have to do something"() {
         given:
         buildFile << """
           class MP implements ComponentMetadataSupplier {
-          
+
             void execute(ComponentMetadataSupplierDetails details) {
                 // does nothing
             }
@@ -644,15 +642,15 @@ class DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest extends Ab
 
           @CacheableRule
           class MP implements ComponentMetadataSupplier {
-          
+
             final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
             @Inject
             MP(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
-            
+
             int calls
             Map<String, String> status = [:]
-          
+
             void execute(ComponentMetadataSupplierDetails details) {
                 def id = details.id
                 println "Providing metadata for \$id"
@@ -830,7 +828,7 @@ group:projectB:2.2;release
                     withModule('group:projectB', VerifyRule)
                 }
             }
-       
+
         """
 
         when:
@@ -911,7 +909,7 @@ group:projectB:2.2;release
             class MyAttributes {
                 public static final CUSTOM_STR = Attribute.of("custom string", String)
             }
-            
+
             configurations.conf.attributes {
                 attribute(MyAttributes.CUSTOM_STR, 'v2')
             }
@@ -959,12 +957,12 @@ group:projectB:2.2;release
 
         buildFile << """
             interface CustomType extends Named {}
-            
+
             class MyAttributes {
                 public static final CUSTOM_STR = Attribute.of("custom", String)
                 public static final CUSTOM_REAL = Attribute.of("custom", CustomType)
             }
-            
+
             configurations.conf.attributes {
                 attribute(MyAttributes.CUSTOM_REAL, objects.named(CustomType, 'v2'))
             }
@@ -1272,17 +1270,17 @@ group:projectB:2.2;release
           import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor
           import javax.inject.Inject
           import org.gradle.api.artifacts.CacheableRule
-          
+
           ${cacheable?'@CacheableRule':''}
           class MP implements ComponentMetadataSupplier {
-          
+
             final RepositoryResourceAccessor repositoryResourceAccessor
-            
+
             @Inject
             MP(RepositoryResourceAccessor accessor) { repositoryResourceAccessor = accessor }
-          
+
             int count
-          
+
             void execute(ComponentMetadataSupplierDetails details) {
                 assert count == 0
                 def id = details.id
@@ -1347,13 +1345,13 @@ group:projectB:2.2;release
     void addDependenciesTo(TestFile buildFile) {
         buildFile << """
           import javax.inject.Inject
-     
+
           if (project.hasProperty('refreshDynamicVersions')) {
                 configurations.all {
                     resolutionStrategy.cacheDynamicVersionsFor 0, "seconds"
                 }
           }
-          
+
           dependencies {
               conf group: "group", name: "projectA", version: "1.+"
               conf group: "group", name: "projectB", version: "latest.release"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
@@ -18,14 +18,11 @@ package org.gradle.integtests.resolve.validation
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 import org.gradle.test.fixtures.gradle.GradleFileModuleAdapter
 import spock.lang.Issue
 
-@RequiredFeatures([
-    @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-])
+@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def "can resolve if component gav information is missing"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractMultiTestRunner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractMultiTestRunner.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.fixtures;
 
+import com.google.common.collect.Iterables;
 import org.gradle.internal.UncheckedException;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
@@ -442,6 +443,9 @@ public abstract class AbstractMultiTestRunner extends Runner implements Filterab
          */
         @Nullable
         <A extends Annotation> A getAnnotation(Class<A> type);
+
+        Annotation[] getAnnotations();
+
     }
 
     private static class TestDescriptionBackedTestDetails implements TestDetails {
@@ -465,6 +469,11 @@ public abstract class AbstractMultiTestRunner extends Runner implements Filterab
                 return annotation;
             }
             return parent.getAnnotation(type);
+        }
+
+        @Override
+        public Annotation[] getAnnotations() {
+            return Iterables.toArray(test.getAnnotations(), Annotation.class);
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BehindFlagFeatureRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BehindFlagFeatureRunner.groovy
@@ -44,13 +44,13 @@ abstract class BehindFlagFeatureRunner extends AbstractMultiTestRunner {
 
     Map<String, String> requiredFeatures() {
         def required = [:]
-        target.annotations.findAll {
-            RequiredFeatures.isAssignableFrom(it.getClass())
-        }.each {
-            extractRequiredFeatures((RequiredFeatures) it, required)
-        }
-
+        getAllAnnotations(RequiredFeature).each { required[it.feature()] = it.value() }
+        getAllAnnotations(RequiredFeatures).each { extractRequiredFeatures(it, required) }
         required
+    }
+
+    private <A> Collection<A> getAllAnnotations(Class<A> annotationType) {
+        (Collection<A>) target.annotations.findAll { annotationType.isAssignableFrom(it.getClass()) }
     }
 
     def isInvalidCombination(Map<String, String> values) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RequiredFeature.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RequiredFeature.java
@@ -17,6 +17,7 @@ package org.gradle.integtests.fixtures;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -26,7 +27,8 @@ import java.lang.annotation.Target;
  * that the feature value is the one defined by {@link #value()}.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Repeatable(RequiredFeatures.class)
 @Inherited
 public @interface RequiredFeature {
     String feature();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RequiredFeatures.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RequiredFeatures.java
@@ -27,6 +27,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Inherited
-public @interface RequiredFeatures {
+@interface RequiredFeatures {
     RequiredFeature[] value();
 }


### PR DESCRIPTION
If used for a single feature, avoid annotation noise by not using the
composite annotation. This also avoids the confusion that the
@RequiredFeature annotation cannot be used independently
(no compile error but does not work).
I made the @RequiredFeatures annotation package-private as it is
only required by the compiler and the runner now.

Signed-off-by: Benjamin Muskalla <bmuskalla@gradle.com>