### PR TITLE
Software Model @UnsupportedWithInstantExecution

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/RuleTaskCreationIntegrationTest.groovy
@@ -18,15 +18,15 @@ package org.gradle.execution.taskgraph
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.model.internal.core.ModelPath
 
+@UnsupportedWithInstantExecution(because = "software model")
 class RuleTaskCreationIntegrationTest extends AbstractIntegrationSpec implements WithRuleBasedTasks {
     def setup() {
         buildFile << ruleBasedTasks()
     }
 
-    @ToBeFixedForInstantExecution
     def "can use rule method to create tasks from model"() {
         given:
         buildFile << """
@@ -67,7 +67,6 @@ class RuleTaskCreationIntegrationTest extends AbstractIntegrationSpec implements
         output.contains "b - task b"
     }
 
-    @ToBeFixedForInstantExecution
     def "can use rule DSL to create tasks"() {
         given:
         buildFile << """
@@ -469,7 +468,6 @@ foo configured
         failure.assertHasCause("Cannot create 'tasks.a' using creation rule 'MyPlugin#addTasks2(ModelMap<Task>, MyModel) > create(a)' as the rule 'MyPlugin#addTasks1(ModelMap<Task>, MyModel) > create(a)' is already registered to create this model element.")
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot create tasks during config of task"() {
         given:
         buildFile << """
@@ -493,7 +491,6 @@ foo configured
         failure.assertHasCause("Attempt to modify a closed view of model element 'tasks' of type 'ModelMap<Task>' given to rule MyPlugin#addTasks(ModelMap<Task>)")
     }
 
-    @ToBeFixedForInstantExecution
     def "failure during task instantiation is reasonably reported"() {
         given:
         buildFile << """
@@ -521,7 +518,6 @@ foo configured
         failure.assertHasCause("Could not create task of type 'Faulty'")
     }
 
-    @ToBeFixedForInstantExecution
     def "failure during task initial configuration is reasonably reported"() {
         given:
         buildFile << """
@@ -545,7 +541,6 @@ foo configured
         failure.assertHasCause("config failure")
     }
 
-    @ToBeFixedForInstantExecution
     def "failure during task configuration is reasonably reported"() {
         given:
         buildFile << """

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/DetailedModelReportIntegrationTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
 
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 
+@UnsupportedWithInstantExecution(because = "software model")
 class DetailedModelReportIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelReportIntegrationTest extends AbstractIntegrationSpec {
 
     def "displays basic structure of an empty project"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportTaskIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.api.reporting.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelReportTaskIntegrationTest extends AbstractIntegrationSpec {
 
     def "should display the model report task options"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecution.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * The annotated test will be skipped by the {@link org.gradle.integtests.fixtures.executer.InstantExecutionGradleExecuter}.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @ExtensionAnnotation(UnsupportedWithInstantExecutionExtension.class)
 public @interface UnsupportedWithInstantExecution {
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecution.java
@@ -33,6 +33,8 @@ import java.lang.annotation.Target;
 @ExtensionAnnotation(UnsupportedWithInstantExecutionExtension.class)
 public @interface UnsupportedWithInstantExecution {
 
+    String because() default "";
+
     String[] bottomSpecs() default {};
 
     /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/UnsupportedWithInstantExecutionExtension.groovy
@@ -22,6 +22,7 @@ import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.SpecInfo
 
 import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.iterationMatches
 import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtension.isAllIterations
@@ -29,6 +30,19 @@ import static org.gradle.integtests.fixtures.ToBeFixedForInstantExecutionExtensi
 
 
 class UnsupportedWithInstantExecutionExtension extends AbstractAnnotationDrivenExtension<UnsupportedWithInstantExecution> {
+
+    @Override
+    void visitSpecAnnotation(UnsupportedWithInstantExecution annotation, SpecInfo spec) {
+        if (GradleContextualExecuter.isInstant()) {
+            if (isAllIterations(annotation.iterationMatchers()) && isEnabledBottomSpec(annotation.bottomSpecs(), { spec.bottomSpec.name == it })) {
+                spec.skipped = true
+            } else {
+                spec.features.each { feature ->
+                    feature.iterationInterceptors.add(new IterationMatchingMethodInterceptor(annotation.iterationMatchers()))
+                }
+            }
+        }
+    }
 
     @Override
     void visitFeatureAnnotation(UnsupportedWithInstantExecution annotation, FeatureInfo feature) {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ConfigurationCycleIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ConfigurationCycleIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ConfigurationCycleIntegrationTest extends AbstractIntegrationSpec {
 
     def "configuration cycle error contains information useful for troubleshooting"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelMapIntegrationTest.groovy
@@ -18,13 +18,13 @@ package org.gradle.model
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.language.base.FunctionalSourceSet
 import org.gradle.platform.base.ComponentSpec
 import spock.lang.Issue
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelMapIntegrationTest extends AbstractIntegrationSpec {
-    @ToBeFixedForInstantExecution
     def "provides basic meta-data for map"() {
         when:
         buildScript '''
@@ -63,7 +63,6 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         output.contains "to-string: ModelMap<Thing> 'things'"
     }
 
-    @ToBeFixedForInstantExecution
     def "can view as ModelElement"() {
         when:
         buildScript '''
@@ -288,7 +287,6 @@ class ModelMapIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Cannot create 'components.main' with type '$FunctionalSourceSet.name' as this is not a subtype of '$ComponentSpec.name'.")
     }
 
-    @ToBeFixedForInstantExecution
     def "withType() returns empty collection for type not implementing ModelMap's base interface"() {
         buildFile << """
         apply plugin: ComponentModelBasePlugin

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingFailureIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingFailureIntegrationTest.groovy
@@ -17,16 +17,16 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
 /**
  * Tests the information provided when a model rule fails to bind.
  *
  * @see ModelRuleBindingValidationIntegrationTest
  */
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "unbound rule by-type subject and inputs are reported"() {
         given:
         buildScript """
@@ -77,7 +77,6 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 '''
     }
 
-    @ToBeFixedForInstantExecution
     def "unbound rule by-path subject and inputs are reported"() {
         given:
         buildScript """
@@ -120,7 +119,6 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 '''
     }
 
-    @ToBeFixedForInstantExecution
     def "unbound dsl rule by-path subject and inputs are reported"() {
         given:
         buildScript '''
@@ -156,7 +154,6 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "suggestions are provided for unbound by-path references"() {
         given:
         buildScript """
@@ -190,7 +187,6 @@ class ModelRuleBindingFailureIntegrationTest extends AbstractIntegrationSpec {
 '''
     }
 
-    @ToBeFixedForInstantExecution
     def "fails on ambiguous by-type reference"() {
         given:
         buildScript """
@@ -324,7 +320,6 @@ model {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "partially bound rules are reported and the report includes the elements bound to"() {
         given:
         buildScript """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingValidationIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleBindingValidationIntegrationTest.groovy
@@ -17,16 +17,16 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
 /**
  * Tests aspects of model rule binding validation such as when/why validation is run.
  *
  * @see ModelRuleBindingFailureIntegrationTest
  */
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelRuleBindingValidationIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "model rule that does not bind specified for project not used in the build does not fail the build"() {
         when:
         settingsFile << """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleCachingIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleCachingIntegrationTest.groovy
@@ -16,10 +16,11 @@
 
 package org.gradle.model
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.longlived.PersistentBuildProcessIntegrationTest
 import org.gradle.model.internal.inspect.ModelRuleExtractor
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelRuleCachingIntegrationTest extends PersistentBuildProcessIntegrationTest {
 
     def setup() {
@@ -42,7 +43,6 @@ class ModelRuleCachingIntegrationTest extends PersistentBuildProcessIntegrationT
         match[0][1] == "true"
     }
 
-    @ToBeFixedForInstantExecution
     def "rules extracted from core plugins are reused across builds"() {
         given:
         buildFile << '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleSamplesIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleSamplesIntegrationTest.groovy
@@ -17,17 +17,17 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Rule
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelRuleSamplesIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule Sample sample = new Sample(testDirectoryProvider)
 
     @UsesSample("modelRules/modelDsl")
-    @ToBeFixedForInstantExecution
     def "dsl creation example works"() {
         when:
         sample sample

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleValidationIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ModelRuleValidationIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelRuleValidationIntegrationTest extends AbstractIntegrationSpec {
 
     def "invalid model name produces error message"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/MutationRuleApplicationOrderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/MutationRuleApplicationOrderIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class MutationRuleApplicationOrderIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedAsProjectPluginIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedAsProjectPluginIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class RuleSourceAppliedAsProjectPluginIntegrationTest extends AbstractIntegrationSpec {
 
     def "plugin class can expose model rules"() {
@@ -393,7 +394,6 @@ model {
         output.contains "value: configured"
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can depend on a concrete task type"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedByRuleMethodIntegrationTest.groovy
@@ -17,9 +17,10 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.language.base.LanguageSourceSet
 
+@UnsupportedWithInstantExecution(because = "software model")
 class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSpec {
     def "@Rule method can apply rules to a particular target"() {
         buildFile << '''
@@ -247,7 +248,6 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         output.contains("p1 = default")
     }
 
-    @ToBeFixedForInstantExecution
     def "elements referenced by @RuleInput property are treated as implicit input of rules on RuleSource"() {
         buildFile << '''
             @Managed
@@ -326,7 +326,6 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         output.contains("thingC = thing c from rule")
     }
 
-    @ToBeFixedForInstantExecution
     def "element referenced by @RuleTarget property is treated as target of RuleSource"() {
         buildFile << '''
             @Managed
@@ -495,7 +494,6 @@ class RuleSourceAppliedByRuleMethodIntegrationTest extends AbstractIntegrationSp
         failure.assertHasCause("broken")
     }
 
-    @ToBeFixedForInstantExecution
     def "@Rules method is not executed when target is not required"() {
         buildFile << '''
             class MyPlugin extends RuleSource {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedToModelMapElementIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceAppliedToModelMapElementIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class RuleSourceAppliedToModelMapElementIntegrationTest extends AbstractIntegrationSpec {
 
     def "rule source can be applied to ModelMap element"() {
@@ -64,7 +65,6 @@ class RuleSourceAppliedToModelMapElementIntegrationTest extends AbstractIntegrat
         output.contains "message: foo"
     }
 
-    @ToBeFixedForInstantExecution
     def "scoped rule execution failure yields useful error message"() {
         when:
         buildScript '''
@@ -94,7 +94,6 @@ class RuleSourceAppliedToModelMapElementIntegrationTest extends AbstractIntegrat
         failure.assertHasCause("I'm broken")
     }
 
-    @ToBeFixedForInstantExecution
     def "invalid rule definitions of scoped rules are reported with a message helping to identify the faulty rule"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/RuleSourceIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class RuleSourceIntegrationTest extends AbstractIntegrationSpec {
     def "cannot create a model element of type RuleSource"() {
         buildFile << '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/ScalarCollectionIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/ScalarCollectionIntegrationTest.groovy
@@ -17,9 +17,10 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ScalarCollectionIntegrationTest extends AbstractIntegrationSpec {
     @Unroll
     def "can create instance of #{type.name}"() {
@@ -54,7 +55,6 @@ apply plugin: Rules
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "can view #{type.name} as ModelElement"() {
         given:
         buildFile << """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/UnmanagedElementIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/UnmanagedElementIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.model
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class UnmanagedElementIntegrationTest extends AbstractIntegrationSpec {
-    @ToBeFixedForInstantExecution
+
     def "can view unmanaged element as ModelElement"() {
         given:
         buildFile << '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/AbstractClassBackedManagedTypeIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/AbstractClassBackedManagedTypeIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "rule can provide a managed model element backed by an abstract class"() {
         when:
         buildScript '''
@@ -57,7 +57,6 @@ class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationS
         output.contains("name: foo")
     }
 
-    @ToBeFixedForInstantExecution
     def "managed type implemented as abstract class can have generative getters"() {
         when:
         buildScript '''
@@ -100,7 +99,6 @@ class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationS
         output.contains("name: Alan Turing")
     }
 
-    @ToBeFixedForInstantExecution
     def "managed type implemented as abstract class can have a custom toString() implementation"() {
         when:
         buildScript '''
@@ -140,7 +138,6 @@ class AbstractClassBackedManagedTypeIntegrationTest extends AbstractIntegrationS
         output.contains("element: custom string representation")
     }
 
-    @ToBeFixedForInstantExecution
     def "calling setters from custom toString() implementation is not allowed"() {
         when:
         buildFile << '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/CyclicalManagedTypeIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/CyclicalManagedTypeIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CyclicalManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "managed types can have cyclical managed type references"() {
         when:
         buildScript '''
@@ -66,7 +66,6 @@ class CyclicalManagedTypeIntegrationTest extends AbstractIntegrationSpec {
         output.contains("name: parent")
     }
 
-    @ToBeFixedForInstantExecution
     def "managed types can have cyclical managed type references where more than two types constitute the cycle"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/EnumsInManagedModelIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/EnumsInManagedModelIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class EnumsInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "can use enums in managed model elements"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/InterfaceBackedManagedTypeIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/InterfaceBackedManagedTypeIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -26,9 +26,9 @@ import spock.lang.Issue
 // Fail since build 125
 @Requires(TestPrecondition.JDK8_OR_EARLIER)
 @Issue('https://github.com/gradle/gradle/issues/721')
+@UnsupportedWithInstantExecution(because = "software model")
 class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "rule method can define a managed model element backed by an interface"() {
         when:
         buildScript '''
@@ -85,7 +85,6 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
         output.contains("name: foo")
     }
 
-    @ToBeFixedForInstantExecution
     def "can view a managed element as ModelElement"() {
         when:
         buildScript '''
@@ -124,7 +123,6 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
         output.contains("display-name: Person 'someone'")
     }
 
-    @ToBeFixedForInstantExecution
     def "rule method can apply defaults to a managed model element"() {
         when:
         buildScript '''
@@ -185,7 +183,6 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
     }
 
     @Requires(TestPrecondition.JDK8_OR_LATER)
-    @ToBeFixedForInstantExecution
     def "managed type implemented as interface can have generative getter default methods"() {
         when:
         file('buildSrc/src/main/java/Rules.java') << '''
@@ -234,7 +231,6 @@ class InterfaceBackedManagedTypeIntegrationTest extends AbstractIntegrationSpec 
     }
 
     @Requires(TestPrecondition.JDK8_OR_LATER)
-    @ToBeFixedForInstantExecution
     def "generative getters implemented as default methods cannot call setters"() {
         when:
         file('buildSrc/src/main/java/Rules.java') << '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelMutationIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelMutationIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class InvalidManagedModelMutationIntegrationTest extends AbstractIntegrationSpec {
 
     def "mutating managed inputs of a rule is not allowed"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/InvalidManagedModelRuleIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
 
     def "provides a useful error message when setting an incompatible type on a managed instance in Groovy"() {
@@ -135,7 +136,6 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Only managed model instances can be set as property 'operatingSystem' of class 'Platform'")
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot use value type as subject of void model rule"() {
         when:
         buildScript '''
@@ -155,7 +155,6 @@ class InvalidManagedModelRuleIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("A model element of type: 'java.lang.String' can not be constructed.")
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot use unknown type as subject of void model rule"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelGroovyScalarConfigurationIntegrationTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
 import static org.hamcrest.CoreMatchers.containsString
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedModelGroovyScalarConfigurationIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String CLASSES = '''
@@ -260,7 +261,6 @@ The following types/formats are supported:
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     void 'non-primitive types can accept null values'() {
         when:
         buildFile << CLASSES
@@ -322,7 +322,6 @@ The following types/formats are supported:
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     void 'boolean types are only true for the literal string "true"'() {
         when:
         buildFile << CLASSES
@@ -347,7 +346,6 @@ The following types/formats are supported:
         'false' | false
     }
 
-    @ToBeFixedForInstantExecution
     void 'can convert CharSequence to any scalar type'() {
         when:
         buildFile << CLASSES
@@ -406,7 +404,6 @@ The following types/formats are supported:
         output.contains 'prop theThing     : NOT_A_TOASTER'
     }
 
-    @ToBeFixedForInstantExecution
     void 'scalar conversion works from a Groovy RuleSource'() {
         when:
         buildFile << CLASSES
@@ -433,7 +430,6 @@ The following types/formats are supported:
         output.contains 'prop theThing     : null'
     }
 
-    @ToBeFixedForInstantExecution
     void 'can convert CharSequence to File'() {
         when:
         buildFile << '''
@@ -514,7 +510,6 @@ The following types/formats are supported:
         output.contains '4: true'
     }
 
-    @ToBeFixedForInstantExecution
     void 'CharSequence to File error cases'() {
         given:
         String model = '''
@@ -566,7 +561,6 @@ The following types/formats are supported:
   - A File'''))
     }
 
-    @ToBeFixedForInstantExecution
     void 'can convert CharSequence to File for multi-project build'() {
 
         given:

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelMapIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelMapIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "rule can create a map of model elements"() {
         when:
         buildScript '''
@@ -73,7 +73,6 @@ class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
         output.contains "things: a:1,b:2"
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can create a map of abstract class backed managed model elements"() {
         when:
         buildScript '''
@@ -126,7 +125,6 @@ class ManagedModelMapIntegrationTest extends AbstractIntegrationSpec {
         output.contains "things: a:1,b:2"
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can create a map of various supported types"() {
         // TODO - can't actually add anything to these maps yet
         when:
@@ -338,7 +336,6 @@ A managed collection can not contain 'java.io.InputStream's""")
         failure.assertHasCause("Attempt to modify a read only view of model element 'people' of type 'ModelMap<Person>' given to rule RulePlugin#check(ModelMap<Person>)")
     }
 
-    @ToBeFixedForInstantExecution
     def "can read children of map when used as input"() {
         when:
         buildScript """
@@ -447,7 +444,6 @@ parent
         output.contains("size: 1")
     }
 
-    @ToBeFixedForInstantExecution
     def "name is not populated when entity is not named"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelPropertyTargetingRuleIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedModelPropertyTargetingRuleIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "rule can target nested element of managed element as input"() {
         when:
         buildScript '''
@@ -82,7 +82,6 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
         output.contains("script name: windows 10")
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can target nested element of managed element as subject"() {
         when:
         buildScript '''
@@ -144,7 +143,6 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
         output.contains("script name: foo os")
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can target managed element as input through a reference"() {
         when:
         buildScript '''
@@ -206,7 +204,6 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
         output.contains("script name: windows 10")
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can target nested element of managed element as input through a reference to managed element"() {
         when:
         buildScript '''
@@ -273,7 +270,6 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
         output.contains("script name: windows 10")
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can target managed element via a series of references"() {
         when:
         buildScript '''
@@ -346,7 +342,6 @@ class ManagedModelPropertyTargetingRuleIntegrationTest extends AbstractIntegrati
         output.contains("script name: windows 10")
     }
 
-    @ToBeFixedForInstantExecution
     def "target of reference is realized when used as an input"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedScalarCollectionsIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedScalarCollectionsIntegrationTest extends AbstractIntegrationSpec {
 
     private final static List<String> MANAGED_SCALAR_COLLECTION_TYPES = ['List', 'Set']

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeImplementationClassCachingSpec.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeImplementationClassCachingSpec.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedTypeImplementationClassCachingSpec extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "managed type implementation class is generated once for each type and reused"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeReferencesIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeReferencesIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedTypeReferencesIntegrationTest extends AbstractIntegrationSpec {
-    @ToBeFixedForInstantExecution
+
     def "rule can provide a managed model element that references another managed model element"() {
         when:
         buildScript '''
@@ -92,7 +93,6 @@ class ManagedTypeReferencesIntegrationTest extends AbstractIntegrationSpec {
         output.contains("platform name: windows")
     }
 
-    @ToBeFixedForInstantExecution
     def "reference can have null value when parent model element is realized"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeWithUnmanagedPropertiesIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ManagedTypeWithUnmanagedPropertiesIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedTypeWithUnmanagedPropertiesIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "can have unmanaged property of unsupported types"() {
         when:
         buildScript '''
@@ -124,7 +124,6 @@ class ManagedTypeWithUnmanagedPropertiesIntegrationTest extends AbstractIntegrat
         output.contains("fromScript: foo")
     }
 
-    @ToBeFixedForInstantExecution
     def "can view unmanaged property as ModelElement"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ModelSetIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ModelSetIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "provides basic meta-data for set"() {
         when:
         buildScript '''
@@ -60,7 +60,6 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains "to-string: ModelSet<Person> 'people'"
     }
 
-    @ToBeFixedForInstantExecution
     def "can view as ModelElement"() {
         when:
         buildScript '''
@@ -97,7 +96,6 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains "to-string: ModelSet<Person> 'people'"
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can create a managed collection of interface backed managed model elements"() {
         when:
         buildScript '''
@@ -156,7 +154,6 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains 'names: p0, p1, p2, p3, p4'
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can create a managed collection of abstract class backed managed model elements"() {
         when:
         buildScript '''
@@ -196,7 +193,6 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains 'people: p1, p2'
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can create a set of various supported types"() {
         when:
         buildScript '''
@@ -264,7 +260,6 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains "setStrings: [[a], [b]]"
     }
 
-    @ToBeFixedForInstantExecution
     def "managed model type has property of collection of managed types"() {
         when:
         buildScript '''
@@ -316,7 +311,6 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains 'Women in computing: Ada Lovelace, Grace Hooper'
     }
 
-    @ToBeFixedForInstantExecution
     def "managed model cannot have a reference to a model set"() {
         when:
         buildScript '''
@@ -353,7 +347,6 @@ class ModelSetIntegrationTest extends AbstractIntegrationSpec {
 - Property 'members' is not valid: it cannot have a setter (ModelSet properties must be read only)"""
     }
 
-    @ToBeFixedForInstantExecution
     def "rule method can apply defaults to a managed set"() {
         when:
         buildScript '''
@@ -407,7 +400,6 @@ finalize
 '''
     }
 
-    @ToBeFixedForInstantExecution
     def "creation and configuration of managed set elements is deferred until required"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/NestedManagedTypeIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/NestedManagedTypeIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class NestedManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "rule can provide a managed model tree"() {
         when:
         buildScript '''
@@ -94,7 +94,6 @@ class NestedManagedTypeIntegrationTest extends AbstractIntegrationSpec {
         output.contains("platform name: windows 8.1")
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can apply defaults to a nested managed model element"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/PolymorphicManagedTypeIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/PolymorphicManagedTypeIntegrationTest.groovy
@@ -17,11 +17,11 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "rule can provide a managed model element backed by an abstract class that implements interfaces"() {
         when:
         buildScript '''
@@ -61,7 +61,6 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
         output.contains("name: foo")
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can provide a managed model element backed by an abstract class that extends other classes"() {
         when:
         buildScript '''
@@ -101,7 +100,6 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
         output.contains("name: foo")
     }
 
-    @ToBeFixedForInstantExecution
     def "managed model interface can extend other interface"() {
         when:
         buildScript '''
@@ -144,7 +142,6 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
         output.contains("name: name, value: value")
     }
 
-    @ToBeFixedForInstantExecution
     def "can depend on managed super type as input and subject"() {
         when:
         buildScript '''
@@ -188,7 +185,6 @@ class PolymorphicManagedTypeIntegrationTest extends AbstractIntegrationSpec {
         output.contains("name: superclass")
     }
 
-    @ToBeFixedForInstantExecution
     def "two managed types can extend the same parent"() {
         when:
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.model.managed
 
 import org.gradle.api.artifacts.Configuration
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "values of primitive types and boxed primitive types are widened as usual when using groovy"() {
         when:
         buildScript '''
@@ -61,7 +61,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "can view property with scalar type as ModelElement"() {
         given:
         buildScript '''
@@ -132,7 +131,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 - Method setLongProperty(long) is not a valid method: it should take parameter with type 'Long'"""
     }
 
-    @ToBeFixedForInstantExecution
     def "values of primitive types are boxed as usual when using java"() {
         when:
         file('buildSrc/src/main/java/Rules.java') << '''
@@ -186,7 +184,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
         succeeds "check"
     }
 
-    @ToBeFixedForInstantExecution
     def "can set/get properties of all supported scalar types using Groovy"() {
         when:
         buildScript '''
@@ -273,7 +270,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
         succeeds "check"
     }
 
-    @ToBeFixedForInstantExecution
     def "can set/get properties of all supported scalar types using Java"() {
         given:
         file('buildSrc/src/main/java/Rules.java') << '''
@@ -397,7 +393,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
         succeeds "model"
     }
 
-    @ToBeFixedForInstantExecution
     def "can read and write to managed property of scalar type when using Groovy"() {
         given:
         def i = 0
@@ -466,7 +461,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "can read and write to managed property of scalar type when using Java"() {
         given:
         def i = 0
@@ -546,7 +540,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot mutate managed property of scalar type when view is immutable"() {
         given:
         def i = 0
@@ -621,7 +614,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "read-only backing set preserves order of insertion"() {
         given: "a managed type that uses a Set of strings"
         buildScript '''
@@ -660,7 +652,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "read-write backing set preserves order of insertion"() {
         given: "a managed type that uses a read-write Set of strings"
         buildScript '''
@@ -701,7 +692,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "read-write backing set retains null value"() {
         buildScript '''
             @Managed
@@ -734,7 +724,6 @@ class ScalarTypesInManagedModelIntegrationTest extends AbstractIntegrationSpec {
         succeeds 'check'
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot mutate read-write scalar collection when not target of a rule"() {
         given: "a managed type that uses a read-write Set of strings"
         buildScript '''

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/UnmanagedCollectionPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/model/managed/UnmanagedCollectionPropertyIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model.managed
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class UnmanagedCollectionPropertyIntegrationTest extends AbstractIntegrationSpec {
 
     def "managed type can have unmanaged properties of collection type with types that are not scalar types"() {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ManagedTypeDslIntegrationTest.groovy
@@ -17,10 +17,11 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ManagedTypeDslIntegrationTest extends AbstractIntegrationSpec {
-    @ToBeFixedForInstantExecution
+
     def "can configure a child of a managed type using a nested closure syntax"() {
         buildFile << '''
 @Managed interface Person extends Named {
@@ -59,7 +60,6 @@ model {
         output.contains("barry lives in Melbourne")
     }
 
-    @ToBeFixedForInstantExecution
     def "can use convenience methods to configure property of scalar type"() {
         buildFile << '''
 @Managed interface Thing {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslCreationIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslCreationIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelDslCreationIntegrationTest extends AbstractIntegrationSpec {
 
     def "can create and initialize elements"() {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelDslIntegrationTest.groovy
@@ -17,12 +17,14 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
 /**
  * Tests the fundamental usages of the model dsl.
  *
  * Boundary tests for the transform and specialised cases should go in other dedicated test classes.
  */
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelDslIntegrationTest extends AbstractIntegrationSpec {
 
     def "can reference rule inputs using dollar method syntax"() {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.model.dsl
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelMapDslIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << '''
@@ -291,7 +292,6 @@ model {
         succeeds "model"
     }
 
-    @ToBeFixedForInstantExecution
     def "can create and configure elements dynamically"() {
         buildFile << '''
 model {
@@ -325,7 +325,6 @@ model {
         outputContains("value = [[a:foo], [b:foo], [c:foo], foo]")
     }
 
-    @ToBeFixedForInstantExecution
     def "can create and configure elements conditionally"() {
         buildFile << '''
 model {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
@@ -17,15 +17,15 @@
 package org.gradle.model.dsl.internal.transform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
 import static org.hamcrest.CoreMatchers.containsString
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "rules are detected when model path is a straight property reference chain - #path"() {
         given:
         def normalisedPath = path.replace('"', '').replaceAll("'", "")

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleInputDetectionIntegrationSpec.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleInputDetectionIntegrationSpec.groovy
@@ -17,11 +17,12 @@
 package org.gradle.model.dsl.internal.transform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
 import static org.hamcrest.CoreMatchers.containsString
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ModelDslRuleInputDetectionIntegrationSpec extends AbstractIntegrationSpec {
 
     @Unroll
@@ -145,7 +146,6 @@ class ModelDslRuleInputDetectionIntegrationSpec extends AbstractIntegrationSpec 
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "input reference can be used as expression statement - #syntax"() {
         when:
         buildScript """
@@ -207,7 +207,6 @@ tasks configured
         ]
     }
 
-    @ToBeFixedForInstantExecution
     def "path for dollar var expression ends with first non-property reference"() {
         when:
         buildScript '''
@@ -266,7 +265,6 @@ tasks configured
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "dollar method is only detected with no explicit receiver - #code"() {
         when:
         buildScript """
@@ -300,7 +298,6 @@ tasks configured
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "dollar var is only detected with no explicit receiver - #code"() {
         when:
         buildScript """
@@ -428,7 +425,6 @@ cl.call()
         failure.assertThatCause(containsString("Model element name ' bar' has illegal first character ' ' (names must start with an ASCII letter or underscore)."))
     }
 
-    @ToBeFixedForInstantExecution
     def "location and suggestions are provided for unbound rule subject specified using a name"() {
         given:
         buildScript '''
@@ -477,7 +473,6 @@ cl.call()
 ''')
     }
 
-    @ToBeFixedForInstantExecution
     def "location and suggestions are provided for unbound rule inputs specified using a name"() {
         given:
         buildScript '''
@@ -521,7 +516,6 @@ cl.call()
     }
 
     // This is temporary. Will be closed once more progress on DSL has been made
-    @ToBeFixedForInstantExecution
     def "can access project and script from rule"() {
         when:
         buildScript """

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/NestedModelDslUsageIntegrationSpec.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/NestedModelDslUsageIntegrationSpec.groovy
@@ -17,11 +17,13 @@
 package org.gradle.model.dsl.internal.transform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.model.dsl.internal.NonTransformedModelDslBacking
 import spock.lang.Unroll
 
 import static org.hamcrest.CoreMatchers.containsString
 
+@UnsupportedWithInstantExecution(because = "software model")
 class NestedModelDslUsageIntegrationSpec extends AbstractIntegrationSpec {
 
     @Unroll

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/NestedModelRuleDslDetectionIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/NestedModelRuleDslDetectionIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.model.dsl.internal.transform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class NestedModelRuleDslDetectionIntegrationTest extends AbstractIntegrationSpec {
     def "rules can contain arbitrary code that includes closures that look like nested rules"() {
         buildFile << '''

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/AutoTestedSamplePlatformBaseIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/AutoTestedSamplePlatformBaseIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.junit.Test
 
+@UnsupportedWithInstantExecution(because = "software model")
 class AutoTestedSamplePlatformBaseIntegrationTest extends AbstractAutoTestedSamplesTest {
     @Test
     void runSamples() {

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/BaseModelIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/BaseModelIntegrationTest.groovy
@@ -18,12 +18,14 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.platform.base.ApplicationSpec
 import org.gradle.platform.base.ComponentSpec
 import org.gradle.platform.base.GeneralComponentSpec
 import org.gradle.platform.base.LibrarySpec
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class BaseModelIntegrationTest extends AbstractIntegrationSpec {
     def "empty containers are visible in model report"() {
         buildFile << """

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/BinariesLifecycleTaskIntegrationTest.groovy
@@ -17,9 +17,10 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.internal.logging.text.DiagnosticsVisitor
 
+@UnsupportedWithInstantExecution(because = "software model")
 class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         settingsFile << """rootProject.name = 'assemble-binary'"""
@@ -60,7 +61,6 @@ class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-    @ToBeFixedForInstantExecution
     def "produces sensible error when there are component binaries and all are not buildable" () {
         withLibBinaries("notBuildableBinary1", "notBuildableBinary2")
         withStandaloneBinaries("ignoreMe")
@@ -93,7 +93,6 @@ class BinariesLifecycleTaskIntegrationTest extends AbstractIntegrationSpec {
         result.assertTasksExecuted(":libBuildableBinary1", ":libBuildableBinary2", ":assemble", ":check", ":build")
     }
 
-    @ToBeFixedForInstantExecution
     def "does not produce error when assemble task has other dependencies" () {
         withLibBinaries("notBuildableBinary")
         buildFile << """

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinariesIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ComponentBinariesIntegrationTest extends AbstractComponentModelIntegrationTest {
     def setup() {
         withCustomComponentType()
@@ -141,7 +142,6 @@ model {
         failure.assertHasCause("Cannot create 'binaries.mylibMain' using creation rule 'mylibMain(CustomBinary) { ... } @ build.gradle line 55, column 9' as the rule 'ComponentModelBasePlugin.PluginRules#collectBinaries(BinaryContainer, ComponentSpecContainer) > put()' is already registered to create this model element.")
     }
 
-    @ToBeFixedForInstantExecution
     def "binaries of a component can be configured using a rule attached to the top level binaries container"() {
         given:
         buildFile << '''

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinarySourcesIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentBinarySourcesIntegrationTest.groovy
@@ -18,8 +18,9 @@ package org.gradle.language.base
 
 import groovy.transform.NotYetImplemented
 import org.gradle.api.reporting.model.ModelReportOutput
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ComponentBinarySourcesIntegrationTest extends AbstractComponentModelIntegrationTest {
     def setup() {
         withCustomComponentType()
@@ -40,7 +41,6 @@ model {
 '''
     }
 
-    @ToBeFixedForInstantExecution
     def "input source sets of binary is union of component source sets and binary specific source sets"() {
         given:
         buildFile << '''
@@ -110,7 +110,6 @@ model {
         succeeds "verify"
     }
 
-    @ToBeFixedForInstantExecution
     def "source sets can be added to the binaries of a component using a rule applied to all components"() {
         given:
         buildFile << '''
@@ -144,7 +143,6 @@ model {
         succeeds "verify"
     }
 
-    @ToBeFixedForInstantExecution
     def "can reference sources container for a binary from a rule"() {
         given:
         buildFile << '''
@@ -236,7 +234,6 @@ model {
         }
     }
 
-    @ToBeFixedForInstantExecution
     def "elements of binary sources container can be referenced in a rule"() {
         given:
         buildFile << '''

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.platform.base.ApplicationSpec
 import org.gradle.platform.base.BinarySpec
 import org.gradle.platform.base.ComponentSpec
@@ -28,6 +29,7 @@ import spock.lang.Unroll
 
 import static org.gradle.util.Matchers.containsText
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ComponentModelIntegrationTest extends AbstractComponentModelIntegrationTest {
 
     def "setup"() {

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
 
     def "model report for unmanaged software components shows them all"() {

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentSourcesIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentSourcesIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ComponentSourcesIntegrationTest extends AbstractComponentModelIntegrationTest {
 
     def "setup"() {
@@ -47,7 +48,6 @@ class ComponentSourcesIntegrationTest extends AbstractComponentModelIntegrationT
         """
     }
 
-    @ToBeFixedForInstantExecution
     def "can reference sources container for a component in a rule"() {
         given:
         withMainSourceSet()
@@ -124,7 +124,6 @@ class ComponentSourcesIntegrationTest extends AbstractComponentModelIntegrationT
         }
     }
 
-    @ToBeFixedForInstantExecution
     def "can reference sources container elements in a rule"() {
         given:
         withMainSourceSet()
@@ -148,7 +147,6 @@ class ComponentSourcesIntegrationTest extends AbstractComponentModelIntegrationT
         output.contains "sources display name: Custom source 'main:someLang'"
     }
 
-    @ToBeFixedForInstantExecution
     def "can reference sources container elements using specialized type in a rule"() {
         given:
         withMainSourceSet()

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentTypeSampleIntegTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentTypeSampleIntegTest.groovy
@@ -17,14 +17,14 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.junit.Rule
 
+@UnsupportedWithInstantExecution(because = "software model")
 class ComponentTypeSampleIntegTest extends AbstractIntegrationSpec {
     @Rule Sample componentTypeSample = new Sample(temporaryFolder, "customModel/componentType")
 
-    @ToBeFixedForInstantExecution
     def "can create custom component with binaries"() {
         given:
         sample componentTypeSample

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomBinaryIntegrationTest extends AbstractIntegrationSpec {
     def "setup"() {
         buildFile << """
@@ -29,7 +30,6 @@ class CustomBinaryIntegrationTest extends AbstractIntegrationSpec {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "custom binary type can be registered and created"() {
         when:
         buildWithCustomBinaryPlugin()
@@ -56,7 +56,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "custom binary type can viewed as ModelElement"() {
         when:
         buildWithCustomBinaryPlugin()
@@ -82,7 +81,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "can configure binary defined by rule method using rule DSL"() {
         when:
         buildWithCustomBinaryPlugin()
@@ -123,7 +121,6 @@ model {
         succeeds "sampleBinary"
     }
 
-    @ToBeFixedForInstantExecution
     def "can register custom binary model without creating"() {
         when:
         buildFile << '''
@@ -155,7 +152,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "can have binary declaration and creation in separate plugins"() {
         when:
         buildFile << '''
@@ -203,7 +199,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "can define and create multiple binary types in the same plugin"() {
         when:
         buildFile << '''

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryInternalViewsIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryInternalViewsIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomBinaryInternalViewsIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         executer.expectDocumentedDeprecationWarning("The jvm-component plugin has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
@@ -239,7 +240,6 @@ class CustomBinaryInternalViewsIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause "Factory registration for 'SampleBinarySpec' is invalid because the implementation type 'DefaultSampleBinarySpec' does not implement internal view 'NotImplementedInternalView', implementation type was registered by RegisterBinaryRules#registerBinary(TypeBuilder<SampleBinarySpec>), internal view was registered by RegisterBinaryRules#registerInternalView(TypeBuilder<SampleBinarySpec>)"
     }
 
-    @ToBeFixedForInstantExecution
     def "can register managed internal view for JarBinarySpec"() {
         buildFile << """
             @Managed

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryTasksIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomBinaryTasksIntegrationTest.groovy
@@ -18,9 +18,10 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec {
 
     def "setup"() {
@@ -97,7 +98,6 @@ class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec {
         tasksNode.sampleLibBinaryOneTask.@type[0] == 'org.gradle.api.DefaultTask'
     }
 
-    @ToBeFixedForInstantExecution
     def "can reference rule-added tasks in model"() {
         given:
         buildFile << '''
@@ -125,7 +125,6 @@ class CustomBinaryTasksIntegrationTest extends AbstractIntegrationSpec {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "rule can declare task with type"() {
         given:
         buildFile << """

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesIntegrationTest.groovy
@@ -18,9 +18,10 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec {
 
     def "setup"() {
@@ -98,7 +99,6 @@ class CustomComponentBinariesIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @ToBeFixedForInstantExecution
     def "can register binaries using @ComponentBinaries rule"() {
         when:
         buildFile << withSimpleComponentBinaries()
@@ -148,7 +148,6 @@ Binaries
 """)
     }
 
-    @ToBeFixedForInstantExecution
     def "links components sourceSets to binaries"() {
         when:
         buildFile << withSimpleComponentBinaries()
@@ -187,7 +186,6 @@ Binaries
         "assemble"        | "assemble task"
     }
 
-    @ToBeFixedForInstantExecution
     def "can access lifecycle task of binary via BinarySpec.buildTask"(){
         when:
         buildFile << withSimpleComponentBinaries()

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesWithComponentReferenceIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentBinariesWithComponentReferenceIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import spock.lang.Issue
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomComponentBinariesWithComponentReferenceIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue("https://issues.gradle.org/browse/GRADLE-3422")

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentIntegrationTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.language.base
 
 import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.platform.base.ApplicationSpec
 import org.gradle.platform.base.ComponentSpec
 import org.gradle.platform.base.GeneralComponentSpec
@@ -26,6 +26,7 @@ import org.gradle.platform.base.LibrarySpec
 import org.gradle.platform.base.SourceComponentSpec
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomComponentIntegrationTest extends AbstractIntegrationSpec {
     @Unroll
     def "can declare custom managed #componentSpecType"() {
@@ -113,7 +114,6 @@ class CustomComponentIntegrationTest extends AbstractIntegrationSpec {
         succeeds "model"
     }
 
-    @ToBeFixedForInstantExecution
     def "can view a component as a ModelElement"() {
         buildFile << """
             @Managed

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentInternalViewsIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentInternalViewsIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomComponentInternalViewsIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         executer.expectDocumentedDeprecationWarning("The jvm-component plugin has been deprecated. This is scheduled to be removed in Gradle 7.0. " +

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentPluginIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomComponentPluginIntegrationTest extends AbstractIntegrationSpec {
     def "setup"() {
         buildFile << """
@@ -30,7 +31,6 @@ interface SampleComponent extends ComponentSpec {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "plugin declares custom component"() {
         when:
         buildWithCustomComponentPlugin()
@@ -57,7 +57,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "can configure component declared by model rule method using model rules DSL"() {
         when:
         buildWithCustomComponentPlugin()
@@ -84,7 +83,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "can configure component declared by model rule DSL using model rule method"() {
         when:
         buildFile << """
@@ -123,7 +121,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "can register custom component model without creating"() {
         when:
         buildFile << '''
@@ -172,7 +169,6 @@ Note: currently not all plugins register their components, so some components ma
 BUILD SUCCESSFUL"""
     }
 
-    @ToBeFixedForInstantExecution
     def "can have component declaration and creation in separate plugins"() {
         when:
         buildFile << '''
@@ -217,7 +213,6 @@ BUILD SUCCESSFUL"""
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "Can define and create multiple component types in the same plugin"(){
         when:
         buildFile << '''

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentSourceSetIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomComponentSourceSetIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomComponentSourceSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "setup"() {
@@ -47,7 +48,6 @@ class CustomComponentSourceSetIntegrationTest extends AbstractIntegrationSpec {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "source order is retained"() {
         buildFile << '''
 class Dump extends RuleSource {

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/CustomManagedBinaryIntegrationTest.groovy
@@ -17,8 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomManagedBinaryIntegrationTest extends AbstractIntegrationSpec {
     def "setup"() {
         buildFile << """
@@ -30,7 +31,6 @@ interface SampleBinary extends BinarySpec {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "custom managed binary type can be registered and created"() {
         when:
         buildWithCustomBinaryPlugin()
@@ -56,7 +56,6 @@ model {
         succeeds "checkModel"
     }
 
-    @ToBeFixedForInstantExecution
     def "can configure managed binary defined by rule method using rule DSL"() {
         when:
         buildWithCustomBinaryPlugin()

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/FunctionalSourceSetIntegrationTest.groovy
@@ -19,13 +19,13 @@ package org.gradle.language.base
 import groovy.transform.NotYetImplemented
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 
+@UnsupportedWithInstantExecution(because = "software model")
 class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForInstantExecution
     def "can create a top level functional source set with a rule"() {
         buildScript """
         apply plugin: 'language-base'
@@ -55,7 +55,6 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains("to-string: FunctionalSourceSet 'fss'")
     }
 
-    @ToBeFixedForInstantExecution
     def "can view a functional source set as a ModelElement"() {
         buildScript """
         apply plugin: 'language-base'
@@ -193,7 +192,6 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         buildType.testSources."0".@creator[0] == 'Rules#addSources(BuildType) > create()'
     }
 
-    @ToBeFixedForInstantExecution
     def "can register a language source set"() {
         buildScript """
         apply plugin: 'language-base'
@@ -216,7 +214,6 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         normaliseFileSeparators(output).contains("source dirs: [${normaliseFileSeparators(testDirectory.path)}/src/main/myJavaSourceSet]")
     }
 
-    @ToBeFixedForInstantExecution
     def "non-component language source sets are not added to the project source set"() {
         buildFile << """
         ${registerJavaLanguage()}
@@ -246,7 +243,6 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "can reference sourceSet elements in a rule"() {
         given:
         buildFile << registerJavaLanguage()
@@ -277,7 +273,6 @@ class FunctionalSourceSetIntegrationTest extends AbstractIntegrationSpec {
         output.contains "sources display name: SomeJava source 'myJavaSourceSet'"
     }
 
-    @ToBeFixedForInstantExecution
     def "can reference sourceSet elements using specialized type in a rule"() {
         given:
         buildFile << registerJavaLanguage()

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 @Requires(TestPrecondition.ONLINE)
+@UnsupportedWithInstantExecution(because = "software model")
 class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     Sample internalViewsSample = new Sample(temporaryFolder, "customModel/internalViews")

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageSourceSetIntegrationTest.groovy
@@ -18,10 +18,11 @@ package org.gradle.language.base
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 
+@UnsupportedWithInstantExecution(because = "software model")
 class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
 
     def "can not create a top level LSS when the language base plugin has not been applied"() {
@@ -61,7 +62,6 @@ class LanguageSourceSetIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Cannot create an instance of type 'DefaultCustomSourceSet' as this type is not known. Known types: org.gradle.platform.base.ComponentSpec, CustomSourceSet, ${LanguageSourceSet.name}")
     }
 
-    @ToBeFixedForInstantExecution
     def "can create a top level LSS with a rule"() {
         buildScript """
         ${registerCustomLanguage()}

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class LanguageTypeIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.language.base
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 @Requires(TestPrecondition.ONLINE)
+@UnsupportedWithInstantExecution(because = "software model")
 class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     Sample languageTypeSample = new Sample(temporaryFolder, "customModel/languageType")

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/VariantAspectExtractionIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/VariantAspectExtractionIntegrationTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.language.base
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 
+@UnsupportedWithInstantExecution(because = "software model")
 class VariantAspectExtractionIntegrationTest extends AbstractIntegrationSpec {
     def "variant annotation on property with illegal type type raises error"() {
         buildFile << """

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/plugins/LanguageBasePluginIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/plugins/LanguageBasePluginIntegrationTest.groovy
@@ -15,7 +15,9 @@
  */
 package org.gradle.language.base.plugins
 
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 
+@UnsupportedWithInstantExecution(because = "software model")
 class LanguageBasePluginIntegrationTest extends WellBehavedPluginTest {
 }

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/CustomJarBinarySpecSubtypeIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/CustomJarBinarySpecSubtypeIntegrationTest.groovy
@@ -18,8 +18,10 @@ package org.gradle.jvm
 
 import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.test.fixtures.archive.JarTestFixture
 
+@UnsupportedWithInstantExecution(because = "software model")
 class CustomJarBinarySpecSubtypeIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/JarBinariesIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/JarBinariesIntegrationTest.groovy
@@ -18,10 +18,11 @@ package org.gradle.jvm
 
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+@UnsupportedWithInstantExecution(because = "software model")
 class JarBinariesIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """
@@ -59,7 +60,6 @@ class JarBinariesIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Requires(TestPrecondition.JDK8_OR_EARLIER)
-    @ToBeFixedForInstantExecution
     def "assemble task produces sensible error when there are no buildable binaries" () {
         buildFile << """
             model {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/JdkDeclarationIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/JdkDeclarationIntegrationTest.groovy
@@ -20,10 +20,12 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.reporting.model.ModelReportOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.internal.jvm.JavaInfo
 import org.gradle.internal.jvm.Jvm
 import spock.lang.Unroll
 
+@UnsupportedWithInstantExecution(because = "software model")
 class JdkDeclarationIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/PlatformJvmComponentReportIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/PlatformJvmComponentReportIntegrationTest.groovy
@@ -16,9 +16,11 @@
 package org.gradle.jvm
 
 import org.gradle.api.reporting.components.AbstractComponentReportIntegrationTest
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+@UnsupportedWithInstantExecution(because = "software model")
 class PlatformJvmComponentReportIntegrationTest extends AbstractComponentReportIntegrationTest {
 
     def setup() {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/AutoTestedSamplePlatformJvmIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/AutoTestedSamplePlatformJvmIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.jvm.plugins
 
 import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.junit.Test
 
+@UnsupportedWithInstantExecution(because = "software model")
 class AutoTestedSamplePlatformJvmIntegrationTest extends AbstractAutoTestedSamplesTest {
     @Test
     void runSamples() {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/JvmComponentPluginGoodBehaviourTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/JvmComponentPluginGoodBehaviourTest.groovy
@@ -16,8 +16,10 @@
 
 package org.gradle.jvm.plugins
 
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 
+@UnsupportedWithInstantExecution(because = "software model")
 class JvmComponentPluginGoodBehaviourTest extends WellBehavedPluginTest {
 
     def setup() {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/JvmComponentPluginIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/plugins/JvmComponentPluginIntegrationTest.groovy
@@ -17,9 +17,10 @@
 package org.gradle.jvm.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import org.gradle.integtests.fixtures.UnsupportedWithInstantExecution
 import org.gradle.test.fixtures.archive.JarTestFixture
 
+@UnsupportedWithInstantExecution(because = "software model")
 class JvmComponentPluginIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
@@ -27,7 +28,6 @@ class JvmComponentPluginIntegrationTest extends AbstractIntegrationSpec {
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#upgrading_jvm_plugins")
     }
 
-    @ToBeFixedForInstantExecution
     def "does not create library or binaries when not configured"() {
         when:
         buildFile << '''
@@ -53,7 +53,6 @@ class JvmComponentPluginIntegrationTest extends AbstractIntegrationSpec {
         !file("build").exists()
     }
 
-    @ToBeFixedForInstantExecution
     def "defines jvm library and binary model objects and lifecycle task"() {
         when:
         buildFile << '''
@@ -178,7 +177,6 @@ class JvmComponentPluginIntegrationTest extends AbstractIntegrationSpec {
         file("build/bin/myJvmLibJar.bin").assertExists()
     }
 
-    @ToBeFixedForInstantExecution
     def "can specify additional builder tasks for binary"() {
         given:
         buildFile << '''
@@ -213,7 +211,6 @@ class JvmComponentPluginIntegrationTest extends AbstractIntegrationSpec {
         output.contains("Constructing Jar 'myJvmLib:jar'")
     }
 
-    @ToBeFixedForInstantExecution
     def "can define multiple jvm libraries in single project"() {
         when:
         buildFile << '''


### PR DESCRIPTION
Annotate all software model integration tests with `@UnsupportedWithInstantExecution` to reduce unnecessary noise when making changes and speed up CI a bit.