### PR TITLE
Add NotYetImplementedASTTransformation to disallowed Groovy compiler classloader classes

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -206,6 +206,7 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
         // or a NoClassDefFoundError will occur. Essentially this is drawing a line between the Groovy compiler and the Groovy
         // library, albeit only for selected classes that run a high risk of being statically referenced from a transform.
         groovyCompilerClassLoaderSpec.disallowClass("groovy.util.GroovyTestCase");
+        groovyCompilerClassLoaderSpec.disallowClass("org.codehaus.groovy.transform.NotYetImplementedASTTransformation");
         groovyCompilerClassLoaderSpec.disallowPackage("groovy.servlet");
         FilteringClassLoader groovyCompilerClassLoader = new FilteringClassLoader(GroovyClassLoader.class.getClassLoader(), groovyCompilerClassLoaderSpec);
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/10248#issuecomment-590712295

Groovy 2.5.10-SNAPSHOT contains a [change](https://github.com/apache/groovy/commit/1437642286adfc0b892f34abc1ad2738b6ea8595#diff-c97d0c653bd2fa38359fea22d60bd9fbR56) that adds a static reference from org.codehaus.groovy.transform.NotYetImplementedASTTransformation to junit.framework.AssertionFailedError. This breaks compilation of Gradle integration tests making them fail with ClassDefNotFound.

Adding `org.codehaus.groovy.transform.NotYetImplementedASTTransformation` to disallowed Groovy compiler classloader classes overcomes this, however, this change has to be in a Gradle distribution before Groovy version is bumped.

If this change does not break any existing tests - I would like to have a nightly built with it and then use that nightly build to further run all the tests against Gradle with Groovy 2.5.10-SNAPSHOT.