### PR TITLE
Fix tooling API metadata - bundling attribute

### DIFF
--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
@@ -233,6 +233,10 @@ open class ShadedJarPlugin : Plugin<Project> {
         tasks.named<Jar>("sourcesJar") {
             from(sourcesPath.incoming.artifactView { lenient(true) }.files)
         }
+        val sourcesElements by configurations
+        sourcesElements.attributes {
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.SHADOWED))
+        }
     }
 
     private

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiResolveIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiResolveIntegrationTest.groovy
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.GradleVersion
+import spock.lang.Unroll
+
+class ToolingApiResolveIntegrationTest extends AbstractIntegrationSpec {
+
+    @Unroll
+    def "can resolve tooling API via #configuration"() {
+        given:
+        def tapiVersion = GradleVersion.current().version
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+            repositories {
+                maven { url '${buildContext.libsRepo.toURI().toURL()}' }
+                ${mavenCentralRepository()}
+            }
+
+            configurations { customConf }
+
+            dependencies {
+                implementation 'org.gradle:gradle-tooling-api:${tapiVersion}'
+                customConf 'org.gradle:gradle-tooling-api:${tapiVersion}'
+            }
+
+            tasks.register('resolve') {
+                doLast {
+                    println configurations.${configuration}.files.collect { it.name }
+                }
+            }
+        """
+
+        when:
+        succeeds 'resolve'
+
+        then:
+        outputContains("[gradle-tooling-api-${tapiVersion}.jar, slf4j-api-1.7.28.jar]")
+
+        where:
+        configuration << ['compileClasspath', 'runtimeClasspath', 'customConf']
+    }
+
+    def "can resolve sources variant of tooling API"() {
+        given:
+        def tapiVersion = GradleVersion.current().version
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+            repositories {
+                maven { url '${buildContext.libsRepo.toURI().toURL()}' }
+                ${mavenCentralRepository()}
+            }
+
+            configurations {
+                sources {
+                    extendsFrom runtimeClasspath
+                    canBeConsumed = false
+                    visible = false
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
+                    }
+                }
+            }
+
+            dependencies {
+                implementation "org.gradle:gradle-tooling-api:${tapiVersion}"
+            }
+
+            tasks.register('resolve') {
+                doLast {
+                    println configurations.sources.files.collect { it.name }
+                }
+            }
+        """
+
+        when:
+        succeeds 'resolve'
+
+        then:
+        outputContains("[gradle-tooling-api-${tapiVersion}-sources.jar]")
+    }
+}


### PR DESCRIPTION
Currently there are two different bundlings used in the metadata:
- runtime variant: SHADOWED
- sources variant: EXTERNAL

Because of that, a resolution without requested attributes is not able to identify the 'runtime' variant as the preferred one.

To resolve that, we now set the sources variant to SHADOWED as well to match the library variant it belongs to. Although it technically does not contain all the sources of the shadowed classes.

Then legacy behavior like: 'configurations.compile.files' (resolving the Tooling API directly through the 'compile' configuration) still works as before. The runtime variant is selected.

**This has been fixed in retrospect for 6.2 and 6.2.1 by removing the module metadata file**
(in previous releases we also only published pom)