### PR TITLE
Let instant execution set included builds ready

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIntegrationTest.groovy
@@ -17,9 +17,12 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.build.BuildTestFile
 
 class CompositeBuildBuildSrcIntegrationTest extends AbstractIntegrationSpec {
+
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "included and composing builds can contain buildSrc builds"() {
         def outerBuild = new BuildTestFile(testDirectory, "root")
         def childBuild = new BuildTestFile(testDirectory.file("child"), "child")

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIntegrationTest.groovy
@@ -39,7 +39,7 @@ class CompositeBuildBuildSrcIntegrationTest extends AbstractIntegrationSpec {
 
         childBuild.settingsFile << "rootProject.name = 'someBuild'"
         childBuild.file('buildSrc/src/main/java/Thing.java') << """
-            class Thing { 
+            class Thing {
                 Thing() { System.out.println("child thing"); }
             }
         """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildClassloadingIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildClassloadingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Issue
@@ -26,6 +27,7 @@ class CompositeBuildClassloadingIntegrationTest extends AbstractCompositeBuildIn
 
     @Issue('GRADLE-3553')
     @LeaksFileHandles
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "init-script with project dependent classpath and included build"() {
         given:
         file('gradle-user-home/init.gradle') << """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationTimeResolveIntegrationTest.groovy
@@ -69,6 +69,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
 
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "references but does not build substituted dependency resolved at configuration time"() {
         configurationTimeDependency 'org.test:buildB:1.0'
 
@@ -83,7 +84,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "uses substituted dependency when same root build dependency is resolved at both configuration and execution time"() {
         configurationTimeDependency 'org.test:buildB:1.0'
         dependency 'org.test:buildB:1.0'
@@ -98,7 +99,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "references substituted dependencies when root build dependencies are resolved at both configuration and execution time"() {
         configurationTimeDependency 'org.test:buildB:1.0'
         dependency 'org.test:b1:1.0'
@@ -116,6 +117,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "included build references substituted dependency from preceding included build"() {
         dependency 'org.test:buildC:1.0'
         configurationTimeDependency buildC, 'org.test:buildB:1.0'
@@ -131,6 +133,7 @@ class CompositeBuildConfigurationTimeResolveIntegrationTest extends AbstractComp
         configured("buildB") == 1
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "included build does not use substituted dependency from subsequent included build"() {
         dependency 'org.test:buildB:1.0'
         configurationTimeDependency buildB, 'org.test:buildC:1.0'

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
@@ -17,12 +17,14 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
 class CompositeBuildDependencyCapabilitiesResolveIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "dependency capabilities travel to the included build"() {
         mavenRepo.module('com.acme.external', 'external', '1.0')
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
@@ -39,7 +39,7 @@ class CompositeBuildDependencyCapabilitiesResolveIntegrationTest extends Abstrac
         file("includedBuild/build.gradle") << """
             group = 'com.acme.external'
             version = '2.0-SNAPSHOT'
-            
+
             configurations {
                 first {
                    attributes {
@@ -54,7 +54,7 @@ class CompositeBuildDependencyCapabilitiesResolveIntegrationTest extends Abstrac
                    outgoing.capability('org:cap2:1.0')
                 }
             }
-            
+
             artifacts {
                 first file("first-\${version}.jar")
                 second file("second-\${version}.jar")
@@ -63,7 +63,7 @@ class CompositeBuildDependencyCapabilitiesResolveIntegrationTest extends Abstrac
 
         buildFile << """
             apply plugin: 'java-library'
-            
+
             dependencies {
                 api("com.acme.external:external:1.0") {
                     capabilities {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCycleIntegrationTest.groovy
@@ -145,7 +145,7 @@ class CompositeBuildDependencyCycleIntegrationTest extends AbstractCompositeBuil
         dependency "org.test:b1:1.0"
         buildB.buildFile << """
 project(':b1') {
-    dependencies { 
+    dependencies {
         implementation "org.test:buildC:1.0"
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCycleIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
@@ -55,6 +56,7 @@ class CompositeBuildDependencyCycleIntegrationTest extends AbstractCompositeBuil
         includedBuilds << buildC
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "direct dependency cycle between included builds"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -88,6 +90,7 @@ class CompositeBuildDependencyCycleIntegrationTest extends AbstractCompositeBuil
         failure.assertHasDescription("Included build dependency cycle: build 'buildB' -> build 'buildC' -> build 'buildB'")
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "indirect dependency cycle between included builds"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -136,6 +139,7 @@ class CompositeBuildDependencyCycleIntegrationTest extends AbstractCompositeBuil
     }
 
     // Not actually a cycle, just documenting behaviour
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "dependency cycle between different projects of included builds"() {
         given:
         dependency "org.test:b1:1.0"
@@ -175,6 +179,7 @@ project(':b1') {
         failure.assertHasDescription("Included build dependency cycle: build 'buildB' -> build 'buildC' -> build 'buildB'")
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "compile-only dependency cycle between included builds"() {
         given:
         dependency "org.test:buildB:1.0"
@@ -209,6 +214,7 @@ project(':b1') {
         failure.assertHasDescription("Included build dependency cycle: build 'buildB' -> build 'buildC' -> build 'buildB'")
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "dependency cycle between subprojects in an included multiproject build"() {
         given:
         dependency "org.test:buildB:1.0"

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -66,6 +66,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
             .assertHasCause("exception thrown on configure")
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "does no substitution when no project matches external dependencies"() {
         given:
         mavenRepo.module("org.different", "buildB", "1.0").publish()
@@ -88,7 +89,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes external dependency with root project dependency"() {
         given:
         buildA.buildFile << """
@@ -112,6 +113,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         executed ":buildB:jar"
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "can resolve dependency graph without building artifacts"() {
         given:
         resolve.withoutBuildingArtifacts()
@@ -137,7 +139,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         notExecuted ":buildB:jar"
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes external dependencies with project dependencies using --include-build"() {
         given:
         singleProjectBuild("buildC") {
@@ -170,7 +172,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes external dependencies with subproject dependencies"() {
         given:
         buildA.buildFile << """
@@ -196,7 +198,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes external dependency with project dependency from same participant build"() {
         given:
         buildA.buildFile << """
@@ -226,7 +228,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes external dependency with subproject dependency that has transitive dependencies"() {
         given:
         def transitive1 = mavenRepo.module("org.test", "transitive1").publish()
@@ -257,7 +259,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes external dependency with subproject dependency that has transitive project dependencies"() {
         given:
         buildA.buildFile << """
@@ -295,7 +297,7 @@ include ':b1:b11'
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "honours excludes defined in substituted subproject dependency that has transitive dependencies"() {
         given:
         def transitive1 = mavenRepo.module("org.test", "transitive1").publish()
@@ -326,7 +328,7 @@ include ':b1:b11'
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes transitive dependency of substituted project dependency"() {
         given:
         buildA.buildFile << """
@@ -362,7 +364,7 @@ include ':b1:b11'
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes transitive dependency of non-substituted external dependency"() {
         given:
         mavenRepo.module("org.external", "external-dep", '1.0').dependsOn("org.test", "buildB", "1.0").publish()
@@ -386,7 +388,7 @@ include ':b1:b11'
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes forced direct dependency"() {
         given:
         buildA.buildFile << """
@@ -408,7 +410,7 @@ include ':b1:b11'
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes transitive dependency with forced version"() {
         given:
         mavenRepo.module("org.external", "external-dep", '1.0').dependsOn("org.test", "buildB", "1.0").publish()
@@ -433,7 +435,7 @@ include ':b1:b11'
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes transitive dependency based on result of resolution rules"() {
         given:
         mavenRepo.module("org.external", "external-dep", '1.0')
@@ -474,7 +476,7 @@ include ':b1:b11'
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "evaluates subprojects when substituting external dependencies with #name"() {
         given:
         buildA.buildFile << """
@@ -508,7 +510,7 @@ afterEvaluate {
         "parallel"            | ["--parallel"]
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "substitutes dependency in composite containing participants with same root directory name"() {
         given:
         buildA.buildFile << """
@@ -546,7 +548,7 @@ afterEvaluate {
         }
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "can substitute dependencies in composite with duplicate publication if not involved in resolution"() {
         given:
         def buildC = multiProjectBuild("buildC", ['a2', 'b2', 'c1']) {
@@ -644,7 +646,7 @@ afterEvaluate {
         failure.assertHasCause("Module version 'org.test:b1:2.0' is not unique in composite: can be provided by [project :buildB:b1, project :buildC:b1].")
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "resolve transitive project dependency that is ambiguous in the composite"() {
         given:
         transitiveDependencyIsAmbiguous("project(':b1')")
@@ -686,7 +688,7 @@ afterEvaluate {
 """
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "handles unused participant with no defined configurations"() {
         given:
         def buildC = singleProjectBuild("buildC")
@@ -729,7 +731,7 @@ afterEvaluate {
             "  - None of the consumable configurations have attributes.")
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "includes build identifier in error message on failure to resolve dependencies of included build"() {
         def m = mavenRepo.module("org.test", "test", "1.2")
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -160,7 +160,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
             dependencies {
                 compileOnly 'org.test:b2:1.0'
             }
-            
+
             gradle.buildFinished {
                 sleep 500
             }
@@ -172,7 +172,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
                     sleep 500
                 }
             }
-            
+
             jar.finalizedBy wait
         """
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -79,7 +79,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         includedBuilds << buildC
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "fires build listener events on included builds"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -92,6 +92,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         verifyBuildEvents()
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "fires build listener events for unused included builds"() {
         when:
         execute()
@@ -129,7 +130,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         logged("Ignoring listeners of task graph ready event, as this build (:buildB) has already executed work.")
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "fires build listener events for included builds with additional discovered (compileOnly) dependencies"() {
         given:
         // BuildB will be initially evaluated with a single dependency on 'b1'.
@@ -149,7 +150,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         verifyBuildEvents()
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "buildFinished for root build is guaranteed to complete after included builds"() {
         given:
 
@@ -205,6 +206,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         lateIncludedBuildTaskPosition < rootBuildFinishedPosition
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "fires build finished events for all builds when build finished event is other builds fail"() {
         given:
         buildA.buildFile << """
@@ -245,7 +247,7 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
                 .assertHasLineNumber(9)
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "fires build finished events for all builds when other builds fail"() {
         given:
         buildA.buildFile << """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
@@ -35,7 +35,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
             assert gradle.includedBuild("buildC").name == "buildC"
             assert gradle.includedBuild("buildC").projectDir == file('${buildC.toURI()}')
             assert gradle.includedBuilds.name == ["buildB", "buildC"]
-            
+
             task broken {
                 doLast {
                     assert gradle.includedBuilds.name == ["buildB", "buildC"]
@@ -72,7 +72,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
             assert gradle.includedBuild("buildC").name == "buildC"
             assert gradle.includedBuild("buildC").projectDir == file('${buildC.toURI()}')
             assert gradle.includedBuilds.name == ["buildB", "buildC"]
-            
+
             task broken {
                 doLast {
                     assert gradle.includedBuilds.name == ["buildB", "buildC"]
@@ -109,7 +109,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
             assert gradle.includedBuild("c1").name == "c1"
             assert gradle.includedBuild("c1").projectDir == file('${buildC.toURI()}')
             assert gradle.includedBuilds.name == ["b1", "c1"]
-            
+
             task broken {
                 doLast {
                     assert gradle.includedBuilds.name == ["b1", "c1"]
@@ -174,7 +174,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
         def buildB = singleProjectBuild("buildB") {
             buildFile << """
                 assert gradle.includedBuilds.empty
-            
+
                 task broken1 {
                     doLast {
                         assert gradle.includedBuilds.empty

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildLookupIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.integtests.composite
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "can query the included builds defined by the root build"() {
         given:
         def buildB = singleProjectBuild("buildB") {
@@ -49,6 +51,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
         failure.assertHasCause("Included build 'unknown' not found in build 'buildA'.")
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "dir name is used as build name"() {
         given:
         def buildB = singleProjectBuild("buildB") {
@@ -85,6 +88,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
         failure.assertHasCause("Included build 'b' not found in build 'buildA'.")
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "build name can be specified at include time"() {
         given:
         def buildB = singleProjectBuild("buildB") {
@@ -121,7 +125,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
         failure.assertHasCause("Included build 'buildB' not found in build 'buildA'.")
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "included builds added from command-line are visible to root build"() {
         given:
         def buildB = singleProjectBuild("buildB") {
@@ -164,7 +168,7 @@ class CompositeBuildLookupIntegrationTest extends AbstractCompositeBuildIntegrat
         execute(buildA, "withoutBuild")
     }
 
-    @ToBeFixedForInstantExecution
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "parent and sibling builds are not visible from included build"() {
         given:
         def buildB = singleProjectBuild("buildB") {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMinimalConfigurationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMinimalConfigurationIntegrationTest.groovy
@@ -98,7 +98,7 @@ class CompositeBuildMinimalConfigurationIntegrationTest extends AbstractComposit
     }
 
     @Unroll
-    @ToBeFixedForInstantExecution(iterationMatchers = ".*building")
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "configures included build only once when #action"() {
         given:
         dependency "org.test:buildB:1.0"

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -402,8 +402,8 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
             }
         """
         buildA.file("b/build.gradle") << """
-            plugins { 
-                id("a-plugin") 
+            plugins {
+                id("a-plugin")
             }
         """
 
@@ -433,8 +433,8 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
             include "b"
         """
         pluginBuild.file("b/build.gradle") << """
-            plugins { 
-                id("a-plugin") 
+            plugins {
+                id("a-plugin")
             }
         """
 
@@ -452,8 +452,8 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
             include "a"
         """
         pluginBuild.file("a/build.gradle") << """
-            plugins { 
-                id("org.test.plugin.pluginBuild") 
+            plugins {
+                id("org.test.plugin.pluginBuild")
             }
         """
         includeBuild pluginBuild

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -196,6 +196,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         executed ":pluginDependencyA:jar", ":jar"
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "can develop a buildscript dependency that is used by multiple projects of main build"() {
         given:
         buildA.settingsFile << """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildWarningJavaProjectIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildWarningJavaProjectIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class CompositeBuildWarningJavaProjectIntegrationTest extends AbstractIntegrationSpec {
 
@@ -50,6 +51,7 @@ class CompositeBuildWarningJavaProjectIntegrationTest extends AbstractIntegratio
         output.count(warningMessage(':buildDependents')) == 0
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "Shows warning when buildDependents task executed on single-project build"() {
         given:
         singleProjectBuild("project") {
@@ -65,6 +67,7 @@ class CompositeBuildWarningJavaProjectIntegrationTest extends AbstractIntegratio
         output.count(warningMessage(':buildDependents')) == 1
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "Shows warning for all buildDependents tasks executed on multi-project build"() {
         given:
         multiProjectBuild("multi-project", ['sub1', 'sub2']) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/plugins/ApplyPluginBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/plugins/ApplyPluginBuildOperationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 
 class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
 
@@ -140,6 +141,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
         p2.details.pluginClass == "Plugin2"
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "associates target to correct build"() {
         when:
         settingsFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/plugins/ApplyPluginBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/plugins/ApplyPluginBuildOperationIntegrationTest.groovy
@@ -60,7 +60,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             class MyPlugin implements Plugin {
                 void apply(t) {}
             }
-            
+
             apply plugin: MyPlugin
         """
 
@@ -84,7 +84,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             class MyPlugin implements Plugin {
                 void apply(t) {}
             }
-            
+
             apply plugin: MyPlugin
         """
 
@@ -116,7 +116,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             }
             class Plugin2 implements Plugin {
                 void apply(project) {
-                    
+
                 }
             }
 
@@ -153,7 +153,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
         file("a/build.gradle") << """
             class PluginA implements Plugin {
                 void apply(project) {
-                    
+
                 }
             }
             apply plugin: PluginA
@@ -161,7 +161,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
         file("b/build.gradle") << """
             class PluginB implements Plugin {
                 void apply(project) {
-                    
+
                 }
             }
             apply plugin: PluginB
@@ -169,7 +169,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             class PluginRoot implements Plugin {
                 void apply(project) {
-                    
+
                 }
             }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ApplyScriptPluginBuildOperationIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.configuration
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
 
@@ -84,6 +85,7 @@ class ApplyScriptPluginBuildOperationIntegrationTest extends AbstractIntegration
         operations.search(ops[2], ApplyScriptPluginBuildOperationType).size() == 0
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "identifies build of application target"() {
         given:
         def subBuildSettingsFile = file("subBuild/settings.gradle")

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import spock.lang.Issue
 
 class DistributionPropertiesLoaderIntegrationTest extends AbstractIntegrationSpec {
 
     @Issue('https://github.com/gradle/gradle/issues/11173')
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "System properties defined in gradle.properties are available in buildSrc and in included builds"() {
         given:
         requireIsolatedGradleDistribution()

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -59,7 +59,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
         customSettingsDir.mkdirs()
         def customSettingsFile = new File(customSettingsDir, "settings.gradle")
         customSettingsFile << """
-        
+
         include "a"
         """
 
@@ -77,15 +77,15 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
         settingsFile << """
             include "a"
             includeBuild "nested"
-            
+
             rootProject.name = "root"
             rootProject.buildFileName = 'root.gradle'
-            
+
         """
 
         def nestedSettingsFile = file("nested/settings.gradle")
         nestedSettingsFile << """
-            rootProject.name = "nested"    
+            rootProject.name = "nested"
         """
         file("nested/build.gradle") << """
         group = "org.acme"

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/EvaluateSettingsBuildOperationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.internal.operations.trace.BuildOperationRecord
 
 class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationSpec {
@@ -71,6 +72,7 @@ class EvaluateSettingsBuildOperationIntegrationTest extends AbstractIntegrationS
         operation().details.buildPath == ":"
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "composite participants expose their settings details"() {
         settingsFile << """
             include "a"

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.internal.operations.trace.BuildOperationRecord
 
 class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegrationSpec {
@@ -109,6 +110,7 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         verifyProject(project(':a'), 'a', ':a', [], customSettingsDir.file('a'))
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "composite participants expose their project structure"() {
         settingsFile << """
         include "a"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -38,7 +38,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
     @ToBeFixedForInstantExecution
     def "resolved configurations are exposed via build operation"() {
         setup:
-        buildFile << """                
+        buildFile << """
             allprojects {
                 apply plugin: "java"
                 repositories {
@@ -86,11 +86,11 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
 
     def "resolved detached configurations are exposed"() {
         setup:
-        buildFile << """                
+        buildFile << """
         repositories {
             maven { url '${mavenHttpRepo.uri}' }
         }
-        
+
         task resolve {
             doLast {
                 project.configurations.detachedConfiguration(dependencies.create('org.foo:dep:1.0')).files
@@ -125,7 +125,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         def m2 = mavenHttpRepo.module('org.foo', 'root-dep').publish()
 
         setupComposite()
-        buildFile << """                
+        buildFile << """
             allprojects {
                 apply plugin: "java"
                 repositories {
@@ -178,7 +178,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         setup:
         def m1 = mavenHttpRepo.module('org.foo', 'root-dep').publish()
         setupComposite()
-        buildFile << """                
+        buildFile << """
             buildscript {
                 repositories {
                     maven { url '${mavenHttpRepo.uri}' }
@@ -188,7 +188,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                     classpath 'org.foo:my-composite-app:1.0'
                 }
             }
-            
+
             apply plugin: "java"
         """
 
@@ -237,7 +237,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         apply from: 'scriptPlugin.gradle'
         '''
 
-        file(scriptFileName) << """                
+        file(scriptFileName) << """
             $scriptBlock {
                 repositories {
                     maven { url '${mavenHttpRepo.uri}' }
@@ -297,7 +297,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                     group "org.sample"
                     version "1.0"
                 }
-                
+
         """
 
         settingsFile << """
@@ -336,11 +336,11 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             repositories {
                 maven { url '${mavenHttpRepo.uri}' }
             }
-            
+
             dependencies {
                 implementation 'org.foo:app-dep:1.0'
             }
-            
+
             tasks.withType(JavaCompile) {
                 options.annotationProcessorPath = files()
             }
@@ -368,22 +368,22 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         }
 
         when:
-        buildFile << """    
+        buildFile << """
             repositories {
                 maven { url = '${mavenHttpRepo.uri}' }
             }
-            
+
             configurations {
                 compile {
                     resolutionStrategy.failOnVersionConflict()
                 }
             }
-                        
+
             dependencies {
                compile 'org:a:1.0'
                compile 'org:b:1.0'
             }
-            
+
             task resolve {
               doLast {
                   println(configurations.compile.files.name)
@@ -415,19 +415,19 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         mod.pomFile << "corrupt"
 
         when:
-        buildFile << """    
+        buildFile << """
             repositories {
                 maven { url = '${mavenHttpRepo.uri}' }
             }
-            
+
             configurations {
                 compile
             }
-                        
+
             dependencies {
                compile 'org:a:1.0'
             }
-            
+
             task resolve {
               doLast {
                   println(configurations.compile.files.name)
@@ -450,19 +450,19 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         def mod = mavenHttpRepo.module('org', 'a', '1.0').publish()
 
         when:
-        buildFile << """    
+        buildFile << """
             repositories {
                 maven { url = '${mavenHttpRepo.uri}' }
             }
-            
+
             configurations {
                 compile
             }
-                        
+
             dependencies {
                implementation 'org:a:1.0'
             }
-            
+
             task resolve {
               doLast {
                   // this will shutdown the project scope services, which is going to trigger a
@@ -471,7 +471,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                   println(configurations.compileClasspath.files.name)
               }
             }
-            
+
 """
         then:
         mod.allowAll()
@@ -505,14 +505,14 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         mavenHttpRepo.module('org.foo', 'child-transitive2').allowAll()
         secondMavenHttpRepo.module('org.foo', 'child-transitive2').publish().allowAll()
 
-        buildFile << """                
+        buildFile << """
             apply plugin: "java"
             repositories {
-                maven { 
+                maven {
                     name 'maven1'
                     url '${mavenHttpRepo.uri}'
                 }
-                maven { 
+                maven {
                     name 'maven2'
                     url '${secondMavenHttpRepo.uri}'
                 }
@@ -524,7 +524,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             }
 
             task resolve { doLast { configurations.runtimeClasspath.resolve() } }
-            
+
             project(':child') {
                 apply plugin: "java"
                 dependencies {
@@ -574,10 +574,10 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             .dependsOn('org.foo', 'transitive1', '1.0')
             .publish().allowAll()
 
-        buildFile << """                
+        buildFile << """
             apply plugin: "java"
             repositories {
-                maven { 
+                maven {
                     name 'maven1'
                     url '${mavenHttpRepo.uri}'
                 }
@@ -589,7 +589,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             }
 
             task resolve { doLast { configurations.runtimeClasspath.resolve() } }
-            
+
             project(':child') {
                 apply plugin: "java"
                 dependencies {
@@ -619,14 +619,14 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
     @ToBeFixedForInstantExecution
     def "resolved components contain their source repository id, even when they are structurally identical"() {
         setup:
-        buildFile << """                
+        buildFile << """
             apply plugin: "java"
             repositories {
-                maven { 
+                maven {
                     name 'withoutCreds'
                     url '${mavenHttpRepo.uri}'
                 }
-                maven { 
+                maven {
                     name 'withCreds'
                     url '${mavenHttpRepo.uri}'
                     credentials {
@@ -672,7 +672,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         mavenHttpRepo.module('org.foo', 'stuff').publish().allowAll()
 
         settingsFile << "include 'fixtures'"
-        buildFile << """                
+        buildFile << """
             allprojects {
                 apply plugin: "java"
                 apply plugin: "java-test-fixtures"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -173,6 +173,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         resolveOperations[1].result.resolvedDependenciesCount == 1
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "resolved configurations of composite builds as build dependencies are exposed"() {
         setup:
         def m1 = mavenHttpRepo.module('org.foo', 'root-dep').publish()
@@ -272,6 +273,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         "init"          | 'initscript'  | 'init.gradle'
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "included build classpath configuration resolution result is exposed"() {
         setup:
         def m1 = mavenHttpRepo.module('org.foo', 'some-dep').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
@@ -163,6 +163,7 @@ repositories {
         outputContains 'test-plugin applied'
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def 'buildscript classpath resolves java-runtime variant'() {
         def otherSettings = file('other/settings.gradle')
         def otherBuild = file('other/build.gradle')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
@@ -108,8 +108,8 @@ task printDeps {
 
         // Create module that will match only if compatibility and disambiguation rules are in place
         mavenRepo.module('test', 'dep', '1.0')
-            .variant("runtime", ["org.gradle.usage" : "java-runtime", 'org.gradle.dependency.bundling' : 'embedded'])
-            .variant("conflictingRuntime", ["org.gradle.usage" : "java-runtime", 'org.gradle.dependency.bundling' : 'shadowed'])
+            .variant("runtime", ["org.gradle.usage": "java-runtime", 'org.gradle.dependency.bundling': 'embedded'])
+            .variant("conflictingRuntime", ["org.gradle.usage": "java-runtime", 'org.gradle.dependency.bundling': 'shadowed'])
             .withModuleMetadata()
             .publish()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.integtests.resolve.constraints
 
 import org.gradle.integtests.fixtures.AbstractPolyglotIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
 
@@ -418,6 +419,7 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         }
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     void "dependency constraints defined for a build are applied when resolving a configuration that uses that build as an included build"() {
         given:
         resolve.expectDefaultConfiguration('default')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -454,6 +454,7 @@ task resolve {
         failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "ignores the lock entry that matches a composite"() {
         given:
         lockfileFixture.createLockfile('lockedConf', ['org:composite:1.1'])

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -626,6 +626,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
 """
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "included build dependencies are used when generating the verification file"() {
         given:
         javaLibrary()

--- a/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/instant-execution/src/integTest/groovy/org/gradle/instantexecution/InstantExecutionCompositeBuildsIntegrationTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+
+class InstantExecutionCompositeBuildsIntegrationTest extends AbstractInstantExecutionIntegrationTest {
+
+    def "warns for not implemented included builds support"() {
+
+        given:
+        def instantExecution = newInstantExecutionFixture()
+        settingsFile << """includeBuild("included")"""
+        file("included/settings.gradle") << ""
+
+        when:
+        instantRun("help")
+
+        then:
+        instantExecution.assertStateStored()
+        output.contains("Gradle runtime: support for included builds is not yet implemented with instant execution.")
+
+        when:
+        instantRun("help")
+
+        then:
+        instantExecution.assertStateLoaded()
+    }
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -40,6 +40,7 @@ import org.gradle.instantexecution.serialization.MutableIsolateContext
 import org.gradle.instantexecution.serialization.beans.BeanConstructors
 import org.gradle.instantexecution.serialization.codecs.Codecs
 import org.gradle.instantexecution.serialization.codecs.WorkNodeCodec
+import org.gradle.instantexecution.serialization.logNotImplemented
 import org.gradle.instantexecution.serialization.readCollection
 import org.gradle.instantexecution.serialization.readFile
 import org.gradle.instantexecution.serialization.readNonNull
@@ -343,6 +344,9 @@ class DefaultInstantExecution internal constructor(
     private
     suspend fun DefaultWriteContext.writeGradleState(gradle: Gradle) {
         withGradleIsolate(gradle) {
+            if (gradle.includedBuilds.isNotEmpty()) {
+                logNotImplemented("included builds")
+            }
             val eventListenerRegistry = service<BuildEventListenerRegistryInternal>()
             writeCollection(eventListenerRegistry.subscriptions)
         }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -106,6 +106,8 @@ class InstantExecutionHost internal constructor(
                 )
                 settingsPreparer.prepareSettings(this)
 
+                includedBuilds = emptyList()
+
                 setBaseProjectClassLoaderScope(coreScope)
                 projectDescriptorRegistry.rootProject!!.name = rootProjectName
             }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/Logging.kt
@@ -80,6 +80,13 @@ fun IsolateContext.logNotImplemented(baseType: Class<*>) {
 }
 
 
+fun IsolateContext.logNotImplemented(feature: String) {
+    logPropertyWarning {
+        text("support for $feature is not yet implemented with instant execution.")
+    }
+}
+
+
 private
 fun IsolateContext.logPropertyWarning(message: StructuredMessageBuilder) {
     val problem = PropertyProblem.Warning(trace, build(message))

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
@@ -25,8 +25,8 @@ class SwiftPackageManagerDependencyMappingIntegrationTest extends AbstractSwiftP
     def "export fails when external dependency cannot be mapped to a git url"() {
         given:
         buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
+            plugins {
+                id 'swiftpm-export'
                 id 'swift-library'
             }
             dependencies {
@@ -44,8 +44,8 @@ class SwiftPackageManagerDependencyMappingIntegrationTest extends AbstractSwiftP
     def "export fails when file dependency is present"() {
         given:
         buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
+            plugins {
+                id 'swiftpm-export'
                 id 'swift-library'
             }
             dependencies {
@@ -63,8 +63,8 @@ class SwiftPackageManagerDependencyMappingIntegrationTest extends AbstractSwiftP
     def "export fails when external dependency defines both branch and version constraint"() {
         given:
         buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
+            plugins {
+                id 'swiftpm-export'
                 id 'swift-library'
             }
             dependencies {
@@ -360,8 +360,8 @@ let package = Package(
             }
         """
         buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
+            plugins {
+                id 'swiftpm-export'
                 id 'swift-library'
             }
             dependencies {
@@ -415,8 +415,8 @@ let package = Package(
             }
         """
         buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
+            plugins {
+                id 'swiftpm-export'
                 id 'swift-library'
             }
             dependencies {
@@ -472,8 +472,8 @@ let package = Package(
             }
         """
         buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
+            plugins {
+                id 'swiftpm-export'
                 id 'swift-library'
             }
             dependencies {
@@ -537,8 +537,8 @@ let package = Package(
             }
         """
         buildFile << """
-            plugins { 
-                id 'swiftpm-export' 
+            plugins {
+                id 'swiftpm-export'
                 id 'swift-library'
             }
             dependencies {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/swiftpm/SwiftPackageManagerDependencyMappingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.swiftpm
 
+import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.vcs.fixtures.GitFileRepository
 import spock.lang.Unroll
 
@@ -205,6 +206,7 @@ let package = Package(
         lib2Repo?.close()
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "produces manifest for Swift component with dependencies on libraries provided by included builds"() {
         given:
         def lib1Repo = GitFileRepository.init(testDirectory.file("repos/lib1"))

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyIntegrationTest.groovy
@@ -41,7 +41,7 @@ abstract class AbstractSourceDependencyIntegrationTest extends AbstractIntegrati
             apply plugin: 'java'
             group = 'org.gradle'
             version = '2.0'
-            
+
             dependencies {
                 implementation "org.test:dep:latest.integration"
             }
@@ -94,12 +94,12 @@ abstract class AbstractSourceDependencyIntegrationTest extends AbstractIntegrati
     def "can use source dependency in build script classpath"() {
         mappingFor(repo, "org.test:dep")
         file("build.gradle").text = """
-            buildscript { 
+            buildscript {
                 dependencies {
                     classpath "org.test:dep:latest.integration"
                 }
             }
-            def dep = new Dep() 
+            def dep = new Dep()
         """
 
         when:

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/AbstractSourceDependencyIntegrationTest.groovy
@@ -64,6 +64,7 @@ abstract class AbstractSourceDependencyIntegrationTest extends AbstractIntegrati
         commit = repo.commit('initial')
     }
 
+    @ToBeFixedForInstantExecution(because = "composite builds")
     def "can define source repositories in root of composite build when child build has classpath dependencies"() {
         settingsFile << """
             includeBuild 'child'


### PR DESCRIPTION
without capturing the information
in order to unblock usage from Studio
