### PR TITLE
Let instant execution serialize enum subtypes correctly

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-library.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-library.gradle.kts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import build.configureKotlinCompilerForGradleBuild
 
 import org.gradle.api.internal.initialization.DefaultClassLoaderScope
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 import org.jlleitschuh.gradle.ktlint.KtlintCheckTask
 import org.jlleitschuh.gradle.ktlint.KtlintFormatTask
-
-import build.configureKotlinCompilerForGradleBuild
 
 
 plugins {

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -1,15 +1,30 @@
 import build.futureKotlin
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-library`
 }
 
 tasks {
+
+    withType<KotlinCompile>().configureEach {
+        kotlinOptions {
+            freeCompilerArgs += listOf(
+                "-XXLanguage:+NewInference",
+                "-XXLanguage:+SamConversionForKotlinFunctions"
+            )
+        }
+    }
+
     processResources {
         from({ project(":instantExecutionReport").tasks.named("assembleReport") }) {
             into("org/gradle/instantexecution")
         }
+    }
+
+    instantIntegTest {
+        enabled = false
     }
 }
 
@@ -65,11 +80,4 @@ dependencies {
 
 gradlebuildJava {
     moduleType = ModuleType.CORE
-}
-
-
-tasks {
-    instantIntegTest {
-        enabled = false
-    }
 }

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -200,6 +200,28 @@ class UserTypesCodecTest {
         )
     }
 
+    @Test
+    fun `can handle anonymous enum subtypes`() {
+        EnumSuperType.values().forEach {
+            assertThat(
+                roundtrip(it),
+                sameInstance(it)
+            )
+        }
+    }
+
+    enum class EnumSuperType {
+
+        SubType1 {
+            override fun displayName() = "one"
+        },
+        SubType2 {
+            override fun displayName() = "two"
+        };
+
+        abstract fun displayName(): String
+    }
+
     private
     inline fun <reified T> assertInstanceOf(any: Any): T {
         assertThat(any, instanceOf(T::class.java))

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -124,7 +124,7 @@ class UserTypesCodecTest {
         assertThat(
             "preserves identities across protocols",
             decodedSerializable.value,
-            sameInstance<Any>(decodedBean)
+            sameInstance(decodedBean)
         )
     }
 
@@ -181,7 +181,7 @@ class UserTypesCodecTest {
         val beanTrace = assertInstanceOf<PropertyTrace.Bean>(fieldTrace.trace)
         assertThat(
             beanTrace.type,
-            sameInstance<Class<*>>(bean.javaClass)
+            sameInstance(bean.javaClass)
         )
     }
 
@@ -398,7 +398,7 @@ class UserTypesCodecTest {
 
         assertThat(
             Peano.fromInt(0),
-            equalTo<Peano>(Peano.Z)
+            equalTo(Peano.Z)
         )
 
         assertThat(


### PR DESCRIPTION
Fixes #12301
