### PR TITLE
Fix a regression when task type uses property getter from abstract superclass

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -395,7 +395,7 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
                 }
             } else {
                 if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Build operation {} could not be started ({} worker(s) in use).", getDisplayName(), root.leasesInUse);
+                    LOGGER.debug("Build operation {} could not be started yet ({} worker(s) in use).", getDisplayName(), root.leasesInUse);
                 }
             }
             return active;

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -75,6 +75,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -760,8 +761,11 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         private void addSetMethods(AbstractClassGenerator.ClassGenerationVisitor visitor) {
             for (PropertyMetadata property : mutableProperties) {
                 if (property.setMethods.isEmpty()) {
+                    Set<Class<?>> appliedTo = new HashSet<>();
                     for (Method setter : property.setters) {
-                        visitor.addSetMethod(property, setter);
+                        if (appliedTo.add(setter.getParameterTypes()[0])) {
+                            visitor.addSetMethod(property, setter);
+                        }
                     }
                 } else if (extensibleTypeHandler.conventionProperties.contains(property)) {
                     for (Method setMethod : property.setMethods) {


### PR DESCRIPTION
Fixes #12133 

### Context

In some situations, the Java compiler can generate bridge methods for a non-abstract method inherited from an abstract superclass. When that method happens to be a getter with a 'managed type' as its return type, Gradle 6.1 would ignore the getter and generate its own managed implementation.

This PR fixes this case, so that the generated type uses the inherited method as expected.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
