### PR TITLE
Let Gradle build timestamp value source implement describable

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/versioning/BuildVersionPlugin.kt
@@ -17,6 +17,7 @@
 package org.gradle.gradlebuild.versioning
 
 import org.gradle.StartParameter
+import org.gradle.api.Describable
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
@@ -212,7 +213,7 @@ fun Project.buildTimestampFromBuildReceipt(): Provider<String> =
     }
 
 
-abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampValueSource.Parameters> {
+abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampValueSource.Parameters>, Describable {
 
     interface Parameters : ValueSourceParameters {
 
@@ -250,6 +251,21 @@ abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampVal
         }
         return timestampFormat.format(buildTime)
     }
+
+    override fun getDisplayName(): String =
+        "the build timestamp ($timestampSource)"
+
+    private
+    val timestampSource: String
+        get() = parameters.run {
+            when {
+                buildTimestampFromBuildReceipt.isPresent -> "from build receipt"
+                buildTimestampFromGradleProperty.isPresent -> "from buildTimestamp property"
+                runningInstallTask.get() -> "from current time because installing"
+                runningOnCi.get() -> "from current time because CI"
+                else -> "from current date"
+            }
+        }
 }
 
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintChecker.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/fingerprint/InstantExecutionFingerprintChecker.kt
@@ -89,5 +89,5 @@ class InstantExecutionFingerprintChecker(private val host: Host) {
     fun buildLogicInputHasChanged(valueSource: ValueSource<Any, ValueSourceParameters>): InvalidationReason =
         (valueSource as? Describable)?.let {
             it.displayName + " has changed"
-        } ?: "a build logic input has changed"
+        } ?: "a build logic input of type '${valueSource.javaClass.simpleName}' has changed"
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionRule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForInstantExecutionRule.groovy
@@ -32,7 +32,7 @@ class ToBeFixedForInstantExecutionRule implements TestRule {
     @Override
     Statement apply(Statement base, Description description) {
         def annotation = description.getAnnotation(ToBeFixedForInstantExecution.class)
-        if (!GradleContextualExecuter.isInstant() || annotation == null) {
+        if (GradleContextualExecuter.isNotInstant() || annotation == null) {
             return base
         }
         def enabledBottomSpec = isEnabledBottomSpec(annotation.bottomSpecs(), { description.className.endsWith(".$it") })

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionRule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionRule.groovy
@@ -31,7 +31,7 @@ class UnsupportedWithInstantExecutionRule implements TestRule {
     @Override
     Statement apply(Statement base, Description description) {
         def annotation = description.getAnnotation(UnsupportedWithInstantExecution.class)
-        if (!GradleContextualExecuter.isInstant() || annotation == null) {
+        if (GradleContextualExecuter.isNotInstant() || annotation == null) {
             return base
         }
         def enabledBottomSpec = isEnabledBottomSpec(annotation.bottomSpecs(), { description.className.endsWith(".$it") })

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleContextualExecuter.java
@@ -80,6 +80,10 @@ public class GradleContextualExecuter extends AbstractDelegatingGradleExecuter {
         return getSystemPropertyExecuter().executeParallel;
     }
 
+    public static boolean isNotInstant() {
+        return !isInstant();
+    }
+
     public static boolean isInstant() {
         return getSystemPropertyExecuter() == Executer.instant;
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.util.TestPrecondition
 
 
 @Requires(value = TestPrecondition.JDK9_OR_LATER, adhoc = {
-    !GradleContextualExecuter.isInstant() && AvailableJavaHomes.getAvailableJdk(new GradleBuildJvmSpec())
+    GradleContextualExecuter.isNotInstant() && GradleBuildJvmSpec.isAvailable()
 })
 class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
 
@@ -95,6 +95,11 @@ class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
 
 
 class GradleBuildJvmSpec implements Spec<JvmInstallation> {
+
+    static boolean isAvailable() {
+        return AvailableJavaHomes.getAvailableJdk(new GradleBuildJvmSpec()) != null
+    }
+
     @Override
     boolean isSatisfiedBy(JvmInstallation jvm) {
         return jvm.javaVersion >= JavaVersion.VERSION_1_9 && jvm.javaVersion <= JavaVersion.VERSION_11


### PR DESCRIPTION
So it's easier to understand when the cache is invalidated due to build timestamp changes (for instance, when the smoke test runs close to midnight).