### PR TITLE
Some performance improvements writing to the instant execution cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
@@ -215,7 +215,6 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
         file('dest').assertHasDescendants('someDir/1.txt')
     }
 
-    @ToBeFixedForInstantExecution
     def "allows user to provide a custom resource for the tarTree"() {
         given:
         TestFile tar = file('tar-contents')

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -36,7 +36,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
             include "b"
             include "a:c"
         """
-        
+
         buildFile << """
             allprojects {
                 task otherTask
@@ -206,7 +206,6 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
         }
     }
 
-    @ToBeFixedForInstantExecution
     def "exposes plan details with nested artifact transforms"() {
         file('producer/src/main/java/artifact/transform/sample/producer/Producer.java') << """
             package artifact.transform.sample.producer;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/CachingTaskInputFileCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/CachingTaskInputFileCollection.java
@@ -38,14 +38,12 @@ import java.util.Collections;
  * TODO - keep the file entries to snapshot later, to avoid a stat on each file during snapshot
  */
 public class CachingTaskInputFileCollection extends DefaultConfigurableFileCollection implements LifecycleAwareValue {
-    private final Factory<PatternSet> patternSetFactory;
     private boolean canCache;
     private MinimalFileSet cachedValue;
 
     // TODO - display name
     public CachingTaskInputFileCollection(PathToFileResolver fileResolver, Factory<PatternSet> patternSetFactory, TaskDependencyFactory taskDependencyFactory) {
-        super(null, fileResolver, taskDependencyFactory, Collections.emptyList());
-        this.patternSetFactory = patternSetFactory;
+        super(null, fileResolver, taskDependencyFactory, patternSetFactory, Collections.emptyList());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecResolver.java
@@ -40,8 +40,14 @@ public interface CopySpecResolver {
 
     RelativePath getDestPath();
 
+    /**
+     * Returns the source files of this copy spec.
+     */
     FileTree getSource();
 
+    /**
+     * Returns the source files of this copy spec and all of its children.
+     */
     FileTree getAllSource();
 
     Collection<? extends Action<? super FileCopyDetails>> getAllCopyActions();

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -64,6 +64,7 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskStatistics;
 import org.gradle.api.internal.tasks.properties.TaskScheme;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.configuration.project.DefaultProjectConfigurationActionContainer;
@@ -315,9 +316,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultDomainObjectCollectionFactory(instantiatorFactory, services, collectionCallbackActionDecorator, MutationGuards.of(projectConfigurator));
     }
 
-    protected ManagedFactoryRegistry createManagedFactoryRegistry(ManagedFactoryRegistry parent, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory) {
+    protected ManagedFactoryRegistry createManagedFactoryRegistry(ManagedFactoryRegistry parent, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory) {
         return new DefaultManagedFactoryRegistry(parent).withFactories(
-            new ManagedFactories.ConfigurableFileCollectionManagedFactory(fileResolver, taskDependencyFactory),
+            new ManagedFactories.ConfigurableFileCollectionManagedFactory(fileResolver, taskDependencyFactory, patternSetFactory),
             new org.gradle.api.internal.file.ManagedFactories.RegularFilePropertyManagedFactory(fileResolver),
             new org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory(fileResolver, fileCollectionFactory),
             new org.gradle.api.internal.file.ManagedFactories.DirectoryPropertyManagedFactory(fileResolver, fileCollectionFactory)

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.internal.CacheFactory;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
@@ -31,6 +32,7 @@ import org.gradle.cache.internal.DefaultCacheFactory;
 import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
 import org.gradle.initialization.DefaultLegacyTypesSupport;
 import org.gradle.initialization.LegacyTypesSupport;
+import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.Deleter;
@@ -112,10 +114,10 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
         return new DefaultDeleter(clock::getCurrentTime, fileSystem::isSymlink, os.isWindows());
     }
 
-    ManagedFactoryRegistry createManagedFactoryRegistry(NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, InstantiatorFactory instantiatorFactory, TaskDependencyFactory taskDependencyFactory) {
+    ManagedFactoryRegistry createManagedFactoryRegistry(NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, InstantiatorFactory instantiatorFactory, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory) {
         return new DefaultManagedFactoryRegistry().withFactories(
             instantiatorFactory.getManagedFactory(),
-            new ConfigurableFileCollectionManagedFactory(fileResolver, taskDependencyFactory),
+            new ConfigurableFileCollectionManagedFactory(fileResolver, taskDependencyFactory, patternSetFactory),
             new RegularFileManagedFactory(),
             new RegularFilePropertyManagedFactory(fileResolver),
             new DirectoryManagedFactory(fileResolver, fileCollectionFactory),

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -162,9 +162,10 @@ class DefaultFileOperationsTest extends Specification {
     }
 
     def copiesFiles() {
+        def fileCollection = Mock(ConfigurableFileCollection)
         def fileTree = Mock(FileTreeInternal)
-        fileCollectionFactory.resolving({ it.contains('file') }) >> fileTree
-        fileTree.asFileTree >> fileTree
+        fileCollectionFactory.configurableFiles() >> fileCollection
+        fileCollection.asFileTree >> fileTree
         fileTree.matching(_) >> fileTree
         resolver.resolve('dir') >> tmpDir.getTestDirectory()
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.internal.Factory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -421,7 +422,7 @@ class DefaultSourceDirectorySetTest extends Specification {
     }
 
     FileCollection dir(String dirPath, Task builtBy) {
-        def collection = new DefaultConfigurableFileCollection(dirPath, resolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), [dirPath])
+        def collection = new DefaultConfigurableFileCollection(dirPath, resolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), Stub(Factory), [dirPath])
         collection.builtBy(builtBy)
         return collection
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyUnresolvedModuleIntegrationTest.groovy
@@ -85,7 +85,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "fails single application dependency resolution if #protocol connection exceeds timeout (retries = #maxRetries)"() {
         maxHttpRetries = maxRetries
 
@@ -115,7 +114,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "fails concurrent application dependency resolution if #protocol connection exceeds timeout"() {
         given:
         MavenHttpModule moduleB = publishMavenModule(mavenHttpRepo, 'b')
@@ -148,7 +146,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
         buildFile << """
             ${mavenRepository(mavenHttpRepo)}
             ${customConfigDependencyAssignment(moduleA)}
-            
+
             configurations {
                 first
                 second
@@ -159,7 +157,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
                 second '${mavenModuleCoordinates(moduleB)}'
                 third '${mavenModuleCoordinates(moduleC)}'
             }
-            
+
             task resolve {
                 doLast {
                     def filesA = configurations.first.resolvedConfiguration.lenientConfiguration.files*.name
@@ -233,7 +231,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "fails build and #abortDescriptor repository search if HTTP connection #reason when resolving metadata"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
@@ -267,7 +264,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "fails build and aborts repository search if HTTP connection #reason when resolving artifact for found module"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
@@ -297,7 +293,6 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "fails build and #abortDescriptor repository search if HTTP connection #reason when resolving dynamic version"() {
         given:
         MavenHttpRepository backupMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
@@ -343,7 +338,7 @@ class DependencyUnresolvedModuleIntegrationTest extends AbstractHttpDependencyRe
             configurations {
                 deps
             }
-            
+
             dependencies {
                 deps ${modules.collect { "'${it}'" }.join(', ')}
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/AbstractHttpsRepoResolveIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.http
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.AuthScheme
@@ -79,7 +78,6 @@ abstract class AbstractHttpsRepoResolveIntegrationTest extends AbstractHttpDepen
         file('libs').assertHasDescendants('my-module-1.0.jar')
     }
 
-    @ToBeFixedForInstantExecution
     def "decent error message when client can't authenticate server"() {
         keyStore = TestKeyStore.init(resources.dir)
         keyStore.enableSslWithServerCert(server)
@@ -96,7 +94,6 @@ abstract class AbstractHttpsRepoResolveIntegrationTest extends AbstractHttpDepen
         failure.assertThatCause(containsText("java.security.cert.CertPathValidatorException"))
     }
 
-    @ToBeFixedForInstantExecution
     def "build fails when server can't authenticate client"() {
         keyStore = TestKeyStore.init(resources.dir)
         keyStore.enableSslWithServerAndBadClientCert(server)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyComponentMetadataRulesStatusIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyComponentMetadataRulesStatusIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.integtests.resolve.ivy
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.integtests.resolve.rules.ComponentMetadataRulesStatusIntegrationTest
 import org.gradle.test.fixtures.server.http.IvyHttpRepository
 
@@ -61,14 +61,12 @@ dependencies {
         file('libs').assertHasDescendants('projectA-1.0.jar')
     }
 
-    @ToBeFixedForInstantExecution
     def "resolve fails if status doesn't match default status scheme"() {
         expect:
         fails 'resolve'
         failure.assertHasCause(/Unexpected status 'silver' specified for org.test:projectA:1.0. Expected one of: [integration, milestone, release]/)
     }
 
-    @ToBeFixedForInstantExecution
     def "resolve fails if status doesn't match custom status scheme"() {
         buildFile <<
                 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyFileRepoResolveIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class IvyFileRepoResolveIntegrationTest extends AbstractDependencyResolutionTest {
     @ToBeFixedForInstantExecution
-    public void "does not cache local artifacts or metadata"() {
+    void "does not cache local artifacts or metadata"() {
         given:
         def repo = ivyRepo()
         def moduleA = repo.module('group', 'projectA', '1.2')
@@ -64,7 +64,7 @@ task retrieve(type: Sync) {
     }
 
     @ToBeFixedForInstantExecution
-    public void "does not cache resolution of dynamic versions or changing modules"() {
+    void "does not cache resolution of dynamic versions or changing modules"() {
         def repo = ivyRepo()
 
         given:
@@ -126,7 +126,6 @@ task retrieve(type: Sync) {
         jarC1.assertHasChangedSince(jarCsnapshot)
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot define authentication for local file repo"() {
         given:
         def repo = ivyRepo()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyHttpRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyHttpRepoResolveIntegrationTest.groovy
@@ -33,7 +33,6 @@ class IvyHttpRepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveInte
         return server
     }
 
-    @ToBeFixedForInstantExecution
     void "fails when configured with AwsCredentials"() {
         given:
         def remoteIvyRepo = server.remoteIvyRepo
@@ -181,13 +180,13 @@ class IvyHttpRepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveInte
                 }
             }
             configurations { compile }
-            dependencies { 
-                compile ':name1:1.0' 
-                compile ':name1:1.0' 
-                compile ':name2:[1.0, 2.0]' 
+            dependencies {
+                compile ':name1:1.0'
+                compile ':name1:1.0'
+                compile ':name2:[1.0, 2.0]'
                 compile ':name3:1.0-SNAPSHOT'
                 compile 'group1::1.0'
-                compile 'group2::[1.0, 2.0]' 
+                compile 'group2::[1.0, 2.0]'
                 compile 'group3::1.0-SNAPSHOT'
                 compile 'group:name'
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -88,7 +88,6 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('projectA-1.2.jar', 'projectB-other-1.6.jar', 'projectD-1.0.jar')
     }
 
-    @ToBeFixedForInstantExecution
     def "fails when project dependency references a configuration that does not exist"() {
         ivyRepo.module('test', 'target', '1.0').publish()
 
@@ -113,7 +112,6 @@ task retrieve(type: Sync) {
         failure.assertHasCause("Project : declares a dependency from configuration 'compile' to configuration 'x86_windows' which is not declared in the descriptor for test:target:1.0.")
     }
 
-    @ToBeFixedForInstantExecution
     def "fails when ivy module references a configuration that does not exist"() {
         def b = ivyRepo.module('test', 'b', '1.0').publish()
         ivyRepo.module('test', 'a', '1.0')
@@ -289,15 +287,15 @@ task retrieve(type: Sync) {
         and:
         buildFile << """
 repositories {
-    ivy { 
-        url "${repo1.uri}" 
+    ivy {
+        url "${repo1.uri}"
         metadataSources {
             ivyDescriptor()
             artifact()
         }
     }
-    ivy { 
-        url "${repo2.uri}" 
+    ivy {
+        url "${repo2.uri}"
         metadataSources {
             ivyDescriptor()
             artifact()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenFileRepoResolveIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class MavenFileRepoResolveIntegrationTest extends AbstractDependencyResolutionTest {
     @ToBeFixedForInstantExecution
-    public void "can resolve snapshots uncached from local Maven repository"() {
+    void "can resolve snapshots uncached from local Maven repository"() {
         given:
         def moduleA = mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT')
         def moduleB = mavenRepo().module('group', 'projectB', '9.1')
@@ -58,7 +58,7 @@ task retrieve(type: Sync) {
     }
 
     @ToBeFixedForInstantExecution
-    public void "does not cache artifacts and metadata from local Maven repository"() {
+    void "does not cache artifacts and metadata from local Maven repository"() {
         given:
         def moduleA = mavenRepo().module('group', 'projectA', '1.2')
         def moduleB = mavenRepo().module('group', 'projectB', '9.1')
@@ -95,7 +95,7 @@ task retrieve(type: Sync) {
         buildDir.file('projectB-9.1.jar').assertIsCopyOf(moduleB.artifactFile)
     }
 
-    public void "uses artifactUrls to resolve artifacts"() {
+    void "uses artifactUrls to resolve artifacts"() {
         given:
         def moduleA = mavenRepo().module('group', 'projectA', '1.2')
         def moduleB = mavenRepo().module('group', 'projectB', '9.1')
@@ -137,7 +137,6 @@ task retrieve(type: Sync) {
         buildDir.file('projectB-9.1.jar').assertIsCopyOf(moduleB.artifactFile)
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot define authentication for local file repo"() {
         given:
         def repo = mavenRepo()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenHttpRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenHttpRepoResolveIntegrationTest.groovy
@@ -370,7 +370,6 @@ task listJars {
         file('libs/projectA-1.0.jar').assertHasNotChangedSince(snapshot)
     }
 
-    @ToBeFixedForInstantExecution
     void "fails when configured with AwsCredentials"() {
         given:
         mavenHttpRepo.module('group', 'projectA', '1.2').publish()
@@ -443,12 +442,12 @@ task listJars {
                 }
             }
             configurations { compile }
-            dependencies { 
-                compile ':name1:1.0' 
-                compile ':name2:[1.0, 2.0]' 
+            dependencies {
+                compile ':name1:1.0'
+                compile ':name2:[1.0, 2.0]'
                 compile ':name3:1.0-SNAPSHOT'
-                compile 'group1::1.0' 
-                compile 'group2::[1.0, 2.0]' 
+                compile 'group1::1.0'
+                compile 'group2::[1.0, 2.0]'
                 compile 'group3::1.0-SNAPSHOT'
                 compile 'group:name'
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLatestResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLatestResolveIntegrationTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Unroll
 
 class MavenLatestResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -54,7 +53,6 @@ class MavenLatestResolveIntegrationTest extends AbstractHttpDependencyResolution
         status << ["integration", "milestone", "release"]
     }
 
-    @ToBeFixedForInstantExecution
     def "latest selector with unknown status leads to failure"() {
         mavenRepo().module('group', 'projectA', '1.0').publish()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -158,7 +158,6 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
     }
 
     @Issue('GRADLE-2034')
-    @ToBeFixedForInstantExecution
     def "mavenLocal fails to resolve artifact if contains pom but not artifact"() {
         given:
         m2.mavenRepo().module('group', 'projectA', '1.2').publishPom()
@@ -247,7 +246,6 @@ Required by:
     }
 
     @Issue('GRADLE-2034')
-    @ToBeFixedForInstantExecution
     def "mavenLocal fails to resolve snapshot artifact if contains pom but not artifact"() {
         given:
         m2.mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT').publishPom()
@@ -275,7 +273,6 @@ Required by:
     }
 
     @Issue('GRADLE-2034')
-    @ToBeFixedForInstantExecution
     def "mavenLocal fails to resolve non-unique snapshot artifact if contains pom but not artifact"() {
         given:
         m2.mavenRepo().module('group', 'projectA', '1.2-SNAPSHOT').withNonUniqueSnapshots().publishPom()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenParentPomResolveIntegrationTest.groovy
@@ -207,7 +207,6 @@ task retrieve(type: Sync) {
         file('libs').assertHasDescendants('child-1.0.jar')
     }
 
-    @ToBeFixedForInstantExecution
     def "fails with reasonable message if parent module is an ivy module"() {
         given:
         def child = mavenHttpRepo.module("org", "child")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomPackagingResolveIntegrationTest.groovy
@@ -222,7 +222,6 @@ if (project.hasProperty('skipCache')) {
         succeeds 'retrieve'
     }
 
-    @ToBeFixedForInstantExecution
     def "fails and reports type-based location if neither packaging-based or type-based artifact can be located"() {
         when:
         buildWithDependencies("compile 'group:projectA:1.0'")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -110,7 +109,6 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
         file("compileClasspath").assertHasDescendants("artifactC-1.0.jar")
     }
 
-    @ToBeFixedForInstantExecution
     def "fails to resolve module if published artifact does not exist with relocated coordinates"() {
         given:
         def original = publishPomWithRelocation('groupA', 'artifactA', 'notExist', 'notExist')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -953,7 +953,6 @@ dependencies {
         file('libs').assertHasDescendants("projectA-1.0.jar")
     }
 
-    @ToBeFixedForInstantExecution
     def "reports failure to find a missing unique snapshot in a Maven HTTP repository"() {
         given:
         def projectA = createModule("org.gradle.integtests.resolve", "projectA", "1.0-SNAPSHOT")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -218,7 +218,6 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
-    @ToBeFixedForInstantExecution
     def "applies transforms to artifacts from local projects matching on implicit format attribute"() {
         given:
         buildFile << """
@@ -276,7 +275,6 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
-    @ToBeFixedForInstantExecution
     def "applies transforms to artifacts from local projects, files and external dependencies"() {
         def dependency = mavenRepo.module("test", "test-dependency", "1.3").publish()
         dependency.artifactFile.text = "dependency"
@@ -357,7 +355,6 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 7
     }
 
-    @ToBeFixedForInstantExecution
     def "applies transforms to artifacts from local projects matching on explicit format attribute"() {
         given:
         buildFile << """
@@ -516,7 +513,6 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
-    @ToBeFixedForInstantExecution
     def "applies transforms to artifacts from local projects matching on some variant attributes"() {
         given:
         buildFile << """
@@ -621,7 +617,6 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         output.count("Transforming") == 0
     }
 
-    @ToBeFixedForInstantExecution
     def "applies chain of transforms to artifacts from local projects matching on some variant attributes"() {
         given:
         buildFile << """
@@ -1517,7 +1512,6 @@ Found the following transforms:
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "user gets a reasonable error message when null is registered via outputs.#method"() {
         given:
         buildFile << """
@@ -1694,7 +1688,6 @@ Found the following transforms:
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "directories are not created for output #method which is part of the input"() {
         given:
         buildFile << """
@@ -1741,7 +1734,6 @@ Found the following transforms:
         method << ["file", "dir"]
     }
 
-    @ToBeFixedForInstantExecution
     def "user gets a reasonable error message when transform returns a file that is not part of the input artifact or in the output directory"() {
         given:
         buildFile << """
@@ -1774,7 +1766,6 @@ Found the following transforms:
         failure.assertHasCause("Transform output ${testDirectory.file('other.jar')} must be a part of the input artifact or refer to a relative path.")
     }
 
-    @ToBeFixedForInstantExecution
     def "user gets a reasonable error message when transform registers an output that is not part of the input artifact or in the output directory"() {
         given:
         buildFile << """
@@ -1815,7 +1806,6 @@ Found the following transforms:
         failure.assertHasCause("Transform output ${testDirectory.file('other.jar')} must be a part of the input artifact or refer to a relative path.")
     }
 
-    @ToBeFixedForInstantExecution
     def "user gets a reasonable error message when transform cannot be instantiated"() {
         given:
         buildFile << """
@@ -1973,7 +1963,6 @@ Found the following transforms:
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
     def "provides useful error message when parameter value cannot be isolated for #type transform"() {
         mavenRepo.module("test", "a", "1.3").publish()
         settingsFile << "include 'lib'"
@@ -2242,7 +2231,6 @@ Found the following transforms:
         }
     }
 
-    @ToBeFixedForInstantExecution
     def "notifies transform listeners and build operation listeners on failed execution"() {
         def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
@@ -2303,7 +2291,6 @@ Found the following transforms:
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6156")
-    @ToBeFixedForInstantExecution
     def "stops resolving dependencies of task when artifact transforms are encountered"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -212,7 +212,6 @@ allprojects {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "transform can access artifact dependencies as a set of files when using ArtifactView"() {
         given:
         setupBuildWithSingleStep()
@@ -270,7 +269,6 @@ project(':common') {
         )
     }
 
-    @ToBeFixedForInstantExecution
     def "transform can access artifact dependencies, in previous transform step, as set of files when using ArtifactView"() {
         given:
         setupBuildWithTwoSteps()
@@ -605,7 +603,6 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
         classpathAnnotation << [Classpath, CompileClasspath]
     }
 
-    @ToBeFixedForInstantExecution
     def "transforms with different dependencies in multiple dependency graphs are executed"() {
         given:
         withColorVariants(mavenHttpRepo.module("org.slf4j", "slf4j-api", "1.7.26")).publish().allowAll()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -26,7 +26,7 @@ import org.gradle.internal.DisplayName;
  */
 public interface ArtifactVisitor {
     /**
-     * Called prior to scheduling resolution of a set of artifacts.
+     * Called prior to scheduling resolution of a set of artifacts. Should be called in result order.
      */
     default FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         return FileCollectionStructureVisitor.VisitType.Visit;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactSet.java
@@ -70,7 +70,7 @@ public interface ResolvedArtifactSet extends TaskDependencyContainer {
      */
     interface AsyncArtifactListener {
         /**
-         * Called prior to scheduling resolution of a set of the given type.
+         * Called prior to scheduling resolution of a set of the given type. Should be called in result order.
          */
         FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source);
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTree.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.api.tasks.util.internal.PatternSets;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.MutableBoolean;
@@ -41,15 +40,12 @@ import java.util.Set;
 import static org.gradle.util.ConfigureUtil.configure;
 
 public abstract class AbstractFileTree extends AbstractFileCollection implements FileTreeInternal {
-
-    protected final Factory<PatternSet> patternSetFactory;
-
     public AbstractFileTree() {
-        this(PatternSets.getNonCachingPatternSetFactory());
+        super();
     }
 
     public AbstractFileTree(Factory<PatternSet> patternSetFactory) {
-        this.patternSetFactory = patternSetFactory;
+        super(patternSetFactory);
     }
 
     @Override
@@ -92,7 +88,7 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
     @Override
     public FileTree matching(PatternFilterable patterns) {
         PatternSet patternSet = (PatternSet) patterns;
-        return new FilteredFileTreeImpl(this, patternSet.getAsSpec());
+        return new FilteredFileTreeImpl(this, patternSet.getAsSpec(), patternSetFactory);
     }
 
     public Map<String, File> getAsMap() {
@@ -177,7 +173,8 @@ public abstract class AbstractFileTree extends AbstractFileCollection implements
         private final AbstractFileTree fileTree;
         private final Spec<FileTreeElement> spec;
 
-        public FilteredFileTreeImpl(AbstractFileTree fileTree, Spec<FileTreeElement> spec) {
+        public FilteredFileTreeImpl(AbstractFileTree fileTree, Spec<FileTreeElement> spec, Factory<PatternSet> patternSetFactory) {
+            super(patternSetFactory);
             this.fileTree = fileTree;
             this.spec = spec;
         }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -26,7 +26,8 @@ import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.util.internal.PatternSets;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -46,6 +47,13 @@ import java.util.Set;
  * <p>The dependencies of this collection are calculated from the result of calling {@link #visitDependencies(TaskDependencyResolveContext)}.</p>
  */
 public abstract class CompositeFileCollection extends AbstractFileCollection implements FileCollectionContainer, TaskDependencyContainer {
+    public CompositeFileCollection(Factory<PatternSet> patternSetFactory) {
+        super(patternSetFactory);
+    }
+
+    public CompositeFileCollection() {
+    }
+
     @Override
     public Set<File> getFiles() {
         return getFiles(getSourceCollections());
@@ -119,7 +127,7 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
 
     @Override
     public FileCollection filter(final Spec<? super File> filterSpec) {
-        return new CompositeFileCollection() {
+        return new CompositeFileCollection(patternSetFactory) {
             @Override
             public void visitContents(FileCollectionResolveContext context) {
                 for (FileCollection collection : CompositeFileCollection.this.getSourceCollections()) {
@@ -146,7 +154,7 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
     }
 
     protected List<? extends FileCollectionInternal> getSourceCollections() {
-        DefaultFileCollectionResolveContext context = new DefaultFileCollectionResolveContext(PatternSets.getNonCachingPatternSetFactory());
+        DefaultFileCollectionResolveContext context = new DefaultFileCollectionResolveContext(patternSetFactory);
         visitContents(context);
         return context.resolveAsFileCollections();
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.file;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.FileTree;
@@ -32,6 +34,7 @@ import org.gradle.api.internal.file.collections.UnpackingVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
@@ -45,7 +48,7 @@ import java.util.Set;
 public class DefaultFileCollectionFactory implements FileCollectionFactory {
     public static final String DEFAULT_COLLECTION_DISPLAY_NAME = "file collection";
     public static final String DEFAULT_TREE_DISPLAY_NAME = "file tree";
-    private static final EmptyFileCollection EMPTY = new EmptyFileCollection(DEFAULT_COLLECTION_DISPLAY_NAME);
+    private static final EmptyFileCollection EMPTY_COLLECTION = new EmptyFileCollection(DEFAULT_COLLECTION_DISPLAY_NAME);
     private final PathToFileResolver fileResolver;
     private final TaskDependencyFactory taskDependencyFactory;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
@@ -68,12 +71,12 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public ConfigurableFileCollection configurableFiles() {
-        return new DefaultConfigurableFileCollection(null, fileResolver, taskDependencyFactory, Collections.emptyList());
+        return new DefaultConfigurableFileCollection(null, fileResolver, taskDependencyFactory, patternSetFactory, Collections.emptyList());
     }
 
     @Override
     public ConfigurableFileCollection configurableFiles(String displayName) {
-        return new DefaultConfigurableFileCollection(displayName, fileResolver, taskDependencyFactory, Collections.emptyList());
+        return new DefaultConfigurableFileCollection(displayName, fileResolver, taskDependencyFactory, patternSetFactory, Collections.emptyList());
     }
 
     @Override
@@ -125,7 +128,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public FileCollectionInternal empty() {
-        return EMPTY;
+        return EMPTY_COLLECTION;
     }
 
     @Override
@@ -191,6 +194,21 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
         @Override
         public String getDisplayName() {
             return DEFAULT_TREE_DISPLAY_NAME;
+        }
+
+        @Override
+        public FileTree matching(Closure filterConfigClosure) {
+            return this;
+        }
+
+        @Override
+        public FileTree matching(Action<? super PatternFilterable> filterConfigAction) {
+            return this;
+        }
+
+        @Override
+        public FileTree matching(PatternFilterable patterns) {
+            return this;
         }
 
         @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionBackFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionBackFileTree.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
+import org.gradle.api.internal.file.collections.ResolvableFileCollectionResolveContext;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
+
+public class FileCollectionBackFileTree extends CompositeFileTree {
+    private final AbstractFileCollection collection;
+
+    public FileCollectionBackFileTree(Factory<PatternSet> patternSetFactory, AbstractFileCollection collection) {
+        super(patternSetFactory);
+        this.collection = collection;
+    }
+
+    public AbstractFileCollection getCollection() {
+        return collection;
+    }
+
+    @Override
+    public void visitContents(FileCollectionResolveContext context) {
+        ResolvableFileCollectionResolveContext nested = context.newContext();
+        nested.add(collection);
+        context.addAll(nested.resolveAsFileTrees());
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        context.add(collection);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return collection.getDisplayName();
+    }
+}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
@@ -43,6 +43,7 @@ public interface FileCollectionStructureVisitor {
      *
      * <p>Note that this method is not necessarily called immediately before one of the visit methods, as some collections may be
      * resolved in parallel. However, all visiting is performed sequentially and in order.
+     * This method is also called sequentially and in order.
      *
      * @return how should the collection be visited?
      */
@@ -51,12 +52,12 @@ public interface FileCollectionStructureVisitor {
     }
 
     /**
-     * Visits a {@link FileCollectionInternal} element that cannot be visited in further detail.
+     * Visits an opaque file collection element that cannot be visited in further detail.
      */
     void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents);
 
     /**
-     * Visits a {@link FileTreeInternal} that does not represents a directory in the file system.
+     * Visits an atomic and opaque {@link FileTreeInternal} that does not represents a directory in the file system.
      */
     void visitGenericFileTree(FileTreeInternal fileTree);
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FilteredFileTree.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.file.FileTree;
+import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
+import org.gradle.api.internal.file.collections.ResolvableFileCollectionResolveContext;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.api.tasks.util.PatternSet;
+
+import java.util.function.Supplier;
+
+public class FilteredFileTree extends CompositeFileTree implements FileCollectionInternal.Source {
+    private final CompositeFileTree tree;
+    private final Supplier<? extends PatternSet> patternSupplier;
+
+    public FilteredFileTree(CompositeFileTree tree, Supplier<? extends PatternSet> patternSupplier) {
+        super(tree.patternSetFactory);
+        this.tree = tree;
+        this.patternSupplier = patternSupplier;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return tree.getDisplayName();
+    }
+
+    public CompositeFileTree getTree() {
+        return tree;
+    }
+
+    /**
+     * The current set of patterns. Both the instance and the patterns it contains can change over time.
+     */
+    public PatternSet getPatterns() {
+        return patternSupplier.get();
+    }
+
+    @Override
+    public void visitContents(FileCollectionResolveContext context) {
+        // For backwards compatibility, need to calculate the patterns on each query
+        PatternFilterable patterns = getPatterns();
+        ResolvableFileCollectionResolveContext nestedContext = context.newContext();
+        tree.visitContents(nestedContext);
+        for (FileTree set : nestedContext.resolveAsFileTrees()) {
+            context.add(set.matching(patterns));
+        }
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        tree.visitDependencies(context);
+    }
+}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -22,7 +22,8 @@ import org.gradle.api.internal.provider.HasConfigurableValueInternal;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.api.tasks.util.internal.PatternSets;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.state.Managed;
@@ -51,7 +52,8 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     private State state = State.Mutable;
     private boolean disallowChanges;
 
-    public DefaultConfigurableFileCollection(@Nullable String displayName, PathToFileResolver fileResolver, TaskDependencyFactory dependencyFactory, Collection<?> files) {
+    public DefaultConfigurableFileCollection(@Nullable String displayName, PathToFileResolver fileResolver, TaskDependencyFactory dependencyFactory, Factory<PatternSet> patternSetFactory, Collection<?> files) {
+        super(patternSetFactory);
         this.displayName = displayName;
         this.resolver = fileResolver;
         this.files = new LinkedHashSet<>();
@@ -178,7 +180,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     }
 
     private void calculateFinalizedValue() {
-        DefaultFileCollectionResolveContext context = new DefaultFileCollectionResolveContext(PatternSets.getNonCachingPatternSetFactory());
+        DefaultFileCollectionResolveContext context = new DefaultFileCollectionResolveContext(patternSetFactory);
         UnpackingVisitor nested = new UnpackingVisitor(context, resolver);
         nested.add(files);
         files.clear();

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ManagedFactories.java
@@ -20,6 +20,8 @@ import com.google.common.base.Objects;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.state.ManagedFactory;
 
@@ -35,10 +37,12 @@ public class ManagedFactories {
 
         private final PathToFileResolver resolver;
         private final TaskDependencyFactory taskDependencyFactory;
+        private final Factory<PatternSet> patternSetFactory;
 
-        public ConfigurableFileCollectionManagedFactory(FileResolver resolver, TaskDependencyFactory taskDependencyFactory) {
+        public ConfigurableFileCollectionManagedFactory(FileResolver resolver, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory) {
             this.resolver = resolver;
             this.taskDependencyFactory = taskDependencyFactory;
+            this.patternSetFactory = patternSetFactory;
         }
 
         @Nullable
@@ -48,7 +52,7 @@ public class ManagedFactories {
                 return null;
             }
             // TODO - should retain display name
-            return type.cast(new DefaultConfigurableFileCollection(null, resolver, taskDependencyFactory, (Set<File>) state));
+            return type.cast(new DefaultConfigurableFileCollection(null, resolver, taskDependencyFactory, patternSetFactory, (Set<File>) state));
         }
 
         @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.internal.tasks.TaskDependencyFactory
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.internal.tasks.TaskResolver
+import org.gradle.internal.Factory
 
 import java.util.concurrent.Callable
 
@@ -32,16 +33,17 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
     def fileResolver = Mock(FileResolver)
     def taskResolver = Mock(TaskResolver)
+    def patternSetFactory = Mock(Factory)
     def taskDependencyFactory = Stub(TaskDependencyFactory) {
         _ * configurableDependency() >> new DefaultTaskDependency(taskResolver)
     }
-    def collection = new DefaultConfigurableFileCollection("<display>", fileResolver, taskDependencyFactory, [])
+    def collection = new DefaultConfigurableFileCollection("<display>", fileResolver, taskDependencyFactory, patternSetFactory, [])
 
     @Override
     AbstractFileCollection containing(File... files) {
         def resolver = Stub(FileResolver)
         _ * resolver.resolve(_) >> { File f -> f }
-        return new DefaultConfigurableFileCollection("<display>", resolver, taskDependencyFactory, files as List)
+        return new DefaultConfigurableFileCollection("<display>", resolver, taskDependencyFactory, patternSetFactory, files as List)
     }
 
     def resolvesSpecifiedFilesUsingFileResolver() {
@@ -50,7 +52,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         def file2 = new File("2")
 
         when:
-        DefaultConfigurableFileCollection collection = new DefaultConfigurableFileCollection("<display>", fileResolver, taskDependencyFactory, ["a", "b"])
+        def collection = new DefaultConfigurableFileCollection("<display>", fileResolver, taskDependencyFactory, patternSetFactory, ["a", "b"])
         def from = collection.from
         def files = collection.files
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -331,7 +331,8 @@ class DefaultInstantExecution internal constructor(
             actionScheme = service(),
             attributesFactory = service(),
             transformListener = service(),
-            valueSourceProviderFactory = service()
+            valueSourceProviderFactory = service(),
+            patternSetFactory = service()
         )
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -87,6 +87,10 @@ class DefaultInstantExecution internal constructor(
         !isInstantExecutionEnabled -> {
             false
         }
+        systemPropertyFlag(SystemProperties.recreateCache) -> {
+            log("Recreating instant execution cache")
+            false
+        }
         startParameter.isRefreshDependencies -> {
             log(
                 "Calculating task graph as instant execution cache cannot be reused due to {}",

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemProperties.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/SystemProperties.kt
@@ -27,4 +27,6 @@ object SystemProperties {
     const val maxProblems = "org.gradle.unsafe.instant-execution.max-problems"
 
     const val failOnProblems = "org.gradle.unsafe.instant-execution.fail-on-problems"
+
+    const val recreateCache = "org.gradle.unsafe.instant-execution.recreate-cache"
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -40,12 +40,14 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.util.PatternSet
 import org.gradle.api.tasks.util.internal.PatternSpecFactory
 import org.gradle.execution.plan.TaskNodeFactory
 import org.gradle.initialization.BuildRequestMetaData
 import org.gradle.instantexecution.serialization.ownerServiceCodec
 import org.gradle.instantexecution.serialization.reentrant
 import org.gradle.instantexecution.serialization.unsupported
+import org.gradle.internal.Factory
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
@@ -96,7 +98,8 @@ class Codecs(
     actionScheme: ArtifactTransformActionScheme,
     attributesFactory: ImmutableAttributesFactory,
     transformListener: ArtifactTransformListener,
-    valueSourceProviderFactory: ValueSourceProviderFactory
+    valueSourceProviderFactory: ValueSourceProviderFactory,
+    patternSetFactory: Factory<PatternSet>
 ) {
 
     val userTypesCodec = BindingsBackedCodec {
@@ -119,7 +122,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory)
 
         bind(ClosureCodec)
         bind(GroovyMetaClassCodec)
@@ -170,7 +173,7 @@ class Codecs(
         baseTypes()
 
         providerTypes(filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory)
 
         bind(TaskNodeCodec(projectStateRegistry, userTypesCodec, taskNodeFactory))
         bind(InitialTransformationNodeCodec(buildOperationExecutor, transformListener))
@@ -213,8 +216,8 @@ class Codecs(
     }
 
     private
-    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory) {
-        bind(FileTreeCodec(directoryFileTreeFactory))
+    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, patternSetFactory: Factory<PatternSet>) {
+        bind(FileTreeCodec(directoryFileTreeFactory, patternSetFactory))
         bind(ConfigurableFileCollectionCodec(fileCollectionFactory))
         bind(FileCollectionCodec(fileCollectionFactory))
         bind(IntersectPatternSetCodec)

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -43,7 +43,7 @@ class DefaultCopySpecCodec(
     override suspend fun WriteContext.encode(value: DefaultCopySpec) {
         encodePreservingIdentityOf(value) {
             write(value.destPath)
-            write(value.resolveSourceFiles())
+            write(value.getSourceFiles())
             write(value.patterns)
             writeCollection(value.children)
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/DefaultCopySpecCodec.kt
@@ -26,6 +26,8 @@ import org.gradle.instantexecution.extensions.uncheckedCast
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.decodePreservingIdentity
+import org.gradle.instantexecution.serialization.encodePreservingIdentityOf
 import org.gradle.instantexecution.serialization.readList
 import org.gradle.instantexecution.serialization.writeCollection
 import org.gradle.internal.reflect.Instantiator
@@ -39,17 +41,23 @@ class DefaultCopySpecCodec(
 ) : Codec<DefaultCopySpec> {
 
     override suspend fun WriteContext.encode(value: DefaultCopySpec) {
-        write(value.destPath)
-        write(value.resolveSourceFiles())
-        write(value.patterns)
-        writeCollection(value.children)
+        encodePreservingIdentityOf(value) {
+            write(value.destPath)
+            write(value.resolveSourceFiles())
+            write(value.patterns)
+            writeCollection(value.children)
+        }
     }
 
     override suspend fun ReadContext.decode(): DefaultCopySpec {
-        val destPath = read() as String?
-        val sourceFiles = read() as FileCollection
-        val patterns = read() as PatternSet
-        val children = readList().uncheckedCast<List<CopySpecInternal>>()
-        return DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, destPath, sourceFiles, patterns, children)
+        return decodePreservingIdentity { id ->
+            val destPath = read() as String?
+            val sourceFiles = read() as FileCollection
+            val patterns = read() as PatternSet
+            val children = readList().uncheckedCast<List<CopySpecInternal>>()
+            val copySpec = DefaultCopySpec(fileResolver, fileCollectionFactory, instantiator, destPath, sourceFiles, patterns, children)
+            isolate.identities.putInstance(id, copySpec)
+            copySpec
+        }
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileTreeCodec.kt
@@ -16,11 +16,14 @@
 
 package org.gradle.instantexecution.serialization.codecs
 
+import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.DefaultCompositeFileTree
+import org.gradle.api.internal.file.FileCollectionBackFileTree
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.FileTreeInternal
+import org.gradle.api.internal.file.FilteredFileTree
 import org.gradle.api.internal.file.archive.TarFileTree
 import org.gradle.api.internal.file.archive.ZipFileTree
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
@@ -30,10 +33,25 @@ import org.gradle.api.tasks.util.PatternSet
 import org.gradle.instantexecution.serialization.Codec
 import org.gradle.instantexecution.serialization.ReadContext
 import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.decodePreservingIdentity
+import org.gradle.instantexecution.serialization.encodePreservingIdentityOf
 import org.gradle.instantexecution.serialization.ownerService
 import org.gradle.instantexecution.serialization.readNonNull
+import org.gradle.internal.Factory
 import java.io.File
 import java.nio.file.Files
+
+
+private
+sealed class FileTreeRootSpec
+
+
+private
+class CompositeFileTreeRootSpec(val roots: List<FileTreeSpec>) : FileTreeRootSpec()
+
+
+private
+class WrappedFileCollectionTreeRootSpec(val collection: AbstractFileCollection) : FileTreeRootSpec()
 
 
 private
@@ -79,36 +97,61 @@ class DummyGeneratedFileTree(file: File) : GeneratedSingletonFileTree(
 
 internal
 class FileTreeCodec(
-    private val directoryFileTreeFactory: DirectoryFileTreeFactory
+    private val directoryFileTreeFactory: DirectoryFileTreeFactory,
+    private val patternSetFactory: Factory<PatternSet>
 ) : Codec<FileTreeInternal> {
 
     override suspend fun WriteContext.encode(value: FileTreeInternal) {
-        write(fileTreeRootsOf(value))
+        encodePreservingIdentityOf(value) {
+            write(rootSpecOf(value))
+        }
     }
 
-    override suspend fun ReadContext.decode(): FileTreeInternal? =
-        DefaultCompositeFileTree(
-            readNonNull<List<FileTreeSpec>>().map {
-                when (it) {
-                    is DirectoryTreeSpec -> FileTreeAdapter(directoryFileTreeFactory.create(it.file, it.patterns))
-                    is GeneratedTreeSpec -> FileTreeAdapter(DummyGeneratedFileTree(it.file))
-                    is ZipTreeSpec -> ownerService<FileOperations>().zipTree(it.file) as FileTreeInternal
-                    is TarTreeSpec -> ownerService<FileOperations>().tarTree(it.file) as FileTreeInternal
-                }
+    override suspend fun ReadContext.decode(): FileTreeInternal? {
+        return decodePreservingIdentity { id ->
+            val spec = readNonNull<FileTreeRootSpec>()
+            val tree = when (spec) {
+                is CompositeFileTreeRootSpec ->
+                    DefaultCompositeFileTree(
+                        spec.roots.map {
+                            when (it) {
+                                is DirectoryTreeSpec -> FileTreeAdapter(directoryFileTreeFactory.create(it.file, it.patterns))
+                                is GeneratedTreeSpec -> FileTreeAdapter(DummyGeneratedFileTree(it.file))
+                                is ZipTreeSpec -> ownerService<FileOperations>().zipTree(it.file) as FileTreeInternal
+                                is TarTreeSpec -> ownerService<FileOperations>().tarTree(it.file) as FileTreeInternal
+                            }
+                        }
+                    )
+                is WrappedFileCollectionTreeRootSpec -> FileCollectionBackFileTree(patternSetFactory, spec.collection)
             }
-        )
+            isolate.identities.putInstance(id, tree)
+            tree
+        }
+    }
 
     private
-    fun fileTreeRootsOf(value: FileTreeInternal): List<FileTreeSpec> {
+    fun rootSpecOf(value: FileTreeInternal): FileTreeRootSpec {
+        // Optimize a common case, where fileCollection.asFileTree.matching(emptyPatterns) is used, eg in SourceTask and in CopySpec
+        // TODO - it would be better to apply this while visiting the tree structure, so that the same short circuiting is applied everywhere
+        //   Would needs some rework of the visiting interfaces
+        val effectiveTree = if (value is FilteredFileTree && value.patterns.isEmpty) {
+            // No filters are applied, so discard the filtering tree
+            value.tree
+        } else {
+            value
+        }
+        if (effectiveTree is FileCollectionBackFileTree) {
+            return WrappedFileCollectionTreeRootSpec(effectiveTree.collection)
+        }
+
         val visitor = FileTreeVisitor()
         value.visitStructure(visitor)
-        return visitor.roots
+        return CompositeFileTreeRootSpec(visitor.roots)
     }
 
     private
     class FileTreeVisitor : FileCollectionStructureVisitor {
 
-        internal
         var roots = mutableListOf<FileTreeSpec>()
 
         override fun visitCollection(source: FileCollectionInternal.Source, contents: Iterable<File>) = throw UnsupportedOperationException()

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -389,7 +389,8 @@ class UserTypesCodecTest {
         actionScheme = mock(),
         attributesFactory = mock(),
         transformListener = mock(),
-        valueSourceProviderFactory = mock()
+        valueSourceProviderFactory = mock(),
+        patternSetFactory = mock()
     )
 
     @Test

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.provider.ManagedFactories
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
+import org.gradle.internal.Factory
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
@@ -806,7 +807,7 @@ class DefaultValueSnapshotterTest extends Specification {
         files1.from(new File("a").absoluteFile)
 
         given:
-        _ * managedFactoryRegistry.lookup(ConfigurableFileCollectionManagedFactory.FACTORY_ID) >> new ConfigurableFileCollectionManagedFactory(TestFiles.resolver(), DefaultTaskDependencyFactory.withNoAssociatedProject())
+        _ * managedFactoryRegistry.lookup(ConfigurableFileCollectionManagedFactory.FACTORY_ID) >> new ConfigurableFileCollectionManagedFactory(TestFiles.resolver(), DefaultTaskDependencyFactory.withNoAssociatedProject(), Stub(Factory))
 
         expect:
         def isolatedEmpty = snapshotter.isolate(empty)

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3RepoResolveIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3RepoResolveIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.resource.s3.ivy
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.resolve.ivy.AbstractIvyRemoteRepoResolveIntegrationTest
 import org.gradle.integtests.resource.s3.fixtures.S3Server
@@ -39,7 +39,6 @@ class IvyS3RepoResolveIntegrationTest extends AbstractIvyRemoteRepoResolveIntegr
         result = executer.withTasks(*tasks).run()
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot add invalid authentication types for s3 repo"() {
         given:
         def remoteIvyRepo = server.getRemoteIvyRepo()

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenS3RepoErrorsIntegrationTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.integtests.resource.s3.maven
 
 import org.gradle.api.credentials.AwsCredentials
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.resource.s3.AbstractS3DependencyResolutionTest
 import org.gradle.integtests.resource.s3.fixtures.MavenS3Module
 
@@ -47,7 +46,6 @@ task retrieve(type: Sync) {
 """
     }
 
-    @ToBeFixedForInstantExecution
     def "should fail with an AWS S3 authentication error"() {
         setup:
         buildFile << mavenAwsRepoDsl()
@@ -63,7 +61,6 @@ task retrieve(type: Sync) {
                 .assertHasCause("The AWS Access Key Id you provided does not exist in our records.")
     }
 
-    @ToBeFixedForInstantExecution
     def "fails when providing PasswordCredentials with decent error"() {
         setup:
         buildFile << """
@@ -87,7 +84,6 @@ repositories {
                 .assertHasCause("Credentials must be an instance of '${AwsCredentials.class.getName()}'.")
     }
 
-    @ToBeFixedForInstantExecution
     def "fails when no credentials provided"() {
         setup:
         buildFile << """
@@ -107,7 +103,6 @@ repositories {
 
     }
 
-    @ToBeFixedForInstantExecution
     def "should include resource uri when file not found"() {
         setup:
         buildFile << mavenAwsRepoDsl()
@@ -128,7 +123,6 @@ Required by:
 """)
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot add invalid authentication types for s3 repo"() {
         given:
         module.publish()

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoErrorsIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/ivy/IvySftpRepoErrorsIntegrationTest.groovy
@@ -16,11 +16,10 @@
 
 package org.gradle.integtests.resolve.resource.sftp.ivy
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.integtests.resolve.resource.sftp.AbstractSftpDependencyResolutionTest
 
 class IvySftpRepoErrorsIntegrationTest extends AbstractSftpDependencyResolutionTest {
-    @ToBeFixedForInstantExecution
     void "resolve missing dependencies from a SFTP Ivy repository"() {
         given:
         buildFile << """
@@ -58,7 +57,6 @@ Required by:
 """)
     }
 
-    @ToBeFixedForInstantExecution
     void "resolve missing dynamic dependencies from a SFTP Ivy repository"() {
         given:
         buildFile << """
@@ -93,7 +91,6 @@ Required by:
 """)
     }
 
-    @ToBeFixedForInstantExecution
     void "resolve dependencies from a SFTP Ivy repository with invalid credentials"() {
         given:
         buildFile << """
@@ -124,7 +121,6 @@ Required by:
                 .assertHasCause("Password authentication not supported or invalid credentials for SFTP server at ${ivySftpRepo.serverUri}")
     }
 
-    @ToBeFixedForInstantExecution
     void "resolve dependencies from a SFTP Ivy repository with unsupported password authentication"() {
         given:
         server.withPasswordAuthenticationDisabled()
@@ -157,7 +153,6 @@ Required by:
                 .assertHasCause("Password authentication not supported or invalid credentials for SFTP server at ${ivySftpRepo.serverUri}")
     }
 
-    @ToBeFixedForInstantExecution
     void "resolve dependencies from an unreachable SFTP Ivy repository"() {
         given:
         buildFile << """
@@ -191,7 +186,6 @@ Required by:
                 .assertHasCause("Could not connect to SFTP server at ${ivySftpRepo.serverUri}")
     }
 
-    @ToBeFixedForInstantExecution
     void 'resolve dependencies from a SFTP Ivy that returns a failure'() {
         given:
         buildFile << """
@@ -227,7 +221,6 @@ Required by:
                 .assertHasCause("Could not get resource '${projectA.ivy.uri}'")
     }
 
-    @ToBeFixedForInstantExecution
     def "cannot add invalid authentication types for sftp repo"() {
         given:
         def remoteIvyRepo = getIvySftpRepo()

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/maven/MavenSftpRepoResolveIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/integtests/resolve/resource/sftp/maven/MavenSftpRepoResolveIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.resolve.resource.sftp.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+
 import org.gradle.integtests.resolve.resource.sftp.AbstractSftpDependencyResolutionTest
 
 class MavenSftpRepoResolveIntegrationTest extends AbstractSftpDependencyResolutionTest {
@@ -59,7 +59,6 @@ class MavenSftpRepoResolveIntegrationTest extends AbstractSftpDependencyResoluti
     }
 
 
-    @ToBeFixedForInstantExecution
     def "cannot add invalid authentication types for sftp repo"() {
         given:
         def mavenSftpRepo = getMavenSftpRepo()


### PR DESCRIPTION

### Context

Write the details for a given `CopySpec` only once to the instant execution cache, rather than several times.

Also add a system property that forces the invalidation of the instant execution cache, to use to benchmark or profile writing to the cache.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
