### PR TITLE
Let precompiled script plugins with CRLF line separators find its accessors

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
@@ -68,24 +68,40 @@ public class TextUtil {
     }
 
     /**
-     * Converts all line separators in the specified non-null string to the specified line separator.
+     * Converts all line separators in the specified non-null string to the Unix line separator {@code \n}.
+     */
+    public static String convertLineSeparatorsToUnix(String str) {
+        return str.indexOf('\r') < 0
+            ? str
+            : replaceAll("\r\n|\r", str, "\n");
+    }
+
+    /**
+     * Converts all line separators in the specified non-null {@link CharSequence} to the specified line separator.
      */
     public static String replaceLineSeparatorsOf(CharSequence string, String bySeparator) {
-        return Pattern.compile("\r\n|\r|\n").matcher(string).replaceAll(bySeparator);
+        return replaceAll("\r\n|\r|\n", string, bySeparator);
+    }
+
+    private static String replaceAll(String regex, CharSequence inString, String byString) {
+        return Pattern.compile(regex).matcher(inString).replaceAll(byString);
     }
 
     /**
      * Converts all line separators in the specified string to the platform's line separator.
      */
     public static String toPlatformLineSeparators(String str) {
-        return str == null ? null : convertLineSeparators(str, getPlatformLineSeparator());
+        return str == null ? null : replaceLineSeparatorsOf(str, getPlatformLineSeparator());
     }
 
     /**
-     * Converts all line separators in the specified string to a single new line character.
+     * Converts all line separators in the specified nullable string to a single new line character ({@code \n}).
+     *
+     * @return null if the given string is null
      */
-    public static String normaliseLineSeparators(String str) {
-        return str == null ? null : convertLineSeparators(str, "\n");
+    @Nullable
+    public static String normaliseLineSeparators(@Nullable String str) {
+        return str == null ? null : convertLineSeparatorsToUnix(str);
     }
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Iterables;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.gradle.internal.SystemProperties;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Arrays;
 import java.util.regex.Pattern;
@@ -61,8 +62,16 @@ public class TextUtil {
     /**
      * Converts all line separators in the specified string to the specified line separator.
      */
-    public static String convertLineSeparators(String str, String sep) {
-        return str == null ? null : str.replaceAll("\r\n|\r|\n", sep);
+    @Nullable
+    public static String convertLineSeparators(@Nullable String str, String sep) {
+        return str == null ? null : replaceLineSeparatorsOf(str, sep);
+    }
+
+    /**
+     * Converts all line separators in the specified non-null string to the specified line separator.
+     */
+    public static String replaceLineSeparatorsOf(CharSequence string, String bySeparator) {
+        return Pattern.compile("\r\n|\r|\n").matcher(string).replaceAll(bySeparator);
     }
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
@@ -37,6 +37,7 @@ public class TextUtil {
             return input.toLowerCase();
         }
     };
+    private static final Pattern NON_UNIX_LINE_SEPARATORS = Pattern.compile("\r\n|\r");
 
     /**
      * Returns the line separator for Windows.
@@ -71,9 +72,7 @@ public class TextUtil {
      * Converts all line separators in the specified non-null string to the Unix line separator {@code \n}.
      */
     public static String convertLineSeparatorsToUnix(String str) {
-        return str.indexOf('\r') < 0
-            ? str
-            : replaceAll("\r\n|\r", str, "\n");
+        return replaceAll(NON_UNIX_LINE_SEPARATORS, str, "\n");
     }
 
     /**
@@ -84,7 +83,11 @@ public class TextUtil {
     }
 
     private static String replaceAll(String regex, CharSequence inString, String byString) {
-        return Pattern.compile(regex).matcher(inString).replaceAll(byString);
+        return replaceAll(Pattern.compile(regex), inString, byString);
+    }
+
+    private static String replaceAll(Pattern pattern, CharSequence inString, String byString) {
+        return pattern.matcher(inString).replaceAll(byString);
     }
 
     /**

--- a/subprojects/core/src/test/groovy/org/gradle/util/TextUtilTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/TextUtilTest.groovy
@@ -65,10 +65,7 @@ class TextUtilTest extends Specification {
         TextUtil.convertLineSeparatorsToUnix(original).is original
 
         where:
-        original          | converted
-        ""                | ""
-        "none"            | "none"
-        "one\ntwo\nthree" | "one\ntwo\nthree"
+        original << ["", "none", "one\ntwo\nthree"]
     }
 
     def containsWhitespace() {

--- a/subprojects/core/src/test/groovy/org/gradle/util/TextUtilTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/TextUtilTest.groovy
@@ -49,13 +49,26 @@ class TextUtilTest extends Specification {
     def normaliseLineSeparators() {
         expect:
         TextUtil.normaliseLineSeparators(original) == converted
+        TextUtil.normaliseLineSeparators(converted).is converted
 
         where:
         original                          | converted
+        null                              | null
         ""                                | ""
         "none"                            | "none"
         "one\rtwo\nthree\r\nfour\n\rfive" | "one\ntwo\nthree\nfour\n\nfive"
         "\r\n\n\r"                        | "\n\n\n"
+    }
+
+    def "convertLineSeparatorsToUnix returns same string when already converted"() {
+        expect:
+        TextUtil.convertLineSeparatorsToUnix(original).is original
+
+        where:
+        original          | converted
+        ""                | ""
+        "none"            | "none"
+        "one\ntwo\nthree" | "one\ntwo\nthree"
     }
 
     def containsWhitespace() {

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -60,6 +60,7 @@ import java.io.File
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
 class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest() {
 
+    @ToBeFixedForInstantExecution
     @Test
     fun `can use type-safe accessors for applied plugins with CRLF line separators`() {
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -39,11 +39,12 @@ import org.gradle.kotlin.dsl.fixtures.pluginDescriptorEntryFor
 import org.gradle.kotlin.dsl.support.zipTo
 
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.util.TextUtil.replaceLineSeparatorsOf
 
-import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.Visibility
@@ -58,6 +59,27 @@ import java.io.File
 
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
 class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest() {
+
+    @Test
+    fun `can use type-safe accessors for applied plugins with CRLF line separators`() {
+
+        withKotlinDslPlugin()
+
+        withPrecompiledKotlinScript("my-java-library.gradle.kts",
+            replaceLineSeparatorsOf(
+                """
+                plugins { java }
+
+                java { }
+
+                tasks.compileJava { }
+                """,
+                "\r\n"
+            )
+        )
+
+        compileKotlin()
+    }
 
     @Test
     @ToBeFixedForInstantExecution

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPlugin.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPlugin.kt
@@ -97,15 +97,15 @@ data class PrecompiledScriptPlugin(internal val scriptFile: File) {
     }
 
     val packageName: String? by lazy {
-        packageNameOf(scriptFile)
+        packageNameOf(scriptText)
     }
 
     val hashString by lazy {
-        PrecompiledScriptDependenciesResolver.hashOf(scriptText)
+        PrecompiledScriptDependenciesResolver.hashOfNormalisedString(scriptText)
     }
 
     val scriptText: String
-        get() = scriptFile.readText()
+        get() = convertLineSeparatorsToUnix(scriptFile.readText())
 
     private
     fun packagePrefixed(id: String) =
@@ -114,12 +114,8 @@ data class PrecompiledScriptPlugin(internal val scriptFile: File) {
 
 
 internal
-fun scriptPluginFilesOf(list: List<PrecompiledScriptPlugin>) = list.map { it.scriptFile }.toSet()
-
-
-private
-fun packageNameOf(file: File): String? =
-    packageNameOf(convertLineSeparatorsToUnix(file.readText()))
+fun scriptPluginFilesOf(list: List<PrecompiledScriptPlugin>) =
+    list.map { it.scriptFile }.toSet()
 
 
 private

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPlugin.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPlugin.kt
@@ -20,12 +20,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
-import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver
 
+import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver
 import org.gradle.kotlin.dsl.support.KotlinScriptType
 import org.gradle.kotlin.dsl.support.KotlinScriptTypeMatch
 
-import org.gradle.util.TextUtil.normaliseLineSeparators
+import org.gradle.util.TextUtil.convertLineSeparatorsToUnix
 
 import org.jetbrains.kotlin.lexer.KotlinLexer
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -119,7 +119,7 @@ fun scriptPluginFilesOf(list: List<PrecompiledScriptPlugin>) = list.map { it.scr
 
 private
 fun packageNameOf(file: File): String? =
-    packageNameOf(normaliseLineSeparators(file.readText()))
+    packageNameOf(convertLineSeparatorsToUnix(file.readText()))
 
 
 private

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPlugin.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPlugin.kt
@@ -20,7 +20,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
-import org.gradle.internal.hash.Hashing
+import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver
 
 import org.gradle.kotlin.dsl.support.KotlinScriptType
 import org.gradle.kotlin.dsl.support.KotlinScriptTypeMatch
@@ -101,7 +101,7 @@ data class PrecompiledScriptPlugin(internal val scriptFile: File) {
     }
 
     val hashString by lazy {
-        Hashing.hashString(scriptText).toString()
+        PrecompiledScriptDependenciesResolver.hashOf(scriptText)
     }
 
     val scriptText: String

--- a/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -248,7 +248,8 @@ fun implicitImportsFrom(file: File): List<String> =
 
 
 private
-fun hashOf(scriptFile: File) = PrecompiledScriptDependenciesResolver.hashOf(scriptFile.readText())
+fun hashOf(scriptFile: File) =
+    PrecompiledScriptDependenciesResolver.hashOf(scriptFile.readText())
 
 
 private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
@@ -36,6 +36,9 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
         fun hashOf(charSequence: CharSequence) =
             hashOfNormalisedString(convertLineSeparatorsToUnix(charSequence.toString()))
 
+        fun hashOfNormalisedString(charSequence: CharSequence) =
+            Hashing.hashString(charSequence).toString()
+
         /**
          * **Optimisation note**: assumes [scriptText] contains only `\n` line separators as any script text
          * coming from the Kotlin compiler already should.
@@ -50,10 +53,6 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
         private
         fun precompiledScriptPluginImportsFrom(environment: Environment?, scriptText: CharSequence): List<String> =
             environment.stringList(hashOfNormalisedString(scriptText))
-
-        private
-        fun hashOfNormalisedString(charSequence: CharSequence) =
-            Hashing.hashString(charSequence).toString()
 
         private
         fun Environment?.stringList(key: String) =

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.precompile
 import org.gradle.internal.hash.Hashing
 
 import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependencies
+import org.gradle.util.TextUtil.replaceLineSeparatorsOf
 
 import java.util.concurrent.Future
 
@@ -33,7 +34,8 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
 
     companion object {
 
-        fun hashOf(charSequence: CharSequence) = Hashing.hashString(charSequence).toString()
+        fun hashOf(charSequence: CharSequence) =
+            Hashing.hashString(replaceLineSeparatorsOf(charSequence, "\n")).toString()
 
         fun implicitImportsForScript(scriptText: CharSequence, environment: Environment?) =
             implicitImportsFrom(environment) + precompiledScriptPluginImportsFrom(environment, scriptText)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
@@ -17,9 +17,8 @@
 package org.gradle.kotlin.dsl.precompile
 
 import org.gradle.internal.hash.Hashing
-
 import org.gradle.kotlin.dsl.resolver.KotlinBuildScriptDependencies
-import org.gradle.util.TextUtil.replaceLineSeparatorsOf
+import org.gradle.util.TextUtil.convertLineSeparatorsToUnix
 
 import java.util.concurrent.Future
 
@@ -35,7 +34,7 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
     companion object {
 
         fun hashOf(charSequence: CharSequence) =
-            hashOfNormalisedString(replaceLineSeparatorsOf(charSequence, "\n"))
+            hashOfNormalisedString(convertLineSeparatorsToUnix(charSequence.toString()))
 
         /**
          * **Optimisation note**: assumes [scriptText] contains only `\n` line separators as any script text

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
@@ -35,8 +35,12 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
     companion object {
 
         fun hashOf(charSequence: CharSequence) =
-            Hashing.hashString(replaceLineSeparatorsOf(charSequence, "\n")).toString()
+            hashOfNormalisedString(replaceLineSeparatorsOf(charSequence, "\n"))
 
+        /**
+         * **Optimisation note**: assumes [scriptText] contains only `\n` line separators as any script text
+         * coming from the Kotlin compiler should already do.
+         */
         fun implicitImportsForScript(scriptText: CharSequence, environment: Environment?) =
             implicitImportsFrom(environment) + precompiledScriptPluginImportsFrom(environment, scriptText)
 
@@ -46,7 +50,11 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
 
         private
         fun precompiledScriptPluginImportsFrom(environment: Environment?, scriptText: CharSequence): List<String> =
-            environment.stringList(hashOf(scriptText))
+            environment.stringList(hashOfNormalisedString(scriptText))
+
+        private
+        fun hashOfNormalisedString(charSequence: CharSequence) =
+            Hashing.hashString(charSequence).toString()
 
         private
         fun Environment?.stringList(key: String) =

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledScriptDependenciesResolver.kt
@@ -38,7 +38,7 @@ class PrecompiledScriptDependenciesResolver : ScriptDependenciesResolver {
 
         /**
          * **Optimisation note**: assumes [scriptText] contains only `\n` line separators as any script text
-         * coming from the Kotlin compiler should already do.
+         * coming from the Kotlin compiler already should.
          */
         fun implicitImportsForScript(scriptText: CharSequence, environment: Environment?) =
             implicitImportsFrom(environment) + precompiledScriptPluginImportsFrom(environment, scriptText)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/string.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/string.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.kotlin.dsl.support
 
-import org.gradle.util.TextUtil
+import org.gradle.util.TextUtil.convertLineSeparatorsToUnix
 
 
-fun String.normaliseLineSeparators() =
-    TextUtil.normaliseLineSeparators(this)
+fun String.normaliseLineSeparators(): String =
+    convertLineSeparatorsToUnix(this)


### PR DESCRIPTION
By normalising the line separators in the script text before computing its hash.

Fixes #12248