### PR TITLE
Removed explicit java plugin application and gradle api dependency declaration from dslWithBuildSrc sample

### DIFF
--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/groovy/buildSrc/build.gradle
@@ -16,7 +16,6 @@
 
 // tag::main-block[]
 plugins {
-    id 'java'
     id 'java-gradle-plugin'
 }
 
@@ -27,9 +26,5 @@ gradlePlugin {
             implementationClass = 'my.MyPlugin'
         }
     }
-}
-
-dependencies {
-    compileOnly gradleApi()
 }
 // end::main-block[]

--- a/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/dslWithBuildSrc/kotlin/buildSrc/build.gradle.kts
@@ -16,7 +16,6 @@
 
 // tag::main-block[]
 plugins {
-    java
     `java-gradle-plugin`
 }
 
@@ -27,9 +26,5 @@ gradlePlugin {
             implementationClass = "my.MyPlugin"
         }
     }
-}
-
-dependencies {
-    compileOnly(gradleApi())
 }
 // end::main-block[]


### PR DESCRIPTION
Removed explicit java plugin application and gradle api dependency declaration from dslWithBuildSrc sample - those are added implicitly with application of `java-gradle-plugin`.
