### PR TITLE
Remove gradleApi() sources resolution

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -132,15 +132,6 @@ You can still manually verify the `gradle-wrapper.jar` by following the instruct
 <a name="plugin-dev"></a>
 ## Improvements for Plugin Development
 
-### Gradle API source code for plugin developers in IDEs
-
-Plugin authors will now have the sources of the `gradleApi()`, `gradleTestKit()` and `localGroovy()` dependencies attached for navigation in the IDE.
-
-This works out of the box with [Eclipse Buildship](https://projects.eclipse.org/projects/tools.buildship).
-
-For IntelliJ IDEA, the sources for `gradleApi()` are only attached when the [Gradle wrapper](userguide/gradle_wrapper.html#sec:adding_wrapper) is used with an `-all` distribution. Sources for `gradleTestKit()` and `localGroovy()` are not attached at the moment.
-This will change once [IDEA-231667](https://youtrack.jetbrains.com/issue/IDEA-231667) is resolved. Then, the sources for all Gradle APIs (`gradleApi()`, `gradleTestKit()` and `localGroovy()`) will be downloaded and attached on-demand regardless of the wrapper in use.
-
 ### Injectable services available to Settings plugins
 
 Our `ExecOperations` and `FileSystemOperations` [injectable services](userguide/custom_gradle_types.html#services_for_injection) are now available to Settings plugins.

--- a/subprojects/docs/src/docs/release/release-features.txt
+++ b/subprojects/docs/src/docs/release/release-features.txt
@@ -1,4 +1,3 @@
  - Dependency checksum and signature verification
  - Documentation links in deprecation messages
  - Shareable read-only dependency cache
- - Navigable Gradle sources for plugin developers in IDE

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseSourcesAndJavadocJarsIntegrationTest.groovy
@@ -15,9 +15,7 @@
  */
 package org.gradle.plugins.ide.eclipse
 
-
 import org.gradle.plugins.ide.AbstractSourcesAndJavadocJarsIntegrationTest
-import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpArtifact
 
 class EclipseSourcesAndJavadocJarsIntegrationTest extends AbstractSourcesAndJavadocJarsIntegrationTest {
@@ -46,13 +44,6 @@ class EclipseSourcesAndJavadocJarsIntegrationTest extends AbstractSourcesAndJava
     void ideFileContainsGradleApi(String apiJarPrefix) {
         def apiLib = findApiLibrary(apiJarPrefix)
         assert apiLib.sourcePath == null
-    }
-
-    @Override
-    void ideFileContainsGradleApiWithSources(String apiJarPrefix) {
-        def apiLib = findApiLibrary(apiJarPrefix)
-        assert apiLib.sourcePath != null
-        assertContainsGradleSources(new TestFile(apiLib.sourcePath))
     }
 
     EclipseClasspathFixture.EclipseLibrary findApiLibrary(String apiJarPrefix) {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaSourcesAndJavadocJarsIntegrationTest.groovy
@@ -15,10 +15,8 @@
  */
 package org.gradle.plugins.ide.idea
 
-
 import org.gradle.plugins.ide.AbstractSourcesAndJavadocJarsIntegrationTest
 import org.gradle.plugins.ide.fixtures.IdeaModuleFixture
-import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpArtifact
 
 class IdeaSourcesAndJavadocJarsIntegrationTest extends AbstractSourcesAndJavadocJarsIntegrationTest {
@@ -39,16 +37,6 @@ class IdeaSourcesAndJavadocJarsIntegrationTest extends AbstractSourcesAndJavadoc
     void ideFileContainsGradleApi(String apiJarPrefix) {
         def libraryEntry = findApiLibrary(apiJarPrefix)
         assert libraryEntry.source.empty
-    }
-
-    @Override
-    void ideFileContainsGradleApiWithSources(String apiJarPrefix) {
-        def libraryEntry = findApiLibrary(apiJarPrefix)
-        assert !libraryEntry.source.isEmpty()
-        TestFile sourcesRoot = file(libraryEntry.source.get(0).replace('file://$MODULE_DIR$/', '')).parentFile
-        assertContainsGradleSources(sourcesRoot)
-        File[] submodules = sourcesRoot.listFiles()
-        assert libraryEntry.source.size() == submodules.length
     }
 
     IdeaModuleFixture.ImlModuleLibrary findApiLibrary(String apiJarPrefix) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
@@ -17,69 +17,26 @@
 package org.gradle.plugins.ide.internal.resolver;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
-import org.gradle.api.internal.artifacts.ArtifactAttributes;
-import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
-import org.gradle.api.internal.artifacts.transform.UnzipTransform;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.artifacts.result.ArtifactResolutionResult;
 import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
-import org.gradle.internal.installation.CurrentGradleInstallation;
-import org.gradle.internal.installation.GradleInstallation;
-import org.gradle.util.GradleVersion;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.base.artifact.SourcesArtifact;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Collections;
 
 public class DefaultGradleApiSourcesResolver implements GradleApiSourcesResolver {
-
-    private static final Logger LOGGER = Logging.getLogger(DefaultGradleApiSourcesResolver.class);
-
-    private static final String GRADLE_REPO_URL = "https://services.gradle.org/";
-    private static final String GRADLE_REPO_URL_OVERRIDE_VAR = "GRADLE_REPO_OVERRIDE";
 
     private static final String GRADLE_LIBS_REPO_URL = "https://repo.gradle.org/gradle/list/libs-releases";
     private static final String GRADLE_LIBS_REPO_OVERRIDE_VAR = "GRADLE_LIBS_REPO_OVERRIDE";
 
     private final Project project;
 
-    private final String zipType = "zip";
-    private final String unzippedDistributionType = "gradle-src-unzip";
-    private final String sourceDirectory = "gradle-src-dir";
-
     public DefaultGradleApiSourcesResolver(Project project) {
         this.project = project;
-    }
-
-    @Override
-    public File resolveGradleApiSources(boolean download) {
-        GradleInstallation gradleInstallation = CurrentGradleInstallation.get();
-        if (gradleInstallation == null) {
-            return null;
-        }
-        File srcDir = gradleInstallation.getSrcDir();
-        if (srcDir.exists()) {
-            return srcDir;
-        }
-        if (!download) {
-            return null;
-        }
-        try {
-            return downloadSources();
-        } catch (DefaultLenientConfiguration.ArtifactResolveException e) {
-            LOGGER.warn("Could not fetch Gradle sources distribution: " + e.getCause().getMessage());
-            return null;
-        }
     }
 
     @Override
@@ -92,79 +49,6 @@ public class DefaultGradleApiSourcesResolver implements GradleApiSourcesResolver
         } finally {
             project.getRepositories().remove(repository);
         }
-    }
-
-    private File downloadSources() {
-        IvyArtifactRepository repository = addGradleSourcesRepository();
-        try {
-            registerTransforms();
-            return transientConfigurationForSourcesDownload();
-        } finally {
-            project.getRepositories().remove(repository);
-        }
-    }
-
-    private IvyArtifactRepository addGradleSourcesRepository() {
-        return project.getRepositories().ivy(a -> {
-            String repoName = repositoryNameFor(gradleVersion());
-            a.setName("Gradle " + repoName);
-            a.setUrl(gradleRepoUrl() + repoName);
-            a.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
-            a.patternLayout(layout -> layout.artifact("[module]-[revision](-[classifier])(.[ext])"));
-        });
-    }
-
-    private String gradleRepoUrl() {
-        String repoOverride = System.getenv(GRADLE_REPO_URL_OVERRIDE_VAR);
-        return repoOverride != null ? repoOverride : GRADLE_REPO_URL;
-    }
-
-    private void registerTransforms() {
-        project.getDependencies().registerTransform(UnzipTransform.class, a -> {
-            a.getFrom().attribute(ArtifactAttributes.ARTIFACT_FORMAT, zipType);
-            a.getTo().attribute(ArtifactAttributes.ARTIFACT_FORMAT, unzippedDistributionType);
-        });
-        project.getDependencies().registerTransform(FindGradleSources.class, a -> {
-            a.getFrom().attribute(ArtifactAttributes.ARTIFACT_FORMAT, unzippedDistributionType);
-            a.getTo().attribute(ArtifactAttributes.ARTIFACT_FORMAT, sourceDirectory);
-        });
-    }
-
-    private File transientConfigurationForSourcesDownload() {
-        Configuration configuration = detachedConfigurationFor(gradleSourceDependency());
-        configuration.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, sourceDirectory);
-        return configuration.getSingleFile();
-    }
-
-    private Configuration detachedConfigurationFor(Dependency dependency) {
-        return project.getConfigurations().detachedConfiguration(dependency);
-    }
-
-    private GradleVersion gradleVersion() {
-        return GradleVersion.version(project.getGradle().getGradleVersion());
-    }
-
-    private Dependency gradleSourceDependency() {
-        Map<String, String> sourceDependency = new HashMap<>();
-        sourceDependency.put("group", "gradle");
-        sourceDependency.put("name", "gradle");
-        sourceDependency.put("version", dependencyVersion());
-        sourceDependency.put("classifier", "src");
-        sourceDependency.put("ext", "zip");
-        return project.getDependencies().create(sourceDependency);
-    }
-
-    private String dependencyVersion() {
-        GradleVersion version = gradleVersion();
-        if (version.isSnapshot()) {
-            return String.format("(6.1.1, %s]", version.getVersion());
-        } else {
-            return version.getVersion();
-        }
-    }
-
-    private static String repositoryNameFor(GradleVersion gradleVersion) {
-        return gradleVersion.isSnapshot() ? "distributions-snapshots" : "distributions";
     }
 
     private File downloadLocalGroovySources(String version) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/GradleApiSourcesResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/GradleApiSourcesResolver.java
@@ -19,7 +19,5 @@ package org.gradle.plugins.ide.internal.resolver;
 import java.io.File;
 
 public interface GradleApiSourcesResolver {
-    File resolveGradleApiSources(boolean download);
-
     File resolveLocalGroovySources(String jarName);
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -223,8 +223,6 @@ public class IdeDependencySet {
                     Set<ResolvedArtifactResult> javaDoc = auxiliaryArtifacts.get(componentIdentifier, JavadocArtifact.class);
                     javaDoc = javaDoc != null ? javaDoc : Collections.<ResolvedArtifactResult>emptySet();
                     visitor.visitModuleDependency(artifact, sources, javaDoc, isTestConfiguration(configurations.get(artifactIdentifier)));
-                } else if (isGradleApiDependency(artifact)) {
-                    visitor.visitGradleApiDependency(artifact, gradleApiSourcesResolver.resolveGradleApiSources(shouldDownloadSources(visitor)), isTestConfiguration(configurations.get(artifactIdentifier)));
                 } else if (isLocalGroovyDependency(artifact)) {
                     File localGroovySources = shouldDownloadSources(visitor) ? gradleApiSourcesResolver.resolveLocalGroovySources(artifact.getFile().getName()) : null;
                     visitor.visitGradleApiDependency(artifact, localGroovySources, isTestConfiguration(configurations.get(artifactIdentifier)));
@@ -239,11 +237,6 @@ public class IdeDependencySet {
             String componentIdentifier = artifact.getId().getComponentIdentifier().getDisplayName();
             return (componentIdentifier.equals(GRADLE_API.displayName) || componentIdentifier.equals(GRADLE_TEST_KIT.displayName) || componentIdentifier.equals(LOCAL_GROOVY.displayName))
                 && artifactFileName.startsWith("groovy-all-");
-        }
-
-        private boolean isGradleApiDependency(ResolvedArtifactResult artifact) {
-            String artifactFileName = artifact.getFile().getName();
-            return artifactFileName.startsWith("gradle-api") || artifactFileName.startsWith("gradle-test-kit");
         }
 
         private boolean shouldDownloadSources(IdeDependencyVisitor visitor) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/NullGradleApiSourcesResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/NullGradleApiSourcesResolver.java
@@ -26,11 +26,6 @@ public class NullGradleApiSourcesResolver implements GradleApiSourcesResolver {
     }
 
     @Override
-    public File resolveGradleApiSources(boolean download) {
-        return null;
-    }
-
-    @Override
     public File resolveLocalGroovySources(String jarName) {
         return null;
     }


### PR DESCRIPTION
Remove `gradleApi()` sources resolution.
1. There has been a [regression](https://github.com/gradle/gradle/issues/12198).
2. Let's rethink the approach.