### PR TITLE
Add project report plugin to plugin reference

### DIFF
--- a/subprojects/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
@@ -125,3 +125,6 @@ Provides support for digitally signing generated files and artifacts.
 
 <<java_gradle_plugin.adoc#,Plugin Development>>::
 Makes it easier to develop and publish a Gradle plugin.
+
+<<project_report_plugin.adoc#,Project Report Plugin>>::
+Helps to generate reports containing useful information about your build.


### PR DESCRIPTION
It is currently missing from the documentation: https://docs.gradle.org/current/userguide/plugin_reference.html

This change adds it to core plugin reference page:
![image](https://user-images.githubusercontent.com/5560673/75047055-d7476d00-54ce-11ea-83b2-a6914a35ea3f.png)
