### PR TITLE
Fix maven repository declarations in build-init build script builder

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -954,7 +954,7 @@ public class BuildScriptBuilder {
         @Override
         public void writeCodeTo(PrettyPrinter printer) {
             ScriptBlockImpl statements = new ScriptBlockImpl();
-            statements.propertyAssignment(null, "url", url);
+            statements.propertyAssignment(null, "url", new MethodInvocationExpression(null, "uri", Collections.singletonList(new StringValue(url))));
             printer.printBlock("maven", statements);
         }
     }

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderGroovyTest.groovy
@@ -114,11 +114,11 @@ repositories {
 
     // Use another repo as well
     maven {
-        url = 'https://somewhere'
+        url = uri('https://somewhere')
     }
 
     maven {
-        url = 'https://somewhere/2'
+        url = uri('https://somewhere/2')
     }
 
     // Use JCenter
@@ -305,11 +305,11 @@ allprojects {
 
         // Use another repo as well
         maven {
-            url = 'https://somewhere'
+            url = uri('https://somewhere')
         }
 
         maven {
-            url = 'https://somewhere/2'
+            url = uri('https://somewhere/2')
         }
 
         // Use JCenter

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/BuildScriptBuilderKotlinTest.groovy
@@ -114,11 +114,11 @@ repositories {
 
     // Use another repo as well
     maven {
-        url = "https://somewhere"
+        url = uri("https://somewhere")
     }
 
     maven {
-        url = "https://somewhere/2"
+        url = uri("https://somewhere/2")
     }
 
     // Use JCenter
@@ -276,11 +276,11 @@ allprojects {
 
         // Use another repo as well
         maven {
-            url = "https://somewhere"
+            url = uri("https://somewhere")
         }
 
         maven {
-            url = "https://somewhere/2"
+            url = uri("https://somewhere/2")
         }
 
         // Use JCenter


### PR DESCRIPTION
Current build script builder generates the maven repo declaration like so:
```
maven {
    url = "some-url"
}
```
This fails with Kotlin build scripts as Kotlin will not infer "some-url" to ba a URI.
This change makes the uri() declaration explicit always, so that the generated code will be:
```
maven {
    url = uri("some-url")
}
```