### PR TITLE
Allow VFS features to be switched off

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -102,12 +102,12 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(VirtualFileSystemServices.class);
 
     /**
-     * System property to enable partial invalidation.
+     * Boolean system property to enable partial invalidation.
      */
     public static final String VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY = "org.gradle.unsafe.vfs.partial-invalidation";
 
     /**
-     * System property to enable retaining VFS state between builds.
+     * Boolean system property to enable retaining VFS state between builds.
      *
      * Also enables partial VFS invalidation.
      *
@@ -131,12 +131,12 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
     public static final String VFS_DROP_PROPERTY = "org.gradle.unsafe.vfs.drop";
 
     public static boolean isPartialInvalidationEnabled(Map<String, String> systemPropertiesArgs) {
-        return getSystemProperty(VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY, systemPropertiesArgs) != null
+        return isSystemPropertyEnabled(VFS_PARTIAL_INVALIDATION_ENABLED_PROPERTY, systemPropertiesArgs)
             || isRetentionEnabled(systemPropertiesArgs);
     }
 
     public static boolean isRetentionEnabled(Map<String, String> systemPropertiesArgs) {
-        return getSystemProperty(VFS_RETENTION_ENABLED_PROPERTY, systemPropertiesArgs) != null;
+        return isSystemPropertyEnabled(VFS_RETENTION_ENABLED_PROPERTY, systemPropertiesArgs);
     }
 
     public static List<File> getChangedPathsSinceLastBuild(PathToFileResolver resolver, Map<String, String> systemPropertiesArgs) {
@@ -148,6 +148,11 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
             .filter(path -> !path.isEmpty())
             .map(resolver::resolve)
             .collect(Collectors.toList());
+    }
+
+    private static boolean isSystemPropertyEnabled(String systemProperty, Map<String, String> systemPropertiesArgs) {
+        String value = getSystemProperty(systemProperty, systemPropertiesArgs);
+        return value != null && !"false".equalsIgnoreCase(value);
     }
 
     @Nullable
@@ -222,7 +227,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                         FileResolver fileResolver = new BaseDirFileResolver(startParameter.getCurrentDir(), () -> {
                             throw new UnsupportedOperationException();
                         });
-                        if (getSystemProperty(VFS_DROP_PROPERTY, systemPropertiesArgs) != null) {
+                        if (isSystemPropertyEnabled(VFS_DROP_PROPERTY, systemPropertiesArgs)) {
                             virtualFileSystem.invalidateAll();
                         } else {
                             List<File> changedPathsSinceLastBuild = getChangedPathsSinceLastBuild(fileResolver, systemPropertiesArgs);

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -178,7 +178,7 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         mainSourceFile.text = sourceFileWithGreeting("Hello World!")
 
         when:
-        run "run"
+        withoutRetention().run "run"
         then:
         outputContains "Hello World!"
         executedAndNotSkipped ":compileJava", ":classes", ":run"
@@ -210,7 +210,7 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
 
         when:
         mainSourceFile.text = sourceFileWithGreeting("Hello VFS!")
-        run "run"
+        withoutRetention().run "run"
         then:
         outputContains "Hello VFS!"
         executedAndNotSkipped ":compileJava", ":classes", ":run"
@@ -228,7 +228,7 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         outputContains(incubatingMessage)
 
         when:
-        run("assemble")
+        withoutRetention().run("assemble")
         then:
         outputDoesNotContain(incubatingMessage)
     }
@@ -476,7 +476,12 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
     }
 
     private def withRetention() {
-        executer.withArgument  "-D${VFS_RETENTION_ENABLED_PROPERTY}"
+        executer.withArgument  "-D${VFS_RETENTION_ENABLED_PROPERTY}=true"
+        this
+    }
+
+    private def withoutRetention() {
+        executer.withArgument  "-D${VFS_RETENTION_ENABLED_PROPERTY}=false"
         this
     }
 


### PR DESCRIPTION
Previously it was only possible to enable VFS retention and partial invalidation via the respective system properties. Now it's possible to set `-Dorg.gradle.unsafe.vfs.retention=false` or `-Dorg.gradle.unsafe.vfs.partial-invalidation=false` to explicitly disable the features.