### PR TITLE
Add dark mode on HTML test report

### DIFF
--- a/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
+++ b/subprojects/core/src/main/resources/org/gradle/reporting/base-style.css
@@ -177,3 +177,34 @@ span.wrapped pre {
 label.hidden {
     display: none;
 }
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    html {
+      background: black;
+    }
+    body, a, a:visited {
+        color: #a3a3a3;
+    }
+    #footer, #footer a {
+        color: #cacaca;
+    }
+    ul.tabLinks li {
+        border: solid 1px #cacaca;
+        background-color: #151515;
+    }
+    ul.tabLinks li:hover {
+        background-color: #383838;
+    }
+    ul.tabLinks li.selected {
+        background-color: #002d32;
+        border-color: #007987;
+    }
+    div.tab th, div.tab table {
+        border-bottom: solid #d0d0d0 1px;
+    }
+    span.code pre {
+        background-color: #0a0a0a;
+        border: solid 1px #5f5f5f;
+    }
+}

--- a/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
+++ b/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
@@ -91,7 +91,6 @@ ul.linkList li {
     #successRate, .summaryGroup {
         border: solid 2px #d0d0d0;
     }
-
     .success, .success a {
         color: #007900;
     }

--- a/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
+++ b/subprojects/testing-base/src/main/resources/org/gradle/api/internal/tasks/testing/report/style.css
@@ -82,3 +82,31 @@ ul.linkList li {
     list-style: none;
     margin-bottom: 5px;
 }
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    .breadcrumbs, .breadcrumbs a {
+        color: #9b9b9b;
+    }
+    #successRate, .summaryGroup {
+        border: solid 2px #d0d0d0;
+    }
+
+    .success, .success a {
+        color: #007900;
+    }
+    div.success, #successRate.success {
+        background-color: #001c00;
+        border-color: #007900;
+    }
+    .failures, .failures a {
+        color: #a30000;
+    }
+    .skipped, .skipped a {
+        color: #a26d13;
+    }
+    div.failures, #successRate.failures {
+        background-color: #170000;
+        border-color: #a30000;
+    }
+}


### PR DESCRIPTION
Issue: #12103

Signed-off-by: Philippe FICHET <philippe.fichet@laposte.net>

### Context
Add dark mode for HTML test report based on media queries level 5 and prefers-color-scheme

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [-] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
