### PR TITLE
Improve and document flags for running multi version tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,13 +70,13 @@ buildTypes {
     // Used for builds to run all tests
     create("fullTest") {
         tasks("test", "forkingIntegTest", "forkingCrossVersionTest")
-        projectProperties("testAllVersions" to true)
+        projectProperties("testVersions" to "all")
     }
 
     // Used for builds to test the code on certain platforms
     create("platformTest") {
         tasks("test", "forkingIntegTest", "forkingCrossVersionTest")
-        projectProperties("testPartialVersions" to true)
+        projectProperties("testVersions" to "partial")
     }
 
     // Tests not using the daemon mode
@@ -135,13 +135,13 @@ buildTypes {
     // Used for cross version tests on CI
     create("allVersionsCrossVersionTest") {
         tasks("allVersionsCrossVersionTests")
-        projectProperties("testAllVersions" to true)
+        projectProperties("testVersions" to "all")
         projectProperties("useAllDistribution" to true)
     }
 
     create("allVersionsIntegMultiVersionTest") {
         tasks("integMultiVersionTest")
-        projectProperties("testAllVersions" to true)
+        projectProperties("testVersions" to "all")
         projectProperties("useAllDistribution" to true)
     }
 
@@ -165,7 +165,7 @@ buildTypes {
 
     create("soakTest") {
         tasks("soak:soakIntegTest")
-        projectProperties("testAllVersions" to true)
+        projectProperties("testVersions" to "all")
     }
 
     // Used to run the dependency management engine in "force component realization" mode

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTestingPlugin.kt
@@ -103,20 +103,11 @@ class DistributionTestingPlugin : Plugin<Project> {
     fun DistributionTest.setSystemPropertiesOfTestJVM(project: Project) {
         // use -PtestVersions=all or -PtestVersions=1.2,1.3…
         val integTestVersionsSysProp = "org.gradle.integtest.versions"
+        val sysPropValue = System.getProperty(integTestVersionsSysProp)
         if (project.hasProperty("testVersions")) {
             systemProperties[integTestVersionsSysProp] = project.property("testVersions")
         } else {
-            if (integTestVersionsSysProp !in systemProperties) {
-                if (project.findProperty("testPartialVersions") == true) {
-                    systemProperties[integTestVersionsSysProp] = "partial"
-                }
-                if (project.findProperty("testAllVersions") == true) {
-                    systemProperties[integTestVersionsSysProp] = "all"
-                }
-                if (integTestVersionsSysProp !in systemProperties) {
-                    systemProperties[integTestVersionsSysProp] = "default"
-                }
-            }
+            systemProperties[integTestVersionsSysProp] = "default"
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractCompatibilityTestRunner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractCompatibilityTestRunner.java
@@ -34,6 +34,8 @@ import static org.gradle.util.CollectionUtils.sort;
 
 /**
  * A base class for those test runners which execute a test multiple times against a set of Gradle versions.
+ * <p>
+ * See {@link AbstractContextualMultiVersionSpecRunner} for information on running these tests.
  */
 public abstract class AbstractCompatibilityTestRunner extends AbstractContextualMultiVersionSpecRunner<GradleDistributionTool> {
     protected final IntegrationTestBuildContext buildContext = IntegrationTestBuildContext.INSTANCE;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContextualMultiVersionSpecRunner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContextualMultiVersionSpecRunner.java
@@ -28,6 +28,23 @@ import java.util.Set;
 
 import static com.google.common.collect.Iterators.getLast;
 
+/**
+ * Tests using this runner and its subtypes will run by default the first version specified.
+ * <p>
+ * The following command line flag is used to determine the versions to run:
+ * <ul>
+ *     <li>{@code -PtestVersions=(default|all|partial|1,2,3)} will run the tests according to the configured value
+ *     <ul>
+ *         <li>{@code default} will run only the first configured version</li>
+ *         <li>{@code all} will run all configured versions</li>
+ *         <li>{@code partial} will run the first and last configured versions</li>
+ *         <li>{@code 1,2,3} will run with versions {@code 1}, {@code 2} and {@code 3}</li>
+ *     </ul>
+ *     </li>
+ * </ul>
+ *
+ * @param <T>
+ */
 public abstract class AbstractContextualMultiVersionSpecRunner<T extends AbstractContextualMultiVersionSpecRunner.VersionedTool> extends AbstractMultiTestRunner {
     public static final String VERSIONS_SYSPROP_NAME = "org.gradle.integtest.versions";
 
@@ -89,7 +106,7 @@ public abstract class AbstractContextualMultiVersionSpecRunner<T extends Abstrac
     }
 
     protected abstract boolean isAvailable(T version);
-    
+
     protected abstract Collection<Execution> createExecutionsFor(T versionedTool);
 
     public AbstractContextualMultiVersionSpecRunner(Class<?> target) {
@@ -147,7 +164,7 @@ public abstract class AbstractContextualMultiVersionSpecRunner<T extends Abstrac
                 }
             }
         }
-        
+
         for (T version : versionsUnderTest) {
             for (Execution execution : createExecutionsFor(version)) {
                 add(execution);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionTestRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionTestRunner.groovy
@@ -26,6 +26,8 @@ import org.gradle.util.GradleVersion
  *
  * <p>A test class can be annotated with {@link TargetVersions} to specify the set of versions the test is compatible with, and {@link IgnoreVersions} to specify the set of versions the
  * test should not be run for.
+ * <p>
+ * See {@link AbstractContextualMultiVersionSpecRunner} for information on running these tests.
  */
 class CrossVersionTestRunner extends AbstractCompatibilityTestRunner {
     CrossVersionTestRunner(Class<? extends CrossVersionIntegrationSpec> target) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionIntegrationSpec.groovy
@@ -20,6 +20,9 @@ import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.gradle.util.VersionNumber
 
+/**
+ * See {@link AbstractContextualMultiVersionSpecRunner} for information on running these tests.
+ */
 @RunWith(MultiVersionSpecRunner)
 @Category(ContextualMultiVersionTest.class)
 abstract class MultiVersionIntegrationSpec extends AbstractIntegrationSpec {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionSpecRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionSpecRunner.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.integtests.fixtures
 /**
- * Runs the target test class against the versions specified in a {@link TargetVersions} or {@link TargetCoverage}
+ * Runs the target test class against the versions specified in a {@link TargetVersions} or {@link TargetCoverage}.
+ * <p>
+ * See {@link AbstractContextualMultiVersionSpecRunner} for information on running these tests.
  */
 class MultiVersionSpecRunner extends AbstractContextualMultiVersionSpecRunner<DefaultVersionedTool> {
     def versions

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeToolChainTestRunner.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/NativeToolChainTestRunner.java
@@ -27,6 +27,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * See {@link AbstractContextualMultiVersionSpecRunner} for information on running these tests.
+ */
 public class NativeToolChainTestRunner extends AbstractContextualMultiVersionSpecRunner<AvailableToolChains.ToolChainCandidate> {
 
     public NativeToolChainTestRunner(Class<? extends AbstractInstalledToolChainIntegrationSpec> target) {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiCompatibilitySuiteRunner.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiCompatibilitySuiteRunner.groovy
@@ -21,6 +21,9 @@ import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.util.GradleVersion
 
+/**
+ * See {@link org.gradle.integtests.fixtures.AbstractContextualMultiVersionSpecRunner} for information on running these tests.
+ */
 class ToolingApiCompatibilitySuiteRunner extends AbstractCompatibilityTestRunner {
     private static final GradleVersion MINIMAL_VERSION = GradleVersion.version("2.6")
 


### PR DESCRIPTION
This commit makes it easier to run all or partial versions of tests.

@big-guy @ghale @rieske Can I get your feedback on this?
@blindpirate Can you sanity check this will not break any CI workflow?