### PR TITLE
Add Group configuration for other IDE tasks

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -137,6 +137,7 @@ public class EclipsePlugin extends IdePlugin {
             @Override
             public void execute(GenerateEclipseProject task) {
                 task.setDescription("Generates the Eclipse project file.");
+                task.setGroup("IDE");
                 task.setInputFile(project.file(".project"));
                 task.setOutputFile(project.file(".project"));
             }
@@ -206,6 +207,7 @@ public class EclipsePlugin extends IdePlugin {
                     @Override
                     public void execute(final GenerateEclipseClasspath task) {
                         task.setDescription("Generates the Eclipse classpath file.");
+                        task.setGroup("IDE");
                         task.setInputFile(project.file(".classpath"));
                         task.setOutputFile(project.file(".classpath"));
                     }
@@ -306,6 +308,7 @@ public class EclipsePlugin extends IdePlugin {
                     public void execute(GenerateEclipseJdt task) {
                         //task properties:
                         task.setDescription("Generates the Eclipse JDT settings file.");
+                        task.setGroup("IDE");
                         task.setOutputFile(project.file(".settings/org.eclipse.jdt.core.prefs"));
                         task.setInputFile(project.file(".settings/org.eclipse.jdt.core.prefs"));
                     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -150,6 +150,7 @@ public class IdeaPlugin extends IdePlugin {
                 @Override
                 public void execute(GenerateIdeaWorkspace task) {
                     task.setDescription("Generates an IDEA workspace file (IWS)");
+                    task.setGroup("IDE");
                     task.setOutputFile(new File(project.getProjectDir(), project.getName() + ".iws"));
                 }
             });
@@ -166,6 +167,7 @@ public class IdeaPlugin extends IdePlugin {
                 @Override
                 public void execute(GenerateIdeaProject projectTask) {
                     projectTask.setDescription("Generates IDEA project file (IPR)");
+                    projectTask.setGroup("IDE");
                 }
             });
             ideaModel.setProject(ideaProject);
@@ -257,6 +259,7 @@ public class IdeaPlugin extends IdePlugin {
             @Override
             public void execute(GenerateIdeaModule task) {
                 task.setDescription("Generates IDEA module files (IML)");
+                task.setGroup("IDE");
             }
         });
         ideaModel.setModule(module);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdePlugin.java
@@ -120,6 +120,8 @@ public abstract class IdePlugin implements Plugin<Project> {
         final TaskProvider<Delete> cleanWorker = project.getTasks().register(cleanName(workerName), Delete.class, new Action<Delete>() {
             @Override
             public void execute(Delete cleanWorker) {
+                cleanWorker.setDescription("Cleans '" + workerName + "' task");
+                cleanWorker.setGroup("IDE");
                 cleanWorker.delete(worker);
             }
         });


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
After run `./gradlew task --all` a lot of tasks for IDE not listed under `IDE tasks`.
They are listed under `Other tasks`.
This change will put all IDE tasks under `IDE tasks`

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

Signed-off-by: Ron Gebauer <ron.gebauer@raytion.com>