### PR TITLE
Add soak tests for VFS retention

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -78,6 +78,7 @@ data class CIBuildModel(
             functionalTests = listOf(
                 TestCoverage(8, TestType.soak, Os.linux, JvmCategory.MAX_VERSION.version, vendor = JvmCategory.MAX_VERSION.vendor),
                 TestCoverage(9, TestType.soak, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
+                TestCoverage(35, TestType.soak, Os.macos, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(10, TestType.allVersionsCrossVersion, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(11, TestType.allVersionsCrossVersion, Os.windows, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),
                 TestCoverage(12, TestType.noDaemon, Os.linux, JvmCategory.MIN_VERSION.version, vendor = JvmCategory.MIN_VERSION.vendor),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,7 +166,7 @@ buildTypes {
     }
 
     create("soakTest") {
-        tasks("soak:soakTest")
+        tasks("soak:soakIntegTest")
         projectProperties("testAllVersions" to true)
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RetryConditions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RetryConditions.groovy
@@ -136,9 +136,9 @@ class RetryConditions {
         // See https://github.com/gradle/gradle-private/issues/744
         if (targetDistVersion < GradleVersion.version('3.5') && daemonsFixture != null && getRootCauseMessage(failure) == 'Build cancelled.') {
             for (daemon in daemonsFixture.daemons) {
-                if (daemon.log.contains('Could not receive message from client.')
-                    && daemon.log.contains('java.lang.NullPointerException')
-                    && daemon.log.contains('org.gradle.launcher.daemon.server.exec.LogToClient')) {
+                if (daemon.logContains('Could not receive message from client.')
+                    && daemon.logContains('java.lang.NullPointerException')
+                    && daemon.logContains('org.gradle.launcher.daemon.server.exec.LogToClient')) {
                     println "Retrying test because the dispatcher was not ready for receiving a log event. Check log of daemon with PID ${daemon.context.pid}."
                     return cleanProjectDir(specification)
                 }
@@ -178,9 +178,9 @@ class RetryConditions {
     }
 
     static daemonStoppedWithSocketExceptionOnWindows(daemon) {
-        runsOnWindowsAndJava7or8() && (daemon.log.contains("java.net.SocketException: Socket operation on nonsocket:")
-            || daemon.log.contains("java.io.IOException: An operation was attempted on something that is not a socket")
-            || daemon.log.contains("java.io.IOException: An existing connection was forcibly closed by the remote host"))
+        runsOnWindowsAndJava7or8() && (daemon.logContains("java.net.SocketException: Socket operation on nonsocket:")
+            || daemon.logContains("java.io.IOException: An operation was attempted on something that is not a socket")
+            || daemon.logContains("java.io.IOException: An existing connection was forcibly closed by the remote host"))
     }
 
     static String getRootCauseMessage(Throwable throwable) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionFixture.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import groovy.transform.SelfType
+import org.junit.Before
+
+@SelfType(AbstractIntegrationSpec)
+trait VfsRetentionFixture {
+
+    @Before
+    void setupFirstBuild() {
+        // Make the first build in each test drop the VFS state
+        executer.withArgument(VfsRetentionHelper.dropVfsArgument)
+    }
+
+    def withRetention() {
+        executer.withArgument(VfsRetentionHelper.enableVfsRetentionArgument)
+        this
+    }
+
+    def withoutRetention() {
+        executer.withArgument(VfsRetentionHelper.disableVfsRetentionArgument)
+        this
+    }
+
+    void waitForChangesToBePickedUp() {
+        VfsRetentionHelper.waitForChangesToBePickedUp()
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionHelper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures;
+
+import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_DROP_PROPERTY;
+import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY;
+
+public class VfsRetentionHelper {
+    public static void waitForChangesToBePickedUp() throws InterruptedException {
+        Thread.sleep(1000);
+    }
+
+    public static String getEnableVfsRetentionArgument() {
+        return systemProperty(VFS_RETENTION_ENABLED_PROPERTY, true);
+    }
+
+    public static String getDisableVfsRetentionArgument() {
+        return systemProperty(VFS_RETENTION_ENABLED_PROPERTY, false);
+    }
+
+    public static String getDropVfsArgument() {
+        return systemProperty(VFS_DROP_PROPERTY, true);
+    }
+
+    private static String systemProperty(String key, Object value) {
+        return "-D" + key + "=" + value;
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
@@ -20,14 +20,19 @@ import org.gradle.integtests.fixtures.ProcessFixture
 import org.gradle.launcher.daemon.context.DaemonContext
 import org.gradle.launcher.daemon.server.api.DaemonStateControl.State
 
-import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.*
+import java.nio.file.Files
+
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Busy
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Canceled
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Idle
+import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Stopped
 
 abstract class AbstractDaemonFixture implements DaemonFixture {
     public static final int STATE_CHANGE_TIMEOUT = 20000
     final DaemonContext context
 
     AbstractDaemonFixture(File daemonLog) {
-        this.context = DaemonContextParser.parseFrom(daemonLog.text)
+        this.context = DaemonContextParser.parseFromFile(daemonLog)
         if (!this.context) {
             println "Could not parse daemon log: \n$daemonLog.text"
         }
@@ -45,6 +50,13 @@ abstract class AbstractDaemonFixture implements DaemonFixture {
 
     DaemonContext getContext() {
         context
+    }
+
+    @Override
+    boolean logContains(String searchString) {
+        Files.lines(logFile.toPath()).withCloseable { lines ->
+            lines.filter { it.contains(searchString) }.findFirst().present
+        }
     }
 
     void becomesIdle() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
@@ -55,7 +55,7 @@ abstract class AbstractDaemonFixture implements DaemonFixture {
     @Override
     boolean logContains(String searchString) {
         Files.lines(logFile.toPath()).withCloseable { lines ->
-            lines.filter { it.contains(searchString) }.findFirst().present
+            lines.anyMatch{ it.contains(searchString) }
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonFixture.java
@@ -37,6 +37,13 @@ public interface DaemonFixture {
     File getLogFile();
 
     /**
+     * Returns whether the log file contains a given String.
+     *
+     * Works without reading the whole log file into memory.
+     */
+    boolean logContains(String searchString);
+
+    /**
      * Returns the TCP port used by this daemon.
      */
     int getPort();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonLogsAnalyzer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonLogsAnalyzer.groovy
@@ -61,7 +61,7 @@ class DaemonLogsAnalyzer implements DaemonsFixture {
 
 
     List<DaemonFixture> getDaemons() {
-        getAllDaemons().findAll { !daemonStoppedWithSocketExceptionOnWindows(it) || it.log.contains("Starting build in new daemon") }
+        getAllDaemons().findAll { !daemonStoppedWithSocketExceptionOnWindows(it) || it.logContains("Starting build in new daemon") }
     }
 
     List<DaemonFixture> getAllDaemons() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/VfsRetentionGradleExecuter.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.fixtures.executer
 
 import com.google.common.collect.ImmutableList
-import org.gradle.internal.service.scopes.VirtualFileSystemServices
+import org.gradle.integtests.fixtures.VfsRetentionHelper
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.GradleVersion
 
@@ -33,17 +33,16 @@ class VfsRetentionGradleExecuter extends DaemonGradleExecuter {
     ) {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext)
         beforeExecute {
-            // Wait a second to pick up changes
-            Thread.sleep(1000)
+            VfsRetentionHelper.waitForChangesToBePickedUp()
         }
     }
 
     @Override
     protected List<String> getAllArgs() {
-        List<Object> conditionalArgs = firstUse ? ["-D${VirtualFileSystemServices.VFS_DROP_PROPERTY}=true"] : ImmutableList.of()
+        List<Object> conditionalArgs = firstUse ? [VfsRetentionHelper.dropVfsArgument] : ImmutableList.of()
         firstUse = false
         super.getAllArgs() + ([
-            "-D${VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY}=true",
+            VfsRetentionHelper.enableVfsRetentionArgument,
         ] + conditionalArgs).collect { it.toString() }
     }
 }

--- a/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
+++ b/subprojects/snapshots/src/integTest/groovy/org/gradle/internal/vfs/VirtualFileSystemRetentionIntegrationTest.groovy
@@ -19,20 +19,18 @@ package org.gradle.internal.vfs
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.VfsRetentionFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
 import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecution.Skip.FLAKY
-import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_DROP_PROPERTY
-import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY
 
 // The whole test makes no sense if there isn't a daemon to retain the state.
 @IgnoreIf({ GradleContextualExecuter.noDaemon || GradleContextualExecuter.vfsRetention })
-class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
+class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, VfsRetentionFixture {
 
     def setup() {
         // Make the first build in each test drop the VFS state
-        executer.withArgument("-D$VFS_DROP_PROPERTY=true")
         executer.requireIsolatedDaemons()
     }
 
@@ -475,16 +473,6 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
         """
     }
 
-    private def withRetention() {
-        executer.withArgument  "-D${VFS_RETENTION_ENABLED_PROPERTY}=true"
-        this
-    }
-
-    private def withoutRetention() {
-        executer.withArgument  "-D${VFS_RETENTION_ENABLED_PROPERTY}=false"
-        this
-    }
-
     private static String sourceFileWithGreeting(String greeting) {
         """
             public class Main {
@@ -507,9 +495,5 @@ class VirtualFileSystemRetentionIntegrationTest extends AbstractIntegrationSpec 
                 }
             }
         """
-    }
-
-    private static void waitForChangesToBePickedUp() {
-        Thread.sleep(1000)
     }
 }

--- a/subprojects/soak/soak.gradle.kts
+++ b/subprojects/soak/soak.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     integTestImplementation(project(":launcher"))
     integTestImplementation(library("slf4j_api"))
     integTestImplementation(testLibrary("jetty"))
+    integTestImplementation(library("gradleProfiler"))
+    // TODO: Use a metadata rule
+    integTestImplementation("com.github.javaparser:javaparser-core:3.1.3")
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }

--- a/subprojects/soak/soak.gradle.kts
+++ b/subprojects/soak/soak.gradle.kts
@@ -49,7 +49,7 @@ tasks.integTest {
     }
 }
 
-tasks.register("soakTest", org.gradle.gradlebuild.test.integrationtests.SoakTest::class) {
+tasks.register("soakIntegTest", org.gradle.gradlebuild.test.integrationtests.SoakTest::class) {
     val integTestSourceSet = sourceSets.integTest.get()
     testClassesDirs = integTestSourceSet.output.classesDirs
     classpath = integTestSourceSet.runtimeClasspath

--- a/subprojects/soak/soak.gradle.kts
+++ b/subprojects/soak/soak.gradle.kts
@@ -34,9 +34,6 @@ dependencies {
     integTestImplementation(project(":launcher"))
     integTestImplementation(library("slf4j_api"))
     integTestImplementation(testLibrary("jetty"))
-    integTestImplementation(library("gradleProfiler"))
-    // TODO: Use a metadata rule
-    integTestImplementation("com.github.javaparser:javaparser-core:3.1.3")
 
     integTestRuntimeOnly(project(":runtimeApiInfo"))
 }

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -33,6 +33,8 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
     List<TestFile> sourceFiles
 
     def setup() {
+        // Use 20 minutes idle timeout since the test may be running longer with an idle daemon
+        executer.withDaemonIdleTimeoutSecs(1200)
         def subprojects = (1..NUMBER_OF_SUBPROJECTS).collect { "project$it" }
         def rootProject = multiProjectBuild("javaProject", subprojects) {
             buildFile << """

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.vfs
+
+import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+import org.gradle.internal.service.scopes.VirtualFileSystemServices
+import org.gradle.profiler.BuildContext
+import org.gradle.profiler.Phase
+import org.gradle.profiler.ScenarioContext
+import org.gradle.profiler.mutations.ApplyAbiChangeToJavaSourceFileMutator
+import org.gradle.soak.categories.SoakTest
+import org.junit.experimental.categories.Category
+
+@Category(SoakTest)
+class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
+
+    def "file watching works with multiple builds on the same daemon"() {
+        def subprojects = (1..50).collect { "project$it" }
+        def rootProject = multiProjectBuild("javaProject", subprojects) {
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java-library'
+                }
+            """
+        }
+        def sourceFiles = subprojects.collectMany { projectDir ->
+            (1..100).collect {
+                def sourceFile = rootProject.file("${projectDir}/src/main/java/my/domain/Dummy${it}.java")
+                sourceFile << """
+                    package my.domain;
+
+
+                    public class Dummy${it} {
+                        public void doNothing() {
+                        }
+                    }
+                """
+                return sourceFile
+            }
+        }
+
+        def scenarioContext = new ScenarioContext(UUID.randomUUID(), "abiChange")
+
+        executer.requireIsolatedDaemons()
+        executer.beforeExecute {
+            withArgument("-D${VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY}=true")
+        }
+
+        when:
+        succeeds("assemble")
+        def daemon = daemons.daemon
+
+        then:
+        daemon.assertIdle()
+
+        when:
+        (1..100).each { iteration ->
+            sourceFiles.each { sourceFile ->
+                applyAbiChangeTo(
+                    sourceFile,
+                    scenarioContext.withBuild(Phase.MEASURE, iteration)
+                )
+            }
+            succeeds("assemble")
+            daemons.daemon.logFile == daemon.logFile
+            daemon.assertIdle()
+            assertWatchingSucceeded()
+            assert receivedFileSystemEvents >= 5000
+        }
+        then:
+        assertWatchingSucceeded()
+        daemons.daemon.logFile == daemon.logFile
+        daemon.assertIdle()
+    }
+
+    private int getReceivedFileSystemEvents() {
+        String eventsSinceLastBuild = result.getOutputLineThatContains("file system events since last build")
+        def numberMatcher = eventsSinceLastBuild =~ /Received (\d+) file system events since last build/
+        return numberMatcher[0][1] as int
+    }
+
+    private void assertWatchingSucceeded() {
+        outputDoesNotContain("Couldn't create watch service")
+        outputDoesNotContain("Couldn't fetch file changes, dropping VFS state")
+        outputDoesNotContain("Dropped VFS state due to lost state")
+    }
+
+    private static void applyAbiChangeTo(File sourceFile, BuildContext context) {
+        new ApplyAbiChangeToJavaSourceFileMutator(sourceFile).beforeBuild(context)
+    }
+}

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -16,15 +16,15 @@
 
 package org.gradle.vfs
 
+import org.gradle.integtests.fixtures.VfsRetentionFixture
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.internal.service.scopes.VirtualFileSystemServices
 import org.gradle.soak.categories.SoakTest
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.experimental.categories.Category
 
 @Category(SoakTest)
-class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
+class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implements VfsRetentionFixture {
 
     private static final int NUMBER_OF_SUBPROJECTS = 50
     private static final int NUMBER_OF_SOURCES_PER_SUBPROJECT = 100
@@ -57,7 +57,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
         }
 
         executer.beforeExecute {
-            withArgument("-D${VirtualFileSystemServices.VFS_RETENTION_ENABLED_PROPERTY}=true")
+            withRetention()
         }
     }
 
@@ -115,10 +115,6 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
             return numberOfChangedFiles * numberOfChangesPerFile * LOST_EVENTS_RATIO_WINDOWS
         }
         throw new AssertionError("Test not supported on OS ${currentOs}")
-    }
-
-    private static void waitForChangesToBePickedUp() {
-        Thread.sleep(1000)
     }
 
     private void changeAllSourceFiles(int iteration) {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -73,7 +73,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
         (1..100).each { iteration ->
             changeAllSourceFiles(iteration)
             waitForChangesToBePickedUp()
-            succeeds("assemble")
+            succeeds("assemble", "--parallel")
             assert daemons.daemon.logFile == daemon.logFile
             daemon.assertIdle()
             assertWatchingSucceeded()
@@ -83,7 +83,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
 
     def "file watching works with many changes between two builds"() {
         when:
-        succeeds("assemble")
+        succeeds("assemble", "--parallel")
         def daemon = daemons.daemon
         then:
         daemon.assertIdle()

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -42,6 +42,10 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
             buildFile << """
                 allprojects {
                     apply plugin: 'java-library'
+
+                    tasks.withType(JavaCompile).configureEach {
+                        options.fork = true
+                    }
                 }
             """
         }

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -29,7 +29,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec {
     private static final int NUMBER_OF_SUBPROJECTS = 50
     private static final int NUMBER_OF_SOURCES_PER_SUBPROJECT = 100
     private static final int TOTAL_NUMBER_OF_SOURCES = NUMBER_OF_SUBPROJECTS * NUMBER_OF_SOURCES_PER_SUBPROJECT
-    private static final double LOST_EVENTS_RATIO_MAC_OS = 0.75
+    private static final double LOST_EVENTS_RATIO_MAC_OS = 0.6
     private static final double LOST_EVENTS_RATIO_WINDOWS = 0.1
 
     List<TestFile> sourceFiles


### PR DESCRIPTION
The PR adds two soak tests for VFS retention:
- many builds with changes in between on one daemon
- two builds on one daemon with many changes in between

Fixes #12227