### PR TITLE
Do not add annotation processor classpaths to IDEA scopes

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -36,7 +36,13 @@ Some plugins will break with this new version of Gradle, for example because the
 [[changes_6.3]]
 == Upgrading from 6.2
 
-There were no breaking changes between Gradle 6.2 and 6.3.
+=== Potential breaking changes
+
+==== IDEA Sync -- annotation processor classpath is no longer added as provided dependencies
+
+Before Gradle introduced <<java_plugin.adoc#sec:incremental_annotation_processing,incremental annotation processing support>>, and with that a separate <<java_plugin.adoc#tab:configurations,annotation processor classpath>>, IDEA required the annotation processors themselves on the classpath to run them when compiling in IDEA directly.
+This is no longer necessary and thus, the processors are no longer added to an IDEA module's classpath when a Gradle project with annotation processors is imported.
+The dependencies IDEA sees at compile time are then equivalent to what Gradle sees when resolving the `compileClasspath`.
 
 === Deprecations
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -433,7 +433,6 @@ public class IdeaPlugin extends IdePlugin {
 
         Collection<Configuration> provided = scopes.get(GeneratedIdeaScope.PROVIDED.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
         provided.add(configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
-        provided.add(configurations.getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME));
 
         Collection<Configuration> runtime = scopes.get(GeneratedIdeaScope.RUNTIME.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
         runtime.add(configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
@@ -441,7 +440,6 @@ public class IdeaPlugin extends IdePlugin {
         Collection<Configuration> test = scopes.get(GeneratedIdeaScope.TEST.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
         test.add(configurations.getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME));
         test.add(configurations.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME));
-        test.add(configurations.getByName(JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME));
 
         ideaModel.getModule().setScopes(scopes);
     }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -126,10 +126,10 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         project.idea.project.languageLevel.level == new IdeaLanguageLevel(project.sourceCompatibility).level
 
         project.idea.module.scopes == [
-                PROVIDED: [plus: [project.configurations.compileClasspath, project.configurations.annotationProcessor], minus: []],
+                PROVIDED: [plus: [project.configurations.compileClasspath], minus: []],
                 COMPILE: [plus: [], minus: []],
                 RUNTIME: [plus: [project.configurations.runtimeClasspath], minus: []],
-                TEST: [plus: [project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath, project.configurations.testAnnotationProcessor], minus: []],
+                TEST: [plus: [project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath], minus: []],
         ]
     }
 


### PR DESCRIPTION
In general this is wrong. But it was done to enable IDEA to pick up the annotation processors (#7067) before it was able to use the _annotation processor_ configurations. There should be no need for this anymore.

Corresponding IDEA issue: https://youtrack.jetbrains.com/issue/IDEA-233440

Nightly to test the change: https://services.gradle.org/distributions-snapshots/gradle-6.3-branch-idea_scope_change-20200226151326+0000-bin.zip
