### PR TITLE
Always use an absolute path for native services

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
@@ -42,6 +42,6 @@ public class NativeServicesTestFixture {
     }
 
     public static File getNativeServicesDir() {
-        return new File("build/native-libs").getAbsoluteFile();
+        return new File("build/native-libs");
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -88,7 +88,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
             if (!initialized) {
                 useNativeIntegrations = "true".equalsIgnoreCase(System.getProperty("org.gradle.native", "true"));
                 if (useNativeIntegrations) {
-                    File nativeBaseDir = getNativeServicesDir(userHomeDir);
+                    File nativeBaseDir = getNativeServicesDir(userHomeDir).getAbsoluteFile();
                     try {
                         net.rubygrapefruit.platform.Native.init(nativeBaseDir);
                     } catch (NativeIntegrationUnavailableException ex) {


### PR DESCRIPTION
by requesting the absolute path in `NativeServices`.

Fixes `GradleNativeIntegrationTest.caches native binaries in specified user home` when running with VFS retention enabled.