### PR TITLE
Fixes so that gradle/gradle functional tests are up-to-date on first load from instant execution cache

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
@@ -19,10 +19,7 @@
  *
  * The assembled jar will:
  *  - be named after `base.archivesBaseName`
- *  - include all sources
  */
-
-import accessors.sourceSets
 
 plugins {
     id("kotlin-library")
@@ -30,12 +27,6 @@ plugins {
 
 // including all sources
 tasks.jar {
-    val main by sourceSets.getting
-    from(main.allSource) {
-        // prevent duplicated zip entries
-        // see https://github.com/gradle/gradle/issues/10005
-        exclude { it.file in main.resources }
-    }
     manifest.attributes.apply {
         put("Implementation-Title", "Gradle Kotlin DSL (${project.name})")
         put("Implementation-Version", archiveVersion.get())

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -33,6 +33,8 @@ import org.gradle.api.internal.component.DefaultSoftwareComponentContainer;
 import org.gradle.api.internal.file.DefaultSourceDirectorySetFactory;
 import org.gradle.api.internal.file.DefaultTemporaryFileProvider;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileFactory;
+import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
@@ -310,12 +312,12 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultDomainObjectCollectionFactory(instantiatorFactory, services, collectionCallbackActionDecorator, MutationGuards.of(projectConfigurator));
     }
 
-    protected ManagedFactoryRegistry createManagedFactoryRegistry(ManagedFactoryRegistry parent, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory) {
+    protected ManagedFactoryRegistry createManagedFactoryRegistry(ManagedFactoryRegistry parent, FileResolver fileResolver, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory, FileFactory fileFactory, FilePropertyFactory filePropertyFactory) {
         return new DefaultManagedFactoryRegistry(parent).withFactories(
             new ManagedFactories.ConfigurableFileCollectionManagedFactory(fileResolver, taskDependencyFactory, patternSetFactory),
-            new org.gradle.api.internal.file.ManagedFactories.RegularFilePropertyManagedFactory(fileResolver),
-            new org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory(fileResolver, fileCollectionFactory),
-            new org.gradle.api.internal.file.ManagedFactories.DirectoryPropertyManagedFactory(fileResolver, fileCollectionFactory)
+            new org.gradle.api.internal.file.ManagedFactories.RegularFilePropertyManagedFactory(filePropertyFactory),
+            new org.gradle.api.internal.file.ManagedFactories.DirectoryManagedFactory(fileFactory),
+            new org.gradle.api.internal.file.ManagedFactories.DirectoryPropertyManagedFactory(filePropertyFactory)
         );
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -18,6 +18,8 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileFactory;
+import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider;
@@ -114,14 +116,14 @@ public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
         return new DefaultDeleter(clock::getCurrentTime, fileSystem::isSymlink, os.isWindows());
     }
 
-    ManagedFactoryRegistry createManagedFactoryRegistry(NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, InstantiatorFactory instantiatorFactory, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory) {
+    ManagedFactoryRegistry createManagedFactoryRegistry(NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, InstantiatorFactory instantiatorFactory, TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory, FileFactory fileFactory, FilePropertyFactory filePropertyFactory) {
         return new DefaultManagedFactoryRegistry().withFactories(
             instantiatorFactory.getManagedFactory(),
             new ConfigurableFileCollectionManagedFactory(fileResolver, taskDependencyFactory, patternSetFactory),
-            new RegularFileManagedFactory(),
-            new RegularFilePropertyManagedFactory(fileResolver),
-            new DirectoryManagedFactory(fileResolver, fileCollectionFactory),
-            new DirectoryPropertyManagedFactory(fileResolver, fileCollectionFactory),
+            new RegularFileManagedFactory(fileFactory),
+            new RegularFilePropertyManagedFactory(filePropertyFactory),
+            new DirectoryManagedFactory(fileFactory),
+            new DirectoryPropertyManagedFactory(filePropertyFactory),
             new SetPropertyManagedFactory(),
             new ListPropertyManagedFactory(),
             new MapPropertyManagedFactory(),

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.DefaultFileSystemOperations;
 import org.gradle.api.internal.file.DefaultProjectLayout;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FilePropertyFactory;
@@ -118,7 +119,7 @@ public class WorkerSharedProjectScopeServices {
                 domainObjectCollectionFactory);
     }
 
-    protected DefaultProjectLayout createProjectLayout(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory) {
-        return new DefaultProjectLayout(projectDir, fileResolver, taskDependencyFactory, fileCollectionFactory);
+    protected DefaultProjectLayout createProjectLayout(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, TaskDependencyFactory taskDependencyFactory, FilePropertyFactory filePropertyFactory, FileFactory fileFactory) {
+        return new DefaultProjectLayout(projectDir, fileResolver, taskDependencyFactory, fileCollectionFactory, filePropertyFactory, fileFactory);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
@@ -35,7 +35,7 @@ class DefaultProjectLayoutTest extends Specification {
 
     def setup() {
         projectDir = tmpDir.createDir("project")
-        layout = new DefaultProjectLayout(projectDir, TestFiles.resolver(projectDir), Stub(TaskDependencyFactory), TestFiles.fileCollectionFactory(projectDir))
+        layout = new DefaultProjectLayout(projectDir, TestFiles.resolver(projectDir), Stub(TaskDependencyFactory), TestFiles.fileCollectionFactory(projectDir), TestFiles.filePropertyFactory(projectDir), TestFiles.fileFactory())
     }
 
     def "can query the project directory"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -226,7 +226,7 @@ class DefaultProjectTest extends Specification {
         ModelSchemaStore modelSchemaStore = Stub(ModelSchemaStore)
         serviceRegistryMock.get((Type) ModelSchemaStore) >> modelSchemaStore
         serviceRegistryMock.get(ModelSchemaStore) >> modelSchemaStore
-        serviceRegistryMock.get((Type) DefaultProjectLayout) >> new DefaultProjectLayout(rootDir, TestFiles.resolver(rootDir), Stub(TaskDependencyFactory), Stub(FileCollectionFactory))
+        serviceRegistryMock.get((Type) DefaultProjectLayout) >> new DefaultProjectLayout(rootDir, TestFiles.resolver(rootDir), Stub(TaskDependencyFactory), Stub(FileCollectionFactory), TestFiles.filePropertyFactory(), TestFiles.fileFactory())
 
         build.getProjectEvaluationBroadcaster() >> Stub(ProjectEvaluationListener)
         build.getParent() >> null

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -119,6 +119,14 @@ public class TestFiles {
         return new DefaultDeleter(Time.clock()::getCurrentTime, fileSystem()::isSymlink, false);
     }
 
+    public static FilePropertyFactory filePropertyFactory() {
+        return new DefaultFilePropertyFactory(resolver(), fileCollectionFactory());
+    }
+
+    public static FilePropertyFactory filePropertyFactory(File baseDir) {
+        return new DefaultFilePropertyFactory(resolver(baseDir), fileCollectionFactory(baseDir));
+    }
+
     public static FileFactory fileFactory() {
         return new DefaultFilePropertyFactory(resolver(), fileCollectionFactory());
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -118,6 +118,11 @@ class TestUtil {
                     return new DefaultObjectFactory(instantiatorFactory.decorate(services), namedObjectInstantiator, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver, fileCollectionFactory), fileCollectionFactory, domainObjectCollectionFactory)
                 }
 
+                ProjectLayout createProjectLayout() {
+                    def filePropertyFactory = new DefaultFilePropertyFactory(fileResolver, fileCollectionFactory)
+                    return new DefaultProjectLayout(fileResolver.resolve("."), fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), fileCollectionFactory, filePropertyFactory, filePropertyFactory)
+                }
+
                 ChecksumService createChecksumService() {
                     new ChecksumService() {
                         @Override
@@ -148,7 +153,6 @@ class TestUtil {
                     }
                 }
             })
-            it.add(ProjectLayout, new DefaultProjectLayout(fileResolver.resolve("."), fileResolver, DefaultTaskDependencyFactory.withNoAssociatedProject(), fileCollectionFactory))
         }
         return services
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -70,7 +70,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         return new FixedFile(file);
     }
 
-    static class FixedDirectory extends DefaultFileSystemLocation implements Directory, Managed {
+    private static class FixedDirectory extends DefaultFileSystemLocation implements Directory, Managed {
         final FileResolver fileResolver;
         private final FileCollectionFactory fileCollectionFactory;
 
@@ -314,13 +314,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
             this.fileCollectionFactory = fileCollectionFactory;
         }
 
-        DefaultDirectoryVar(FileResolver resolver, FileCollectionFactory fileCollectionFactory, Object value) {
-            super(Directory.class);
-            this.resolver = resolver;
-            this.fileCollectionFactory = fileCollectionFactory;
-            resolveAndSet(value);
-        }
-
         @Override
         public Class<?> publicType() {
             return DirectoryProperty.class;
@@ -334,12 +327,6 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         @Override
         public FileTree getAsFileTree() {
             return fileCollectionFactory.resolving(this).getAsFileTree();
-        }
-
-        void resolveAndSet(Object value) {
-            File resolved = resolver.resolve(value);
-            FileResolver dirResolver = resolver.newResolver(resolved);
-            set(new FixedDirectory(resolved, dirResolver, fileCollectionFactory.withResolver(dirResolver)));
         }
 
         @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/ManagedFactories.java
@@ -21,7 +21,6 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.file.DefaultFilePropertyFactory.FixedDirectory;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.state.ManagedFactory;
 
@@ -31,15 +30,19 @@ public class ManagedFactories {
 
     public static class RegularFileManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = RegularFile.class;
-        private static final Class<?> IMPL_TYPE = DefaultFilePropertyFactory.FixedFile.class;
-        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
+        private final FileFactory fileFactory;
+
+        public RegularFileManagedFactory(FileFactory fileFactory) {
+            this.fileFactory = fileFactory;
+        }
 
         @Override
         public <T> T fromState(Class<T> type, Object state) {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new DefaultFilePropertyFactory.FixedFile((File) state));
+            return type.cast(fileFactory.file((File) state));
         }
 
         @Override
@@ -50,13 +53,12 @@ public class ManagedFactories {
 
     public static class RegularFilePropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = RegularFileProperty.class;
-        private static final Class<?> IMPL_TYPE = DefaultFilePropertyFactory.DefaultRegularFileVar.class;
-        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
-        private final FileResolver fileResolver;
+        private final FilePropertyFactory filePropertyFactory;
 
-        public RegularFilePropertyManagedFactory(FileResolver fileResolver) {
-            this.fileResolver = fileResolver;
+        public RegularFilePropertyManagedFactory(FilePropertyFactory filePropertyFactory) {
+            this.filePropertyFactory = filePropertyFactory;
         }
 
         @Override
@@ -64,7 +66,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new DefaultFilePropertyFactory.DefaultRegularFileVar(fileResolver).value((Provider<RegularFile>) state));
+            return type.cast(filePropertyFactory.newFileProperty().value((Provider<RegularFile>) state));
         }
 
         @Override
@@ -75,15 +77,12 @@ public class ManagedFactories {
 
     public static class DirectoryManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = Directory.class;
-        private static final Class<?> IMPL_TYPE = FixedDirectory.class;
-        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
-        private final FileResolver fileResolver;
-        private final FileCollectionFactory fileCollectionFactory;
+        private final FileFactory fileFactory;
 
-        public DirectoryManagedFactory(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
-            this.fileResolver = fileResolver;
-            this.fileCollectionFactory = fileCollectionFactory;
+        public DirectoryManagedFactory(FileFactory fileFactory) {
+            this.fileFactory = fileFactory;
         }
 
         @Override
@@ -91,7 +90,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new FixedDirectory((File) state, fileResolver, fileCollectionFactory));
+            return type.cast(fileFactory.dir((File) state));
         }
 
         @Override
@@ -102,15 +101,12 @@ public class ManagedFactories {
 
     public static class DirectoryPropertyManagedFactory implements ManagedFactory {
         private static final Class<?> PUBLIC_TYPE = DirectoryProperty.class;
-        private static final Class<?> IMPL_TYPE = DefaultFilePropertyFactory.DefaultDirectoryVar.class;
-        public static final int FACTORY_ID = Objects.hashCode(IMPL_TYPE.getName());
+        public static final int FACTORY_ID = Objects.hashCode(PUBLIC_TYPE.getName());
 
-        private final FileResolver fileResolver;
-        private final FileCollectionFactory fileCollectionFactory;
+        private final FilePropertyFactory filePropertyFactory;
 
-        public DirectoryPropertyManagedFactory(FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
-            this.fileResolver = fileResolver;
-            this.fileCollectionFactory = fileCollectionFactory;
+        public DirectoryPropertyManagedFactory(FilePropertyFactory filePropertyFactory) {
+            this.filePropertyFactory = filePropertyFactory;
         }
 
         @Override
@@ -118,7 +114,7 @@ public class ManagedFactories {
             if (!type.isAssignableFrom(PUBLIC_TYPE)) {
                 return null;
             }
-            return type.cast(new DefaultFilePropertyFactory.DefaultDirectoryVar(fileResolver, fileCollectionFactory).value((Provider<Directory>) state));
+            return type.cast(filePropertyFactory.newDirectoryProperty().value((Provider<Directory>) state));
         }
 
         @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DirectoryPropertyTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DirectoryPropertyTest.groovy
@@ -63,7 +63,7 @@ class DirectoryPropertyTest extends FileSystemPropertySpec<Directory> {
 
     @Override
     ManagedFactory managedFactory() {
-        new ManagedFactories.DirectoryPropertyManagedFactory(resolver, fileCollectionFactory)
+        new ManagedFactories.DirectoryPropertyManagedFactory(factory)
     }
 
     def "can view directory as a file tree"() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FilePropertyTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FilePropertyTest.groovy
@@ -63,6 +63,6 @@ class FilePropertyTest extends FileSystemPropertySpec<RegularFile> {
 
     @Override
     ManagedFactory managedFactory() {
-        new ManagedFactories.RegularFilePropertyManagedFactory(resolver)
+        new ManagedFactories.RegularFilePropertyManagedFactory(factory)
     }
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -337,7 +337,8 @@ class DefaultInstantExecution internal constructor(
             transformListener = service(),
             valueSourceProviderFactory = service(),
             patternSetFactory = service(),
-            fileSystem = service()
+            fileSystem = service(),
+            fileFactory = service()
         )
     }
 

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/Codecs.kt
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformParameterScheme
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.FileFactory
 import org.gradle.api.internal.file.FileLookup
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.FilePropertyFactory
@@ -101,7 +102,8 @@ class Codecs(
     transformListener: ArtifactTransformListener,
     valueSourceProviderFactory: ValueSourceProviderFactory,
     patternSetFactory: Factory<PatternSet>,
-    fileSystem: FileSystem
+    fileSystem: FileSystem,
+    fileFactory: FileFactory
 ) {
 
     val userTypesCodec = BindingsBackedCodec {
@@ -124,7 +126,7 @@ class Codecs(
         bind(ListenerBroadcastCodec(listenerManager))
         bind(LoggerCodec)
 
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory, fileSystem)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory, fileSystem, fileFactory)
 
         bind(ClosureCodec)
         bind(GroovyMetaClassCodec)
@@ -175,7 +177,7 @@ class Codecs(
         baseTypes()
 
         providerTypes(filePropertyFactory, buildServiceRegistry, valueSourceProviderFactory)
-        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory, fileSystem)
+        fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, patternSetFactory, fileSystem, fileFactory)
 
         bind(TaskNodeCodec(projectStateRegistry, userTypesCodec, taskNodeFactory))
         bind(InitialTransformationNodeCodec(buildOperationExecutor, transformListener))
@@ -218,7 +220,9 @@ class Codecs(
     }
 
     private
-    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, patternSetFactory: Factory<PatternSet>, fileSystem: FileSystem) {
+    fun BindingsBuilder.fileCollectionTypes(directoryFileTreeFactory: DirectoryFileTreeFactory, fileCollectionFactory: FileCollectionFactory, patternSetFactory: Factory<PatternSet>, fileSystem: FileSystem, fileFactory: FileFactory) {
+        bind(DirectoryCodec(fileFactory))
+        bind(RegularFileCodec(fileFactory))
         bind(FileTreeCodec(directoryFileTreeFactory, patternSetFactory, fileSystem))
         bind(ConfigurableFileCollectionCodec(fileCollectionFactory))
         bind(FileCollectionCodec(fileCollectionFactory))

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCodecs.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/serialization/codecs/FileCodecs.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution.serialization.codecs
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.internal.file.FileFactory
+import org.gradle.instantexecution.serialization.Codec
+import org.gradle.instantexecution.serialization.ReadContext
+import org.gradle.instantexecution.serialization.WriteContext
+import org.gradle.instantexecution.serialization.readFile
+import org.gradle.instantexecution.serialization.writeFile
+
+
+class DirectoryCodec(private val fileFactory: FileFactory) : Codec<Directory> {
+    override suspend fun WriteContext.encode(value: Directory) {
+        writeFile(value.asFile)
+    }
+
+    override suspend fun ReadContext.decode(): Directory {
+        return fileFactory.dir(readFile())
+    }
+}
+
+
+class RegularFileCodec(private val fileFactory: FileFactory) : Codec<RegularFile> {
+    override suspend fun WriteContext.encode(value: RegularFile) {
+        writeFile(value.asFile)
+    }
+
+    override suspend fun ReadContext.decode(): RegularFile {
+        return fileFactory.file(readFile())
+    }
+}

--- a/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
+++ b/subprojects/instant-execution/src/test/kotlin/org/gradle/instantexecution/serialization/codecs/UserTypesCodecTest.kt
@@ -413,7 +413,8 @@ class UserTypesCodecTest {
         transformListener = mock(),
         valueSourceProviderFactory = mock(),
         patternSetFactory = mock(),
-        fileSystem = mock()
+        fileSystem = mock(),
+        fileFactory = mock()
     )
 
     @Test


### PR DESCRIPTION

### Context

This PR contains 2 fixes so that the Gradle `core:integTest` and `instantExecution:integTest` tasks are up-to-date on first load from the instant execution cache. This should allow these tasks to be used from the IDE to run tests with instant execution enabled.

- Don't include the Kotlin DSL sources in the runtime Jars, but instead include these source files in the source distribution to be distributed in the same way as other source files. This was broken because `PatternSet` specs are not serialized yet. At some point this will need to be fixed, but for now, remove the unnecessary files from the Jars.
- Correctly deserialize `Directory` instances so that `Directory.file(path)` and `Directory.dir(path)` methods produce the correct result. Previously, these were always resolving paths relative to the project directory, rather than the directory itself. This meant that the functional test tasks were out of date because the files from the test distribution were declared as inputs were missing when the task was loaded from the cache, because the build logic would be looking in the wrong location for them.

This PR also refactors creation of `Directory`, `RegularFile`, `DirectoryProperty` and `RegularFileProperty` instances so that instantiation is always done by a factory, to avoid the second kind of problem in the future.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
