### PR TITLE
Fix VFS retention soak test

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -70,4 +70,11 @@ class FunctionalTest(
             }
         }
     }
+
+    if (testCoverage.testType == TestType.soak) {
+        failureConditions {
+            // Some soak tests produce OOM exceptions
+            javaCrash = false
+        }
+    }
 })

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionHelper.java
@@ -21,7 +21,7 @@ import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_R
 
 public class VfsRetentionHelper {
     public static void waitForChangesToBePickedUp() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(100);
     }
 
     public static String getEnableVfsRetentionArgument() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/VfsRetentionHelper.java
@@ -21,7 +21,7 @@ import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_R
 
 public class VfsRetentionHelper {
     public static void waitForChangesToBePickedUp() throws InterruptedException {
-        Thread.sleep(100);
+        Thread.sleep(80);
     }
 
     public static String getEnableVfsRetentionArgument() {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -111,7 +111,11 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
     }
 
     private static void waitBetweenChangesToAvoidOverflow() {
-        Thread.sleep(150)
+        if (OperatingSystem.current().windows) {
+            Thread.sleep(200)
+        } else {
+            Thread.sleep(150)
+        }
     }
 
     private static int minimumExpectedFileSystemEvents(int numberOfChangedFiles, int numberOfChangesPerFile) {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -119,7 +119,11 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
     }
 
     private static void waitBetweenChangesToAvoidOverflow() {
-        Thread.sleep(150)
+        if (OperatingSystem.current().windows) {
+            Thread.sleep(200)
+        } else {
+            Thread.sleep(150)
+        }
     }
 
     private static int minimumExpectedFileSystemEvents(int numberOfChangedFiles, int numberOfChangesPerFile) {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -87,7 +87,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
     def "file watching works with many changes between two builds"() {
         // Use 20 minutes idle timeout since the test may be running longer with an idle daemon
         executer.withDaemonIdleTimeoutSecs(1200)
-        def numberOfChangedSourcesFilesPerBatch = MAX_FILE_CHANGES_WITHOUT_OVERFLOW
+        def numberOfChangedSourcesFilesPerBatch = maxFileChangesWithoutOverflow
         def numberOfChangeBatches = 500
 
         when:
@@ -110,12 +110,16 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
         retainedFilesInCurrentBuild - numberOfChangedSourcesFilesPerBatch == retainedFilesSinceLastBuild
     }
 
-    private static void waitBetweenChangesToAvoidOverflow() {
+    private static int getMaxFileChangesWithoutOverflow() {
         if (OperatingSystem.current().windows) {
-            Thread.sleep(300)
+            800
         } else {
-            Thread.sleep(150)
+            1000
         }
+    }
+
+    private static void waitBetweenChangesToAvoidOverflow() {
+        Thread.sleep(150)
     }
 
     private static int minimumExpectedFileSystemEvents(int numberOfChangedFiles, int numberOfChangesPerFile) {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -22,9 +22,7 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.soak.categories.SoakTest
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.experimental.categories.Category
-import spock.lang.Unroll
 
-@Unroll
 @Category(SoakTest)
 class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implements VfsRetentionFixture {
 
@@ -101,7 +99,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
         when:
         numberOfChangeBatches.times { iteration ->
             changeSourceFiles(iteration, numberOfChangedSourcesFilesPerBatch)
-            waitForChangesToBePickedUp()
+            waitBetweenChangesToAvoidOverflow()
         }
         then:
         succeeds("assemble")
@@ -110,6 +108,11 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
         assertWatchingSucceeded()
         receivedFileSystemEvents >= minimumExpectedFileSystemEvents(numberOfChangedSourcesFilesPerBatch, numberOfChangeBatches)
         retainedFilesInCurrentBuild - numberOfChangedSourcesFilesPerBatch == retainedFilesSinceLastBuild
+    }
+
+    private void waitBetweenChangesToAvoidOverflow() {
+        waitForChangesToBePickedUp()
+        waitForChangesToBePickedUp()
     }
 
     private static int minimumExpectedFileSystemEvents(int numberOfChangedFiles, int numberOfChangesPerFile) {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -112,7 +112,7 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
 
     private static void waitBetweenChangesToAvoidOverflow() {
         if (OperatingSystem.current().windows) {
-            Thread.sleep(200)
+            Thread.sleep(300)
         } else {
             Thread.sleep(150)
         }

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -110,9 +110,8 @@ class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implement
         retainedFilesInCurrentBuild - numberOfChangedSourcesFilesPerBatch == retainedFilesSinceLastBuild
     }
 
-    private void waitBetweenChangesToAvoidOverflow() {
-        waitForChangesToBePickedUp()
-        waitForChangesToBePickedUp()
+    private static void waitBetweenChangesToAvoidOverflow() {
+        Thread.sleep(150)
     }
 
     private static int minimumExpectedFileSystemEvents(int numberOfChangedFiles, int numberOfChangesPerFile) {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/VirtualFileSystemRetentionSoakTest.groovy
@@ -22,9 +22,7 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.soak.categories.SoakTest
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.experimental.categories.Category
-import spock.lang.Ignore
 
-@Ignore("https://github.com/gradle/gradle-private/issues/2974")
 @Category(SoakTest)
 class VirtualFileSystemRetentionSoakTest extends DaemonIntegrationSpec implements VfsRetentionFixture {
 


### PR DESCRIPTION
This PR adjust the parameters of the soak test, so the file watcher does not receive the overflow event.

It does so by making at most 1000 file changes as batch.

After some tests, we also reduce the wait time for changes to be picked up to 80ms. That seems to work quite well on macOS and Windows.

Fixes https://github.com/gradle/gradle-private/issues/2974
Fixes https://github.com/gradle/gradle-private/issues/2979