### PR TITLE
Rework readme to include relevant links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,22 @@ Contributors must follow the Code of Conduct outlined at [https://gradle.org/con
 
 ## Making Changes
 
+### Installing from source
+
+To create an install from the source tree you can run either of the following:
+
+    ./gradlew install -Pgradle_installPath=/usr/local/gradle-source-build
+
+This will create a minimal installation; just what's needed to run Gradle (i.e. no docs).
+
+You can then build a Gradle based project with this installation:
+
+    /usr/local/gradle-source-build/bin/gradle «some task»
+
+To create a full installation (includes docs):
+
+    ./gradlew installAll -Pgradle_installPath=/usr/local/gradle-source-build
+
 ### Development Setup
 
 In order to make changes to Gradle, you'll need:

--- a/README.md
+++ b/README.md
@@ -1,31 +1,41 @@
 <img src="gradle.png" width="350px" alt="Gradle Logo" />
 
-Gradle is a build tool with a focus on build automation and support for multi-language development. If you are building, testing, publishing, and deploying software on any platform, Gradle offers a flexible model that can support the entire development lifecycle from compiling and packaging code to publishing web sites. Gradle has been designed to support build automation across multiple languages and platforms including Java, Scala, Android, C/C++, and Groovy, and is closely integrated with development tools and continuous integration servers including Eclipse, IntelliJ, and Jenkins.
+[Gradle](https://gradle.org/) is a build tool with a focus on build automation and support for multi-language development. If you are building, testing, publishing, and deploying software on any platform, Gradle offers a flexible model that can support the entire development lifecycle from compiling and packaging code to publishing web sites. Gradle has been designed to support build automation across multiple languages and platforms including Java, Scala, Android, C/C++, and Groovy, and is closely integrated with development tools and continuous integration servers including Eclipse, IntelliJ, and Jenkins.
 
-For more information about Gradle, please visit: https://gradle.org
+**For more information, please visit the [official project homepage](https://gradle.org)**
 
-This project adheres to the [Gradle Code of Conduct](https://gradle.org/conduct/). By participating, you are expected to uphold this code.
+## Getting Started
 
-## Downloading
+* [Installing Gradle](https://docs.gradle.org/current/userguide/installation.html)
+* [Building Android Apps](https://developer.android.com/training/basics/firstapp/)
+* [Building Java Libraries](https://guides.gradle.org/building-java-libraries/)
+* [Building Kotlin JVM Libraries](https://guides.gradle.org/building-kotlin-jvm-libraries/)
+* [Building and Testing C++ Libraries](https://guides.gradle.org/building-cpp-libraries/)
+* [Building Spring Boot 2 Applications with Gradle](https://guides.gradle.org/building-spring-boot-2-projects-with-gradle/)
+* [Creating Build Scans](https://guides.gradle.org/creating-build-scans/)
 
-You can download released versions and nightly build artifacts from: https://gradle.org/downloads
+## Stay in Flow
+Enjoy first-class Gradle support in your IDE of choice.
 
-### Installing from source
+* [Android Studio](https://developer.android.com/studio/build/index.html)
+* [Eclipse](https://www.vogella.com/tutorials/EclipseGradle/article.html)
+* [IntelliJ IDEA](https://www.jetbrains.com/help/idea/gradle.html)
+* [NetBeans](http://plugins.netbeans.org/plugin/44510/gradle-support)
+* [Visual Studio Code](https://code.visualstudio.com/docs/languages/java)
 
-To create an install from the source tree you can run either of the following:
+## Need Help?
 
-    ./gradlew install -Pgradle_installPath=/usr/local/gradle-source-build
+* Get familiar with the [Gradle User Manual](https://docs.gradle.org/current/userguide/userguide.html)
+* [Upcoming trainings](https://gradle.com/training/)
+* Ask on the [forum](https://discuss.gradle.org/) or [StackOverflow](https://stackoverflow.com/questions/tagged/gradle)
+* Have a look at the [Samples](https://docs.gradle.org/current/samples/index.html)
+* Checkout the [Community Resources](https://gradle.org/resources/) as well
+* Join our [Slack Channel](https://gradl.es/slack-invite-2019)
 
-This will create a minimal installation; just what's needed to run Gradle (i.e. no docs).
-
-You can then build a Gradle based project with this installation:
-
-    /usr/local/gradle-source-build/bin/gradle «some task»
-
-To create a full installation (includes docs):
-
-    ./gradlew installAll -Pgradle_installPath=/usr/local/gradle-source-build
 
 ## Contributing
 
 If you're looking to contribute to Gradle or provide a patch/pull request, you can find more info [here](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md).
+
+This project adheres to the [Gradle Code of Conduct](https://gradle.org/conduct/). By participating, you are expected to uphold this code.
+


### PR DESCRIPTION
* Moved the local installation instructions to the contributors guide as its usually not relevant for regular gradle users
* Add links to beginner topics 
* Add pointers where to get help