### PR TITLE
Add a system property to configure the daemon log level

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLoggingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLoggingIntegrationTest.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.daemon
+
+import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+import org.gradle.launcher.daemon.server.exec.LogToClient
+
+class DaemonLoggingIntegrationTest extends DaemonIntegrationSpec {
+
+    def "can configure daemon logging"() {
+        file("gradle.properties") << """
+            systemProp.${LogToClient.DAEMON_LOGLEVEL_PROPERTY_NAME}=WARN
+        """
+
+        file("build.gradle") << """
+            println "Lifecycle"
+        """
+
+        when:
+        succeeds("help")
+        def daemonLog = new DaemonLogLevelFixture(daemons.daemon.logFile)
+        then:
+        !daemonLog.debugLogLevel
+        daemonLog.infoLogLevelBeforeBuildStarts
+        !daemonLog.infoLogLevelAfterBuildFinished
+        daemonLog.contains("Lifecycle")
+
+        when:
+        daemonLog.truncate()
+        succeeds("help")
+        then:
+        !daemonLog.debugLogLevel
+        !daemonLog.infoLogLevelBeforeBuildStarts
+        !daemonLog.infoLogLevelAfterBuildFinished
+        daemonLog.contains("Lifecycle")
+
+        when:
+        file("gradle.properties").text = "systemProp.${LogToClient.DAEMON_LOGLEVEL_PROPERTY_NAME}=DEBUG"
+        daemonLog.truncate()
+        succeeds("help")
+        then:
+        daemonLog.debugLogLevel
+    }
+
+    static class DaemonLogLevelFixture {
+
+        private final File daemonLog
+
+        DaemonLogLevelFixture(File daemonLog) {
+            this.daemonLog = daemonLog
+        }
+
+        private boolean isDebugLogLevel() {
+            daemonLog.text.contains("[DEBUG]")
+        }
+
+        private boolean isInfoLogLevelBeforeBuildStarts() {
+            daemonLog.text.contains("Marking the daemon as busy")
+        }
+
+        private boolean isInfoLogLevelAfterBuildFinished() {
+            daemonLog.text.contains("Marking the daemon as idle")
+        }
+
+        boolean contains(String expected) {
+            daemonLog.text.contains(expected)
+        }
+
+        void truncate() {
+            daemonLog.text = ""
+        }
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -189,7 +189,7 @@ public class DaemonMain extends EntryPoint {
 
         //Making the daemon infrastructure log with DEBUG. This is only for the infrastructure!
         //Each build request carries it's own log level and it is used during the execution of the build (see LogToClient)
-        loggingManager.setLevelInternal(LogLevel.DEBUG);
+        loggingManager.setLevelInternal(LogLevel.INFO);
 
         loggingManager.start();
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/LogToClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/LogToClient.java
@@ -81,7 +81,7 @@ public class LogToClient extends BuildCommandOnly {
 
     private class AsynchronousLogDispatcher extends Thread {
         private final CountDownLatch completionLock = new CountDownLatch(1);
-        private final Queue<OutputEvent> eventQueue = new ConcurrentLinkedQueue<OutputEvent>();
+        private final Queue<OutputEvent> eventQueue = new ConcurrentLinkedQueue<>();
         private final DaemonConnection connection;
         private final OutputEventListener listener;
         private volatile boolean shouldStop;


### PR DESCRIPTION
Related to https://github.com/gradle/gradle/issues/2688

Currently, the daemon always logs with `DEBUG` log level in the daemon log. This was fine up to now (mostly), since not much happened between builds.

When file watching is enabled, a lot happens between builds - file changes are collected. In order to prevent the daemon log to overflow, it should be possible to set the log level differently - e.g. to `INFO`.

This PR introduces a system property `org.gradle.daemon.loglevel` which the daemon tries to pick up from the current build context and then changes the logging level after the build accordingly.