### PR TITLE
Add Gradle samples

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -92,6 +92,7 @@
         <ul>
             <li><a href="../userguide/userguide.html">Docs Home</a></li>
             <li><a href="https://guides.gradle.org">Tutorials</a></li>
+            <li><a href="../samples/index.html">Samples</a></li>
             <li><a href="../release-notes.html">Release Notes</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#gradle-api" aria-expanded="false" aria-controls="gradle-api">Gradle API</a>
                 <ul id="gradle-api">


### PR DESCRIPTION
As discussed in the @gradle/jvm team, the samples are really hard to find.  Added a link to the top section to make them more visible. Left the original link intact (in "Authoring Gradle Builds/Example Gradle Projects/Gradle Samples")

Signed-off-by: Benjamin Muskalla <bmuskalla@gradle.com>