### PR TITLE
Make instant execution compatible with retry plugin

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -38,6 +38,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
+    @ToBeFixedForInstantExecution
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--dsl', scriptDsl.id)
@@ -89,7 +90,6 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "creates sample source using testng instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', 'testng', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -38,7 +38,6 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
@@ -88,7 +87,6 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "creates sample source using testng instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'testng', '--dsl', scriptDsl.id)
@@ -137,7 +135,6 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "creates sample source with package and #testFramework and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'testng', '--package', 'my.lib', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -183,7 +183,6 @@ ${TextUtil.indent(configLines.join("\n"), "                        ")}
         assert text.contains(publishingBlock)
     }
 
-    @ToBeFixedForInstantExecution
     def "singleModule with explicit project dir"() {
         setup:
         resources.maybeCopy('MavenConversionIntegrationTest/singleModule')
@@ -204,7 +203,6 @@ ${TextUtil.indent(configLines.join("\n"), "                        ")}
         failure.assertHasCause("There were failing tests.")
     }
 
-    @ToBeFixedForInstantExecution
     def 'sourcesJar'() {
         when: 'build is initialized'
         run 'init'
@@ -246,7 +244,6 @@ ${TextUtil.indent(configLines.join("\n"), "                        ")}
         file('build/libs/util-2.5-tests.jar').exists()
     }
 
-    @ToBeFixedForInstantExecution
     def 'javadocJar'() {
         when: 'build is initialized'
         run 'init'

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -19,8 +19,8 @@ package org.gradle.buildinit.plugins
 import org.gradle.buildinit.plugins.fixtures.WrapperTestFixture
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpModule
@@ -148,7 +148,6 @@ Root project 'webinar-parent'
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "singleModule"() {
         when:
         run 'init'

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -33,6 +33,7 @@ import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.api.invocation.Gradle
@@ -152,6 +153,7 @@ class Codecs(
         bind(ownerServiceCodec<BuildOperationListenerManager>())
         bind(ownerServiceCodec<BuildRequestMetaData>())
         bind(ownerServiceCodec<ListenerManager>())
+        bind(ownerServiceCodec<ClassLoaderCache>())
         bind(ServicesCodec())
 
         bind(ProxyCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -242,6 +242,8 @@ class Codecs(
         // Only serialize certain List implementations
         bind(arrayListCodec)
         bind(linkedListCodec)
+        bind(vectorCodec)
+        bind(stackCodec)
         bind(ImmutableListCodec)
 
         // Only serialize certain Set implementations for now, as some custom types extend Set (eg DomainObjectContainer)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/CollectionCodecs.kt
@@ -25,13 +25,23 @@ import org.gradle.instantexecution.serialization.writeArray
 import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.instantexecution.serialization.writeMap
 import java.util.LinkedList
+import java.util.Stack
 import java.util.TreeMap
 import java.util.TreeSet
+import java.util.Vector
 import java.util.concurrent.ConcurrentHashMap
 
 
 internal
 val arrayListCodec: Codec<ArrayList<Any?>> = collectionCodec { ArrayList<Any?>(it) }
+
+
+internal
+val vectorCodec: Codec<Vector<Any?>> = collectionCodec { Vector<Any?>(it) }
+
+
+internal
+val stackCodec: Codec<Stack<Any?>> = collectionCodec { Stack<Any?>() }
 
 
 internal

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.integtests.samples.java
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
@@ -146,7 +146,6 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("testing/testng/groups/groovy")
-    @ToBeFixedForInstantExecution
     def "can filter tests by TestNG group"() {
         given:
         executer.inDirectory(sample.dir)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -226,7 +226,6 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("testing/testng/preserveorder/groovy")
-    @ToBeFixedForInstantExecution
     def "can use the preserveOrder option with TestNG tests"() {
         given:
         executer.inDirectory(sample.dir)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -249,7 +249,6 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample("testing/testng/groupbyinstances/groovy")
-    @ToBeFixedForInstantExecution
     def "can use the groupByInstances option with TestNG tests"() {
         given:
         executer.inDirectory(sample.dir)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/TestRetryPluginSmokeTest.groovy
@@ -16,14 +16,13 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Issue
 
 class TestRetryPluginSmokeTest extends AbstractSmokeTest {
 
-    @ToBeFixedForInstantExecution
     @Issue('https://plugins.gradle.org/plugin/org.gradle.test-retry')
     def 'test retry plugin'() {
         when:
@@ -47,7 +46,7 @@ class TestRetryPluginSmokeTest extends AbstractSmokeTest {
                 doFirst {
                     file("marker.file").delete()
                 }
-            
+
                 useJUnitPlatform()
                 retry {
                     maxRetries = 2

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
@@ -16,12 +16,11 @@
 
 package org.gradle.testing
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
-
 import org.gradle.api.internal.tasks.testing.operations.ExecuteTestBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.junit.Rule
 
 import static org.gradle.testing.TestExecutionBuildOperationTestUtils.assertJunit
@@ -49,24 +48,6 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
         assertJunit(rootTestOp, operations)
     }
-
-    @ToBeFixedForInstantExecution
-    def "emitsBuildOperationsForTestNgTests"() {
-        given:
-        executer.withRepositoryMirrors()
-
-        when:
-        run "test"
-
-        then: "test build operations are emitted in expected hierarchy"
-        def rootTestOp = operations.first(ExecuteTestBuildOperationType)
-        rootTestOp.details.testDescriptor.name.startsWith("Gradle Test Run :test")
-        rootTestOp.details.testDescriptor.className == null
-        rootTestOp.details.testDescriptor.composite == true
-
-        assertTestNg(rootTestOp, operations)
-    }
-
 
     def "emits test operations as expected for two builds in a row"() {
         given:
@@ -106,7 +87,7 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
             task testng {
                 dependsOn gradle.includedBuild('testng').task(':test')
             }
-            
+
             task junit {
                 dependsOn gradle.includedBuild('junit').task(':test')
             }

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
@@ -49,6 +49,22 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         assertJunit(rootTestOp, operations)
     }
 
+    def "emitsBuildOperationsForTestNgTests"() {
+        given:
+        executer.withRepositoryMirrors()
+
+        when:
+        run "test"
+
+        then: "test build operations are emitted in expected hierarchy"
+        def rootTestOp = operations.first(ExecuteTestBuildOperationType)
+        rootTestOp.details.testDescriptor.name.startsWith("Gradle Test Run :test")
+        rootTestOp.details.testDescriptor.className == null
+        rootTestOp.details.testDescriptor.composite == true
+
+        assertTestNg(rootTestOp, operations)
+    }
+
     def "emits test operations as expected for two builds in a row"() {
         given:
         executer.withRepositoryMirrors()

--- a/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -101,7 +101,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         succeeds "verifyTestResultConventions"
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "test results show passing and failing tests"() {
         given:
         createPassingFailingTest()
@@ -121,7 +120,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeOtherTest').assertTestPassed(passingTestCaseName)
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "test results capture test output"() {
         Assume.assumeTrue(capturesTestOutput())
         given:
@@ -140,7 +138,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeTest').assertStderr(CoreMatchers.containsString("some error output"))
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "failing tests cause report url to be printed"() {
         given:
         createPassingFailingTest()
@@ -152,7 +149,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         failure.assertHasCause("There were failing tests. See the report at:")
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "lack of tests produce an empty report"() {
         given:
         createEmptyProject()
@@ -164,7 +160,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.assertNoTestClassesExecuted()
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "adding and removing tests remove old tests from reports"() {
         given:
         createPassingFailingTest()
@@ -176,7 +171,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.assertTestClassesExecuted('SomeTest', 'NewTest')
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "honors test case filter from --tests flag"() {
         given:
         createPassingFailingTest()
@@ -189,7 +183,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeOtherTest').assertTestPassed(passingTestCaseName)
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "honors test suite filter from --tests flag"() {
         given:
         createPassingFailingTest()
@@ -202,7 +195,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         testResult.testClass('SomeOtherTest').assertTestPassed(passingTestCaseName)
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "reports when no matching methods found"() {
         given:
         createPassingFailingTest()
@@ -221,7 +213,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         failure.assertHasCause("No tests found for given includes: [${testSuite('SomeTest')}.missingMethod](filter.includeTestsMatching)")
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "task is out of date when --tests argument changes"() {
         given:
         createPassingFailingTest()
@@ -250,7 +241,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "can select multiple tests from command line #scenario"() {
         given:
         createPassingFailingTest()
@@ -284,7 +274,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "can deduplicate test filters when #scenario"() {
         given:
         createPassingFailingTest()

--- a/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.testing
 import com.google.common.collect.Lists
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.hamcrest.CoreMatchers
 import org.junit.Assume
 import spock.lang.Unroll

--- a/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -44,7 +44,6 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         return testSuite
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = ["TestNGTestFrameworkIntegrationTest", "XCTestTestFrameworkIntegrationTest"])
     def "can listen for test results"() {
         given:
         createPassingFailingTest()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOutputListenerIntegrationTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.testing
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
@@ -174,7 +173,6 @@ test.testLogging {
     }
 
     @Test
-    @ToBeFixedForInstantExecution
     def "shows standard stream also for testNG"() {
         given:
         ignoreWhenJUnitPlatform()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -17,8 +17,8 @@ package org.gradle.testing
 
 import org.apache.commons.lang.RandomStringUtils
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -182,7 +182,6 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2313")
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*useTestNG.*")
     def "can clean test after extracting class file with #framework"() {
         when:
         ignoreWhenJUnitPlatform()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.testing.fixture
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 import spock.lang.Unroll
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -73,7 +73,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         pattern << ['FooTest.pass', 'org.gradle.FooTest.pass']
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "executes multiple methods from a test class"() {
         buildFile << """
             test {
@@ -108,7 +107,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         result.testClass("FooTest").assertTestCount(2, 0, 0)
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "executes multiple methods from different classes"() {
         buildFile << """
             test {
@@ -150,7 +148,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "reports when no matching methods found"() {
         file("src/test/java/org/gradle/FooTest.java") << """
             package org.gradle;
@@ -174,7 +171,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         pattern << ['FooTest.missingMethod', 'org.gradle.FooTest.missingMethod']
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "adds import/export rules to report about no matching methods found"() {
         file("src/test/java/FooTest.java") << """import $imports;
             public class FooTest {
@@ -193,7 +189,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         then: failure.assertHasCause("No tests found for given includes: [FooTest*](include rules) [NotImportant*](exclude rules) [FooTest.missingMethod](--tests filter)")
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "does not report when matching method has been filtered before via include/exclude"() { //current behavior, not necessarily desired
         file("src/test/java/FooTest.java") << """import $imports;
             public class FooTest {
@@ -207,7 +202,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         succeeds("test", "--tests", 'FooTest.missingMethod')
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "task is out of date when --tests argument changes"() {
         file("src/test/java/FooTest.java") << """import $imports;
             public class FooTest {
@@ -231,7 +225,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "can select multiple tests from commandline #scenario"() {
         given:
         file("src/test/java/Foo1Test.java") << """import $imports;
@@ -287,7 +280,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
 
     @Issue("https://github.com/gradle/gradle/issues/1571")
     @Unroll
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "option --tests filter in combined with #includeType"() {
         given:
         buildFile << """
@@ -313,7 +305,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         "filter.includePatterns"      | "filter { includePatterns = ['*ATest*', '*CTest*'] }"
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "invoking testNameIncludePatterns does not influence include/exclude filter"() {
         given:
         buildFile << """
@@ -334,7 +325,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         !output.contains('CTest!')
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "invoking filter.includePatterns not disable include/exclude filter"() {
         given:
         buildFile << """
@@ -355,7 +345,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         !output.contains('CTest!')
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "can exclude tests"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/AbstractTestFilteringIntegrationTest.groovy
@@ -16,8 +16,8 @@
 package org.gradle.testing.fixture
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -36,7 +36,6 @@ abstract class AbstractTestFilteringIntegrationTest extends MultiVersionIntegrat
         """
     }
 
-    @ToBeFixedForInstantExecution(bottomSpecs = "TestNGFilteringIntegrationTest")
     def "executes single method from a test class"() {
         buildFile << """
             test {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
@@ -17,9 +17,9 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.TestNGExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Before
 import org.junit.Rule

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
@@ -137,7 +137,6 @@ class TestNGClassIntegrationTest extends MultiVersionIntegrationSpec {
         containsEvent(FINISHED, DefaultTestSuiteDescriptor, 'TestSuite > FullTest')
     }
 
-    @ToBeFixedForInstantExecution
     def "synthesized events for broken configuration methods reference test class descriptors"() {
         given:
         file("src/test/java/org/company/TestWithBrokenSetupMethod.java") << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.internal.tasks.testing.DefaultTestSuiteDescriptor
 import org.gradle.api.tasks.testing.TestDescriptor
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 
 import static org.gradle.testing.fixture.TestNGCoverage.FIXED_ICLASS_LISTENER

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGClassIntegrationTest.groovy
@@ -20,9 +20,9 @@ import org.gradle.api.internal.tasks.testing.DefaultTestClassDescriptor
 import org.gradle.api.internal.tasks.testing.DefaultTestMethodDescriptor
 import org.gradle.api.internal.tasks.testing.DefaultTestSuiteDescriptor
 import org.gradle.api.tasks.testing.TestDescriptor
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 
 import static org.gradle.testing.fixture.TestNGCoverage.FIXED_ICLASS_LISTENER
@@ -46,20 +46,20 @@ class TestNGClassIntegrationTest extends MultiVersionIntegrationSpec {
             import org.gradle.api.internal.tasks.testing.results.TestListenerInternal
             import org.gradle.api.tasks.testing.TestOutputEvent
             import org.gradle.api.tasks.testing.TestResult
-    
+
             test {
                 useTestNG()
             }
-    
+
             gradle.addListener(new TestListenerInternal() {
                 void started(TestDescriptorInternal d, TestStartEvent s) {
                     printEventInformation('$STARTED', d)
                 }
-    
+
                 void completed(TestDescriptorInternal d, TestResult result, TestCompleteEvent cE) {
                     printEventInformation('$FINISHED', d)
                 }
-    
+
                 private void printEventInformation(String eventTypeDescription, TestDescriptorInternal d) {
                     def name = d.name
                     def descriptor = d;
@@ -69,14 +69,13 @@ class TestNGClassIntegrationTest extends MultiVersionIntegrationSpec {
                     }
                     println "\$eventTypeDescription event type \${d.descriptor.class.name} for \${name}"
                 }
-    
+
                 void output(TestDescriptorInternal descriptor, TestOutputEvent output) {
                 }
             })
         """
     }
 
-    @ToBeFixedForInstantExecution
     def "test class events references correct suite as parent"() {
         given:
         def testNgSuite = file("src/test/resources/testng.xml")
@@ -91,10 +90,10 @@ class TestNGClassIntegrationTest extends MultiVersionIntegrationSpec {
 
         file("src/test/java/org/company/SystemOutTest.java") << """
             package org.company;
-    
+
             import org.testng.Assert;
             import org.testng.annotations.Test;
-    
+
             public class SystemOutTest {
                 @Test
                 public void testOut() {
@@ -143,10 +142,10 @@ class TestNGClassIntegrationTest extends MultiVersionIntegrationSpec {
         given:
         file("src/test/java/org/company/TestWithBrokenSetupMethod.java") << """
             package org.company;
-    
+
             import org.testng.Assert;
             import org.testng.annotations.*;
-    
+
             public class TestWithBrokenSetupMethod {
                 @BeforeMethod
                 public void broken() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
@@ -92,7 +92,6 @@ Gradle test > org.gradle.TestNGTest.badTest FAILED
         """)
     }
 
-    @ToBeFixedForInstantExecution
     def customQuietLogging() {
         when:
         executer.withStackTraceChecksDisabled()
@@ -114,7 +113,6 @@ Gradle suite FAILED
         """)
     }
 
-    @ToBeFixedForInstantExecution
     def "standardOutputLogging"() {
         given:
         buildFile.text = """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
@@ -81,7 +81,6 @@ class TestNGConsoleLoggingIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-    @ToBeFixedForInstantExecution
     def "defaultLifecycleLogging"() {
         when:
         fails "test"

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGConsoleLoggingIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 // can make assumptions about order in which test methods of TestNGTest get executed
 // because the methods are chained with 'methodDependsOn'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.TestClassExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.junit.Rule
 
 import static org.gradle.testing.fixture.TestNGCoverage.NEWEST

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -17,10 +17,10 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestClassExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.junit.Rule
 
 import static org.gradle.testing.fixture.TestNGCoverage.NEWEST
@@ -39,7 +39,6 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
         """
     }
 
-    @ToBeFixedForInstantExecution
     def "skips tests after a config method failure by default"() {
         when:
         usingTestNG(NEWEST)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -51,7 +51,6 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
         testResults.assertTestSkipped("someTest")
     }
 
-    @ToBeFixedForInstantExecution
     def "can be configured to continue executing tests after a config method failure"() {
         when:
         usingTestNG(NEWEST)
@@ -69,7 +68,6 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
         testResults.assertTestPassed("someTest")
     }
 
-    @ToBeFixedForInstantExecution
     def "informative error is shown when trying to use config failure policy and a version that does not support it"() {
         when:
         usingTestNG("5.12.1")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
@@ -75,7 +75,6 @@ public class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegra
     }
 
     @Issue("GRADLE-3112")
-    @ToBeFixedForInstantExecution
     def "suites can be filtered from the command-line"() {
         given:
         theUsualFiles()
@@ -94,7 +93,6 @@ public class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegra
     }
 
     @Issue("GRADLE-3112")
-    @ToBeFixedForInstantExecution
     def "suites can be filtered from the build file"() {
         given:
         theUsualFiles()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
@@ -18,20 +18,20 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.AbstractTestFilteringIntegrationTest
+import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 
-import static org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec.*
+import static org.gradle.integtests.fixtures.AbstractIntegrationSpec.mavenCentralRepository
 
 @TargetCoverage({TestNGCoverage.STANDARD_COVERAGE})
 public class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegrationTest {
 
     String imports = "org.testng.annotations.*"
     String framework = "TestNG"
-    String dependencies = "testImplementation 'org.testng:testng:${dependencyVersion}'"
+    String dependencies = "testImplementation 'org.testng:testng:${JUnitMultiVersionIntegrationSpec.getDependencyVersion()}'"
 
     void theUsualFiles() {
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.testing.testng
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
@@ -24,7 +23,6 @@ import org.gradle.testing.fixture.TestNGCoverage
 @TargetCoverage({TestNGCoverage.GROUP_BY_INSTANCES})
 public class TestNGGroupByInstancesIntegrationTest extends MultiVersionIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "run tests using groupByInstances"() {
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 public class TestNGGroupByInstancesNotSupportedIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "run tests using TestNG version not supporting groupByInstances"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -86,7 +86,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         new DefaultTestExecutionResult(testDirectory).testClass('org.gradle.OkTest').assertTestPassed('ok')
     }
 
-    @ToBeFixedForInstantExecution
     def "can listen for test results"() {
         given:
         buildFile << """
@@ -136,7 +135,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("GRADLE-1532")
-    @ToBeFixedForInstantExecution
     def "supports thread pool size"() {
         given:
         file('src/test/java/SomeTest.java') << '''
@@ -153,7 +151,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         succeeds 'test'
     }
 
-    @ToBeFixedForInstantExecution
     def "supports test groups"() {
         buildFile << """
             ext {
@@ -192,7 +189,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         result.testClass('org.gradle.groups.SomeTest').assertTestsExecuted("databaseTest")
     }
 
-    @ToBeFixedForInstantExecution
     def "supports test factory"() {
         given:
         file('src/test/java/org/gradle/factory/FactoryTest.java') << '''
@@ -266,7 +262,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         result.assertTestsFailed()
     }
 
-    @ToBeFixedForInstantExecution
     def "tries to execute unparseable test classes"() {
         given:
         testDirectory.file('build/classes/java/test/com/example/Foo.class').text = "invalid class file"
@@ -283,7 +278,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/7878")
-    @ToBeFixedForInstantExecution
     def "can concurrently execute the same test class multiple times"() {
         given:
         file('src/test/java/TestNG7878.java') << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -35,7 +35,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         TestNGCoverage.enableTestNG(buildFile, version)
     }
 
-    @ToBeFixedForInstantExecution
     def "executes tests in correct environment"() {
         given:
         buildFile << """
@@ -47,15 +46,15 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         """.stripIndent()
         file('src/test/java/org/gradle/OkTest.java') << '''
             package org.gradle;
-            
+
             import static org.testng.Assert.*;
-            
+
             public class OkTest {
                 @org.testng.annotations.Test
                 public void ok() throws Exception {
                     // check working dir
                     assertEquals(System.getProperty("testDir"), System.getProperty("user.dir"));
-            
+
                     // check Gradle classes not visible
                     try {
                         getClass().getClassLoader().loadClass("org.gradle.api.Project");
@@ -63,16 +62,16 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
                     } catch (ClassNotFoundException e) {
                         // Expected
                     }
-            
+
                     // check context classloader
                     assertSame(getClass().getClassLoader(), Thread.currentThread().getContextClassLoader());
-            
+
                     // check sys properties
                     assertEquals("value", System.getProperty("testSysProperty"));
-            
+
                     // check env vars
                     assertEquals("value", System.getenv("TEST_ENV_VAR"));
-            
+
                     // check other environmental stuff
                     assertEquals("Test worker", Thread.currentThread().getName());
                     assertNull(System.getSecurityManager());
@@ -94,7 +93,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
             test {
                 ignoreFailures = true
             }
-            
+
             ${testListener()}
         """.stripIndent()
         file('src/test/java/AppException.java') << 'public class AppException extends Exception {}'
@@ -102,13 +101,13 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
             public class SomeTest {
                 @org.testng.annotations.Test
                 public void pass() {}
-            
+
                 @org.testng.annotations.Test
                 public void fail() { assert false; }
-            
+
                 @org.testng.annotations.Test
                 public void knownError() { throw new RuntimeException("message"); }
-            
+
                 @org.testng.annotations.Test
                 public void unknownError() throws AppException { throw new AppException(); }
             }
@@ -143,7 +142,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/SomeTest.java') << '''
             import org.testng.Assert;
             import org.testng.annotations.Test;
-            
+
             public class SomeTest {
                 @Test(invocationCount = 2, threadPoolSize = 2)
                 public void someTest() { Assert.assertTrue(true); }
@@ -160,7 +159,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
             ext {
                 ngIncluded = "database"
                 ngExcluded = "slow"
-            }            
+            }
             test {
                 useTestNG {
                     includeGroups ngIncluded
@@ -171,14 +170,14 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/org/gradle/groups/SomeTest.java') << '''
             package org.gradle.groups;
             import org.testng.annotations.Test;
-            
+
             public class SomeTest {
                 @Test(groups = "web")
                 public void webTest() {}
-            
+
                 @Test(groups = "database")
                 public void databaseTest() {}
-            
+
                 @Test(groups = {"database", "slow"})
                 public void slowDatabaseTest() {}
             }
@@ -199,8 +198,8 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/org/gradle/factory/FactoryTest.java') << '''
             package org.gradle.factory;
             import org.testng.annotations.Test;
-            
-            public class FactoryTest {            
+
+            public class FactoryTest {
                 private final String name;
                 public FactoryTest(String name) { this.name = name; }
 
@@ -211,7 +210,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/org/gradle/factory/TestNGFactory.java') << '''
             package org.gradle.factory;
             import org.testng.annotations.Factory;
-            
+
             public class TestNGFactory {
                 @Factory
                 public Object[] factory() {
@@ -239,7 +238,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/SomeTest.java') << """
             import org.testng.Assert;
             import org.testng.annotations.Test;
-            
+
             public class SomeTest {
                 @Test(invocationCount = 2, threadPoolSize = 2)
                 public void someTest() { Assert.assertTrue(true); }
@@ -253,7 +252,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         file('src/test/java/SomeTest.java') << """
             import org.testng.Assert;
             import org.testng.annotations.Test;
-            
+
             public class SomeTest {
                 @Test(invocationCount = 2, threadPoolSize = 2)
                 public void someTest() { Assert.assertTrue(false); }
@@ -291,19 +290,19 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
             import org.testng.annotations.Factory;
             import org.testng.annotations.Test;
             import org.testng.Assert;
-            
+
             public class TestNG7878 {
                 @Factory
                 public static Object[] createTests() {
-                    return new Object[]{ 
-                            new TestNG7878(), 
-                            new TestNG7878() 
+                    return new Object[]{
+                            new TestNG7878(),
+                            new TestNG7878()
                     };
                 }
-            
+
                 @Test
                 public void runFirst() {}
-                
+
                 @Test(dependsOnMethods = "runFirst")
                 public void testGet2() {
                     Assert.assertEquals(true, true);
@@ -324,7 +323,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         return '''
             def listener = new TestListenerImpl()
             test {
-                addTestListener(listener)                
+                addTestListener(listener)
             }
             class TestListenerImpl implements TestListener {
                 void beforeSuite(TestDescriptor suite) { println "START [$suite] [$suite.name]" }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.testing.testng
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Ignore
 import spock.lang.Issue

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGJdkNavigationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGJdkNavigationIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestResources
 import org.junit.Rule
 import spock.lang.Issue
@@ -28,7 +27,6 @@ class TestNGJdkNavigationIntegrationTest extends AbstractSampleIntegrationTest {
     @Rule
     final TestResources resources = new TestResources(testDirectoryProvider)
 
-    @ToBeFixedForInstantExecution
     def shouldNotNavigateToJdkClasses() {
         when:
         succeeds('test')

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestClassExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.GradleVersion
 
 import static org.gradle.testing.fixture.TestNGCoverage.FIXED_ICLASS_LISTENER

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.testing.testng
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestClassExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.util.GradleVersion
 
 import static org.gradle.testing.fixture.TestNGCoverage.FIXED_ICLASS_LISTENER
@@ -81,7 +81,6 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
         """
     }
 
-    @ToBeFixedForInstantExecution
     def "attaches events to correct test descriptors of a suite"() {
         buildFile << "test.useTestNG { suites 'suite.xml' }"
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -116,7 +116,6 @@ class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationS
         assertTestClassExecutionResultReport(classReport)
     }
 
-    @ToBeFixedForInstantExecution
     def "attaches output events to correct test descriptors"() {
         when: succeeds "test"
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
@@ -78,7 +78,6 @@ class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/4457")
-    @ToBeFixedForInstantExecution
     def "can persist configurations in xml"() {
         given:
         createTests(3, 3)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
@@ -20,7 +20,6 @@ package org.gradle.testing.testng
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGParallelSuiteIntegrationTest.groovy
@@ -18,9 +18,9 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 
@@ -64,7 +64,6 @@ class TestNGParallelSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("GRADLE-3190")
-    @ToBeFixedForInstantExecution
     def "runs with multiple parallel threads"() {
         given:
         createTests(200, 20)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.testing.testng
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.TestNGCoverage
@@ -24,7 +23,6 @@ import org.gradle.testing.fixture.TestNGCoverage
 @TargetCoverage({TestNGCoverage.PRESERVE_ORDER})
 public class TestNGPreserveOrderIntegrationTest extends MultiVersionIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "run tests using preserveOrder"() {
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 public class TestNGPreserveOrderNotSupportedIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "run tests using TestNG version not supporting preserveOrder"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
@@ -16,9 +16,9 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 public class TestNGProducesOldReportsIntegrationTest extends AbstractIntegrationSpec {
@@ -26,7 +26,6 @@ public class TestNGProducesOldReportsIntegrationTest extends AbstractIntegration
         executer.noExtraLogging()
     }
 
-    @ToBeFixedForInstantExecution
     def "always produces the new xml reports"() {
         given:
         file("src/test/java/org/MixedMethodsTest.java") << """package org;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.testing.testng
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 public class TestNGProducesOldReportsIntegrationTest extends AbstractIntegrationSpec {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGProducesOldReportsIntegrationTest.groovy
@@ -61,7 +61,6 @@ test {
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     "can generate the old xml reports"() {
         given:
         file("src/test/java/org/SomeTest.java") << """package org;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
@@ -71,7 +71,6 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-2841")
-    @ToBeFixedForInstantExecution
     def "captures logging from System streams referenced from static initializer"() {
         file("src/test/java/FooTest.java") << """
             import org.testng.annotations.*;
@@ -96,7 +95,6 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
         testResult.testClass("FooTest").assertTestCaseStderr("foo", is("err output from test\n"))
     }
 
-    @ToBeFixedForInstantExecution
     def "test can generate output from multiple threads"() {
         file("src/test/java/OkTest.java") << """
 import java.util.logging.Logger;

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 
@@ -37,7 +37,6 @@ class TestNGStaticLoggingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-2841")
-    @ToBeFixedForInstantExecution
     def "captures output from logging frameworks"() {
         buildFile << """
             dependencies { implementation "org.slf4j:slf4j-simple:1.7.10", "org.slf4j:slf4j-api:1.7.10" }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGStaticLoggingIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteInitialisationIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.TestExecutionResult.EXECUTION_FAILURE
@@ -27,7 +26,6 @@ import static org.hamcrest.CoreMatchers.startsWith
 class TestNGSuiteInitialisationIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("GRADLE-1710")
-    @ToBeFixedForInstantExecution
     def "reports suite fatal failure"() {
         buildFile << """
             apply plugin: 'java'
@@ -39,7 +37,7 @@ class TestNGSuiteInitialisationIntegrationTest extends AbstractIntegrationSpec {
         """
         file("src/test/java/FooTest.java") << """
             import org.testng.annotations.*;
-            
+
             public class FooTest {
                 public FooTest() { throw new NullPointerException(); }
                 @Test public void foo() {}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -87,7 +87,6 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
     }
 
     @Issue("GRADLE-3020")
-    @ToBeFixedForInstantExecution
     def "can specify test suite by string"() {
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -18,9 +18,9 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import org.junit.Test
 import spock.lang.Issue
@@ -57,7 +57,6 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
         outputContains 'Property from task again: test'
     }
 
-    @ToBeFixedForInstantExecution
     def "methodMissing propagates failures"() {
         buildFile << """
     apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -20,7 +20,6 @@ package org.gradle.testing.testng
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.testing.fixture.TestNGCoverage
 import org.junit.Test
 import spock.lang.Issue

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
@@ -32,9 +32,9 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
         file('src/test/java/SomeTest.java') << """
             public class SomeTest {
                 @org.testng.annotations.Test
-                public void ${failingTestCaseName}() { 
+                public void ${failingTestCaseName}() {
                     System.err.println("some error output");
-                    assert false : "test failure message"; 
+                    assert false : "test failure message";
                 }
                 @org.testng.annotations.Test
                 public void ${passingTestCaseName}() {}
@@ -78,7 +78,6 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3545")
-    @ToBeFixedForInstantExecution
     def "can run tests with ignored test class"() {
         given:
         file("src/test/java/DisabledTest.java") << """
@@ -97,14 +96,13 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3545")
-    @ToBeFixedForInstantExecution
     def "can run tests with ignored test methods"() {
         given:
         file("src/test/java/DisabledTest.java") << """
             public class DisabledTest {
                 @org.testng.annotations.Test(enabled = false)
                 public void testOne() {}
-                
+
                 @org.testng.annotations.Test(enabled = false)
                 public void testTwo() {}
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testing.testng
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.testing.AbstractTestFrameworkIntegrationTest
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -46,7 +46,6 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @Issue('https://github.com/gradle/gradle/issues/4924')
-    @ToBeFixedForInstantExecution
     def 'test task is up-to-date when #property is changed because it should not impact output'() {
         given:
         TestNGCoverage.enableTestNG(buildFile)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
@@ -17,13 +17,24 @@
 
 package org.gradle.testing.testng
 
-import org.gradle.integtests.fixtures.*
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.HtmlTestExecutionResult
+import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
+import org.gradle.integtests.fixtures.TestExecutionResult
+import org.gradle.integtests.fixtures.TestResultOutputAssociation
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Shared
 import spock.lang.Unroll
 
 import static org.gradle.integtests.fixtures.TestResultOutputAssociation.WITH_SUITE
 import static org.gradle.integtests.fixtures.TestResultOutputAssociation.WITH_TESTCASE
-import static org.hamcrest.CoreMatchers.*
+import static org.hamcrest.CoreMatchers.allOf
+import static org.hamcrest.CoreMatchers.anyOf
+import static org.hamcrest.CoreMatchers.anything
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.not
 
 @Unroll
 public class TestNGXmlResultAndHtmlReportIntegrationTest extends
@@ -45,7 +56,6 @@ public class TestNGXmlResultAndHtmlReportIntegrationTest extends
         setupTestCases()
     }
 
-    @ToBeFixedForInstantExecution
     def "produces JUnit xml results - #mode.name"() {
         when:
         runWithTestConfig("useTestNG(); $mode.config")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
@@ -67,7 +67,6 @@ public class TestNGXmlResultAndHtmlReportIntegrationTest extends
         mode << modes
     }
 
-    @ToBeFixedForInstantExecution
     def "produces JUnit xml results when running tests in parallel - #mode.name"() {
         when:
         runWithTestConfig("useTestNG(); maxParallelForks 2; $mode.config")
@@ -79,7 +78,6 @@ public class TestNGXmlResultAndHtmlReportIntegrationTest extends
         mode << modes
     }
 
-    @ToBeFixedForInstantExecution
     def "produces JUnit xml results with aggressive forking - #mode.name"() {
         when:
         runWithTestConfig("useTestNG(); forkEvery 1; $mode.config")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGXmlResultAndHtmlReportIntegrationTest.groovy
@@ -17,13 +17,11 @@
 
 package org.gradle.testing.testng
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TestExecutionResult
 import org.gradle.integtests.fixtures.TestResultOutputAssociation
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Shared
 import spock.lang.Unroll
 


### PR DESCRIPTION
### Context

This PR makes an attempt to fix instant execution and to make it work with test-retry-plugin.