### PR TITLE
Add JavaVersion constants up to and including latest LTS Java 17

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -60,6 +60,33 @@ public enum JavaVersion {
     VERSION_14,
 
     /**
+     * Java 15 major version.
+     * Not officially supported by Gradle. Use at your own risk.
+     *
+     * @since 6.3
+     */
+    @Incubating
+    VERSION_15,
+
+    /**
+     * Java 16 major version.
+     * Not officially supported by Gradle. Use at your own risk.
+     *
+     * @since 6.3
+     */
+    @Incubating
+    VERSION_16,
+
+    /**
+     * Java 17 major version.
+     * Not officially supported by Gradle. Use at your own risk.
+     *
+     * @since 6.3
+     */
+    @Incubating
+    VERSION_17,
+
+    /**
      * Higher version of Java.
      * @since 4.7
      */

--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -52,6 +52,14 @@ public enum JavaVersion {
     VERSION_13,
 
     /**
+     * Java 14 major version.
+     *
+     * @since 6.3
+     */
+    @Incubating
+    VERSION_14,
+
+    /**
      * Higher version of Java.
      * @since 4.7
      */

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
@@ -49,7 +49,8 @@ class JavaVersionSpec extends Specification {
         JavaVersion.VERSION_11.toString() == "11"
         JavaVersion.VERSION_12.toString() == "12"
         JavaVersion.VERSION_13.toString() == "13"
-        JavaVersion.VERSION_HIGHER.toString() == "14"
+        JavaVersion.VERSION_14.toString() == "14"
+        JavaVersion.VERSION_HIGHER.toString() == "15"
     }
 
     def convertsStringToVersion() {
@@ -82,6 +83,8 @@ class JavaVersionSpec extends Specification {
 
         JavaVersion.toVersion("11-ea") == JavaVersion.VERSION_11
         JavaVersion.toVersion("12-ea") == JavaVersion.VERSION_12
+        JavaVersion.toVersion("13-ea") == JavaVersion.VERSION_13
+        JavaVersion.toVersion("14-ea") == JavaVersion.VERSION_14
         JavaVersion.toVersion("999-ea") == JavaVersion.VERSION_HIGHER
     }
 
@@ -100,6 +103,7 @@ class JavaVersionSpec extends Specification {
         JavaVersion.forClassVersion(55) == JavaVersion.VERSION_11
         JavaVersion.forClassVersion(56) == JavaVersion.VERSION_12
         JavaVersion.forClassVersion(57) == JavaVersion.VERSION_13
+        JavaVersion.forClassVersion(58) == JavaVersion.VERSION_14
         JavaVersion.forClassVersion(999) == JavaVersion.VERSION_HIGHER
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/JavaVersionSpec.groovy
@@ -50,7 +50,10 @@ class JavaVersionSpec extends Specification {
         JavaVersion.VERSION_12.toString() == "12"
         JavaVersion.VERSION_13.toString() == "13"
         JavaVersion.VERSION_14.toString() == "14"
-        JavaVersion.VERSION_HIGHER.toString() == "15"
+        JavaVersion.VERSION_15.toString() == "15"
+        JavaVersion.VERSION_16.toString() == "16"
+        JavaVersion.VERSION_17.toString() == "17"
+        JavaVersion.VERSION_HIGHER.toString() == "18"
     }
 
     def convertsStringToVersion() {
@@ -85,6 +88,9 @@ class JavaVersionSpec extends Specification {
         JavaVersion.toVersion("12-ea") == JavaVersion.VERSION_12
         JavaVersion.toVersion("13-ea") == JavaVersion.VERSION_13
         JavaVersion.toVersion("14-ea") == JavaVersion.VERSION_14
+        JavaVersion.toVersion("15-ea") == JavaVersion.VERSION_15
+        JavaVersion.toVersion("16-ea") == JavaVersion.VERSION_16
+        JavaVersion.toVersion("17-ea") == JavaVersion.VERSION_17
         JavaVersion.toVersion("999-ea") == JavaVersion.VERSION_HIGHER
     }
 
@@ -104,6 +110,9 @@ class JavaVersionSpec extends Specification {
         JavaVersion.forClassVersion(56) == JavaVersion.VERSION_12
         JavaVersion.forClassVersion(57) == JavaVersion.VERSION_13
         JavaVersion.forClassVersion(58) == JavaVersion.VERSION_14
+        JavaVersion.forClassVersion(59) == JavaVersion.VERSION_15
+        JavaVersion.forClassVersion(60) == JavaVersion.VERSION_16
+        JavaVersion.forClassVersion(61) == JavaVersion.VERSION_17
         JavaVersion.forClassVersion(999) == JavaVersion.VERSION_HIGHER
     }
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/10248

Add JavaVersion constants up to and including latest LTS Java 17.
Aim to support JDK14 with 6.3 and add Javadoc warnings stating about future versions as not officially supported.
