### PR TITLE
Delete no longer used defaultBuildSourceScript.txt file

### DIFF
--- a/subprojects/core/src/main/resources/org/gradle/initialization/buildsrc/defaultBuildSourceScript.txt
+++ b/subprojects/core/src/main/resources/org/gradle/initialization/buildsrc/defaultBuildSourceScript.txt
@@ -1,6 +1,0 @@
-apply plugin: 'groovy'
-dependencies {
-    compile gradleApi()
-    compile localGroovy()
-}
-


### PR DESCRIPTION
This file was used to configure the `buildSrc` module.
Since https://github.com/gradle/gradle/commit/fde004c1acde10d19590bbed1203782a26cc33f3 this is done programmatically and this file is no longer used.