### PR TITLE
Fix KotlinDslScriptsModelCrossVersionSpec flakiness

### DIFF
--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -133,6 +133,9 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCro
     def "single request models equal multi requests models"() {
 
         given:
+        toolingApi.requireIsolatedUserHome()
+
+        and:
         def spec = withMultiProjectBuildWithBuildSrc()
 
         when:


### PR DESCRIPTION
Require isolated user home to prevent flakiness caused by timeout waiting for artifact transform cache lock.

Flakiness was caused by several tests running in parallel and fighting for a lock on the artifact transform cache while the source distro transform is taking too long. It only happens on Windows, most probably just because of slower i/o.

In practice it shouldn't happen as this transform is supposed to be triggered once when you import a project in the IDE.