### PR TITLE
Add access to POM packaging in component metadata rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataContext.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataContext.java
@@ -28,7 +28,6 @@ public interface ComponentMetadataContext {
 
     /**
      * Used to access a specific descriptor format.
-     * For Ivy descriptor, an {@link org.gradle.api.artifacts.ivy.IvyModuleDescriptor ivy module descriptor} is returned.
      *
      * @param descriptorClass the descriptor class
      * @param <T> the descriptor type
@@ -36,6 +35,7 @@ public interface ComponentMetadataContext {
      * @return a descriptor, or {@code null} if there was none of the requested type.
      *
      * @see org.gradle.api.artifacts.ivy.IvyModuleDescriptor
+     * @see org.gradle.api.artifacts.maven.PomModuleDescriptor
      */
     @Nullable
     <T> T getDescriptor(Class<T> descriptorClass);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentMetadataHandler.java
@@ -78,6 +78,8 @@ public interface ComponentMetadataHandler {
      * <ul>
      *     <li>{@link org.gradle.api.artifacts.ivy.IvyModuleDescriptor} - additional Ivy-specific
      *     metadata. Rules declaring this parameter will only be invoked for components packaged as an Ivy module.</li>
+     *     <li>{@link org.gradle.api.artifacts.maven.PomModuleDescriptor} - additional Maven-specific
+     *     metadata. Rules declaring this parameter will only be invoked for components packaged as a POM module.</li>
      * </ul>
      *
      * @param rule the rule to be added
@@ -94,10 +96,10 @@ public interface ComponentMetadataHandler {
      * <ul>
      *     <li>must return void.</li>
      *     <li>must have {@link ComponentMetadataDetails} as the first parameter.</li>
-     *     <li>may have an additional parameter of type {@link org.gradle.api.artifacts.ivy.IvyModuleDescriptor}.</li>
+     *     <li>may have an additional parameter of type {@link org.gradle.api.artifacts.ivy.IvyModuleDescriptor} or {@link org.gradle.api.artifacts.maven.PomModuleDescriptor}.</li>
      * </ul>
      *
-     * @param ruleSource  the rule source object to be added
+     * @param ruleSource the rule source object to be added
      * @return this
      */
     ComponentMetadataHandler all(Object ruleSource);

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/maven/PomModuleDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/maven/PomModuleDescriptor.java
@@ -16,9 +16,14 @@
 
 package org.gradle.api.artifacts.maven;
 
+import org.gradle.api.Incubating;
+
 /**
  * The metadata about a Maven POM that acts as an input to a component metadata rule.
+ *
+ * @since 6.3
  */
+@Incubating
 public interface PomModuleDescriptor {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/maven/PomModuleDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/maven/PomModuleDescriptor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts.maven;
+
+/**
+ * The metadata about a Maven POM that acts as an input to a component metadata rule.
+ */
+public interface PomModuleDescriptor {
+
+    /**
+     * Returns the packaging for this POM.
+     *
+     * @return the packaging type
+     */
+    String getPackaging();
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/maven/package-info.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/maven/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Classes for declaring and using Maven modules.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.api.artifacts.maven;

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -112,7 +112,6 @@ dependencies {
 @CacheableRule
 class PomRule implements ComponentMetadataRule {
     public void execute(ComponentMetadataContext context) {
-        println(context)
         assert context.getDescriptor(PomModuleDescriptor) != null
         assert context.getDescriptor(PomModuleDescriptor).packaging == "jar"
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -100,6 +100,7 @@ dependencies {
         outputDoesNotContain('See dependency')
     }
 
+    @ToBeFixedForInstantExecution
     @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def 'cached rule can access PomModuleDescriptor for Maven component'() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesErrorHandlingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesErrorHandlingIntegrationTest.groovy
@@ -87,7 +87,7 @@ class ComponentMetadataRulesErrorHandlingIntegrationTest extends AbstractHttpDep
         "String vs ->"                       | "First parameter of rule action closure must be of type 'ComponentMetadataDetails'."
         "ComponentMetadata cm, String s ->"  | "Rule may not have an input parameter of type: java.lang.String. " +
                                                "Second parameter must be of type: " +
-                                               "org.gradle.api.artifacts.ivy.IvyModuleDescriptor."
+                                               "org.gradle.api.artifacts.ivy.IvyModuleDescriptor or org.gradle.api.artifacts.maven.PomModuleDescriptor."
     }
 
     def "produces sensible error when rule throws an exception" () {
@@ -120,7 +120,7 @@ class ComponentMetadataRulesErrorHandlingIntegrationTest extends AbstractHttpDep
                     throw new Exception('From Test')
                 }
             }
-             
+
             dependencies {
                 components {
                     withModule('org.test', UnusedRule)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -503,6 +503,7 @@ dependencies {
         succeeds 'resolve'
     }
 
+    @ToBeFixedForInstantExecution
     @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
     def 'rule can access PomModuleDescriptor for Maven component'() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -443,6 +443,7 @@ dependencies {
             """
 def plainRuleInvoked = false
 def ivyRuleInvoked = false
+def mavenRuleInvoked = false
 
 dependencies {
     components {
@@ -452,11 +453,15 @@ dependencies {
         all { ComponentMetadataDetails details, IvyModuleDescriptor descriptor ->
             ivyRuleInvoked = true
         }
+        all { ComponentMetadataDetails details, PomModuleDescriptor descriptor ->
+            mavenRuleInvoked = true
+        }
     }
 }
 
 resolve.doLast {
     assert plainRuleInvoked
+    assert mavenRuleInvoked
     assert !ivyRuleInvoked
 }
 """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultPomModuleDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultPomModuleDescriptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.maven.PomModuleDescriptor;
+import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
+
+public class DefaultPomModuleDescriptor implements PomModuleDescriptor {
+
+    private final String packaging;
+
+    public DefaultPomModuleDescriptor(MavenModuleResolveMetadata mavenMetadata) {
+        this.packaging = mavenMetadata.getPackaging();
+    }
+
+    @Override
+    public String getPackaging() {
+        return packaging;
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
@@ -18,13 +18,7 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import org.gradle.api.artifacts.ComponentMetadataContext;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
-import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
-import org.gradle.api.artifacts.maven.PomModuleDescriptor;
-import org.gradle.api.internal.artifacts.DefaultPomModuleDescriptor;
-import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
-import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
 
 class DefaultComponentMetadataContext implements ComponentMetadataContext {
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
@@ -23,6 +23,7 @@ import org.gradle.internal.component.external.model.ModuleComponentResolveMetada
 class DefaultComponentMetadataContext implements ComponentMetadataContext {
 
     private final ComponentMetadataDetails details;
+    // We keep this field for access from Groovy scripts, as we currently miss some public API: https://github.com/gradle/gradle/issues/12349
     private final ModuleComponentResolveMetadata metadata;
     private final MetadataDescriptorFactory descriptorFactory;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataContext.java
@@ -19,29 +19,28 @@ package org.gradle.api.internal.artifacts.dsl;
 import org.gradle.api.artifacts.ComponentMetadataContext;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.artifacts.maven.PomModuleDescriptor;
+import org.gradle.api.internal.artifacts.DefaultPomModuleDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
 
 class DefaultComponentMetadataContext implements ComponentMetadataContext {
 
     private final ComponentMetadataDetails details;
     private final ModuleComponentResolveMetadata metadata;
+    private final MetadataDescriptorFactory descriptorFactory;
 
     DefaultComponentMetadataContext(ComponentMetadataDetails details, ModuleComponentResolveMetadata metadata) {
         this.details = details;
         this.metadata = metadata;
+        this.descriptorFactory = new MetadataDescriptorFactory(metadata);
     }
 
     @Override
     public <T> T getDescriptor(Class<T> descriptorClass) {
-        if (IvyModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
-            if (metadata instanceof IvyModuleResolveMetadata) {
-                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
-                return descriptorClass.cast(new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus()));
-            }
-        }
-        return null;
+        return descriptorFactory.createDescriptor(descriptorClass);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.artifacts.maven.PomModuleDescriptor;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -59,7 +60,6 @@ import org.gradle.internal.typeconversion.UnsupportedNotationException;
 
 public class DefaultComponentMetadataHandler implements ComponentMetadataHandler, ComponentMetadataHandlerInternal, ComponentMetadataProcessorFactory {
     private static final String ADAPTER_NAME = ComponentMetadataHandler.class.getSimpleName();
-    private static final Class<?> VALIDATOR_PARAM = IvyModuleDescriptor.class;
     private static final String INVALID_SPEC_ERROR = "Could not add a component metadata rule for module '%s'.";
 
     private final Instantiator instantiator;
@@ -103,7 +103,7 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     }
 
     private static RuleActionAdapter createAdapter() {
-        RuleActionValidator ruleActionValidator = new DefaultRuleActionValidator(VALIDATOR_PARAM);
+        RuleActionValidator ruleActionValidator = new DefaultRuleActionValidator(IvyModuleDescriptor.class, PomModuleDescriptor.class);
         return new DefaultRuleActionAdapter(ruleActionValidator, ADAPTER_NAME);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -263,15 +263,12 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         if (!shouldExecute(action, metadata)) {
             return;
         }
-        final List<Object> inputs = Lists.newArrayList();
-        Object additionalInput = gatherAdditionalInput(action, metadata);
-        if (additionalInput != null) {
-            inputs.add(additionalInput);
-        }
+
+        List<?> inputs = gatherAdditionalInputs(action, metadata);
         executeAction(action, inputs, details);
     }
 
-    private void executeAction(RuleAction<? super ComponentMetadataDetails> action, List<Object> inputs, ComponentMetadataDetails details) {
+    private void executeAction(RuleAction<? super ComponentMetadataDetails> action, List<?> inputs, ComponentMetadataDetails details) {
         try {
             synchronized (this) {
                 action.execute(details, inputs);
@@ -291,15 +288,16 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         return true;
     }
 
-    private Object gatherAdditionalInput(RuleAction<? super ComponentMetadataDetails> action, ModuleComponentResolveMetadata metadata) {
+    private List<?> gatherAdditionalInputs(RuleAction<? super ComponentMetadataDetails> action, ModuleComponentResolveMetadata metadata) {
+        final List<Object> inputs = Lists.newArrayList();
         for (Class<?> inputType : action.getInputTypes()) {
             MetadataDescriptorFactory descriptorFactory = new MetadataDescriptorFactory(metadata);
             Object descriptor = descriptorFactory.createDescriptor(inputType);
             if (descriptor != null) {
-                return descriptor;
+                inputs.add(descriptor);
             }
         }
-        return null;
+        return inputs;
     }
 
     private static class ExceptionHandler implements InstantiatingAction.ExceptionHandler<ComponentMetadataContext> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -26,12 +26,10 @@ import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VariantMetadata;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessor;
 import org.gradle.api.internal.artifacts.MetadataResolutionContext;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
-import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.UserProvidedMetadata;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
@@ -46,7 +44,6 @@ import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ivy.DefaultIvyModuleResolveMetadata;
-import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ivy.RealisedIvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.DefaultMavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.RealisedMavenModuleResolveMetadata;
@@ -262,25 +259,19 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         if (!specRuleAction.getSpec().isSatisfiedBy(details)) {
             return;
         }
-
-        final List<Object> inputs = Lists.newArrayList();
         final RuleAction<? super ComponentMetadataDetails> action = specRuleAction.getAction();
-        for (Class<?> inputType : action.getInputTypes()) {
-            if (inputType == IvyModuleDescriptor.class) {
-                // Ignore the rule if it expects Ivy metadata and this isn't an Ivy module
-                if (!(metadata instanceof IvyModuleResolveMetadata)) {
-                    return;
-                }
-
-                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
-                inputs.add(new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus()));
-                continue;
-            }
-
-            // We've already validated the inputs: should never get here.
-            throw new IllegalStateException();
+        if (!shouldExecute(action, metadata)) {
+            return;
         }
+        final List<Object> inputs = Lists.newArrayList();
+        Object additionalInput = gatherAdditionalInput(action, metadata);
+        if (additionalInput != null) {
+            inputs.add(additionalInput);
+        }
+        executeAction(action, inputs, details);
+    }
 
+    private void executeAction(RuleAction<? super ComponentMetadataDetails> action, List<Object> inputs, ComponentMetadataDetails details) {
         try {
             synchronized (this) {
                 action.execute(details, inputs);
@@ -290,6 +281,25 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         } catch (Exception e) {
             throw new InvalidUserCodeException(String.format("There was an error while evaluating a component metadata rule for %s.", details.getId()), e);
         }
+    }
+
+    private boolean shouldExecute(RuleAction<? super ComponentMetadataDetails> action, ModuleComponentResolveMetadata metadata) {
+        List<Class<?>> inputTypes = action.getInputTypes();
+        if (!inputTypes.isEmpty()) {
+            return inputTypes.stream().anyMatch(input -> MetadataDescriptorFactory.isMatchingMetadata(input, metadata));
+        }
+        return true;
+    }
+
+    private Object gatherAdditionalInput(RuleAction<? super ComponentMetadataDetails> action, ModuleComponentResolveMetadata metadata) {
+        for (Class<?> inputType : action.getInputTypes()) {
+            MetadataDescriptorFactory descriptorFactory = new MetadataDescriptorFactory(metadata);
+            Object descriptor = descriptorFactory.createDescriptor(inputType);
+            if (descriptor != null) {
+                return descriptor;
+            }
+        }
+        return null;
     }
 
     private static class ExceptionHandler implements InstantiatingAction.ExceptionHandler<ComponentMetadataContext> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactory.java
@@ -33,20 +33,28 @@ class MetadataDescriptorFactory {
     }
 
     public <T> T createDescriptor(Class<T> descriptorClass) {
-        if (IvyModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
-            if (metadata instanceof IvyModuleResolveMetadata) {
-                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
-                IvyModuleDescriptor descriptor = new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus());
-                return descriptorClass.cast(descriptor);
-            }
-        } else if (PomModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
-            if (metadata instanceof MavenModuleResolveMetadata) {
-                MavenModuleResolveMetadata mavenMetadata = (MavenModuleResolveMetadata) metadata;
-                PomModuleDescriptor descriptor = new DefaultPomModuleDescriptor(mavenMetadata);
-                return descriptorClass.cast(descriptor);
-            }
+        if (isIvyMetadata(descriptorClass, metadata)) {
+            IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
+            IvyModuleDescriptor descriptor = new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus());
+            return descriptorClass.cast(descriptor);
+        } else if (isPomMetadata(descriptorClass, metadata)) {
+            MavenModuleResolveMetadata mavenMetadata = (MavenModuleResolveMetadata) metadata;
+            PomModuleDescriptor descriptor = new DefaultPomModuleDescriptor(mavenMetadata);
+            return descriptorClass.cast(descriptor);
         }
         return null;
+    }
+
+    public static boolean isMatchingMetadata(Class<?> descriptor, ModuleComponentResolveMetadata metadata) {
+        return isPomMetadata(descriptor, metadata) || isIvyMetadata(descriptor, metadata);
+    }
+
+    private static boolean isIvyMetadata(Class<?> descriptor, ModuleComponentResolveMetadata metadata) {
+        return descriptor == IvyModuleDescriptor.class && metadata instanceof IvyModuleResolveMetadata;
+    }
+
+    private static boolean isPomMetadata(Class<?> descriptor, ModuleComponentResolveMetadata metadata) {
+        return descriptor == PomModuleDescriptor.class && metadata instanceof MavenModuleResolveMetadata;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
+import org.gradle.api.artifacts.maven.PomModuleDescriptor;
+import org.gradle.api.internal.artifacts.DefaultPomModuleDescriptor;
+import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
+import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
+
+class MetadataDescriptorFactory {
+
+    private final ModuleComponentResolveMetadata metadata;
+
+    public MetadataDescriptorFactory(ModuleComponentResolveMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public <T> T createDescriptor(Class<T> descriptorClass) {
+        if (IvyModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
+            if (metadata instanceof IvyModuleResolveMetadata) {
+                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
+                IvyModuleDescriptor descriptor = new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus());
+                return descriptorClass.cast(descriptor);
+            }
+        } else if (PomModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
+            if (metadata instanceof MavenModuleResolveMetadata) {
+                MavenModuleResolveMetadata mavenMetadata = (MavenModuleResolveMetadata) metadata;
+                PomModuleDescriptor descriptor = new DefaultPomModuleDescriptor(mavenMetadata);
+                return descriptorClass.cast(descriptor);
+            }
+        }
+        return null;
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactory.java
@@ -50,11 +50,11 @@ class MetadataDescriptorFactory {
     }
 
     private static boolean isIvyMetadata(Class<?> descriptor, ModuleComponentResolveMetadata metadata) {
-        return descriptor == IvyModuleDescriptor.class && metadata instanceof IvyModuleResolveMetadata;
+        return IvyModuleDescriptor.class.isAssignableFrom(descriptor) && metadata instanceof IvyModuleResolveMetadata;
     }
 
     private static boolean isPomMetadata(Class<?> descriptor, ModuleComponentResolveMetadata metadata) {
-        return descriptor == PomModuleDescriptor.class && metadata instanceof MavenModuleResolveMetadata;
+        return PomModuleDescriptor.class.isAssignableFrom(descriptor) && metadata instanceof MavenModuleResolveMetadata;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/WrappingComponentMetadataContext.java
@@ -19,13 +19,10 @@ package org.gradle.api.internal.artifacts.dsl;
 import org.gradle.api.artifacts.ComponentMetadataContext;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
-import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataDetailsAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl;
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataImpl;
-import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
@@ -40,6 +37,7 @@ class WrappingComponentMetadataContext implements ComponentMetadataContext {
     private final NotationParser<Object, DependencyConstraintMetadataImpl> dependencyConstraintMetadataNotationParser;
     private final NotationParser<Object, ComponentIdentifier> componentIdentifierParser;
     private final PlatformSupport platformSupport;
+    private final MetadataDescriptorFactory descriptorFactory;
 
     private MutableModuleComponentResolveMetadata mutableMetadata;
     private ComponentMetadataDetails details;
@@ -55,17 +53,12 @@ class WrappingComponentMetadataContext implements ComponentMetadataContext {
         this.dependencyConstraintMetadataNotationParser = dependencyConstraintMetadataNotationParser;
         this.componentIdentifierParser = componentIdentifierParser;
         this.platformSupport = platformSupport;
+        this.descriptorFactory = new MetadataDescriptorFactory(metadata);
     }
 
     @Override
     public <T> T getDescriptor(Class<T> descriptorClass) {
-        if (IvyModuleDescriptor.class.isAssignableFrom(descriptorClass)) {
-            if (metadata instanceof IvyModuleResolveMetadata) {
-                IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metadata;
-                return descriptorClass.cast(new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus()));
-            }
-        }
-        return null;
+        return descriptorFactory.createDescriptor(descriptorClass);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultPomModuleDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultPomModuleDescriptorTest.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts
+
+import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata
+import spock.lang.Specification
+
+class DefaultPomModuleDescriptorTest extends Specification {
+
+    def 'exposes packaging for maven metadata'() {
+        given:
+        def metadata = Mock(MavenModuleResolveMetadata)
+        metadata.getPackaging() >> "foo"
+        def pomDescriptor = new DefaultPomModuleDescriptor(metadata)
+
+        when:
+        def packaging = pomDescriptor.packaging
+
+        then:
+        packaging == "foo"
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -430,7 +430,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         InvalidUserCodeException e = thrown()
         e.message == "The closure provided is not valid as a rule for 'ComponentMetadataHandler'."
         e.cause instanceof RuleActionValidationException
-        e.cause.message == "Rule may not have an input parameter of type: java.lang.String. Second parameter must be of type: org.gradle.api.artifacts.ivy.IvyModuleDescriptor."
+        e.cause.message == "Rule may not have an input parameter of type: java.lang.String. Second parameter must be of type: org.gradle.api.artifacts.ivy.IvyModuleDescriptor or org.gradle.api.artifacts.maven.PomModuleDescriptor."
     }
 
     def "supports rule with multiple inputs in arbitrary order"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactoryTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl
+
+import org.gradle.api.artifacts.ivy.IvyModuleDescriptor
+import org.gradle.api.artifacts.maven.PomModuleDescriptor
+import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
+import org.gradle.internal.component.external.model.ivy.DefaultIvyModuleResolveMetadata
+import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata
+import com.google.common.collect.ImmutableMap;
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.xml.namespace.QName
+
+class MetadataDescriptorFactoryTest extends Specification {
+
+    def 'exposes ivy descriptor if ivy metadata present'() {
+        given:
+        DefaultIvyModuleResolveMetadata metadata = Stub()
+        def key = new NamespaceId("", "foo")
+        metadata.getExtraAttributes() >> ImmutableMap.copyOf([(key): "bar"])
+        metadata.getStatus() >> "status"
+        metadata.getBranch() >> "branch"
+        def factory = new MetadataDescriptorFactory(metadata)
+
+        when:
+        def descriptor = factory.createDescriptor(IvyModuleDescriptor)
+
+        then:
+        descriptor.branch == "branch"
+        descriptor.ivyStatus == "status"
+        descriptor.extraInfo.asMap() == [(new QName("foo")): "bar"]
+    }
+
+    def 'exposes pom descriptor if pom metadata present'() {
+        given:
+        MavenModuleResolveMetadata metadata = Stub()
+        metadata.getPackaging() >> "pack"
+        def factory = new MetadataDescriptorFactory(metadata)
+
+        when:
+        def descriptor = factory.createDescriptor(PomModuleDescriptor)
+
+        then:
+        descriptor.packaging == "pack"
+    }
+
+    @Unroll
+    def 'does not expose #name descriptor if no #name metadata present'() {
+        given:
+        def metadata = Mock(ModuleComponentResolveMetadata)
+        def factory = new MetadataDescriptorFactory(metadata)
+
+        when:
+        def descriptor = factory.createDescriptor(descriptorType)
+
+        then:
+        descriptor == null
+
+        where:
+        name      | descriptorType
+        "ivy"     | IvyModuleDescriptor
+        "maven"   | PomModuleDescriptor
+    }
+
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/MetadataDescriptorFactoryTest.groovy
@@ -16,13 +16,14 @@
 
 package org.gradle.api.internal.artifacts.dsl
 
+import com.google.common.collect.ImmutableMap
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor
 import org.gradle.api.artifacts.maven.PomModuleDescriptor
 import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.external.model.ivy.DefaultIvyModuleResolveMetadata
+import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata
 import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata
-import com.google.common.collect.ImmutableMap;
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -74,9 +75,29 @@ class MetadataDescriptorFactoryTest extends Specification {
         descriptor == null
 
         where:
-        name      | descriptorType
-        "ivy"     | IvyModuleDescriptor
-        "maven"   | PomModuleDescriptor
+        name    | descriptorType
+        "ivy"   | IvyModuleDescriptor
+        "maven" | PomModuleDescriptor
+    }
+
+    @Unroll
+    def '#descriptorType and metadata #metadataType should match: #match'() {
+        given:
+        def metadata = Mock(metadataType)
+        def factory = new MetadataDescriptorFactory(metadata)
+
+        when:
+        def actualMatch = factory.isMatchingMetadata(descriptorType, metadata)
+
+        then:
+        actualMatch == match
+
+        where:
+        metadataType               | descriptorType      | match
+        IvyModuleResolveMetadata   | IvyModuleDescriptor | true
+        MavenModuleResolveMetadata | PomModuleDescriptor | true
+        MavenModuleResolveMetadata | IvyModuleDescriptor | false
+        IvyModuleResolveMetadata   | PomModuleDescriptor | false
     }
 
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/DefaultRuleActionValidatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/DefaultRuleActionValidatorTest.groovy
@@ -36,7 +36,7 @@ class DefaultRuleActionValidatorTest extends Specification {
         when:
         def ruleValidator = new DefaultRuleActionValidator()
         ruleValidator.validate(Stub(RuleAction) {
-            getInputTypes() >> { [ Long ] }
+            getInputTypes() >> { [Long] }
         })
 
         then:
@@ -44,13 +44,38 @@ class DefaultRuleActionValidatorTest extends Specification {
         failure.message == "Rule may not have an input parameter of type: java.lang.Long."
     }
 
-    def "accepts valid type" () {
+    def "rejects invalid type when multiple types are configured"() {
+        when:
+        def ruleValidator = new DefaultRuleActionValidator(Integer, Short)
+        ruleValidator.validate(Stub(RuleAction) {
+            getInputTypes() >> { [Long] }
+        })
+
+        then:
+        def failure = thrown(RuleActionValidationException)
+        failure.message == "Rule may not have an input parameter of type: java.lang.Long. Second parameter must be of type: java.lang.Integer or java.lang.Short."
+    }
+
+    def "accepts valid type"() {
         def ruleValidator = new DefaultRuleActionValidator(String)
         def ruleAction = Stub(RuleAction) {
-            getInputTypes() >> { [ String ] }
+            getInputTypes() >> { [String] }
         }
 
         expect:
         ruleValidator.validate(ruleAction) == ruleAction
+    }
+
+    def "accepts valid type with multiple valid types"() {
+        def ruleValidator = new DefaultRuleActionValidator(String, Long)
+        def ruleAction = Stub(RuleAction) {
+            getInputTypes() >> { [parameterType] }
+        }
+
+        expect:
+        ruleValidator.validate(ruleAction) == ruleAction
+
+        where:
+        parameterType << [String, Long]
     }
 }

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
@@ -283,12 +283,22 @@ However, modifying attributes or capabilities on Ivy configurations has no effec
 
 For very Ivy specific use cases, the component metadata rules API also offers access to other details only found in Ivy metadata.
 These are available through the link:{javadocPath}/org/gradle/api/artifacts/ivy/IvyModuleDescriptor.html[IvyModuleDescriptor] interface and can be accessed using `getDescriptor(IvyModuleDescriptor)` on the link:{javadocPath}/org/gradle/api/artifacts/ComponentMetadataContext.html[ComponentMetadataContext].
-(Note that for other types of metadata this method returns null.)
 
 .Ivy component metadata rule
 ====
 include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy",files="build.gradle[tags=ivy-component-metadata-rule]"]
 include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin",files="build.gradle.kts[tags=ivy-component-metadata-rule]"]
+====
+
+== Filter using Maven metadata  ==
+
+For Maven specific use cases, the component metadata rules API also offers access to other details only found in POM metadata.
+These are available through the link:{javadocPath}/org/gradle/api/artifacts/maven/PomModuleDescriptor.html[PomModuleDescriptor] interface and can be accessed using `getDescriptor(PomModuleDescriptor)` on the link:{javadocPath}/org/gradle/api/artifacts/ComponentMetadataContext.html[ComponentMetadataContext].
+
+.Access pom packaging type in component metadata rule
+====
+include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy",files="build.gradle[tags=maven-packaging-component-metadata-rule]"]
+include::sample[dir="snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin",files="build.gradle.kts[tags=maven-packaging-component-metadata-rule]"]
 ====
 
 == Modifying metadata on the component level for alignment

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy/build.gradle
@@ -246,6 +246,16 @@ class IvyComponentRule implements ComponentMetadataRule {
 }
 // end::ivy-component-metadata-rule[]
 
+// tag::maven-packaging-component-metadata-rule[]
+class MavenComponentRule implements ComponentMetadataRule {
+    void execute(ComponentMetadataContext context) {
+        val descriptor = context.getDescriptor(PomModuleDescriptor)
+        if (descriptor != null && descriptor.packaging == "war") {
+            // ...
+        }
+    }
+}
+// end::maven-packaging-component-metadata-rule[]
 
 // tag::custom-status-scheme[]
 class CustomStatusRule implements ComponentMetadataRule {

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy/build.gradle
@@ -257,6 +257,13 @@ class MavenComponentRule implements ComponentMetadataRule {
 }
 // end::maven-packaging-component-metadata-rule[]
 
+dependencies {
+    components {
+        all(MavenComponentRule)
+    }
+}
+
+
 // tag::custom-status-scheme[]
 class CustomStatusRule implements ComponentMetadataRule {
     void execute(ComponentMetadataContext context) {

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/groovy/build.gradle
@@ -238,7 +238,7 @@ dependencies {
 // tag::ivy-component-metadata-rule[]
 class IvyComponentRule implements ComponentMetadataRule {
     void execute(ComponentMetadataContext context) {
-        val descriptor = context.getDescriptor(IvyModuleDescriptor)
+        def descriptor = context.getDescriptor(IvyModuleDescriptor)
         if (descriptor != null && descriptor.branch == "testing") {
             context.details.status = "rc"
         }
@@ -249,7 +249,7 @@ class IvyComponentRule implements ComponentMetadataRule {
 // tag::maven-packaging-component-metadata-rule[]
 class MavenComponentRule implements ComponentMetadataRule {
     void execute(ComponentMetadataContext context) {
-        val descriptor = context.getDescriptor(PomModuleDescriptor)
+        def descriptor = context.getDescriptor(PomModuleDescriptor)
         if (descriptor != null && descriptor.packaging == "war") {
             // ...
         }
@@ -259,6 +259,7 @@ class MavenComponentRule implements ComponentMetadataRule {
 
 dependencies {
     components {
+        all(IvyComponentRule)
         all(MavenComponentRule)
     }
 }

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin/build.gradle.kts
@@ -256,6 +256,7 @@ open class MavenComponentRule : ComponentMetadataRule {
 
 dependencies {
     components {
+        all<IvyComponentRule>()
         all<MavenComponentRule>()
     }
 }

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin/build.gradle.kts
@@ -243,6 +243,16 @@ open class IvyComponentRule : ComponentMetadataRule {
 }
 // end::ivy-component-metadata-rule[]
 
+// tag::maven-packaging-component-metadata-rule[]
+open class MavenComponentRule : ComponentMetadataRule {
+    override fun execute(context: ComponentMetadataContext) {
+        val descriptor = context.getDescriptor(PomModuleDescriptor::class)
+        if (descriptor != null && descriptor.packaging == "war") {
+            // ...
+        }
+    }
+}
+// end::maven-packaging-component-metadata-rule[]
 
 // tag::custom-status-scheme[]
 open class CustomStatusRule : ComponentMetadataRule {

--- a/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/userguide/dependencyManagement/customizingResolution/metadataRule/kotlin/build.gradle.kts
@@ -254,6 +254,12 @@ open class MavenComponentRule : ComponentMetadataRule {
 }
 // end::maven-packaging-component-metadata-rule[]
 
+dependencies {
+    components {
+        all<MavenComponentRule>()
+    }
+}
+
 // tag::custom-status-scheme[]
 open class CustomStatusRule : ComponentMetadataRule {
     override fun execute(context: ComponentMetadataContext) {


### PR DESCRIPTION
Fixes #11955

* Introduced PomModuleDescriptor analogous to IvyModuleDescriptor
* Extracted descriptor creation into new factory to be shared between real and caching context