### PR TITLE
Remove eclipse plugin from Gradle build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,22 +62,6 @@ NOTE: Due to the project size, the initial import can take a while and IntelliJ 
 
 IntelliJ automatically hides stacktrace elements from the `org.gradle` package, which makes running/debugging tests more difficult.  You can disable this behavior by changing IntelliJ Preferences under Editor -> General -> Console. In the "Fold lines that contain" section, remove the `org.gradle` entry.
 
-### Eclipse
-
-You can generate the Eclipse projects by running
-
-    ./gradlew eclipse
-
-Then you can import the generated projects into Eclipse
-
-1. Install Eclipse 4.5 (Mars) at least
-2. Install the Groovy Eclipse plugin from http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/
-3. Make sure you have a Java 8 compatible JDK configured in your workspace
-4. In `Window->Preferences->Groovy->Compiler`, check `Enable Script folder support` and add `**/*.gradle`
-5. Import all projects using the "Import Existing Projects into Workspace" wizard
-
-
-
 ### Code Change Guidelines
 
 All code contributions should contain the following:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -66,7 +66,6 @@ subprojects {
 
         apply(from = "../../../gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")
     }
-    apply(plugin = "eclipse")
 }
 
 allprojects {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -139,5 +139,4 @@ fun Project.configureIde(testType: TestType) {
             }
         }
     }
-
 }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -1,6 +1,5 @@
 package org.gradle.gradlebuild.test.integrationtests
 
-import accessors.eclipse
 import accessors.groovy
 import accessors.java
 import org.gradle.api.Action
@@ -8,7 +7,6 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
-import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import java.io.File
 
@@ -142,12 +140,4 @@ fun Project.configureIde(testType: TestType) {
         }
     }
 
-    plugins.withType<EclipsePlugin> {
-        eclipse {
-            classpath.plusConfigurations.apply {
-                add(compile)
-                add(runtime)
-            }
-        }
-    }
 }

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/accessors/accessors.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/accessors/accessors.kt
@@ -27,8 +27,6 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.GroovySourceSet
 import org.gradle.api.tasks.SourceSet
 
-import org.gradle.plugins.ide.eclipse.model.EclipseModel
-
 import org.gradle.kotlin.dsl.*
 
 
@@ -46,7 +44,3 @@ val Project.reporting
 
 val SourceSet.groovy: SourceDirectorySet
     get() = withConvention(GroovySourceSet::class) { groovy }
-
-
-fun Project.eclipse(configure: EclipseModel.() -> Unit): Unit =
-    extensions.configure("eclipse", configure)

--- a/subprojects/smoke-test/smoke-test.gradle.kts
+++ b/subprojects/smoke-test/smoke-test.gradle.kts
@@ -103,13 +103,6 @@ plugins.withType<IdeaPlugin>().configureEach {
     }
 }
 
-plugins.withType<EclipsePlugin>().configureEach {
-    eclipse.classpath {
-        plusConfigurations.add(smokeTestCompileClasspath)
-        plusConfigurations.add(smokeTestRuntimeClasspath)
-    }
-}
-
 tasks {
 
     /**

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -100,16 +100,6 @@ gradlebuildJava {
 
 apply(from = "buildship.gradle")
 
-eclipse {
-    classpath {
-        file.whenMerged(Action<Classpath> {
-            //**TODO
-            entries.removeAll { it is SourceFolder && it.path.contains("src/test/groovy") }
-            entries.removeAll { it is SourceFolder && it.path.contains("src/integTest/groovy") }
-        })
-    }
-}
-
 val integTestTasks: DomainObjectCollection<IntegrationTest> by extra
 
 integTestTasks.configureEach {

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -15,12 +15,9 @@
  */
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
-import accessors.*
 import org.gradle.build.BuildReceipt
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
-import org.gradle.plugins.ide.eclipse.model.Classpath
-import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 plugins {
     `java-library`


### PR DESCRIPTION
Given you can't really import Gradle into Eclipse due to the major
limitations Eclipse has (Groovy, Kotlin, Spock, ...), simplify the
build scripts and the documentation to clarify that.