### PR TITLE
Refine build configurations on EC2 agents

### DIFF
--- a/.teamcity/common/extensions.kt
+++ b/.teamcity/common/extensions.kt
@@ -113,9 +113,7 @@ fun buildToolGradleParameters(daemon: Boolean = true, isContinue: Boolean = true
         if (daemon) "--daemon" else "--no-daemon",
         if (isContinue) "--continue" else "",
         """-I "%teamcity.build.checkoutDir%/gradle/init-scripts/build-scan.init.gradle.kts"""",
-        "-Dorg.gradle.internal.tasks.createops",
-        // // https://github.com/gradle/gradle-private/issues/2725
-        if (os == Os.macos) "" else "-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%"
+        "-Dorg.gradle.internal.tasks.createops"
     )
 
 fun buildToolParametersString(daemon: Boolean = true, os: Os = Os.linux) = buildToolGradleParameters(daemon, os = os).joinToString(separator = " ")

--- a/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
@@ -126,5 +126,5 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "") =
-        "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -Dorg.gradle.unsafe.vfs.drop=true -s $daemon --continue -I \"%teamcity.build.checkoutDir%/gradle/init-scripts/build-scan.init.gradle.kts\" -Dorg.gradle.internal.tasks.createops -Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url% $extraParameters -PteamCityToken=%teamcity.user.bot-gradle.token% -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\""
+        "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -Dorg.gradle.unsafe.vfs.drop=true -s $daemon --continue -I \"%teamcity.build.checkoutDir%/gradle/init-scripts/build-scan.init.gradle.kts\" -Dorg.gradle.internal.tasks.createops $extraParameters -PteamCityToken=%teamcity.user.bot-gradle.token% -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\""
 }

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -74,7 +74,6 @@ class PerformanceTestBuildTypeTest {
                 "-I",
                 "\"%teamcity.build.checkoutDir%/gradle/init-scripts/build-scan.init.gradle.kts\"",
                 "-Dorg.gradle.internal.tasks.createops",
-                "-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%",
                 "-Porg.gradle.performance.buildTypeId=Gradle_Check_IndividualPerformanceScenarioWorkersLinux",
                 "-Porg.gradle.performance.workerTestTaskName=fullPerformanceTest",
                 "-Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id%",

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -176,10 +176,16 @@ open class BuildScanPlugin : Plugin<Project> {
     }
 
     private
+    fun isEc2Agent() = java.net.InetAddress.getLocalHost().hostName.startsWith("ip-")
+
+    private
     fun Project.extractCiOrLocalData() {
         if (isCiServer) {
             buildScan {
                 tag("CI")
+                if(isEc2Agent()) {
+                   tag("EC2")
+                }
                 when {
                     isTravis -> {
                         link("Travis Build", System.getenv("TRAVIS_BUILD_WEB_URL"))

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -183,8 +183,8 @@ open class BuildScanPlugin : Plugin<Project> {
         if (isCiServer) {
             buildScan {
                 tag("CI")
-                if(isEc2Agent()) {
-                   tag("EC2")
+                if (isEc2Agent()) {
+                    tag("EC2")
                 }
                 when {
                     isTravis -> {

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -65,7 +65,7 @@ if (System.getProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY) == null && !isEc2Age
     // https://github.com/gradle/gradle-private/issues/2951
     System.setProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY, "https://dev12.gradle.org/artifactory/gradle-plugins/")
     gradle.buildFinished {
-        System.setProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY, null)
+        System.clearProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY)
     }
 }
 

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -40,6 +40,8 @@ fun isEc2Agent() = java.net.InetAddress.getLocalHost().hostName.startsWith("ip-"
 
 fun isMacAgent() = System.getProperty("os.name").toLowerCase().contains("mac")
 
+fun ignoreMirrors() = System.getenv("IGNORE_MIRROR")?.toBoolean() ?: false
+
 fun withMirrors(handler: RepositoryHandler) {
     if ("CI" !in System.getenv() || isEc2Agent()) {
         return
@@ -60,7 +62,7 @@ fun normalizeUrl(url: String): String {
     return if (result.endsWith("/")) result else "$result/"
 }
 
-if (System.getProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY) == null && !isEc2Agent() && !isMacAgent()) {
+if (System.getProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY) == null && !isEc2Agent() && !isMacAgent() && !ignoreMirrors()) {
     // https://github.com/gradle/gradle-private/issues/2725
     // https://github.com/gradle/gradle-private/issues/2951
     System.setProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY, "https://dev12.gradle.org/artifactory/gradle-plugins/")


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle-private/issues/2951

Fixed https://github.com/gradle/gradle-private/issues/2943

### Context

This PR adds an `EC2` tag to build scan.

This PR moves `org.gradle.internal.plugins.portal.url.override` property from build parameters to init script so we can disable this property on EC2 agents.
