### PR TITLE
Rebaseline inception perf test due to new APIs in use

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -54,7 +54,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionGradleInternalP
     }
 
     def setup() {
-        def targetVersion = "6.2-20200107231456+0000"
+        def targetVersion = "6.2-rc-1"
         runner.targetVersions = [targetVersion]
         runner.minimumBaseVersion = GradleVersion.version(targetVersion).baseVersion.version
     }


### PR DESCRIPTION
Gradle build requires newly introduced `providers.gradleProperty` API.