### PR TITLE
Let @ToBeFixedForInstantExecution support matching @Unroll-ed tests iterations

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMinimalConfigurationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMinimalConfigurationIntegrationTest.groovy
@@ -98,7 +98,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*building")
     def "configures included build only once when #action"() {
         given:
         dependency "org.test:buildB:1.0"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
@@ -46,7 +46,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*tasks task.*")
     def "shows deprecation warning when executing #task task in undefined build"() {
         expect:
         executer.expectDocumentedDeprecationWarning("Executing Gradle tasks as part of an undefined build has been deprecated. This will fail with an error in Gradle 7.0. " +

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
@@ -29,8 +29,8 @@ import static org.gradle.api.tasks.PathSensitivity.RELATIVE
 abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegrationSpec {
 
     @ToBeFixedForInstantExecution(
-        bottomSpecs = "CachedPathSensitivityIntegrationTest",
-        iterationMatchers = [".*RELATIVE.*", ".*NAME_ONLY.*"]
+        skip = ToBeFixedForInstantExecution.Skip.FLAKY,
+        bottomSpecs = "CachedPathSensitivityIntegrationTest"
     )
     def "single source file renamed with #pathSensitive as input is loaded from cache: #expectedOutcome"() {
         given:
@@ -67,8 +67,8 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
     }
 
     @ToBeFixedForInstantExecution(
-        bottomSpecs = "CachedPathSensitivityIntegrationTest",
-        iterationMatchers = ".*RELATIVE.*"
+        skip = ToBeFixedForInstantExecution.Skip.FLAKY,
+        bottomSpecs = "CachedPathSensitivityIntegrationTest"
     )
     def "single source file moved within hierarchy with #pathSensitive as input is loaded from cache: #expectedOutcome"() {
         given:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
@@ -28,7 +28,10 @@ import static org.gradle.api.tasks.PathSensitivity.RELATIVE
 @Unroll
 abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "CachedPathSensitivityIntegrationTest")
+    @ToBeFixedForInstantExecution(
+        bottomSpecs = "CachedPathSensitivityIntegrationTest",
+        iterationMatchers = [".*RELATIVE.*", ".*NAME_ONLY.*"]
+    )
     def "single source file renamed with #pathSensitive as input is loaded from cache: #expectedOutcome"() {
         given:
         file("sources/input.txt").text = "input"
@@ -63,7 +66,10 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
         NONE          | statusForReusedOutput
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "CachedPathSensitivityIntegrationTest")
+    @ToBeFixedForInstantExecution(
+        bottomSpecs = "CachedPathSensitivityIntegrationTest",
+        iterationMatchers = ".*RELATIVE.*"
+    )
     def "single source file moved within hierarchy with #pathSensitive as input is loaded from cache: #expectedOutcome"() {
         given:
         file("src/data1").createDir()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractPathSensitivityIntegrationSpec.groovy
@@ -29,7 +29,7 @@ import static org.gradle.api.tasks.PathSensitivity.RELATIVE
 abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegrationSpec {
 
     @ToBeFixedForInstantExecution(bottomSpecs = "CachedPathSensitivityIntegrationTest")
-    def "single source file renamed with #pathSensitive as input is loaded from cache: #expectSkipped"() {
+    def "single source file renamed with #pathSensitive as input is loaded from cache: #expectedOutcome"() {
         given:
         file("sources/input.txt").text = "input"
 
@@ -64,7 +64,7 @@ abstract class AbstractPathSensitivityIntegrationSpec extends AbstractIntegratio
     }
 
     @ToBeFixedForInstantExecution(bottomSpecs = "CachedPathSensitivityIntegrationTest")
-    def "single source file moved within hierarchy with #pathSensitive as input is loaded from cache: #expectSkipped"() {
+    def "single source file moved within hierarchy with #pathSensitive as input is loaded from cache: #expectedOutcome"() {
         given:
         file("src/data1").createDir()
         file("src/data2").createDir()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -297,7 +297,7 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
                     new File(outputDirectory, "output.txt").text = "Success"
                     changes.getFileChanges(input).each {
                         println "Changes > \$it"
-                    }                    
+                    }
                 }
             }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -483,7 +483,7 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
         outputDir.assertIsEmptyDir()
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*ConfigurableFileTree.*")
     def "outputs are cleaned out on rebuild (output type: #type)"() {
         file("buildSrc").deleteDir()
         buildFile.text = """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/InputPropertyAnnotationOverrideIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/InputPropertyAnnotationOverrideIntegrationTest.groovy
@@ -38,7 +38,7 @@ class InputPropertyAnnotationOverrideIntegrationTest extends AbstractIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*@Input\$")
     def "can override @Internal with @#inputType.simpleName"() {
         buildFile << """
             class InternalBaseTask extends BaseTask {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -36,27 +36,27 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 @Nested
                 Object bean
             }
-            
+
             class NestedBeanWithInput {
                 @Input${kind}
                 @PathSensitive(PathSensitivity.NONE)
                 ${type.name} input
             }
-            
+
             class GeneratorTask extends DefaultTask {
                 @Output${kind}
                 final ${type.name} output = project.objects.${factory}()
-                
+
                 @TaskAction
                 void doStuff() {
                     output${generatorAction}
                 }
             }
-            
+
             task generator(type: GeneratorTask) {
                 output.set(project.layout.buildDirectory.${lookup}('output'))
             }
-            
+
             task consumer(type: TaskWithNestedProperty) {
                 bean = new NestedBeanWithInput(input: project.objects.${factory}())
                 bean.input.set(generator.output)
@@ -80,26 +80,26 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 @Nested
                 Object bean
             }
-            
+
             class NestedBeanWithInput {
                 @InputFiles
                 FileCollection input
             }
-            
+
             class GeneratorTask extends DefaultTask {
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.getAsFile().get().text = "Hello"
                 }
             }
-            
+
             task generator(type: GeneratorTask) {
                 outputFile = project.layout.buildDirectory.file('output')
             }
-            
+
             task consumer(type: TaskWithNestedProperty) {
                 bean = new NestedBeanWithInput(input: files(generator.outputFile))
             }
@@ -118,26 +118,26 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 @Nested
                 Object bean
             }
-            
+
             class NestedBeanWithInput {
                 @InputFile
                 RegularFileProperty file
             }
-            
+
             class GeneratorTask extends DefaultTask {
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.getAsFile().get().text = "Hello"
                 }
             }
-            
+
             task generator(type: GeneratorTask) {
                 outputFile = project.layout.buildDirectory.file('output')
             }
-            
+
             task consumer(type: TaskWithNestedProperty) {
                 bean = new NestedBeanWithInput(file: generator.outputFile)
             }
@@ -162,7 +162,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                     taskWithNestedProperty.bean = secondBean
                 }
             }
-            
+
             taskWithNestedProperty.dependsOn(configureTask)
         """
 
@@ -195,7 +195,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         def fixture = new NestedBeanTestFixture()
 
         buildFile << fixture.taskWithNestedProperty()
-        buildFile << """      
+        buildFile << """
             taskWithNestedProperty.bean = ${from}
 
             task configureTask {
@@ -203,7 +203,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                     taskWithNestedProperty.bean = ${to}
                 }
             }
-            
+
             taskWithNestedProperty.dependsOn(configureTask)
         """
 
@@ -269,9 +269,9 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         def fixture = new NestedBeanTestFixture()
         fixture.prepareInputFiles()
         buildFile << fixture.taskWithNestedProperty()
-        buildFile << """   
+        buildFile << """
             taskWithNestedProperty.bean = ${from}
-            
+
             taskWithNestedProperty.doLast {
                 bean = ${to}
             }
@@ -351,60 +351,60 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         String taskWithNestedProperty() {
             """
             class TaskWithNestedProperty extends DefaultTask {
-                @Nested     
+                @Nested
                 @Optional
                 Object bean
-    
+
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
-    
+
                 @TaskAction
                 void writeInputToFile() {
                     outputFile.getAsFile().get().text = bean == null ? 'null' : bean.toString()
                     if (bean != null) {
-                        bean.doStuff()     
+                        bean.doStuff()
                     }
                 }
             }
-    
+
             class NestedBean {
                 @Input
                 String firstInput
-    
+
                 @InputFile
                 File firstInputFile
-    
+
                 @OutputFile
                 File firstOutputFile
-    
+
                 String toString() {
                     firstInput
                 }
-    
+
                 void doStuff() {
                     firstOutputFile.text = firstInputFile.text
                 }
             }
-    
+
             class OtherNestedBean {
                 @Input
                 String secondInput
-    
+
                 @InputFile
                 File secondInputFile
-    
+
                 @OutputFile
                 File secondOutputFile
-    
+
                 String toString() {
                     secondInput
                 }
-    
+
                 void doStuff() {
                     secondOutputFile.text = secondInputFile.text
                 }
             }
-            
+
             def firstString = project.findProperty('firstInput')
             def firstBean = new NestedBean(firstInput: firstString, firstOutputFile: file("${firstOutputFile}"), firstInputFile: file("${firstInputFile}"))
 
@@ -426,19 +426,19 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 Object getNested() {
                     throw new RuntimeException("BOOM")
                 }
-                
+
                 @Input
                 String input = "Hello"
-                
+
                 @OutputFile
                 File outputFile
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.text = input
                 }
-            }            
-            
+            }
+
             task myTask(type: TaskWithFailingNestedInput) {
                 outputFile = file('build/output.txt')
             }
@@ -455,22 +455,22 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             class TaskWithAbsentNestedInput extends DefaultTask {
                 @Nested
                 Object nested
-                
+
                 @Input
                 String input = "Hello"
-                
+
                 @OutputFile
                 File outputFile
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.text = input
                 }
-            }            
-            
+            }
+
             task myTask(type: TaskWithAbsentNestedInput) {
                 outputFile = file('build/output.txt')
-            }            
+            }
         """
 
         expect:
@@ -485,22 +485,22 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 @Nested
                 @Optional
                 Object nested
-                
+
                 @Input
                 String input = "Hello"
-                
+
                 @OutputFile
                 File outputFile
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.text = input
                 }
-            }            
-            
+            }
+
             task myTask(type: TaskWithAbsentNestedInput) {
                 outputFile = file('build/output.txt')
-            }            
+            }
         """
 
         expect:
@@ -513,28 +513,28 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             class TaskWithNestedInput extends DefaultTask {
                 @Nested
                 Object nested
-                
+
                 @OutputFile
                 File outputFile
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.text = nested.input
                 }
             }
-            
+
             class NestedBean {
                 @Input
                 input
             }
-            
+
             class OtherNestedBean {
                 @Input
                 input
             }
-            
+
             boolean useOther = project.findProperty('useOther')
-            
+
             task myTask(type: TaskWithNestedInput) {
                 outputFile = file('build/output.txt')
                 nested = useOther ? new OtherNestedBean(input: 'string') : new NestedBean(input: 'string')
@@ -566,12 +566,12 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 @Optional
                 Iterable<Object> beans
             }
-            
+
             class NestedBean {
                 @Input
                 String input
             }
-            
+
             task myTask(type: TaskWithNestedIterable) {
                 beans = [new NestedBean(input: 'input'), null]
             }
@@ -589,18 +589,18 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             class TaskWithNestedIterable extends DefaultTask {
                 @Nested
                 Iterable<Object> beans
-                
+
                 @OutputFile
                 File outputFile
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.text = beans.flatten()*.input.join('\\n')
                 }
             }
-            
+
             def inputString = project.findProperty('input') ?: 'input'
-            
+
             task myTask(type: TaskWithNestedIterable) {
                 outputFile = file('build/output.txt')
                 beans = [[new NestedBean(inputString)], [new NestedBean('secondInput')]]
@@ -629,29 +629,29 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             class TaskWithNestedInput extends DefaultTask {
                 @Nested
                 Object nested
-                
+
                 @Input
                 String input = "Hello"
-                
+
                 @OutputFile
                 File outputFile
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.text = input
                 }
-            }            
-            
+            }
+
             class NestedBean {
                 @Nested
                 NestedBean nested
             }
-            
+
             task myTask(type: TaskWithNestedInput) {
                 outputFile = file('build/output.txt')
                 nested = new NestedBean()
                 nested.nested = nested
-            }            
+            }
         """
 
         expect:
@@ -664,7 +664,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         buildFile << taskWithNestedInput()
         buildFile << namedBeanClass()
         buildFile << """
-            myTask.nested = [new NamedBean('name', 'value1'), new NamedBean('name', 'value2')]           
+            myTask.nested = [new NamedBean('name', 'value1'), new NamedBean('name', 'value2')]
         """
 
         expect:
@@ -701,8 +701,8 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
     def "input changes for task with named nested beans"() {
         buildFile << taskWithNestedInput()
         buildFile << namedBeanClass()
-        buildFile << """                                   
-            myTask.nested = [new NamedBean(project.property('namedName'), 'value1'), new NamedBean('name', 'value2')]           
+        buildFile << """
+            myTask.nested = [new NamedBean(project.property('namedName'), 'value1'), new NamedBean('name', 'value2')]
         """
         def taskPath = ':myTask'
 
@@ -728,8 +728,8 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
     def "input changes for task with nested map"() {
         buildFile << taskWithNestedInput()
         buildFile << nestedBeanWithStringInput()
-        buildFile << """                                   
-            myTask.nested = [(project.property('key')): new NestedBean('value1'), key2: new NestedBean('value2')]           
+        buildFile << """
+            myTask.nested = [(project.property('key')): new NestedBean('value1'), key2: new NestedBean('value2')]
         """
         def taskPath = ':myTask'
 
@@ -812,7 +812,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         buildFile << """
             def domainObjectCollection = objects.domainObjectContainer(Bean)
             myTask.nested = domainObjectCollection
-            
+
             domainObjectCollection.create('first') { prop = project.property('value') }
             domainObjectCollection.create('second') { prop = '2' }
         """
@@ -867,13 +867,13 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             class TaskWithNestedInput extends DefaultTask {
                 @Nested
                 Object nested
-                
+
                 @Input
                 String input = "Hello"
-                
+
                 @OutputFile
                 File outputFile
-                
+
                 @TaskAction
                 void doStuff() {
                     outputFile.text = input
@@ -890,7 +890,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         """
             class NestedBean {
                 @Input final String input
-                
+
                 NestedBean(String input) {
                     this.input = input
                 }
@@ -903,11 +903,11 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         taskWithNestedBeanWithAction()
         buildFile << """
             extensions.create("bean", NestedBeanWithAction.class)
-            
+
             bean {
                 withAction { it.text = "hello" }
             }
-            
+
             task myTask(type: TaskWithNestedBeanWithAction) {
                 bean = project.bean
             }
@@ -944,11 +944,11 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 apply plugin: 'base'
 
                 extensions.create("bean", NestedBeanWithAction.class)
-                
+
                 bean {
                     withAction { it.text = "hello" }
                 }
-                
+
                 task myTask(type: TaskWithNestedBeanWithAction) {
                     bean = project.bean
                     outputs.cacheIf { true }
@@ -990,14 +990,14 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             import org.gradle.api.tasks.Nested;
             import org.gradle.api.Action;
             import java.io.File;
-            
+
             public class NestedBeanWithAction {
                 private Action<File> action;
-                
+
                 public void withAction(Action<File> action) {
                     this.action = action;
                 }
-                
+
                 @Nested
                 public Action<File> getAction() {
                     return action;
@@ -1015,32 +1015,32 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
             import org.gradle.api.tasks.Nested;
             import org.gradle.api.tasks.OutputFile;
             import org.gradle.api.tasks.TaskAction;
-            
+
             import java.io.File;
-            
+
             @NonNullApi
             public class TaskWithNestedBeanWithAction extends DefaultTask {
                 private File outputFile = new File(getTemporaryDir(), "output.txt");
                 private NestedBeanWithAction bean;
-                
+
                 @OutputFile
                 public File getOutputFile() {
                     return outputFile;
                 }
-            
+
                 public void setOutputFile(File outputFile) {
                     this.outputFile = outputFile;
                 }
-            
+
                 @Nested
                 public NestedBeanWithAction getBean() {
                     return bean;
                 }
-                
+
                 public void setBean(NestedBeanWithAction bean) {
                     this.bean = bean;
                 }
-            
+
                 @TaskAction
                 public void doStuff() {
                     bean.getAction().execute(outputFile);

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -231,7 +231,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*inputProperty.*")
     def "re-configuring #change in nested bean after the task started executing has no effect"() {
         def fixture = new NestedBeanTestFixture()
         fixture.prepareInputFiles()
@@ -264,7 +264,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*from firstBean to null.*")
     def "re-configuring a nested bean from #from to #to after the task started executing has no effect"() {
         def fixture = new NestedBeanTestFixture()
         fixture.prepareInputFiles()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
@@ -871,7 +871,7 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle#1108")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*includeEmptyDirs=true.*")
     def "can copy files into a different root with includeEmptyDirs=#includeEmptyDirs"() {
         Assume.assumeFalse("This test case is not implemented when includeEmptyDirs=true", includeEmptyDirs)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1023,7 +1023,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*scheduled: true\\)")
     def "failure in resolution propagates to chain (scheduled: #scheduled)"() {
         given:
         def module = mavenHttpRepo.module("test", "test", "1.3").publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1061,7 +1061,10 @@ If the artifacts are trustworthy, you will need to update the gradle/verificatio
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(because = "breaks the IE assumption that visiting a file collection multiple times will always throw the same exception")
+    @ToBeFixedForInstantExecution(
+        iterationMatchers = ".*key = false\\)",
+        because = "breaks the IE assumption that visiting a file collection multiple times will always throw the same exception"
+    )
     def "can mix globally trusted keys and artifact specific keys (trust artifact key = #addLocalKey)"() {
         def keyring = newKeyRing()
         keyServerFixture.registerPublicKey(keyring.publicKey)

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -63,7 +63,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
                     assert testFile.exists()
                 }
             }
-            
+
             ${
             injectedTaskActionTask('javaexecInjectedTaskAction', '''
                 File testFile = project.file("${project.buildDir}/$name")
@@ -120,7 +120,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
                     assert testFile.exists()
                 }
             }
-            
+
             ${
             injectedTaskActionTask('execInjectedTaskAction', '''
                 File testFile = project.file("${project.buildDir}/$name")
@@ -155,8 +155,8 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
                 void myAction() {
                     $taskActionBody
                 }
-            }            
-            
+            }
+
             task $taskName(type: InjectedServiceTask) {
                 dependsOn(sourceSets.main.runtimeClasspath)
             }
@@ -213,30 +213,30 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
             class JavaTestCommand implements CommandLineArgumentProvider {
                 @Internal
                 File expectedWorkingDir
-                
+
                 @Input
                 String getExpectedWorkingDirPath() {
                     return expectedWorkingDir.absolutePath
                 }
-                
+
                 @Classpath
                 FileCollection classPath
-                
+
                 @OutputFile
                 File outputFile
-            
+
                 @Override
                 Iterable<String> asArguments() {
                     ['-cp', classPath.asPath, 'org.gradle.TestMain', expectedWorkingDirPath, outputFile.absolutePath]
                 }
             }
-            
+
             task run(type: Exec) {
                 ext.testFile = file("$buildDir/out.txt")
                 argumentProviders << new JavaTestCommand(
                     expectedWorkingDir: projectDir,
                     classPath: sourceSets.main.runtimeClasspath,
-                    outputFile: testFile 
+                    outputFile: testFile
                 )
                 executable = org.gradle.internal.jvm.Jvm.current().getJavaExecutable()
                 doLast {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ExecIntegrationTest.groovy
@@ -29,7 +29,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*javaexecTask")
     def 'can execute java with #task'() {
         given:
         buildFile << """
@@ -86,7 +86,7 @@ class ExecIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*execTask")
     def 'can execute commands with #task'() {
         given:
         buildFile << """

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -132,7 +132,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3073")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*not up-to-date")
     def "output files changed from #before to #after marks task #upToDateString"() {
         buildFile << """
             class CustomTask extends DefaultTask {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -106,7 +106,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                 @OutputFile
                 @Optional
                 File outputFile
-            
+
                 @TaskAction
                 void doAction() {
                     if (outputFile != null) {
@@ -114,7 +114,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                     }
                 }
             }
-            
+
             task customTask(type: CustomTask) {
                 outputFile = project.hasProperty('outputFile') ? file(project.property("outputFile")) : null
             }
@@ -138,7 +138,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
             class CustomTask extends DefaultTask {
                 @OutputFiles
                 List<Object> outputFiles
-            
+
                 @TaskAction
                 void doAction() {
                     outputFiles.each { output ->
@@ -149,13 +149,13 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                     }
                 }
             }
-            
+
             def lazyProperty(String name) {
                 def value = project.findProperty(name)
                 def outputFile = value ? file(value) : null
                 return { -> outputFile }
             }
-            
+
             task customTask(type: CustomTask) {
                 int numOutputs = Integer.valueOf(project.findProperty('numOutputs'))
                 outputFiles = (0..(numOutputs-1)).collect { lazyProperty("output\$it") }
@@ -204,10 +204,10 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                 @Optional
                 @InputFile
                 File inputFile
-                
+
                 @OutputFile
                 File outputFile
-            
+
                 @TaskAction
                 void doAction() {
                     if (inputFile != null) {
@@ -215,7 +215,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                     }
                 }
             }
-            
+
             task customTask(type: CustomTask) {
                 inputFile = project.hasProperty('inputFile') ? file(project.property("inputFile")) : null
                 outputFile = file("output.txt")
@@ -239,14 +239,14 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
             class CustomTask extends DefaultTask {
                 @OutputFiles
                 FileTree outputFiles
-            
+
                 @TaskAction
                 void doAction() {
                     project.file("build/output.txt").text = "Hello"
                     project.file("build/build.log") << "Produced at \${new Date()}\\n"
                 }
             }
-            
+
             task customTask(type: CustomTask) {
                 outputFiles = fileTree(file("build")) {
                     exclude "*.log"
@@ -317,14 +317,14 @@ import org.gradle.api.tasks.TaskAction
             abstract class MyTask extends DefaultTask {
                 @OutputFiles
                 abstract ConfigurableFileCollection getOutputFiles()
-                
+
                 @TaskAction
                 void doStuff() {
                     project.file('build/dir1/output1.txt').text = "first"
                     project.file('build/dir2/output2.txt').text = "second"
                 }
             }
-            
+
             tasks.register("myTask", MyTask) {
                 outputFiles.from(fileTree('build/dir1'))
                 outputFiles.from(fileTree('build/dir2'))
@@ -352,17 +352,17 @@ import org.gradle.api.tasks.TaskAction
                 File input
                 @OutputFile
                 File output
-                
+
                 @TaskAction
                 void doStuff() {
                     output.text = input.list().join('\\n')
                 }
-            }           
-            
+            }
+
             task myTask(type: MyTask) {
                 input = file(inputDir)
                 output = project.file("build/output.txt")
-            }          
+            }
 
             myTask.input.mkdirs()
         """
@@ -386,18 +386,18 @@ import org.gradle.api.tasks.TaskAction
     def "missing directory is ignored"() {
         buildFile << """
             class TaskWithInputDir extends DefaultTask {
-            
+
                 @InputFiles
                 FileTree inputDir
-                
+
                 @OutputFile
                 File outputFile
-            
+
                 @TaskAction
-                void doStuff() { 
-                    outputFile.text = inputDir.files.collect { it.name }.join("\\n") 
+                void doStuff() {
+                    outputFile.text = inputDir.files.collect { it.name }.join("\\n")
                 }
-            }                             
+            }
 
             task myTask1(type: TaskWithInputDir) {
                 inputDir = fileTree(file('input'))

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecution.java
@@ -43,6 +43,12 @@ public @interface ToBeFixedForInstantExecution {
      */
     String[] bottomSpecs() default {};
 
+    /**
+     * Declare regular expressions matching the iteration name.
+     * Defaults to an empty array, meaning this annotation applies to all iterations of the annotated feature.
+     */
+    String[] iterationMatchers() default {};
+
     String because() default "";
 
     /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionExtension.groovy
@@ -72,6 +72,11 @@ class ToBeFixedForInstantExecutionExtension extends AbstractAnnotationDrivenExte
      * Registration happens as late as possible and to the utmost position in the stack in order to catch
      * failures without being sensible to other spock extensions that re-order interceptors nor to the place
      * of annotated spock features in hierarchies of spec classes.
+     *
+     * This is also so that failures in setup and cleanup methods are taken into account by the annotation.
+     * Unfortunately this leads to not being able to throw from inside the interceptors but instead throw
+     * from outside the test execution, after setup/test/cleanup, in Spock's core, effectively stopping the
+     * whole spec execution. In practice, as soon as a test doesn't behave, we stop executing subsequent tests.
      */
     private static class CatchFeatureFailuresRunListener extends AbstractRunListener {
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionRule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionRule.groovy
@@ -22,6 +22,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.isEnabledBottomSpec
+import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.iterationMatches
 
 /**
  * JUnit Rule supporting the {@link ToBeFixedForInstantExecution} annotation.
@@ -34,7 +35,9 @@ class ToBeFixedForInstantExecutionRule implements TestRule {
         if (!GradleContextualExecuter.isInstant() || annotation == null) {
             return base
         }
-        if (isEnabledBottomSpec(annotation.bottomSpecs(), { description.className.endsWith(".$it") })) {
+        def enabledBottomSpec = isEnabledBottomSpec(annotation.bottomSpecs(), { description.className.endsWith(".$it") })
+        def enabledIteration = iterationMatches(annotation.iterationMatchers(), description.methodName)
+        if (enabledBottomSpec && enabledIteration) {
             ToBeFixedForInstantExecution.Skip skip = annotation.skip()
             if (skip == ToBeFixedForInstantExecution.Skip.DO_NOT_SKIP) {
                 return new ExpectingFailureRuleStatement(base)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionExtension.groovy
@@ -22,6 +22,8 @@ import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.FeatureInfo
 
+import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.iterationMatches
+import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.isAllIterations
 import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.isEnabledBottomSpec
 
 
@@ -38,14 +40,6 @@ class UnsupportedWithInstantExecutionExtension extends AbstractAnnotationDrivenE
         }
     }
 
-    static boolean iterationMatches(String[] iterationMatchers, String iterationName) {
-        return isAllIterations(iterationMatchers) || iterationMatchers.any { iterationName.matches(it) }
-    }
-
-    private static boolean isAllIterations(String[] iterationMatchers) {
-        return iterationMatchers.length == 0
-    }
-
     private static class IterationMatchingMethodInterceptor implements IMethodInterceptor {
 
         private final String[] iterationMatchers
@@ -59,7 +53,7 @@ class UnsupportedWithInstantExecutionExtension extends AbstractAnnotationDrivenE
             if (!iterationMatches(iterationMatchers, invocation.iteration.name)) {
                 invocation.proceed()
             } else {
-                // This will show up in test reports, necessary because we can't mark the test as skipped
+                // This will show up in test reports, necessary because we can't mark the iteration as skipped
                 println("Skipping test @${UnsupportedWithInstantExecution.simpleName}")
             }
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionExtension.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.junit.AssumptionViolatedException
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
@@ -53,8 +54,7 @@ class UnsupportedWithInstantExecutionExtension extends AbstractAnnotationDrivenE
             if (!iterationMatches(iterationMatchers, invocation.iteration.name)) {
                 invocation.proceed()
             } else {
-                // This will show up in test reports, necessary because we can't mark the iteration as skipped
-                println("Skipping test @${UnsupportedWithInstantExecution.simpleName}")
+                throw new AssumptionViolatedException("Unsupported with instant execution")
             }
         }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionRule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionRule.groovy
@@ -21,8 +21,8 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
+import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.iterationMatches
 import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.isEnabledBottomSpec
-import static org.gradle.integtests.fixtures.UnsupportedWithInstantExecutionExtension.iterationMatches
 import static org.junit.Assume.assumeFalse
 
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
@@ -32,7 +32,7 @@ class JavaSourceIncrementalCompilationIntegrationTest extends AbstractSourceIncr
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*annotated types")
     def "change to #retention retention annotation class recompiles #desc"() {
         def annotationClass = file("src/main/${language.name}/SomeAnnotation.${language.name}") << """
             import java.lang.annotation.*;

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
@@ -71,7 +71,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".* source\\.t.*readonly true.*")
     def "using compressed files as inputs - #source - readonly #readonly"() {
         given:
         def packDir = file("pack").createDir()

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/SamplesMavenPomGenerationIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/SamplesMavenPomGenerationIntegrationTest.groovy
@@ -45,7 +45,7 @@ class SamplesMavenPomGenerationIntegrationTest extends AbstractSampleIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "can deploy to local repository with #dsl dsl"() {
         given:
         def pomProjectDir = sample.dir.file(dsl)
@@ -70,7 +70,7 @@ class SamplesMavenPomGenerationIntegrationTest extends AbstractSampleIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "can install to local repository with #dsl dsl"() {
         given:
         def pomProjectDir = sample.dir.file(dsl)
@@ -105,7 +105,7 @@ class SamplesMavenPomGenerationIntegrationTest extends AbstractSampleIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "write new pom with #dsl dsl"() {
         given:
         def pomProjectDir = sample.dir.file(dsl)
@@ -121,7 +121,7 @@ class SamplesMavenPomGenerationIntegrationTest extends AbstractSampleIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "write deployer pom with #dsl dsl"() {
         given:
         def pomProjectDir = sample.dir.file(dsl)

--- a/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/SamplesMavenPomGenerationIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/integtests/publish/maven/SamplesMavenPomGenerationIntegrationTest.groovy
@@ -45,7 +45,7 @@ class SamplesMavenPomGenerationIntegrationTest extends AbstractSampleIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
+    @ToBeFixedForInstantExecution
     def "can deploy to local repository with #dsl dsl"() {
         given:
         def pomProjectDir = sample.dir.file(dsl)
@@ -70,7 +70,7 @@ class SamplesMavenPomGenerationIntegrationTest extends AbstractSampleIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
+    @ToBeFixedForInstantExecution
     def "can install to local repository with #dsl dsl"() {
         given:
         def pomProjectDir = sample.dir.file(dsl)
@@ -121,7 +121,7 @@ class SamplesMavenPomGenerationIntegrationTest extends AbstractSampleIntegration
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
+    @ToBeFixedForInstantExecution
     def "write deployer pom with #dsl dsl"() {
         given:
         def pomProjectDir = sample.dir.file(dsl)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -225,7 +225,7 @@ class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "should not use cache for project dependencies with #dsl dsl"() {
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir).withTasks(":$API_NAME:checkProjectDependency").run()

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesRepositoriesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesRepositoriesIntegrationTest.groovy
@@ -40,7 +40,7 @@ class SamplesRepositoriesIntegrationTest extends AbstractIntegrationSpec {
     @Unroll
     @LeaksFileHandles
     @UsesSample("userguide/artifacts/defineRepository")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can use repositories notation with #dsl dsl"() {
         // This test is not very strong. Its main purpose is to the for the correct syntax as we use many
         // code snippets from this build script in the user's guide.

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/bestpractices/SamplesAuthoringMaintainableBuildsIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/bestpractices/SamplesAuthoringMaintainableBuildsIntegrationTest.groovy
@@ -67,7 +67,7 @@ generateDocs - Generates the HTML documentation for this project.""")
 
     @Unroll
     @UsesSample('userguide/bestPractices/logicDuringConfiguration')
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "can execute logic during execution phase with #dsl dsl"() {
         executer.inDirectory(sample.dir.file("$subDirName/$dsl"))
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesComponentSelectionRulesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesComponentSelectionRulesIntegrationTest.groovy
@@ -33,7 +33,7 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/customizingResolution/selectionRule")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can run resolveConfiguration sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -51,7 +51,7 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/customizingResolution/selectionRule")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can run reject sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -67,7 +67,7 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/customizingResolution/selectionRule")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can run metadata rules sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -84,7 +84,7 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/customizingResolution/selectionRule")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can run targeted rule sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringDependenciesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringDependenciesIntegrationTest.groovy
@@ -101,7 +101,7 @@ class SamplesDeclaringDependenciesIntegrationTest extends AbstractSampleIntegrat
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/declaringDependencies/fileDependencies")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can use declare and resolve file dependencies with #dsl dsl"() {
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDefiningUsingConfigurationsIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDefiningUsingConfigurationsIntegrationTest.groovy
@@ -39,7 +39,7 @@ class SamplesDefiningUsingConfigurationsIntegrationTest extends AbstractIntegrat
     @Unroll
     @UsesSample("userguide/dependencyManagement/definingUsingConfigurations/custom")
     @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
-    def "can declare and resolve custom configuration"() {
+    def "can declare and resolve custom configuration with #dsl dsl"() {
         setup:
         executer.inDirectory(sample.dir.file(dsl))
         executer.requireGradleDistribution() // required to avoid multiple Servlet API JARs in classpath

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDefiningUsingConfigurationsIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDefiningUsingConfigurationsIntegrationTest.groovy
@@ -38,7 +38,7 @@ class SamplesDefiningUsingConfigurationsIntegrationTest extends AbstractIntegrat
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/definingUsingConfigurations/custom")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can declare and resolve custom configuration"() {
         setup:
         executer.inDirectory(sample.dir.file(dsl))

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDependencySubstitutionIntegrationTest.groovy
@@ -35,7 +35,7 @@ class SamplesDependencySubstitutionIntegrationTest extends AbstractIntegrationSp
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/customizingResolution/conditionalSubstitutionRule")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can run sample with all external dependencies with #dsl dsl" () {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -56,7 +56,7 @@ class SamplesDependencySubstitutionIntegrationTest extends AbstractIntegrationSp
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/customizingResolution/conditionalSubstitutionRule")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can run sample with some internal projects with #dsl dsl" () {
         executer.inDirectory(sample.dir.file(dsl))
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesResolutionStrategyIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesResolutionStrategyIntegrationTest.groovy
@@ -35,7 +35,7 @@ class SamplesResolutionStrategyIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/customizingResolution/resolutionStrategy")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can resolve dependencies in #dsl dsl"() {
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
@@ -104,7 +104,7 @@ commons-codec:commons-codec:1.7""")
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/workingWithDependencies/accessMetadataArtifact")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can accessing a module's metadata artifact with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
@@ -39,7 +39,7 @@ class SamplesWorkingWithDependenciesIntegrationTest extends AbstractIntegrationS
 
     @Unroll
     @UsesSample("userguide/dependencyManagement/workingWithDependencies/iterateDependencies")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl")
     def "can iterate over dependencies assigned to a configuration with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesFilesMiscIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesFilesMiscIntegrationTest.groovy
@@ -34,7 +34,7 @@ class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UsesSample("userguide/files/misc")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "can create a directory with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)
@@ -52,7 +52,7 @@ class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UsesSample("userguide/files/misc")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "can move a directory with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)
@@ -119,7 +119,7 @@ class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @UsesSample("userguide/files/misc")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "can use the rootDir property in a child project with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
@@ -45,7 +45,7 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
 
     @Unroll
     @UsesSample("testKit/gradleRunner/junitQuickstart")
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     def "junitQuickstart with #dsl dsl"() {
         expect:
         executer.inDirectory(sample.dir.file(dsl))
@@ -65,7 +65,7 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
     @Unroll
     @UsesSample("testKit/gradleRunner/manualClasspathInjection")
     @Requires(JDK8_OR_EARLIER)
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*kotlin dsl.*")
     // Uses Gradle 2.8 which does not support Java 9
     def "manualClasspathInjection with #dsl dsl"() {
         expect:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -182,8 +182,8 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2313")
     @Unroll
-    @ToBeFixedForInstantExecution
-    "can clean test after extracting class file with #framework"() {
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*useTestNG.*")
+    def "can clean test after extracting class file with #framework"() {
         when:
         ignoreWhenJUnitPlatform()
         buildFile << """

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -33,7 +33,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
     def "can use worker api with composite builds using #pluginId"() {
         settingsFile << """
             rootProject.name = "app"
-            
+
             includeBuild "plugin"
             includeBuild "lib"
         """
@@ -67,7 +67,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
                 id "java"
                 id "org.gradle.test.${pluginId}"
             }
-       
+
             dependencies {
                 implementation "org.gradle.test:lib:1.0"
             }
@@ -90,14 +90,14 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
         plugin.file("src/main/java/LegacyParameter.java") << """
             import java.io.File;
             import java.io.Serializable;
-            
+
             public class LegacyParameter implements Serializable {
                 private final File outputFile;
-                
+
                 public LegacyParameter(File outputFile) {
                     this.outputFile = outputFile;
                 }
-                
+
                 public File getOutputFile() {
                     return this.outputFile;
                }
@@ -108,15 +108,15 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import javax.inject.Inject;
             import java.io.File;
             import org.gradle.test.FileHelper;
-            
+
             public class LegacyRunnable implements Runnable {
                 private File outputFile;
-                
+
                 @Inject
                 public LegacyRunnable(LegacyParameter parameter) {
                     this.outputFile = parameter.getOutputFile();
                 }
-                
+
                 public void run() {
                     FileHelper.write("foo", outputFile);
                 }
@@ -130,16 +130,16 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.workers.*;
             import javax.inject.Inject;
             import java.io.File;
-            
+
             public class LegacyWorkerTask extends DefaultTask {
                 private final WorkerExecutor workerExecutor;
                 private File outputFile;
-                
+
                 @Inject
                 public LegacyWorkerTask(WorkerExecutor workerExecutor) {
                     this.workerExecutor = workerExecutor;
-                } 
-                
+                }
+
                 @TaskAction
                 public void runWork() {
                     workerExecutor.submit(LegacyRunnable.class, new Action<WorkerConfiguration>() {
@@ -149,12 +149,12 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
                         }
                     });
                 }
-                
+
                 @OutputFile
                 File getOutputFile() {
                     return outputFile;
                 }
-                
+
                 void setOutputFile(File outputFile) {
                     this.outputFile = outputFile;
                 }
@@ -165,7 +165,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.api.Plugin;
             import org.gradle.api.Project;
             import java.io.File;
-            
+
             public class LegacyWorkerPlugin implements Plugin<Project> {
                 public void apply(Project project) {
                     project.getTasks().create("runWork", LegacyWorkerTask.class)
@@ -176,7 +176,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
 
         plugin.file("build.gradle") << """
             apply plugin: "java-gradle-plugin"
-            
+
             gradlePlugin {
                 plugins {
                     LegacyWorkerPlugin {
@@ -192,7 +192,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
         plugin.file("src/main/java/TypedParameter.java") << """
             import org.gradle.workers.WorkParameters;
             import org.gradle.api.file.RegularFileProperty;
-            
+
             public interface TypedParameter extends WorkParameters {
                 RegularFileProperty getOutputFile();
             }
@@ -201,7 +201,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
         plugin.file("src/main/java/TypedWorkAction.java") << """
             import org.gradle.workers.WorkAction;
             import org.gradle.test.FileHelper;
-            
+
             abstract public class TypedWorkAction implements WorkAction<TypedParameter> {
                 public void execute() {
                     FileHelper.write("foo", getParameters().getOutputFile().getAsFile().get());
@@ -217,17 +217,17 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.workers.*;
             import javax.inject.Inject;
             import java.io.File;
-            
+
             public class TypedWorkerTask extends DefaultTask {
                 private final WorkerExecutor workerExecutor;
                 private final RegularFileProperty outputFile;
-                
+
                 @Inject
                 public TypedWorkerTask(WorkerExecutor workerExecutor) {
                     this.workerExecutor = workerExecutor;
                     this.outputFile = getProject().getObjects().fileProperty();
-                } 
-                
+                }
+
                 @TaskAction
                 public void runWork() {
                     workerExecutor.noIsolation().submit(TypedWorkAction.class, new Action<TypedParameter>() {
@@ -236,7 +236,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
                         }
                     });
                 }
-                
+
                 @OutputFile
                 RegularFileProperty getOutputFile() {
                     return outputFile;
@@ -248,7 +248,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
             import org.gradle.api.Plugin;
             import org.gradle.api.Project;
             import java.io.File;
-            
+
             public class TypedWorkerPlugin implements Plugin<Project> {
                 public void apply(Project project) {
                     project.getTasks().create("runWork", TypedWorkerTask.class)
@@ -259,7 +259,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
 
         plugin.file("build.gradle") << """
             apply plugin: "java-gradle-plugin"
-            
+
             gradlePlugin {
                 plugins {
                     TypedWorkerPlugin {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -201,7 +201,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
         buildFile << """
             ext.memoryHog = new byte[1024*1024*150] // ~150MB
-            
+
             tasks.withType(WorkerTask) { task ->
                 isolationMode = IsolationMode.PROCESS
                 // Force a new daemon to be used
@@ -403,22 +403,22 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             class MutableItem {
                 static String value = "foo"
             }
-            
+
             abstract class MutatingWorkAction extends TestWorkAction {
                 @Inject
                 public MutatingWorkAction() { }
-                
+
                 public void execute() {
                     MutableItem.value = getParameters().files[0]
                 }
             }
-            
+
             task mutateValue(type: WorkerTask) {
                 list = [ "bar" ]
                 isolationMode = IsolationMode.NONE
                 workActionClass = MutatingWorkAction.class
-            } 
-            
+            }
+
             task verifyNotIsolated {
                 dependsOn mutateValue
                 doLast {
@@ -438,22 +438,22 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             class MutableItem {
                 static String value = "foo"
             }
-            
+
             abstract class MutatingWorkAction extends TestWorkAction {
                 @Inject
                 public MutatingWorkAction() { }
-                
+
                 public void execute() {
                     MutableItem.value = getParameters().files[0]
                 }
             }
-            
+
             task mutateValue(type: WorkerTask) {
                 list = [ "bar" ]
                 isolationMode = IsolationMode.CLASSLOADER
                 workActionClass = MutatingWorkAction.class
-            } 
-            
+            }
+
             task verifyIsolated {
                 dependsOn mutateValue
                 doLast {
@@ -470,24 +470,24 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         fixture.withWorkActionClassInBuildScript()
 
         buildFile << """
-            import java.util.jar.Manifest 
-            
+            import java.util.jar.Manifest
+
             repositories {
                 mavenCentral()
             }
-            
+
             configurations {
                 customGuava
             }
-            
+
             dependencies {
                 customGuava "com.google.guava:guava:23.1-jre"
             }
-            
+
             abstract class GuavaVersionWorkAction extends TestWorkAction {
                 @Inject
                 public GuavaVersionWorkAction() { }
-                
+
                 public void execute() {
                     Enumeration<URL> resources = this.getClass().getClassLoader()
                             .getResources("META-INF/MANIFEST.MF")
@@ -501,18 +501,18 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                             break
                         }
                     }
-                    
+
                     // This method was removed in Guava 24.0
                     def predicatesClass = this.getClass().getClassLoader().loadClass("com.google.common.base.Predicates")
                     assert predicatesClass.getDeclaredMethods().any { it.name == "assignableFrom" }
                 }
             }
-            
+
             task checkGuavaVersion(type: WorkerTask) {
                 isolationMode = IsolationMode.${isolationMode}
                 workActionClass = GuavaVersionWorkAction.class
                 additionalClasspath = configurations.customGuava
-            } 
+            }
         """
 
         expect:
@@ -528,14 +528,14 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     def "classloader is minimal when using #isolationMode"() {
         fixture.withWorkActionClassInBuildSrc()
 
-        buildFile << """         
-            abstract class SneakyWorkAction extends TestWorkAction {            
+        buildFile << """
+            abstract class SneakyWorkAction extends TestWorkAction {
                 @Inject
                 public SneakyWorkAction() { }
-                
+
                 public void execute() {
                     super.execute()
-                    // These classes were chosen to be relatively stable and would be unusual to see in a worker. 
+                    // These classes were chosen to be relatively stable and would be unusual to see in a worker.
                     def gradleApiClasses = [
                         "${com.google.common.collect.Lists.canonicalName}",
                     ]
@@ -544,7 +544,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                         throw new IllegalArgumentException("These classes should not be visible to the worker action: " + reachableClasses)
                     }
                 }
-                
+
                 boolean reachable(String classname) {
                     try {
                         Class.forName(classname)
@@ -556,11 +556,11 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                     }
                 }
             }
-            
+
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.$isolationMode
                 workActionClass = SneakyWorkAction
-            } 
+            }
         """
 
         when:
@@ -602,7 +602,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                 workActionClass = ResourceWorkAction
                 additionalClasspath = tasks.jarFoo.outputs.files
                 dependsOn jarFoo
-            } 
+            }
         """
 
         when:
@@ -643,7 +643,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
                 isolationMode = $isolationMode
                 workActionClass = ${workerThatChangesContextClassLoader.name}.class
             }
-            
+
             task checkClassLoader(type: WorkerTask) {
                 dependsOn changeClassloader
                 isolationMode = $isolationMode
@@ -665,9 +665,9 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     void withParameterClassReferencingClassInAnotherPackage() {
         file("buildSrc/src/main/java/org/gradle/another/Bar.java").text = """
             package org.gradle.another;
-            
+
             import java.io.Serializable;
-            
+
             public class Bar implements Serializable { }
         """
 
@@ -677,7 +677,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             import java.io.Serializable;
             import org.gradle.another.Bar;
 
-            public class Foo implements Serializable { 
+            public class Foo implements Serializable {
                 Bar bar = new Bar();
             }
         """

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -40,7 +40,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*PROCESS")
     def "can create and use a work action defined in buildSrc in #isolationMode"() {
         fixture.withWorkActionClassInBuildSrc()
 
@@ -75,7 +75,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         isolationMode << ISOLATION_MODES
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*PROCESS")
     def "can create and use a work action defined in build script in #isolationMode"() {
         fixture.withWorkActionClassInBuildScript()
 
@@ -110,7 +110,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         isolationMode << ISOLATION_MODES
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(iterationMatchers = ".*PROCESS")
     def "can create and use a work action defined in an external jar in #isolationMode"() {
         def workActionJarName = "workAction.jar"
         withWorkActionClassInExternalJar(file(workActionJarName))


### PR DESCRIPTION
In order to enable more coverage, and get proper signal when the outcome of a case of an `@Unroll`ed test changes.