### PR TITLE
Update wrapper and enable VFS retention

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,7 @@ systemProp.gradle.publish.skip.namespace.check=true
 # Enable VFS retention using file watching on Windows, Linux and macOS
 # Note that CI builds have this property explicitly disabled via command-line
 # Remove the property when VFS retention is enabled by default
-### Disabled temporarily because inotify handles ran out on our Linux CI machines
-### systemProp.org.gradle.unsafe.vfs.retention=true
+systemProp.org.gradle.unsafe.vfs.retention=true
 
 # Enable partial VFS invalidation, i.e. only remove the in-memory file system state for declared outputs before running task actions.
 # Remove the property when partial invalidation is enabled by default.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.3-20200211235333+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-6.3-20200217095419+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
by default. This allows us to dogfood VFS retention.