### PR TITLE
Add HeapDumpOnOutOfMemoryError for worker daemons

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -207,6 +207,7 @@ fun Project.applyGroovyProjectConventions() {
     tasks.withType<GroovyCompile>().configureEach {
         groovyOptions.apply {
             encoding = "utf-8"
+            forkOptions.jvmArgs?.add("-XX:+HeapDumpOnOutOfMemoryError")
         }
         options.apply {
             isFork = true

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -121,6 +121,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
             }
             tasks.withType<GroovyCompile>().configureEach {
                 groovyOptions.encoding = "utf-8"
+                groovyOptions.forkOptions.jvmArgs?.add("-XX:+HeapDumpOnOutOfMemoryError")
                 configureCompileTask(this, options, jdkForCompilation)
             }
         }
@@ -156,6 +157,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         options.isFork = true
         options.encoding = "utf-8"
         options.isIncremental = true
+        options.forkOptions.jvmArgs?.add("-XX:+HeapDumpOnOutOfMemoryError")
         options.compilerArgs = mutableListOf("-Xlint:-options", "-Xlint:-path")
         if (!jdkForCompilation.current) {
             options.forkOptions.javaHome = jdkForCompilation.javaHome

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -121,7 +121,6 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
             }
             tasks.withType<GroovyCompile>().configureEach {
                 groovyOptions.encoding = "utf-8"
-                groovyOptions.forkOptions.jvmArgs?.add("-XX:+HeapDumpOnOutOfMemoryError")
                 configureCompileTask(this, options, jdkForCompilation)
             }
         }


### PR DESCRIPTION
This closes https://github.com/gradle/gradle-private/issues/2950

We add HeapDumpOnOutOfMemoryError for all worker daemons.