### PR TITLE
Remove FIX_TO_WORK_ON_JAVA9 constraints from tests that pass with Java9+

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -50,8 +50,6 @@ class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
                 //downgrade version:
                 pmd "$testDependency"
             }
-
-            ${!TestPrecondition.FIX_TO_WORK_ON_JAVA9.fulfilled ? "sourceCompatibility = 1.6" : ""}
         """.stripIndent()
 
         then:

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
-import org.gradle.util.TestPrecondition
 
 class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
 

--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/ScalaLanguageIncrementalBuildIntegrationTest.groovy
@@ -20,11 +20,8 @@ import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.integtests.fixtures.jvm.TestJvmComponent
 import org.gradle.integtests.language.AbstractJvmLanguageIncrementalBuildIntegrationTest
 import org.gradle.language.scala.fixtures.TestScalaComponent
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 
 @TestReproducibleArchives
-@Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9) // Pruning sources from previous analysis, due to incompatible CompileSetup.
 class ScalaLanguageIncrementalBuildIntegrationTest extends AbstractJvmLanguageIncrementalBuildIntegrationTest {
     TestJvmComponent testComponent = new TestScalaComponent()
 }

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -19,8 +19,6 @@ package org.gradle.api.reporting.plugins
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
@@ -338,7 +336,6 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
         hasReport(':subproject:test', 'junitXml')
     }
 
-    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
     @ToBeFixedForInstantExecution
     void 'dashboard includes JaCoCo reports'() {
         given:

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/CachedScalaCompileIntegrationTest.groovy
@@ -20,8 +20,6 @@ import org.gradle.api.tasks.compile.AbstractCachedCompileIntegrationTest
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
 import org.gradle.scala.ScalaCompilationFixture
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 
 class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegrationTest {
     String compilationTask = ':compileScala'
@@ -65,7 +63,7 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
             }
 
             ${mavenCentralRepository()}
-            
+
             dependencies {
                 implementation group: 'org.scala-lang', name: 'scala-library', version: '2.11.12'
             }
@@ -242,7 +240,6 @@ class CachedScalaCompileIntegrationTest extends AbstractCachedCompileIntegration
         !class2.exists()
     }
 
-    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9) // Zinc cannot do incremental compilation on Java 9, yet
     @ToBeFixedForInstantExecution
     def "zinc handles removal of stale output files after loading from cache"() {
         createJavaClass("Class1")

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerUnsupportedFeatureFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerUnsupportedFeatureFailureIntegrationTest.groovy
@@ -28,7 +28,6 @@ import spock.lang.Retry
 import static org.gradle.integtests.fixtures.RetryConditions.cleanProjectDir
 
 @NonCrossVersion
-@Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
 @Retry(condition = { failure.class != UnsupportedFeatureException && cleanProjectDir(instance) }, count = 2)
 class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
@@ -56,6 +55,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         }
     }
 
+    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
     @Debug
     def "fails informatively when trying to inspect build output in debug mode with unsupported gradle version"() {
         def maxUnsupportedVersion = getMaxUnsupportedVersion(TestKitFeature.CAPTURE_BUILD_RESULT_OUTPUT_IN_DEBUG)
@@ -77,6 +77,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         e.message == "The version of Gradle you are using ($maxUnsupportedVersion) does not capture build output in debug mode with the GradleRunner. Support for this is available in Gradle $minSupportedVersion and all later versions."
     }
 
+    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
     def "fails informatively when trying to inject plugin classpath with unsupported gradle version"() {
         def maxUnsupportedVersion = getMaxUnsupportedVersion(TestKitFeature.PLUGIN_CLASSPATH_INJECTION)
         def minSupportedVersion = TestKitFeature.PLUGIN_CLASSPATH_INJECTION.since.version
@@ -95,6 +96,7 @@ class GradleRunnerUnsupportedFeatureFailureIntegrationTest extends BaseGradleRun
         e.message == "The version of Gradle you are using ($maxUnsupportedVersion) does not support plugin classpath injection. Support for this is available in Gradle $minSupportedVersion and all later versions."
     }
 
+    @Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)
     def "fails informatively if trying to use conventional plugin classpath on version that does not support injection"() {
         given:
         def maxUnsupportedVersion = getMaxUnsupportedVersion(TestKitFeature.PLUGIN_CLASSPATH_INJECTION)


### PR DESCRIPTION
`@Requires(TestPrecondition.FIX_TO_WORK_ON_JAVA9)` ignores the test if it is run on JDK9 or newer.
This change removes this restriction from tests that actually work with JDK9+ now.