### PR TITLE
Force AbstractTestDirectoryProvider to use Class

### DIFF
--- a/subprojects/base-services/src/integTest/groovy/org/gradle/internal/SystemPropertiesIntegrationTest.groovy
+++ b/subprojects/base-services/src/integTest/groovy/org/gradle/internal/SystemPropertiesIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 
 class SystemPropertiesIntegrationTest extends ConcurrentSpec {
     @Rule SetSystemProperties properties = new SetSystemProperties()
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def "sets a system property for the duration of a Factory operation"() {
         final int threadCount = 100

--- a/subprojects/base-services/src/test/groovy/org/gradle/api/internal/DocumentationRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/api/internal/DocumentationRegistryTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DocumentationRegistryTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final GradleVersion gradleVersion = GradleVersion.current()
     final DocumentationRegistry registry = new DocumentationRegistry()
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/IoActionsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/IoActionsTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.internal.IoActions.*
 
 class IoActionsTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmp
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     def "can use file action to write to text file"() {
         given:

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/jvm/AppleJvmTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/jvm/AppleJvmTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class AppleJvmTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule SetSystemProperties sysProp = new SetSystemProperties()
     OperatingSystem os = Mock(OperatingSystem)
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/jvm/JvmTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/jvm/JvmTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 
 class JvmTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule
     SetSystemProperties sysProp = new SetSystemProperties()
     OperatingSystem os = Mock() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
@@ -26,7 +26,7 @@ import java.lang.reflect.Modifier
 
 class OperatingSystemTest extends Specification {
     @Rule SetSystemProperties systemProperties = new SetSystemProperties()
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
         OperatingSystem.resetCurrent()

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/process/ArgWriterTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/process/ArgWriterTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class ArgWriterTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final StringWriter writer = new StringWriter()
     final PrintWriter printWriter = new PrintWriter(writer, true)
     final ArgWriter argWriter = ArgWriter.unixStyle(printWriter)

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GFileUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GFileUtilsTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.util.GFileUtils.touch
 
 class GFileUtilsTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def "can read the file's tail"() {
         def f = temp.file("foo.txt") << """

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
@@ -52,7 +52,7 @@ class HttpBuildCacheServiceTest extends Specification {
     @Rule
     HttpServer server = new HttpServer()
     @Rule
-    TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider(getClass())
 
     BuildCacheService cache
     BuildCacheServiceFactory.Describer buildCacheDescriber

--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
@@ -41,7 +41,7 @@ import static org.gradle.internal.file.TreeType.FILE
 @CleanupTestDirectory
 abstract class AbstractTarBuildCacheEntryPackerSpec extends Specification {
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def readOrigin = Stub(OriginReader)
     def writeOrigin = Stub(OriginWriter)
 

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerTest.groovy
@@ -79,7 +79,7 @@ class DefaultBuildCacheControllerTest extends Specification {
     def operations = new TestBuildOperationExecutor()
 
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     interface Local extends BuildCacheService, LocalBuildCacheService {}
 

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/service/LoadTargetTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/service/LoadTargetTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 class LoadTargetTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def target = new LoadTarget(temporaryFolder.file("file"))
 

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/service/StoreTargetTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/service/StoreTargetTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 class StoreTargetTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def target = new StoreTarget(temporaryFolder.file("file") << "test")
 

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactoryTest.groovy
@@ -47,7 +47,7 @@ class DirectoryBuildCacheServiceFactoryTest extends Specification {
     def config = Mock(DirectoryBuildCache)
     def buildCacheDescriber = new NoopBuildCacheDescriber()
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def "can create service with default directory"() {
         def cacheDir = temporaryFolder.file("build-cache-1")

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Specification
 @UsesNativeServices
 @CleanupTestDirectory
 class DirectoryBuildCacheServiceTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def cacheDir = temporaryFolder.createDir("cache")
     def fileStore = new DefaultPathKeyFileStore(TestUtil.checksumService, cacheDir)
     def persistentCache = Mock(PersistentCache) {

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/WrapperPluginSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/WrapperPluginSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class WrapperPluginSpec extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(testDir.testDirectory)
 
     def "adds 'wrapper' task"() {

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/AbstractBuildScriptBuilderTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/AbstractBuildScriptBuilderTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 abstract class AbstractBuildScriptBuilderTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def fileResolver = TestFiles.resolver(tmpDir.testDirectory)
 

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/GitIgnoreGeneratorTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 class GitIgnoreGeneratorTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def fileResolver = TestFiles.resolver(tmpDir.testDirectory)
 

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/maven/MavenProjectsCreatorSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/maven/MavenProjectsCreatorSpec.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class MavenProjectsCreatorSpec extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
     private settings = new DefaultMavenSettingsProvider({} as MavenFileLocations)
     private creator = new MavenProjectsCreator()
 
@@ -161,7 +161,7 @@ class MavenProjectsCreatorSpec extends Specification {
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.gradle.commons</groupId>
   <artifactId>commons</artifactId>
-  
+
 </project>
 """
         def mavenProjects = creator.create(settings.buildSettings(), parentPom)

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
@@ -38,7 +38,7 @@ import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFrame
 @UsesNativeServices
 class InitBuildSpec extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
 
     InitBuild init
 

--- a/subprojects/build-profile/src/test/groovy/org/gradle/profile/ProfileReportRendererTest.groovy
+++ b/subprojects/build-profile/src/test/groovy/org/gradle/profile/ProfileReportRendererTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class ProfileReportRendererTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def "renders report"() {
         def model = new BuildProfile(new StartParameter())

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
@@ -38,7 +38,7 @@ class AbstractBuildScanPluginPerformanceTest extends Specification {
 
     static String incomingDir = "../../incoming"
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @AutoCleanup
     @Shared

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -41,7 +41,7 @@ import spock.lang.Specification
 
 class DefaultIncludedBuildRegistryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def includedBuildFactory = Stub(IncludedBuildFactory)
     def registry = new DefaultIncludedBuildRegistry(includedBuildFactory, Stub(IncludedBuildDependencySubstitutionsBuilder), Stub(GradleLauncherFactory), Stub(ListenerManager), Stub(BuildTreeScopeServices))
 

--- a/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/StartParameterTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.util.Matchers.isSerializable
 import static org.junit.Assert.assertThat
 
 class StartParameterTest extends Specification {
-    @Rule private TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule private TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule private SetSystemProperties systemProperties = new SetSystemProperties()
 
     void "new instance has correct state"() {

--- a/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.internal.FileUtils.canonicalize
 class BuildLayoutParametersTest extends Specification {
 
     @Rule SetSystemProperties props = new SetSystemProperties()
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     @Requires(TestPrecondition.NOT_EC2_AGENT)
     @Issue('https://github.com/gradle/gradle-private/issues/2876')

--- a/subprojects/core-api/src/test/groovy/org/gradle/initialization/DistributionInitScriptFinderTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/initialization/DistributionInitScriptFinderTest.groovy
@@ -20,7 +20,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DistributionInitScriptFinderTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final def distDir = tmpDir.createDir("gradle-home")
     final DistributionInitScriptFinder finder = new DistributionInitScriptFinder(distDir)
 

--- a/subprojects/core-api/src/test/groovy/org/gradle/initialization/UserHomeInitScriptFinderTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/initialization/UserHomeInitScriptFinderTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 @CleanupTestDirectory
 class UserHomeInitScriptFinderTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     private UserHomeInitScriptFinder finder
 
     def setup() {

--- a/subprojects/core-api/src/test/groovy/org/gradle/internal/installation/CurrentGradleInstallationLocatorTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/internal/installation/CurrentGradleInstallationLocatorTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Unroll
 // This test keeps the jars locked on Windows JDK 1.7
 class CurrentGradleInstallationLocatorTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     List<Closeable> loaders = []
 
     TestFile distDir

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Issue
 class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def nativeDir = new File(executer.gradleUserHomeDir, 'native')
     def library

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
@@ -40,7 +40,7 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
     private final static long JAR_GENERATION_TIME_MS = 2000L
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Rule
     RedirectStdOutAndErr stdout = new RedirectStdOutAndErr()

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/AbstractFileWatcherTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/AbstractFileWatcherTest.groovy
@@ -41,7 +41,7 @@ abstract class AbstractFileWatcherTest extends Specification {
     })
 
     @Rule
-    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
     // We default to 10 seconds polling on some OS / JVM versions
     // Since this code is going to be replaced with native file watching soon, this fix is fine for now
     long waitForEventsMillis = 11000L

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/DefaultFileSystemChangeWaiterTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/DefaultFileSystemChangeWaiterTest.groovy
@@ -29,7 +29,7 @@ import org.junit.Rule
 import java.util.concurrent.atomic.AtomicReference
 
 class DefaultFileSystemChangeWaiterTest extends ConcurrentSpec {
-    @Rule TestNameTestDirectoryProvider testDirectory
+    @Rule TestNameTestDirectoryProvider testDirectory = new TestNameTestDirectoryProvider(getClass())
     FileWatcherEventListener reporter = new LoggingFileWatchEventListener()
     def fileSystem = Stub(FileSystem)
     def pendingChangesListener = Mock(PendingChangesListener)

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -61,7 +61,7 @@ abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
         .build()
     final MessagingServer server = services.get(MessagingServer.class)
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule
     final RedirectStdOutAndErr stdout = new RedirectStdOutAndErr()
     final CacheFactory factory = services.get(CacheFactory.class)

--- a/subprojects/core/src/test/groovy/org/gradle/api/file/FileCollectionSymlinkTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/file/FileCollectionSymlinkTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Unroll
 @UsesNativeServices
 class FileCollectionSymlinkTest extends Specification {
     @Shared Project project = ProjectBuilder.builder().build()
-    @Shared @ClassRule TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    @Shared @ClassRule TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
     @Shared TestFile baseDir = temporaryFolder.createDir('baseDir')
     @Shared TestFile file = baseDir.file("file")
     @Shared TestFile symlink = baseDir.file("symlink")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifactTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifactTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class ArchivePublishArtifactTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     def testUtil = TestUtil.create(temporaryFolder)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class CachingFileHasherTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def target = Mock(FileHasher)
     def cache = Mock(PersistentIndexedCache)
     def cacheAccess = Mock(CrossBuildFileHashCache)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournalTest.groovy
@@ -37,7 +37,7 @@ import static org.gradle.util.GUtil.loadProperties
 
 class DefaultFileAccessTimeJournalTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def userHome = tmpDir.createDir("user-home")
     def cacheScopeMapping = new DefaultCacheScopeMapping(userHome, null, GradleVersion.current())

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class ZipHasherTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     ZipHasher zipHasher = new ZipHasher(new RuntimeClasspathResourceHasher(), ResourceFilter.FILTER_NOTHING)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class DefaultModuleRegistryTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     TestFile runtimeDep
     TestFile externalRuntimeDep
     TestFile resourcesDir

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/ManifestUtilTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/ManifestUtilTest.groovy
@@ -27,7 +27,7 @@ import java.util.zip.ZipEntry
 
 public class ManifestUtilTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def jarFile = tmpDir.file("mydir/jarfile.jar").createFile()
 
     def "creates manifest classpath with relative urls"() {
@@ -43,11 +43,11 @@ public class ManifestUtilTest extends Specification {
         def tmpDirPath = tmpDir.testDirectory.toURI().rawPath
         def file1 = tmpDir.file('different/jar1.jar')
         def file2 = tmpDir.file('different/nested/jar2.jar')
-        
+
         then:
         ManifestUtil.createManifestClasspath(jarFile, [file1, file2]) == "${tmpDirPath}different/jar1.jar ${tmpDirPath}different/nested/jar2.jar"
     }
-    
+
     def "url encodes spaces in manifest classpath"() {
         when:
         def classpathFiles = [tmpDir.file('mydir/jar one.jar'), tmpDir.file('mydir/nested dir/jar two.jar')]
@@ -60,17 +60,17 @@ public class ManifestUtilTest extends Specification {
         when:
         def nonexistent = new File("does no exist");
         def directory = tmpDir.createDir("new_directory");
-        
+
         then:
         ManifestUtil.parseManifestClasspath(nonexistent) == []
         ManifestUtil.parseManifestClasspath(directory) == []
     }
-    
+
     def "returns empty classpath for non-jar file"() {
         when:
         def file = tmpDir.createFile('non-jar.zip')
         file << "text"
-        
+
         then:
         ManifestUtil.parseManifestClasspath(file) == []
     }
@@ -114,7 +114,7 @@ public class ManifestUtilTest extends Specification {
 
         and:
         def classpathURI = ManifestUtil.parseManifestClasspath(jarFile)[0]
-        
+
         then:
         new File(classpathURI).absoluteFile == classpathFile.absoluteFile
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
@@ -34,7 +34,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 @UsesNativeServices
 class BaseDirFileResolverSpec extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Requires(TestPrecondition.SYMLINKS)
     def "normalizes absolute path which points to an absolute link"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverTest.groovy
@@ -38,7 +38,7 @@ class BaseDirFileResolverTest {
     File testDir
 
     BaseDirFileResolver baseDirConverter
-    @Rule public TestNameTestDirectoryProvider rootDir = new TestNameTestDirectoryProvider()
+    @Rule public TestNameTestDirectoryProvider rootDir = new TestNameTestDirectoryProvider(getClass())
     @Rule public PreconditionVerifier preconditions = new PreconditionVerifier()
 
     @Before public void setUp() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BasicFileResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BasicFileResolverTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class BasicFileResolverTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def baseDir = tmpDir.createDir("base-dir")
     def resolver = new BasicFileResolver(baseDir)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CachingTaskInputFileCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/CachingTaskInputFileCollectionTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class CachingTaskInputFileCollectionTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def collection = new CachingTaskInputFileCollection(TestFiles.resolver(), TestFiles.patternSetFactory, DefaultTaskDependencyFactory.withNoAssociatedProject(), Stub(PropertyHost))
 
     def "results are live prior to task execution"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -49,7 +49,7 @@ class DefaultFileOperationsTest extends Specification {
     private final FileCollectionFactory fileCollectionFactory = Mock()
     private DefaultFileOperations fileOperations = instance()
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     private DefaultFileOperations instance(FileResolver resolver = resolver) {
         instantiator.newInstance(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.util.Matchers.strictlyEquals
 
 class DefaultProjectLayoutTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     TestFile projectDir
     DefaultProjectLayout layout
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
@@ -40,7 +40,7 @@ import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTy
 import static org.hamcrest.CoreMatchers.equalTo
 
 class DefaultSourceDirectorySetTest extends Specification {
-    @Rule public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     private final TestFile testDir = tmpDir.testDirectory
     private FileResolver resolver = TestFiles.resolver(testDir)
     private FileCollectionFactory fileCollectionFactory = TestFiles.fileCollectionFactory(testDir)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultTemporaryFileProviderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultTemporaryFileProviderTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultTemporaryFileProviderTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     DefaultTemporaryFileProvider provider
 
     def setup() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class FileOrUriNotationConverterTest extends Specification {
 
-    @Rule public TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider();
+    @Rule public TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider(getClass());
 
     def "with File returns this File"() {
         setup:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/AbstractArchiveFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/AbstractArchiveFileTreeTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class AbstractArchiveFileTreeTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "visits structure when backing file is known"() {
         def owner = Stub(FileTreeInternal)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
@@ -38,7 +38,7 @@ import static org.hamcrest.CoreMatchers.equalTo
 @CleanupTestDirectory
 public class TarCopyActionSpec extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
     private TarCopyAction action;
 
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarFileTreeTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class TarFileTreeTest {
-    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     @Rule public final Resources resources = new Resources();
     private final TestFile tarFile = tmpDir.getTestDirectory().file("test.tar");
     private final TestFile rootDir = tmpDir.getTestDirectory().file("root");

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipCopyActionTest.groovy
@@ -37,7 +37,7 @@ import static org.hamcrest.CoreMatchers.equalTo
 class ZipCopyActionTest extends Specification {
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     ZipCopyAction visitor
     TestFile zipFile

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/ZipFileTreeTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class ZipFileTreeTest {
-    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     @Rule public final Resources resources = new Resources();
     private final TestFile zipFile = tmpDir.getTestDirectory().file("test.zip");
     private final TestFile rootDir = tmpDir.getTestDirectory().file("root");

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecResolutionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecResolutionTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 class DefaultCopySpecResolutionTest extends Specification {
 
     @Rule
-    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
     def fileResolver = TestFiles.resolver(testDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(testDir.testDirectory)
     def instantiator = TestUtil.instantiatorFactory().decorateLenient()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/DefaultCopySpecTest.groovy
@@ -40,7 +40,7 @@ import java.nio.charset.Charset
 
 class DefaultCopySpecTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass());
     private FileCollectionFactory fileCollectionFactory = TestFiles.fileCollectionFactory(testDir.testDirectory)
     private FileResolver fileResolver = TestFiles.resolver(testDir.testDirectory)
     private Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/FileCopyActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/FileCopyActionTest.groovy
@@ -28,7 +28,7 @@ class FileCopyActionTest extends Specification {
     private File destDir
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def setup() throws IOException {
         destDir = tmpDir.getTestDirectory().file("dest")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
@@ -38,7 +38,7 @@ class DefaultClassLoaderScopeTest extends Specification {
     DefaultClassLoaderCache classLoaderCache = new DefaultClassLoaderCache(new DefaultHashingClassLoaderFactory(classpathHasher), classpathHasher)
 
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
         file("root/root") << "root"

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
@@ -43,7 +43,7 @@ class DefaultClassLoaderCacheTest extends Specification {
     }
 
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     TestFile file(String path) {
         def f = testDirectoryProvider.testDirectory.file(path)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -43,7 +43,7 @@ class DefaultPluginContainerTest extends Specification {
     def container = pluginManager.pluginContainer
 
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
     private Class<?> plugin1Class = classLoader.parseClass("""
         import org.gradle.api.Plugin
         import org.gradle.api.Project

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
@@ -45,7 +45,7 @@ class DefaultPluginManagerTest extends Specification {
     Class<? extends Plugin> imperativeClass
 
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
         rulesClass = classLoader.parseClass("""

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 class DefaultPluginRegistryTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
     def classLoader = Mock(ClassLoader)
     def classLoaderScope = Stub(ClassLoaderScope) {
         getLocalClassLoader() >> classLoader

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/RuleSourceApplicationTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/RuleSourceApplicationTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class RuleSourceApplicationTest extends Specification {
 
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     private ProjectInternal buildProject() {
         ProjectBuilder.builder().withProjectDir(temporaryFolder.testDirectory).build()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectRegistryTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectRegistryTest.java
@@ -42,7 +42,7 @@ public class DefaultProjectRegistryTest {
     private DefaultProjectRegistry<ProjectInternal> projectRegistry;
 
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
 
     @Before
     public void setUp() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -42,7 +42,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class DefaultProjectSpec extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "can create file collection configured with an Action"() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -104,7 +104,7 @@ class DefaultProjectTest extends Specification {
     static final String TEST_BUILD_FILE_NAME = 'build.gradle'
 
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     Task testTask
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/ProjectFactoryTest.groovy
@@ -33,7 +33,7 @@ import spock.lang.Specification
 
 class ProjectFactoryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def instantiator = Mock(Instantiator)
     def projectDescriptor = Stub(DefaultProjectDescriptor)
     def gradle = Stub(GradleInternal)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -45,7 +45,7 @@ import java.util.concurrent.Callable
 
 class DefaultTaskInputsTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     private final fileCollectionFactory = TestFiles.fileCollectionFactory(temporaryFolder.testDirectory)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -46,7 +46,7 @@ import static org.gradle.internal.file.TreeType.FILE
 class DefaultTaskOutputsTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     private def taskStatusNagger = Stub(TaskMutator) {
         mutate(_ as String, _ as Runnable) >> { String method, Runnable action ->

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipperTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipperTest.groovy
@@ -31,7 +31,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultEmptySourceTaskSkipperTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     final task = Stub(TaskInternal)
     final inputFiles = Mock(FileCollectionInternal)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertThat
 @UsesNativeServices
 class DefaultJavaForkOptionsTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     private final resolver = TestFiles.pathToFileResolver(tmpDir.testDirectory)
     private final fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     private DefaultJavaForkOptions options

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/ant/AntTargetTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/ant/AntTargetTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 public class AntTargetTest {
     @Rule
-    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass());
 
     private final Target antTarget = new Target();
     private final File baseDir = testDir.getTestDirectory();

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCacheScopeMappingTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultCacheScopeMappingTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class DefaultCacheScopeMappingTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def userHome = tmpDir.createDir("user-home")
     def gradleVersion = Stub(GradleVersion) {
         getVersion() >> "version"

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
@@ -36,7 +36,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class DefaultFileContentCacheFactoryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def listenerManager = new DefaultListenerManager()
     def virtualFileSystem = Mock(VirtualFileSystem)
     def cacheRepository = new DefaultCacheRepository(new DefaultCacheScopeMapping(tmpDir.file("user-home"), tmpDir.file("build-dir"), GradleVersion.current()), new InMemoryCacheFactory())

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
@@ -34,7 +34,7 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 class DefaultGeneratedGradleJarCacheTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def cacheRepository = Mock(CacheRepository)
     def gradleVersion = GradleVersion.current().version

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 
 class GradleUserHomeCleanupServiceTest extends Specification implements GradleUserHomeCleanupFixture {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def userHomeDir = temporaryFolder.createDir("user-home")
     def currentCacheDir = createVersionSpecificCacheDir(currentVersion, NOT_USED_WITHIN_30_DAYS)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/UsedGradleVersionsFromGradleUserHomeCachesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/UsedGradleVersionsFromGradleUserHomeCachesTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Subject
 @CleanupTestDirectory
 class UsedGradleVersionsFromGradleUserHomeCachesTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def userHomeDir = temporaryFolder.createDir("user-home")
     def cacheBaseDir = userHomeDir.createDir(DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
@@ -34,7 +34,7 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 
 class VersionSpecificCacheCleanupActionTest extends Specification implements GradleUserHomeCleanupFixture {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def userHomeDir = temporaryFolder.createDir("user-home")
     def currentCacheDir = createVersionSpecificCacheDir(currentVersion, NOT_USED_WITHIN_30_DAYS)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheDirectoryScannerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheDirectoryScannerTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Subject
 @CleanupTestDirectory
 class VersionSpecificCacheDirectoryScannerTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     TestFile cacheBaseDir = temporaryFolder.createDir(DefaultCacheScopeMapping.GLOBAL_CACHE_DIR_NAME)
 
     @Subject def versionSpecificCacheDirectoryService = new VersionSpecificCacheDirectoryScanner(cacheBaseDir)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Subject
 
 class WrapperDistributionCleanupActionTest extends Specification implements GradleUserHomeCleanupFixture {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def userHomeDir = temporaryFolder.createDir("user-home")
     def usedGradleVersions = Mock(UsedGradleVersions) {

--- a/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/impl/DefaultBuildCacheCommandFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/internal/controller/impl/DefaultBuildCacheCommandFactoryTest.groovy
@@ -56,7 +56,7 @@ class DefaultBuildCacheCommandFactoryTest extends Specification {
     def originReader = Mock(OriginReader)
     def originWriter = Mock(OriginWriter)
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def "load invokes unpacker and fingerprints trees"() {
         def outputFile = temporaryFolder.file("output.txt")

--- a/subprojects/core/src/test/groovy/org/gradle/caching/internal/packaging/impl/DefaultTarPackerFileSystemSupportTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/caching/internal/packaging/impl/DefaultTarPackerFileSystemSupportTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.internal.file.TreeType.FILE
 @CleanupTestDirectory
 class DefaultTarPackerFileSystemSupportTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def deleter = TestFiles.deleter()
     def fileSystemSupport = new DefaultTarPackerFileSystemSupport(deleter)
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
@@ -42,7 +42,7 @@ import spock.lang.Specification
 
 abstract class AbstractExecutionPlanSpec extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
     private def backing = TestUtil.createRootProject(temporaryFolder.testDirectory)
     private def locks = new ArrayList<MockLock>()
     private def acquired = new HashSet<MockLock>()

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/DefaultScriptTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class DefaultScriptTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    public final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     def testApplyMetaData() {
         ServiceRegistry serviceRegistryMock = Mock(ServiceRegistry)

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/TextResourceScriptSourceTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/TextResourceScriptSourceTest.java
@@ -42,7 +42,7 @@ public class TextResourceScriptSourceTest {
     private File scriptFile;
     private URI scriptFileUri;
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
 
     @Before
     public void setUp() throws URISyntaxException {

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/BuildScriptTransformerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/BuildScriptTransformerSpec.groovy
@@ -32,7 +32,7 @@ import spock.lang.Unroll
 class BuildScriptTransformerSpec extends Specification {
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def importsReader = Mock(ImportsReader) {
         getImportPackages() >> ([] as String[])

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandlerTest.groovy
@@ -84,7 +84,7 @@ class DefaultScriptCompilationHandlerTest extends Specification {
 
     private ImportsReader importsReader
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule
     public SetSystemProperties systemProperties = new SetSystemProperties()
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/BuildFileProjectSpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/BuildFileProjectSpecTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 @CleanupTestDirectory
 class BuildFileProjectSpecTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     private File file
     private File otherFile
     private BuildFileProjectSpec spec

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
@@ -34,7 +34,7 @@ import static org.gradle.util.WrapUtil.toMap;
 
 public class DefaultCommandLineConverterTest extends CommandLineConverterTestSupport {
     @Rule
-    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass());
 
     public DefaultCommandLineConverterTest() {
         super();

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -53,7 +53,7 @@ class DefaultGradleLauncherSpec extends Specification {
     def otherService = Mock(Stoppable)
     def includedBuildControllers = Mock(IncludedBuildControllers)
     def instantExecution = Mock(InstantExecution)
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def failure = new RuntimeException("main")
     def transformedException = new RuntimeException("transformed")

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradlePropertiesLoaderTest.java
@@ -47,7 +47,7 @@ public class DefaultGradlePropertiesLoaderTest {
     private Map<String, String> envProperties = new HashMap<>();
     private StartParameterInternal startParameter = new StartParameterInternal();
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     @Rule
     public SetSystemProperties sysProp = new SetSystemProperties();
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultProjectDescriptorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultProjectDescriptorTest.groovy
@@ -39,7 +39,7 @@ class DefaultProjectDescriptorTest extends Specification {
     final TestName testName = new TestName()
 
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     final TestFile testDirectory = tmpDir.testDirectory
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InitScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InitScriptHandlerTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class InitScriptHandlerTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider testDirectoryProvider
+    @Rule TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
 
     def processor = Mock(InitScriptProcessor)
     def executor = new TestBuildOperationExecutor()

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InitScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InitScriptHandlerTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class InitScriptHandlerTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def processor = Mock(InitScriptProcessor)
     def executor = new TestBuildOperationExecutor()

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -51,7 +51,7 @@ class InstantiatingBuildLoaderTest extends Specification {
     }
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
         projectFactory = Mock(IProjectFactory)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.internal.FileUtils.canonicalize
 class LayoutCommandLineConverterTest extends Specification {
 
     def converter = new LayoutCommandLineConverter()
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def convert(String... args) {
         converter.convert(Arrays.asList(args), new BuildLayoutParameters())

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
@@ -29,7 +29,7 @@ import javax.tools.ToolProvider
 
 class MixInLegacyTypesClassLoaderTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def classesDir = tmpDir.file("classes")
     def srcDir = tmpDir.file("source")
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectDirectoryProjectSpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectDirectoryProjectSpecTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.util.WrapUtil.toSet
 @CleanupTestDirectory
 public class ProjectDirectoryProjectSpecTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
     private final File dir = temporaryFolder.createDir("build");
     private final ProjectDirectoryProjectSpec spec = new ProjectDirectoryProjectSpec(dir);
     private int counter;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class ProjectPropertySettingBuildLoaderTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     final BuildLoader target = Mock()
     final GradleInternal gradle = Mock()
     final SettingsInternal settings = Mock()

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcUpdateFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/buildsrc/BuildSrcUpdateFactoryTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class BuildSrcUpdateFactoryTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def launcher = Stub(BuildController)
     def listener = Stub(BuildSrcBuildListenerFactory.Listener)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/BuildLayoutFactoryTest.groovy
@@ -30,7 +30,7 @@ class BuildLayoutFactoryTest extends Specification {
     ]
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Unroll
     def "returns current directory when it contains a #settingsFilename file when script languages #extensions"() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/ProjectCacheDirTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/ProjectCacheDirTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 
 class ProjectCacheDirTest extends Specification implements VersionSpecificCacheCleanupFixture {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def cacheDir = temporaryFolder.createDir(".gradle")
     def progressLoggerFactory = Mock(ProgressLoggerFactory)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class DefaultCachedClasspathTransformerTest extends Specification {
-    @Rule TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
     def testDir = testDirectoryProvider.testDirectory
 
     def cachedDir = testDir.file("cached")

--- a/subprojects/core/src/test/groovy/org/gradle/internal/file/JarCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/file/JarCacheTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class JarCacheTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def original = tmpDir.createFile("original.txt")
     def cacheDir = tmpDir.createDir("cache")
     def fileHasher = Stub(FileHasher)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/jdk7/WatchPointsRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/jdk7/WatchPointsRegistryTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class WatchPointsRegistryTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass());
 
     WatchPointsRegistry registry
     TestFile rootDir

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
@@ -36,7 +36,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class DefaultClasspathFingerprinterTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def stringInterner = Stub(StringInterner) {
         intern(_) >> { String s -> s }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
@@ -34,7 +34,7 @@ class AbsolutePathFileCollectionFingerprinterTest extends Specification {
     def listener = Mock(ChangeListener)
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "retains order of files in the snapshot"() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
@@ -41,7 +41,7 @@ import javax.annotation.Nullable
 
 class DefaultFileCollectionSnapshotterTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def snapshotter = TestFiles.fileCollectionSnapshotter()
     def noopGenerationListener = {} as Action
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/installation/GradleRuntimeShadedJarDetectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/installation/GradleRuntimeShadedJarDetectorTest.groovy
@@ -29,7 +29,7 @@ class GradleRuntimeShadedJarDetectorTest extends Specification {
     private static final String CLASS_NAME = 'org/gradle/test/Registry'
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def jarFile = tmpDir.file('lib.jar')
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/DefaultBuildOperationLoggerFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/DefaultBuildOperationLoggerFactoryTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Unroll
 
 class DefaultBuildOperationLoggerFactoryTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     Logger logger = Mock()
     def outputDir = tmpDirProvider.testDirectory.file("logs")

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/DefaultBuildOperationLoggerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/DefaultBuildOperationLoggerTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.api.logging.LogLevel.*
 
 @CleanupTestDirectory
 class DefaultBuildOperationLoggerTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     Logger logger = Mock()
 
     def outputFile = temporaryFolder.file("test-output.txt")

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/DefaultPathKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/DefaultPathKeyFileStoreTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 @UsesNativeServices
 class DefaultPathKeyFileStoreTest extends Specification {
-    @Rule TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider(getClass())
     TestFile fsBase
     PathKeyFileStore store
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/GroupedAndNamedUniqueFileStoreTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Subject
 
 class GroupedAndNamedUniqueFileStoreTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     TestFile baseDir = tmpDir.createDir("base")
     TemporaryFileProvider temporaryFileProvider = new DefaultTemporaryFileProvider({ tmpDir.createDir("tmp") })

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/PathNormalisingKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/PathNormalisingKeyFileStoreTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class PathNormalisingKeyFileStoreTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider(getClass())
     TestFile fsBase
     PathNormalisingKeyFileStore store
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/UniquePathKeyFileStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/resource/local/UniquePathKeyFileStoreTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class UniquePathKeyFileStoreTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider();
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
     Action<File> action = Mock()
 
     UniquePathKeyFileStore uniquePathKeyFileStore

--- a/subprojects/core/src/test/groovy/org/gradle/internal/vfs/RoutingVirtualFileSystemTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/vfs/RoutingVirtualFileSystemTest.groovy
@@ -31,7 +31,7 @@ import java.util.function.Function
 class RoutingVirtualFileSystemTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     VirtualFileSystem gradleUserHomeVirtualFileSystem = Mock(VirtualFileSystem)
     VirtualFileSystem buildSessionScopedVirtualFileSystem = Mock(VirtualFileSystem)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/xml/XmlTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/xml/XmlTransformerTest.groovy
@@ -27,7 +27,7 @@ import javax.xml.parsers.DocumentBuilderFactory
 
 class XmlTransformerTest extends Specification {
     final XmlTransformer transformer = new XmlTransformer()
-    @Rule TestNameTestDirectoryProvider tmpDir
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "returns original string when no actions are provided"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecActionFactoryTest.groovy
@@ -29,7 +29,7 @@ import org.junit.Rule
 
 class DefaultExecActionFactoryTest extends ConcurrentSpec {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def resolver = TestFiles.resolver(tmpDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     def instantiator = TestUtil.instantiatorFactory()

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -35,7 +35,7 @@ import java.util.concurrent.Executor
 @UsesNativeServices
 @Timeout(60)
 class DefaultExecHandleSpec extends ConcurrentSpec {
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     private BuildCancellationToken buildCancellationToken = Mock(BuildCancellationToken)
 
     void "forks process"() {

--- a/subprojects/core/src/test/groovy/org/gradle/reporting/HtmlReportRendererTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/reporting/HtmlReportRendererTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 
 class HtmlReportRendererTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final HtmlReportRenderer renderer = new HtmlReportRenderer()
 
     def "renders HTML to file encoded with UTF-8"() {

--- a/subprojects/core/src/test/groovy/org/gradle/testfixtures/ProjectBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/testfixtures/ProjectBuilderTest.groovy
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class ProjectBuilderTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     @Rule
     public final Resources resources = new Resources()
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -45,7 +45,7 @@ abstract class AbstractProjectBuilderSpec extends Specification {
     // Naming the field "temporaryFolder" since that is the default field intercepted by the
     // @CleanupTestDirectory annotation.
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     @Rule SetSystemProperties systemProperties
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 class DefaultArtifactCacheLockingManagerTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def cacheRepository = new DefaultCacheRepository(null, new InMemoryCacheFactory())
     def cacheDir = temporaryFolder.createDir(CacheLayout.ROOT.key)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadataTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultArtifactCacheMetadataTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def scopeMapping = Stub(CacheScopeMapping)
 
     def "calculates file store directory"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -43,7 +43,7 @@ import spock.lang.Specification
 
 abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
     final FileResourceRepository fileRepository = TestFiles.fileRepository()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractPomReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractPomReaderTest.groovy
@@ -27,7 +27,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 abstract class AbstractPomReaderTest extends Specification {
-    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     PomReader pomReader
     TestFile pomFile
     LocallyAvailableExternalResource locallyAvailableExternalResource

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -115,7 +115,7 @@ class GradleModuleMetadataParserTest extends Specification {
     ]
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def identifierFactory = new DefaultImmutableModuleIdentifierFactory()
     def parser = new GradleModuleMetadataParser(AttributeTestUtil.attributesFactory(), identifierFactory, TestUtil.objectInstantiator())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
@@ -44,7 +44,7 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 class IvyXmlModuleDescriptorParserTest extends Specification {
     @Rule
     public final Resources resources = new Resources()
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     DefaultImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
     FileResourceRepository fileRepository = TestFiles.fileRepository()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRendererTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/HtmlDependencyVerificationReportRendererTest.groovy
@@ -51,7 +51,7 @@ class HtmlDependencyVerificationReportRendererTest extends Specification {
     static private File dummyFileSig = new File("dummy.asc")
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     File verificationFile = temporaryFolder.createFile("verification-metadata.xml")
     File reportsDir = temporaryFolder.testDirectory

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Subject
 
 class ModuleMetadataStoreTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def pathKeyFileStore = Mock(PathKeyFileStore)
     def repository = "repositoryId"
     def fileStoreEntry = Mock(LocallyAvailableResource)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
@@ -35,7 +35,7 @@ import java.nio.file.Path
 
 class DefaultModuleArtifactCacheTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider(getClass())
 
     ArtifactCacheLockingManager cacheLockingManager = Mock(ArtifactCacheLockingManager)
     BuildCommencedTimeProvider timeProvider = Mock(BuildCommencedTimeProvider)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
@@ -37,7 +37,7 @@ class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescripto
     private final ComponentIdentifier componentId = new OpaqueComponentIdentifier("foo")
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     def canConvert() {
         expect:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/DefaultBinaryStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/DefaultBinaryStoreTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 
 class DefaultBinaryStoreTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def "stores binary data"() {
         def store = new DefaultBinaryStore(temp.file("foo.bin"))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/mvnsettings/DefaultLocalMavenRepositoryLocatorTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class DefaultLocalMavenRepositoryLocatorTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     SimpleMavenFileLocations locations
     DefaultLocalMavenRepositoryLocator locator

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AbstractCachingTransformationWorkspaceProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AbstractCachingTransformationWorkspaceProviderTest.groovy
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class AbstractCachingTransformationWorkspaceProviderTest extends ConcurrentSpec {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def executionHistoryStore = Mock(ExecutionHistoryStore)
     private workspaceProvider = new AbstractCachingTransformationWorkspaceProvider(new TestTransformationWorkspaceProvider(tmpDir.file("transforms"), executionHistoryStore)) {}
@@ -80,7 +80,7 @@ class AbstractCachingTransformationWorkspaceProviderTest extends ConcurrentSpec 
         then:
         noExceptionThrown()
     }
-    
+
     def "has cached result works as expected"() {
         expect:
         !workspaceProvider.getCachedResult(new TestWorkspaceIdentity("first"))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -53,7 +53,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
     public static final TEST_ATTRIBUTE = Attribute.of("TEST", String)
 
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def instantiatorFactory = TestUtil.instantiatorFactory()
     def transformerInvocationFactory = Mock(TransformerInvocationFactory)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
@@ -41,7 +41,7 @@ import static org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFacto
 class DependencyClassPathNotationConverterTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def instantiator = TestUtil.instantiatorFactory().decorateLenient()
     def classPathRegistry = Mock(ClassPathRegistry)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -47,7 +47,7 @@ import spock.lang.Issue
 class RuntimeShadedJarCreatorTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def progressLoggerFactory = Stub(ProgressLoggerFactory)
     def relocatedJarCreator

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
@@ -35,7 +35,7 @@ import java.text.SimpleDateFormat
 
 class DefaultIvyModuleDescriptorWriterTest extends Specification {
 
-    private @Rule TestNameTestDirectoryProvider temporaryFolder;
+    private @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "projectA"), "1.0")
     ComponentSelectorConverter componentSelectorConverter = Mock(ComponentSelectorConverter)
     def ivyXmlModuleDescriptorWriter = new DefaultIvyModuleDescriptorWriter(componentSelectorConverter)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -38,7 +38,7 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 
 class DefaultDependencyLockingProviderTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     TestFile lockDir = tmpDir.createDir(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Subject
 
 class LockFileReaderWriterTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     TestFile lockDir = tmpDir.createDir(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/AbstractCachedIndexTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/AbstractCachedIndexTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.internal.serialize.BaseSerializerFactory.STRING_SERIALI
 
 class AbstractCachedIndexTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     static final CACHE_NAME = "my-cache"
     def cacheLockingManager = new ArtifactCacheLockingManagerStub()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Unroll
 class DefaultArtifactResolutionCacheTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     BuildCommencedTimeProvider timeProvider = Stub(BuildCommencedTimeProvider) {
         getCurrentTime() >> 1234L

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndexTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultCachedExternalResourceIndexTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class DefaultCachedExternalResourceIndexTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider folder = new TestNameTestDirectoryProvider(getClass())
 
     def commonPath = folder.createDir("common").toPath()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/local/LazyLocallyAvailableResourceCandidatesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/local/LazyLocallyAvailableResourceCandidatesTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class LazyLocallyAvailableResourceCandidatesTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmp
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     def "does not query factory until necessary"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -42,7 +42,7 @@ import spock.lang.Issue
 import spock.lang.Specification
 
 class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider(getClass())
     final repository = Mock(ExternalResourceRepository)
     final progressLoggingRepo = Mock(ExternalResourceRepository)
     final index = Mock(CachedExternalResourceIndex)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/DefaultExternalResourceRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transport/DefaultExternalResourceRepositoryTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 
 class DefaultExternalResourceRepositoryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def resourceAccessor = Mock(ExternalResourceAccessor)
     def resourceUploader = Mock(ExternalResourceUploader)
     def resourceLister = Mock(ExternalResourceLister)

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/AbstractReportTaskTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/AbstractReportTaskTest.groovy
@@ -33,7 +33,7 @@ class AbstractReportTaskTest extends Specification {
     private TestReportTask task
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = TestNameTestDirectoryProvider.newInstance()
+    public TestNameTestDirectoryProvider tmpDir = TestNameTestDirectoryProvider.newInstance(getClass())
     private ProjectInternal project = TestUtil.create(tmpDir).rootProject()
 
     def setup() throws Exception {

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/PropertyReportTaskTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/PropertyReportTaskTest.groovy
@@ -28,7 +28,7 @@ class PropertyReportTaskTest extends Specification {
     private PropertyReportTask task
 
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
         _ * project.absoluteProjectPath("list") >> ":path"

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/TextReportRendererSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/TextReportRendererSpec.groovy
@@ -28,7 +28,7 @@ import static org.gradle.util.Matchers.containsLine
 @CleanupTestDirectory
 public class TextReportRendererSpec extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
     private final TextReportRenderer renderer = new TextReportRenderer();
 
     def "writes report to a file"() {

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
@@ -34,7 +34,7 @@ class DefaultDeploymentDescriptorTest extends Specification {
     private ObjectFactory objectFactory = TestUtil.objectFactory()
 
     def descriptor = new DefaultDeploymentDescriptor({ it } as FileResolver, objectFactory)
-    @Rule TestNameTestDirectoryProvider tmpDir
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "writes default descriptor"() {
         def file = tmpDir.file("out.xml")

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -78,7 +78,7 @@ import static org.gradle.internal.reflect.TypeValidationContext.Severity.ERROR
 class IncrementalExecutionIntegrationTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     def virtualFileSystem = TestFiles.virtualFileSystem()
     def snapshotter = new DefaultFileCollectionSnapshotter(virtualFileSystem, TestFiles.genericFileTreeSnapshotter(), TestFiles.fileSystem())

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOutputFilesRepositoryTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOutputFilesRepositoryTest.groovy
@@ -35,7 +35,7 @@ import spock.lang.Specification
 class DefaultOutputFilesRepositoryTest extends Specification {
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def outputFiles = new InMemoryIndexedCache<String, Boolean>(BaseSerializerFactory.BOOLEAN_SERIALIZER)
     def cacheAccess = Stub(PersistentCache) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/OutputFilterUtilTest.groovy
@@ -39,7 +39,7 @@ class OutputFilterUtilTest extends Specification {
     private static final FileCollectionFingerprint EMPTY_OUTPUT_FINGERPRINT = AbsolutePathFingerprintingStrategy.IGNORE_MISSING.emptyFingerprint
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     def virtualFileSystem = TestFiles.virtualFileSystem()
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupOutputsStepTest.groovy
@@ -32,7 +32,7 @@ import org.junit.Rule
 
 class CleanupOutputsStepTest extends StepSpec<InputChangesContext> implements FingerprinterFixture {
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def afterPreviousExecution = Mock(AfterPreviousExecutionState)
     def beforeExecutionState = Mock(BeforeExecutionState)
     def delegateResult = Mock(Result)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
@@ -30,7 +30,7 @@ import java.util.function.Consumer
 
 abstract class StepSpec<C extends Context> extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
     final buildOperationExecutor = new TestBuildOperationExecutor()
 
     final displayName = "job ':test'"

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/CompositeFileCollectionTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class CompositeFileCollectionTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def file1 = new File("1")
     def file2 = new File("2")
     def file3 = new File("3")

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -44,7 +44,7 @@ import java.util.concurrent.Callable
 class DefaultFileCollectionFactoryTest extends Specification {
     @ClassRule
     @Shared
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def factory = new DefaultFileCollectionFactory(TestFiles.pathToFileResolver(tmpDir.testDirectory), Stub(TaskDependencyFactory), TestFiles.directoryFileTreeFactory(), Stub(Factory), Stub(PropertyHost), TestFiles.fileSystem())
 
     def "lazily queries contents of collection created from MinimalFileSet"() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 
 class DefaultFilePropertyFactoryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     TestFile projectDir
     DefaultFilePropertyFactory factory
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileTreeElementTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileTreeElementTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultFileTreeElementTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "permissions on file can be read"() {
         def stat = Mock(Stat)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileCollectionSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileCollectionSpec.groovy
@@ -30,7 +30,7 @@ import static org.gradle.util.WrapUtil.toSet
 @UsesNativeServices // via DirectoryFileTree
 abstract class FileCollectionSpec extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
 
     abstract AbstractFileCollection containing(File... files)
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
@@ -24,7 +24,7 @@ import org.junit.Rule
 
 abstract class FileSystemPropertySpec<T extends FileSystemLocation> extends PropertySpec<T> {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def resolver = TestFiles.resolver(tmpDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     def factory = new DefaultFilePropertyFactory(host, resolver, fileCollectionFactory)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileTreeTest.groovy
@@ -40,7 +40,7 @@ import static org.gradle.api.tasks.AntBuilderAwareUtil.assertSetContainsForAllTy
 class DefaultConfigurableFileTreeTest extends AbstractTestForPatternSet {
     TaskDependencyFactory taskDependencyFactory = DefaultTaskDependencyFactory.withNoAssociatedProject()
     DefaultConfigurableFileTree fileSet
-    @Rule public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     File testDir = tmpDir.testDirectory
     FileResolver fileResolverStub = resolver(testDir)
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultUnauthorizedDirectoryWalkerTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultUnauthorizedDirectoryWalkerTest.groovy
@@ -33,7 +33,7 @@ import java.nio.file.AccessDeniedException
 class DefaultUnauthorizedDirectoryWalkerTest extends Specification {
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def rootDir
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class GeneratedSingletonFileTreeSpec extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def fileSystem = Stub(FileSystem)
 
     def "visiting creates file if visitor queries the file location"() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeTest.java
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 public class GeneratedSingletonFileTreeTest {
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     private TestFile rootDir = tmpDir.getTestDirectory();
 
     private Factory<File> fileFactory = new Factory<File>() {

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/SingleIncludePatternFileTreeSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/SingleIncludePatternFileTreeSpec.groovy
@@ -28,7 +28,7 @@ import spock.lang.Specification
 
 @UsesNativeServices
 class SingleIncludePatternFileTreeSpec extends Specification {
-    @Shared @ClassRule TestNameTestDirectoryProvider tempDir
+    @Shared @ClassRule TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider(SingleIncludePatternFileTreeSpec)
 
     def visitor = Mock(FileVisitor)
 

--- a/subprojects/file-collections/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
+++ b/subprojects/file-collections/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger
 @UsesNativeServices
 abstract class AbstractDirectoryWalkerTest<T> extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Rule
     SetSystemProperties setSystemPropertiesRule

--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/DefaultFileHierarchySetTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/DefaultFileHierarchySetTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Unroll
 
 class DefaultFileHierarchySetTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "creates from a single file"() {
         def dir = tmpDir.createDir("dir")

--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/AbstractSymlinkDeleterTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/AbstractSymlinkDeleterTest.groovy
@@ -29,7 +29,7 @@ abstract class AbstractSymlinkDeleterTest extends Specification {
     static final boolean FOLLOW_SYMLINKS = true
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     DefaultDeleter deleter = new DefaultDeleter(
         { System.currentTimeMillis() },
         { NativeServicesTestFixture.getInstance().get(FileSystem).isSymlink(it) },

--- a/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/internal/file/impl/DefaultDeleterTest.groovy
@@ -31,7 +31,7 @@ import static org.junit.Assume.assumeTrue
 
 class DefaultDeleterTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     DefaultDeleter deleter = new DefaultDeleter(
         { System.currentTimeMillis() },
         { File file -> Files.isSymbolicLink(file.toPath()) },

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/DefaultVisualStudioProjectTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/DefaultVisualStudioProjectTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.ide.visualstudio.internal.DefaultVisualStudioProject.ge
 
 class DefaultVisualStudioProjectTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def component = Mock(NativeComponentSpec)
     def fileResolver = Mock(FileResolver)
     def vsProject = project("projectName")

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistryTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistryTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Specification
 
 class VisualStudioProjectRegistryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def fileResolver = Mock(FileResolver)
     def ideArtifactRegistry = Mock(IdeArtifactRegistry)
     def registry = new VisualStudioProjectRegistry(fileResolver, TestUtil.instantiatorFactory().decorateLenient(), ideArtifactRegistry, CollectionCallbackActionDecorator.NOOP, TestUtil.objectFactory(), new DefaultProviderFactory())

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPluginTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class VisualStudioPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("root").build()
 

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/RelativeFileNameTransformerTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/RelativeFileNameTransformerTest.groovy
@@ -27,7 +27,7 @@ class RelativeFileNameTransformerTest extends Specification {
     static rootDir = new File("root")
 
     @Rule
-    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
 
     def "returns canonical path where file outside of root"() {
         expect:

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioFiltersFileTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioFiltersFileTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class VisualStudioFiltersFileTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     Transformer<String, File> fileNameTransformer = { it.name } as Transformer<String, File>
     def filtersFile = new VisualStudioFiltersFile(new XmlTransformer(), fileNameTransformer)

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioProjectFileTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioProjectFileTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class VisualStudioProjectFileTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     Transformer<String, File> fileNameTransformer = { it.name } as Transformer<String, File>
     def generator = new VisualStudioProjectFile(new XmlTransformer(), fileNameTransformer)

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioSolutionFileTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/tasks/internal/VisualStudioSolutionFileTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.ide.visualstudio.internal.DefaultVisualStudioProject.ge
 
 class VisualStudioSolutionFileTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def solutionFile = new VisualStudioSolutionFile()
 

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/plugins/XcodePluginTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/plugins/XcodePluginTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class XcodePluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("root").build()
 

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/tasks/internal/XcodeSchemeFileTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/tasks/internal/XcodeSchemeFileTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class XcodeSchemeFileTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def generator = new XcodeSchemeFile(new XmlTransformer())
 

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/tasks/internal/XcodeWorkspaceSettingsFileTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/xcode/tasks/internal/XcodeWorkspaceSettingsFileTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class XcodeWorkspaceSettingsFileTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def generator = new XcodeWorkspaceSettingsFile(new PropertyListTransformer<NSDictionary>())
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ClasspathTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ClasspathTest.groovy
@@ -40,7 +40,7 @@ public class ClasspathTest extends Specification {
     private final Classpath classpath = new Classpath(new XmlTransformer(), fileReferenceFactory)
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
         fileReferenceFactory.addPathVariable("USER_LIB_PATH", new File('/user/lib/path'))

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ProjectTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/ProjectTest.groovy
@@ -33,7 +33,7 @@ public class ProjectTest extends Specification {
         new DefaultResourceFilter(ResourceFilterAppliesTo.FOLDERS, ResourceFilterType.INCLUDE_ONLY, false, new DefaultResourceFilterMatcher('org.eclipse.ui.ide.orFilterMatcher', null, [new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-node_modules', [] as LinkedHashSet), new DefaultResourceFilterMatcher('org.eclipse.ui.ide.multiFilter', '1.0-name-matches-false-false-target', [] as LinkedHashSet)] as LinkedHashSet))] as LinkedHashSet
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     final Project project = new Project(new XmlTransformer())
 
     def loadFromReader() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/WtpComponentTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/WtpComponentTest.groovy
@@ -29,7 +29,7 @@ public class WtpComponentTest extends Specification {
     private final WtpComponent component = new WtpComponent(new XmlTransformer())
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "load existing XML file"() {
         when:

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/WtpFacetTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/WtpFacetTest.groovy
@@ -28,7 +28,7 @@ public class WtpFacetTest extends Specification {
     private final WtpFacet facet = new WtpFacet(new XmlTransformer())
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "load existing XML file"() {
         when:

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/FileReferenceFactoryTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/FileReferenceFactoryTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class FileReferenceFactoryTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final TestFile rootDir = tmpDir.createDir("root")
     final FileReferenceFactory factory = new FileReferenceFactory()
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/PathFactoryTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/PathFactoryTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class PathFactoryTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final PathFactory factory = new PathFactory()
 
     def createsPathForAFileUnderARootDir() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/ProjectLibraryTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/ProjectLibraryTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class ProjectLibraryTest extends Specification {
-    @Rule TestNameTestDirectoryProvider testDirProvider
+    @Rule TestNameTestDirectoryProvider testDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     def "has friendly defaults"() {
         def library = new ProjectLibrary()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/generator/PropertiesPersistableConfigurationObjectTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/generator/PropertiesPersistableConfigurationObjectTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class PropertiesPersistableConfigurationObjectTest extends Specification {
-    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     String propertyValue
     final org.gradle.plugins.ide.internal.generator.PropertiesPersistableConfigurationObject object = new org.gradle.plugins.ide.internal.generator.PropertiesPersistableConfigurationObject(new PropertiesTransformer()) {
         @Override protected String getDefaultResourceName() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/generator/XmlPersistableConfigurationObjectTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/generator/XmlPersistableConfigurationObjectTest.groovy
@@ -24,7 +24,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class XmlPersistableConfigurationObjectTest extends Specification {
-    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     String rootElement
     final XmlPersistableConfigurationObject object = new XmlPersistableConfigurationObject(new XmlTransformer()) {
         @Override protected String getDefaultResourceName() {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilderTest.groovy
@@ -34,7 +34,7 @@ import spock.lang.Unroll
 class BuildInvocationsBuilderTest extends Specification {
     @Shared
     @ClassRule
-    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
     @Shared
     def project = TestUtil.builder(temporaryFolder).withName("root").build()
     @Shared

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
@@ -35,7 +35,7 @@ import spock.lang.Specification
 class GradleBuildBuilderTest extends Specification {
     @Shared
     @ClassRule
-    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
     def builder = new GradleBuildBuilder()
     @Shared
     def project = TestUtil.builder(temporaryFolder).withName("root").build()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/TasksFactoryTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/TasksFactoryTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class TasksFactoryTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     final Project project = Mock()
     final def eclipseProject = new DefaultEclipseProject(null, null, null, null, [])
     final task = TestUtil.create(temporaryFolder).task(AbstractTask)

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/fixture/TempDirIsUniquePerTestSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/fixture/TempDirIsUniquePerTestSpec.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 
 class TempDirIsUniquePerTestSpec extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider();
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass());
     static tests = new HashSet()
     static tmpDirs = new HashSet()
 
@@ -31,12 +31,12 @@ class TempDirIsUniquePerTestSpec extends Specification {
         //it's very important we try to access the test dir in the setup()
         tmp.testDirectory
     }
-    
+
     def "testOne"() {
         when:
         tests << "testOne"
         tmpDirs << tmp.testDirectory
-        
+
         then:
         tests.size() == tmpDirs.size()
     }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/fixtures/SampleSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/fixtures/SampleSpec.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class SampleSpec extends Specification {
 
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
     Sample sample = new Sample(testDirectoryProvider, 'java/multiproject')
     @Rule TestRule rule = RuleChain.outerRule(testDirectoryProvider).around(sample)
 

--- a/subprojects/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuterIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/integTest/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuterIntegrationTest.groovy
@@ -33,7 +33,7 @@ class InProcessGradleExecuterIntegrationTest extends Specification {
     @Rule
     RedirectStdOutAndErr outputs = new RedirectStdOutAndErr()
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def distribution = new UnderDevelopmentGradleDistribution(IntegrationTestBuildContext.INSTANCE)
     def executer = new GradleContextualExecuter(distribution, temporaryFolder, IntegrationTestBuildContext.INSTANCE)
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -57,7 +57,7 @@ import static org.gradle.util.Matchers.normalizedLineSeparators
 class AbstractIntegrationSpec extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     GradleDistribution distribution = new UnderDevelopmentGradleDistribution(getBuildContext())
     GradleExecuter executer = createExecuter()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
@@ -35,7 +35,7 @@ import java.io.File;
 
 public abstract class AbstractIntegrationTest {
     @Rule
-    public final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass());
 
     @Rule
     public final UnsupportedWithInstantExecutionRule unsupportedWithInstantExecution = new UnsupportedWithInstantExecutionRule();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
@@ -32,7 +32,7 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 @RunWith(CrossVersionTestRunner)
 @Retry(condition = { RetryConditions.onIssueWithReleasedGradleVersion(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
 abstract class CrossVersionIntegrationSpec extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     private final List<GradleExecuter> executers = []
     final GradleDistribution current = new UnderDevelopmentGradleDistribution()
     static GradleDistribution previous

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuterTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuterTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class AbstractGradleExecuterTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass());
 
     def gradleDistribution = Mock(GradleDistribution)
 

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/jvm/UbuntuJvmLocatorTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/jvm/UbuntuJvmLocatorTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class UbuntuJvmLocatorTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def libDir = tmpDir.file("lib")
     def fileCanonicalizer = Stub(FileCanonicalizer) {
         canonicalize(_) >> { File f -> f.canonicalFile }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriterTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriterTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Unroll
 class JUnitPlatformTestRewriterTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def 'build.gradle should be rewritten'() {
         given:
@@ -44,8 +44,8 @@ dependencies { testCompile 'junit:junit:4.12' }
     def 'modular build.gradle should be rewritten'() {
         given:
         temporaryFolder.testDirectory.file('build.gradle') << '''
-dependencies { 
-    testImplementation 'junit:junit:4.12' 
+dependencies {
+    testImplementation 'junit:junit:4.12'
 }
 compileTestJava {
     def args = ["--add-modules", "junit",
@@ -61,8 +61,8 @@ test {
 
         then:
         temporaryFolder.testDirectory.file('build.gradle').text == '''
-dependencies { 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0','org.junit.jupiter:junit-jupiter-engine:5.1.0' 
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0','org.junit.jupiter:junit-jupiter-engine:5.1.0'
 }
 compileTestJava {
     def args = ["--add-modules", "org.junit.jupiter.api",
@@ -131,16 +131,16 @@ public class OkTest {
     public void ok() throws Exception {
         assertEquals("4.12", new org.junit.runner.JUnitCore().getVersion());
     }
-    
+
     @After
     public void broken() {
         fail("failed");
     }
-    
+
     @AfterClass
     public void clean() {
     }
-    
+
     @org.junit.AfterClass
     public void clean() {
     }
@@ -155,16 +155,16 @@ public class OkTest {
     public void ok() throws Exception {
         assertEquals("4.12", new org.junit.runner.JUnitCore().getVersion());
     }
-    
+
     @AfterEach
     public void broken() {
         fail("failed");
     }
-    
+
     @AfterAll
     public void clean() {
     }
-    
+
     @org.junit.jupiter.api.AfterAll
     public void clean() {
     }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenFileModuleTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenFileModuleTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class MavenFileModuleTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     TestFile testFile
     MavenModule mavenFileModule
     MavenModule snapshotMavenFileModule

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenLocalModuleTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/maven/MavenLocalModuleTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class MavenLocalModuleTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     TestFile testFile
     MavenModule mavenLocalModule
     MavenModule snapshotMavenLocalModule

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
@@ -24,7 +24,7 @@ import org.junit.Rule
 
 class BlockingHttpServerTest extends ConcurrentSpec {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def server = new BlockingHttpServer(1000)
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
@@ -37,7 +37,7 @@ class AbstractCrossBuildPerformanceTest extends Specification {
     protected final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
 
     @Rule
     PerformanceTestIdProvider performanceTestIdProvider = new PerformanceTestIdProvider()

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleInternalPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleInternalPerformanceTest.groovy
@@ -47,7 +47,7 @@ class AbstractCrossVersionGradleInternalPerformanceTest extends Specification {
     private static def reporter = SlackReporter.wrap(resultStore)
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
 
     private final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleProfilerPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossVersionGradleProfilerPerformanceTest.groovy
@@ -48,7 +48,7 @@ class AbstractCrossVersionGradleProfilerPerformanceTest extends Specification {
     private static def reporter = SlackReporter.wrap(resultStore)
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
 
     private final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractGradleVsMavenPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractGradleVsMavenPerformanceTest.groovy
@@ -39,7 +39,7 @@ class AbstractGradleVsMavenPerformanceTest extends Specification {
     private static final GradleVsMavenBuildResultsStore RESULT_STORE = new GradleVsMavenBuildResultsStore()
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
 
     final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -80,7 +80,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
     protected final static GradleDistribution CURRENT = new UnderDevelopmentGradleDistribution()
 
     static def resultStore = new CrossVersionResultsStore()
-    final TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new PerformanceTestDirectoryProvider(getClass())
 
     protected ToolingApiExperiment experiment
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestDirectoryProvider.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestDirectoryProvider.groovy
@@ -20,8 +20,8 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 
 class PerformanceTestDirectoryProvider extends TestNameTestDirectoryProvider {
-    PerformanceTestDirectoryProvider() {
+    PerformanceTestDirectoryProvider(Class<?> klass) {
         // NOTE: the space in the directory name is intentional
-        root = new TestFile(new File("build/tmp/performance-test-files"))
+        super(new TestFile(new File("build/tmp/performance-test-files")), klass)
     }
 }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/GradleInternalCrossVersionPerformanceTestRunnerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/GradleInternalCrossVersionPerformanceTestRunnerTest.groovy
@@ -37,7 +37,7 @@ class GradleInternalCrossVersionPerformanceTestRunnerTest extends ResultSpecific
     private static final String MOST_RECENT_RELEASE = "2.10"
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Rule
     SetSystemProperties systemProperties = new SetSystemProperties(

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
@@ -25,7 +25,7 @@ import static org.gradle.performance.measure.Duration.minutes
 
 class CrossBuildResultsStoreTest extends ResultSpecification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule
     SetSystemProperties properties = new SetSystemProperties("org.gradle.performance.db.url": "jdbc:h2:" + tmpDir.testDirectory)
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Shared
 import static org.gradle.performance.measure.Duration.minutes
 
 class CrossVersionResultsStoreTest extends ResultSpecification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule SetSystemProperties properties = new SetSystemProperties("org.gradle.performance.db.url": "jdbc:h2:" + tmpDir.testDirectory)
     final dbFile = tmpDir.file("results")
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProviderTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProviderTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Subject
 
 class DefaultPerformanceExecutionDataProviderTest extends ResultSpecification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Subject
     DefaultPerformanceExecutionDataProvider provider

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/report/ReportGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/report/ReportGeneratorTest.groovy
@@ -25,7 +25,7 @@ import org.junit.Rule
 
 class ReportGeneratorTest extends ResultSpecification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule
     SetSystemProperties properties = new SetSystemProperties("org.gradle.performance.db.url": "jdbc:h2:" + tmpDir.testDirectory)
     final dbFile = tmpDir.file("results")

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -32,17 +32,23 @@ import java.util.regex.Pattern;
  * A JUnit rule which provides a unique temporary folder for the test.
  */
 abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryProvider {
-    protected TestFile root;
+    private final TestFile root;
+    private final String className;
 
     private static final Random RANDOM = new Random();
     private static final int ALL_DIGITS_AND_LETTERS_RADIX = 36;
     private static final int MAX_RANDOM_PART_VALUE = Integer.valueOf("zzzzz", ALL_DIGITS_AND_LETTERS_RADIX);
     private static final Pattern WINDOWS_RESERVED_NAMES = Pattern.compile("(con)|(prn)|(aux)|(nul)|(com\\d)|(lpt\\d)", Pattern.CASE_INSENSITIVE);
 
-    private TestFile dir;
     private String prefix;
+    private TestFile dir;
     private boolean cleanup = true;
     private boolean suppressCleanupErrors = false;
+
+    protected AbstractTestDirectoryProvider(TestFile root, Class<?> testClass) {
+        this.root = root;
+        this.className = testClass.getSimpleName();
+    }
 
     @Override
     public void suppressCleanup() {
@@ -71,7 +77,7 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
 
     @Override
     public Statement apply(final Statement base, Description description) {
-        init(description.getMethodName(), description.getTestClass().getSimpleName());
+        init(description.getMethodName());
 
         return new TestDirectoryCleaningStatement(base, description);
     }
@@ -122,7 +128,7 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
         }
     }
 
-    protected void init(String methodName, String className) {
+    protected void init(String methodName) {
         if (methodName == null) {
             // must be a @ClassRule; use the rule's class name instead
             methodName = getClass().getSimpleName();
@@ -139,7 +145,7 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
     @Override
     public TestFile getTestDirectory() {
         if (dir == null) {
-           dir = createUniqueTestDirectory();
+            dir = createUniqueTestDirectory();
         }
         return dir;
     }
@@ -162,20 +168,20 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
         if (prefix == null) {
             // This can happen if this is used in a constructor or a @Before method. It also happens when using
             // @RunWith(SomeRunner) when the runner does not support rules.
-            prefix = "unknown-test-class";
+            prefix = className;
         }
         return prefix;
     }
 
     public TestFile file(Object... path) {
-        return getTestDirectory().file((Object[]) path);
+        return getTestDirectory().file(path);
     }
 
     public TestFile createFile(Object... path) {
-        return file((Object[]) path).createFile();
+        return file(path).createFile();
     }
 
     public TestFile createDir(Object... path) {
-        return file((Object[]) path).createDir();
+        return file(path).createDir();
     }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  * A JUnit rule which provides a unique temporary folder for the test.
  */
 abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryProvider {
-    private final TestFile root;
+    protected final TestFile root;
     private final String className;
 
     private static final Random RANDOM = new Random();

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestDistributionDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestDistributionDirectoryProvider.java
@@ -21,17 +21,13 @@ import org.junit.runners.model.FrameworkMethod;
 import java.io.File;
 
 public class TestDistributionDirectoryProvider extends AbstractTestDirectoryProvider {
-    public TestDistributionDirectoryProvider() {
-        root = new TestFile(new File("build/tmp/test distros"));
-    }
-
-    public static TestDistributionDirectoryProvider newInstance() {
-        return new TestDistributionDirectoryProvider();
+    public TestDistributionDirectoryProvider(Class<?> klass) {
+        super(new TestFile(new File("build/tmp/test distros")), klass);
     }
 
     public static TestDistributionDirectoryProvider newInstance(FrameworkMethod method, Object target) {
-        TestDistributionDirectoryProvider testDirectoryProvider = new TestDistributionDirectoryProvider();
-        testDirectoryProvider.init(method.getName(), target.getClass().getSimpleName());
+        TestDistributionDirectoryProvider testDirectoryProvider = new TestDistributionDirectoryProvider(target.getClass());
+        testDirectoryProvider.init(method.getName());
         return testDirectoryProvider;
     }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestNameTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestNameTestDirectoryProvider.java
@@ -23,18 +23,22 @@ import java.io.File;
  * A JUnit rule which provides a unique temporary folder for the test.
  */
 public class TestNameTestDirectoryProvider extends AbstractTestDirectoryProvider {
-    public TestNameTestDirectoryProvider() {
+    public TestNameTestDirectoryProvider(Class<?> klass) {
         // NOTE: the space in the directory name is intentional
-        root = new TestFile(new File("build/tmp/test files"));
+        super(new TestFile(new File("build/tmp/test files")), klass);
     }
 
-    public static TestNameTestDirectoryProvider newInstance() {
-        return new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider(TestFile root, Class<?> klass) {
+        super(root, klass);
+    }
+
+    public static TestNameTestDirectoryProvider newInstance(Class<?> testClass) {
+        return new TestNameTestDirectoryProvider(testClass);
     }
 
     public static TestNameTestDirectoryProvider newInstance(FrameworkMethod method, Object target) {
-        TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider();
-        testDirectoryProvider.init(method.getName(), target.getClass().getSimpleName());
+        TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(target.getClass());
+        testDirectoryProvider.init(method.getName());
         return testDirectoryProvider;
     }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/WorkspaceTest.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/WorkspaceTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 @CleanupTestDirectory
 abstract class WorkspaceTest extends Specification {
 
-    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     TestFile getTestDirectory() {
         temporaryFolder.testDirectory

--- a/subprojects/internal-testing/src/test/groovy/org/gradle/util/TempDirIsUniquePerTestSpec.groovy
+++ b/subprojects/internal-testing/src/test/groovy/org/gradle/util/TempDirIsUniquePerTestSpec.groovy
@@ -21,7 +21,7 @@ import spock.lang.Specification
 
 class TempDirIsUniquePerTestSpec extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
     static tests = new HashSet()
     static tmpDirs = new HashSet()
 
@@ -29,12 +29,12 @@ class TempDirIsUniquePerTestSpec extends Specification {
         //it's very important we try to access the test dir in the setup()
         temp.testDirectory
     }
-    
+
     def "testOne"() {
         when:
         tests << "testOne"
         tmpDirs << temp.testDirectory
-        
+
         then:
         tests.size() == tmpDirs.size()
     }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -49,7 +49,7 @@ import spock.lang.Specification
 
 class DefaultIvyPublicationTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def instantiator = TestUtil.instantiatorFactory().decorateLenient()
     def objectFactory = TestUtil.objectFactory()

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
@@ -42,7 +42,7 @@ import static org.gradle.util.TestUtil.objectFactory
 
 class IvyDescriptorFileGeneratorTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     VersionMappingStrategyInternal versionMappingStrategy = Mock() {
         findStrategyForVariant(_) >> Mock(VariantVersionMappingStrategyInternal)

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
@@ -41,7 +41,7 @@ import static org.gradle.util.CollectionUtils.toSet
 
 class ValidatingIvyPublisherTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def delegate = Mock(IvyPublisher)
     DefaultImmutableModuleIdentifierFactory moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()

--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtensionSpec.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoTaskExtensionSpec.groovy
@@ -29,7 +29,7 @@ class JacocoTaskExtensionSpec extends Specification {
     JavaForkOptions task = Mock()
     Project project = ProjectBuilder.builder().build()
     JacocoTaskExtension extension = new JacocoTaskExtension(project, agent, task)
-    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def 'asJvmArg with default arguments assembles correct string'() {
         setup:

--- a/subprojects/javascript/src/test/groovy/org/gradle/plugins/javascript/envjs/http/simple/SimpleHttpFileServerFactoryTest.groovy
+++ b/subprojects/javascript/src/test/groovy/org/gradle/plugins/javascript/envjs/http/simple/SimpleHttpFileServerFactoryTest.groovy
@@ -25,7 +25,7 @@ import java.nio.charset.Charset
 
 class SimpleHttpFileServerFactoryTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
     TestFile root
 
     def setup() {

--- a/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
+++ b/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/FolderBasedTest.kt
@@ -13,7 +13,7 @@ abstract class FolderBasedTest {
 
     @JvmField
     @Rule
-    val tempFolder = TestNameTestDirectoryProvider()
+    val tempFolder = TestNameTestDirectoryProvider(javaClass)
 
     val root: File
         get() = tempFolder.testDirectory

--- a/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
+++ b/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/TestWithTempFiles.kt
@@ -15,7 +15,7 @@ abstract class TestWithTempFiles {
 
     @JvmField
     @Rule
-    val tempFolder = TestNameTestDirectoryProvider()
+    val tempFolder = TestNameTestDirectoryProvider(javaClass)
 
     protected
     val root: File

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/JavaHomeBasedJavaToolChainTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/JavaHomeBasedJavaToolChainTest.groovy
@@ -25,7 +25,7 @@ import org.junit.Rule
 @CleanupTestDirectory
 class JavaHomeBasedJavaToolChainTest extends AbstractJavaToolChainTest {
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     JvmVersionDetector jvmVersionDetector = Stub(JvmVersionDetector) {
         getJavaVersion(_) >> {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CommandLineJavaCompilerArgumentsGeneratorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/CommandLineJavaCompilerArgumentsGeneratorTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder
 
 class CommandLineJavaCompilerArgumentsGeneratorTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tempDir
+    TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider(getClass())
 
     CommandLineJavaCompilerArgumentsGenerator argsGenerator = new CommandLineJavaCompilerArgumentsGenerator()
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder
 
 class JavaCompilerArgumentsBuilderTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider(getClass())
 
     def defaultOptionsWithoutClasspath = ["-g", "-sourcepath", "", "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION]
     def defaultOptions = ["-g", "-sourcepath", "", "-proc:none", USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotterTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotterTest.groovy
@@ -34,7 +34,7 @@ import spock.lang.Subject
 @UsesNativeServices
 class DefaultClasspathEntrySnapshotterTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def fileHasher = Mock(FileHasher)
     def streamHasher = Mock(StreamHasher)

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/OutputToNameConverterTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/OutputToNameConverterTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Subject
 
 class OutputToNameConverterTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
     @Subject provider = new OutputToNameConverter(temp.createDir("root/dir"))
 
     def "provides class name"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirsTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirsTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class CompilationSourceDirsTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def compilationSourceDirs = new CompilationSourceDirs(["src/main/java", "src/main/java2"].collect { temp.file(it) })
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetectorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetectorTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.api.internal.tasks.compile.processing.AnnotationProcess
 
 class AnnotationProcessorDetectorTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     Logger logger = Mock(Logger) {
         0 * _

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/JavadocOptionFileWriterTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/JavadocOptionFileWriterTest.groovy
@@ -25,7 +25,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class JavadocOptionFileWriterTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     JavadocOptionFile optionfile = Mock()
     JavadocOptionFileWriter javadocOptionFileWriter = new JavadocOptionFileWriter(optionfile)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
 class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
-    @Rule final TestNameTestDirectoryProvider testDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider testDirProvider = new TestNameTestDirectoryProvider(getClass())
     @Rule public final Sample assembler = sample(testDirProvider, 'assembler')
     @Rule public final Sample c = sample(testDirProvider, 'c')
     @Rule public final Sample cpp = sample(testDirProvider, 'cpp')

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 class DefaultCppApplicationTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     def application = project.objects.newInstance(DefaultCppApplication, "main")
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppBinaryTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Specification
 
 class DefaultCppBinaryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     def implementation = Stub(ConfigurationInternal)
     def headerDirs = Stub(FileCollection)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
@@ -29,7 +29,7 @@ import javax.inject.Inject
 
 class DefaultCppComponentTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     DefaultCppComponent component
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 class DefaultCppLibraryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     DefaultCppLibrary library
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 class CppApplicationPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testApp").build()
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
@@ -44,7 +44,7 @@ import spock.lang.Specification
 
 class CppBasePluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("test").build()
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
@@ -34,7 +34,7 @@ import spock.lang.Specification
 
 class CppLibraryPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testLib").build()
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultNativeBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultNativeBinaryTest.groovy
@@ -32,7 +32,7 @@ import javax.inject.Inject
 
 class DefaultNativeBinaryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     Configuration implementation = Stub(ConfigurationInternal)
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/DefaultSourceIncludesResolverTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/DefaultSourceIncludesResolverTest.groovy
@@ -26,7 +26,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultSourceIncludesResolverTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def virtualFileSystem = TestFiles.virtualFileSystem()
     def testDirectory = temporaryFolder.testDirectory
     def sourceDirectory = testDirectory.createDir("sources")

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
@@ -34,7 +34,7 @@ import javax.annotation.Nullable
 @UsesNativeServices
 class IncrementalCompileProcessorTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def includesParser = Mock(SourceIncludesParser)
     def dependencyResolver = new DummyResolver()

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompilerTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 @UsesNativeServices
 class IncrementalNativeCompilerTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def delegateCompiler = Mock(Compiler)
     def outputs = Mock(TaskOutputsInternal)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/SourceParseAndResolutionTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/SourceParseAndResolutionTest.groovy
@@ -30,7 +30,7 @@ import org.junit.Rule
 @UsesNativeServices
 class SourceParseAndResolutionTest extends SerializerSpec {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def includeDir = tmpDir.createDir("headers")
     def header = includeDir.createFile("hello.h")
     def sourceDir = tmpDir.createDir("src")
@@ -477,7 +477,7 @@ class SourceParseAndResolutionTest extends SerializerSpec {
             #define HEADER_NAME "hello.h"
             #define HEADER_ do not use this
             #define NAME do not use this
-            #define HEADER(X, Y) HEADER_ ## NAME 
+            #define HEADER(X, Y) HEADER_ ## NAME
             #include HEADER(ignore, ignore) // replaced with HEADER_NAME then "hello.h"
         """
 
@@ -699,10 +699,10 @@ class SourceParseAndResolutionTest extends SerializerSpec {
             #define FUNC1(X) X
             #define FUNC2(X) (X)
             #define ARGS ("hello.h")
-            
+
             #define HEADER_(X) X
             #define HEADER(X) HEADER_(FUNC1 FUNC2 X)
-            
+
             #include HEADER(ARGS) // replaced by FUNC1 FUNC2 ("hello.h") then FUNC1 ("hello.h")
         """
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/sourceparser/RegexBackedCSourceParserTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/sourceparser/RegexBackedCSourceParserTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Unroll
 
 class RegexBackedCSourceParserTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     CSourceParser parser = new RegexBackedCSourceParser()
 
     protected TestFile getSourceFile() {
@@ -526,11 +526,11 @@ class RegexBackedCSourceParserTest extends Specification {
 #include <system3> /*
    A comment here
 */
-#include MACRO1  // A comment here 
+#include MACRO1  // A comment here
 #include MACRO2 /*
    A comment here
 */
-#include MACRO1()  // A comment here 
+#include MACRO1()  // A comment here
 #include MACRO2() /*
    A comment here
 */
@@ -859,16 +859,16 @@ st3"
         when:
         sourceFile << """
   #   define     SOME_STRING         "abc"      // some extra
-  /*    
-  
+  /*
+
   */  \\
   #/*
-  
-  
+
+
   */\u0000define \\
         /*
          */STRING_2\\
-/*         
+/*
 */"123"\\
     /* */   // some extra"""
 
@@ -1240,16 +1240,16 @@ st3"
         when:
         sourceFile << """
   #   define     SOME_STRING(     )     "abc"      // some extra
-  /*    
-  
+  /*
+
   */  \\
   #/*
-  
-  
+
+
   */ define \\
         /*
          */STRING_2(\\
-/*         
+/*
 */)/* */"123"\\
     /* */  "some extra"""
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -59,7 +59,7 @@ import spock.lang.Specification
 
 class NativeBasePluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testComponent").build()
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftApplicationTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 
 class DefaultSwiftApplicationTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     def app = project.objects.newInstance(DefaultSwiftApplication, "main")
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
@@ -35,7 +35,7 @@ import spock.lang.Specification
 
 class DefaultSwiftBinaryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     def implementation = Stub(ConfigurationInternal)
     def compile = Stub(Configuration)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftComponentTest.groovy
@@ -31,7 +31,7 @@ import javax.inject.Inject
 
 class DefaultSwiftComponentTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     DefaultSwiftComponent component
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Specification
 
 class DefaultSwiftLibraryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     DefaultSwiftLibrary library
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class SwiftApplicationPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testApp").build()
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -48,7 +48,7 @@ import spock.lang.Specification
 
 class SwiftBasePluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("test").build()
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Specification
 
 class SwiftLibraryPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testLib").build()
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/swiftpm/plugins/SwiftPackageManagerExportPluginTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Specification
 
 class SwiftPackageManagerExportPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testLib").build()
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionsFactoryTest.groovy
@@ -38,7 +38,7 @@ class BuildActionsFactoryTest extends Specification {
     @Rule
     public final SetSystemProperties sysProperties = new SetSystemProperties();
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     ServiceRegistry loggingServices = new DefaultServiceRegistry()
     boolean useCurrentProcess
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
@@ -45,7 +45,7 @@ class DefaultCommandLineActionFactoryTest extends Specification {
     @Rule
     public final SetSystemProperties sysProperties = new SetSystemProperties();
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     final ExecutionListener executionListener = Mock()
     final LoggingServiceRegistry loggingServices = Mock()
     final LoggingManagerInternal loggingManager = Mock()

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/LayoutToPropertiesConverterTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class LayoutToPropertiesConverterTest extends Specification {
 
     @Rule SetSystemProperties sysProperties = new SetSystemProperties()
-    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
     def converter = new LayoutToPropertiesConverter(new BuildLayoutFactory())
     BuildLayoutParameters layout
     Map<String, String> props = new HashMap<String, String>()

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/PropertiesToDaemonParametersConverterTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Unroll
 @UsesNativeServices
 class PropertiesToDaemonParametersConverterTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def converter = new PropertiesToDaemonParametersConverter()
     def params = new DaemonParameters(new BuildLayoutParameters(), TestFiles.fileCollectionFactory())

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientServicesTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientServicesTest.groovy
@@ -30,7 +30,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DaemonClientServicesTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
     final DaemonParameters parameters = new DaemonParameters(new BuildLayoutParameters(), TestFiles.fileCollectionFactory()).setBaseDir(tmp.testDirectory)
     final parentServices = ServiceRegistryBuilder.builder()
             .parent(LoggingServiceRegistry.newEmbeddableLogging())

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
@@ -32,7 +32,7 @@ import java.nio.charset.Charset
 @UsesNativeServices
 class BuildProcessTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule
     final SetSystemProperties systemPropertiesSet = new SetSystemProperties()
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/context/DaemonCompatibilitySpecSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class DaemonCompatibilitySpecSpec extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     def clientConfigure = {}
     def serverConfigure = {}

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/diagnostics/DaemonDiagnosticsTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/diagnostics/DaemonDiagnosticsTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class DaemonDiagnosticsTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temp
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     def "tailing the daemon log is always safe"() {
         given:

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
@@ -34,7 +34,7 @@ import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Idl
 class DaemonRegistryServicesTest extends Specification {
     def lockManager = new DefaultFileLockManager(Stub(ProcessMetaDataProvider), Stub(FileLockContentionHandler))
     def chmod = Stub(Chmod)
-    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
     def parent = new DefaultServiceRegistry() {{
         add(FileLockManager, lockManager)
         add(Chmod, chmod)

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/PersistentDaemonRegistryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/PersistentDaemonRegistryTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.launcher.daemon.server.api.DaemonStateControl.State.Idl
 
 class PersistentDaemonRegistryTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     int addressCounter = 0
     def lockManager = createDefaultFileLockManager()

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonRegistryUnavailableExpirationStrategyTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonRegistryUnavailableExpirationStrategyTest.groovy
@@ -36,7 +36,7 @@ import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.GR
 class DaemonRegistryUnavailableExpirationStrategyTest extends Specification {
     Daemon daemon = Mock(Daemon)
     @Subject DaemonRegistryUnavailableExpirationStrategy expirationStrategy = new DaemonRegistryUnavailableExpirationStrategy(daemon)
-    @Rule TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tempDir = new TestNameTestDirectoryProvider(getClass())
     File daemonDir = tempDir.createDir("test_daemon_dir")
 
     def "daemon should expire when registry file is unreachable"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonServicesTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonServicesTest.groovy
@@ -33,7 +33,7 @@ import static java.util.Arrays.asList
 @UsesNativeServices
 class DaemonServicesTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     final DaemonServices services = new DaemonServices(new DefaultDaemonServerConfiguration("uid", tmp.testDirectory, 100, 50, false, DaemonParameters.Priority.NORMAL, asList()),
         LoggingServiceRegistry.newEmbeddableLogging(), Mock(LoggingManagerInternal), Stub(ClassPath))

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/AbstractClassGraphSpec.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/AbstractClassGraphSpec.groovy
@@ -26,7 +26,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 abstract class AbstractClassGraphSpec extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     /**
      * Returns the classpath for the given classes.

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ProviderStartParameterConverterTest.groovy
@@ -24,7 +24,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class ProviderStartParameterConverterTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temp
+    @Rule TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
     def params = Stub(ProviderOperationParameters)
 
     def "allows configuring the start parameter with build arguments"() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/serialization/DaemonSidePayloadClassLoaderFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/serialization/DaemonSidePayloadClassLoaderFactoryTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class DaemonSidePayloadClassLoaderFactoryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def factory = Mock(PayloadClassLoaderFactory)
     def classpathTransformer = Mock(CachedClasspathTransformer)
 

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/DefaultArtifactPomTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/DefaultArtifactPomTest.groovy
@@ -42,8 +42,8 @@ class DefaultArtifactPomTest extends Specification {
     private MavenPom testPom
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
     def setup() {
         testPom = new DefaultMavenPom(Mock(ConfigurationContainer), Mock(Conf2ScopeMappingContainer),
                 Mock(PomDependenciesConverter), Mock(FileResolver))
@@ -79,7 +79,7 @@ class DefaultArtifactPomTest extends Specification {
 
         artifactPom.addArtifact(mainArtifact, mainFile)
         artifactPom.addArtifact(classifierArtifact, classifierFile)
-        
+
         then:
         artifactPom.getArtifact().getName() == "someName"
         artifactPom.getArtifact().getExtension() == "mainPackaging"

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/pom/DefaultMavenPomTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/pom/DefaultMavenPomTest.groovy
@@ -37,7 +37,7 @@ class DefaultMavenPomTest extends Specification {
     static final String EXPECTED_VERSION = "v\u00E9rsi\u00F8n"; // note the utf-8 chars
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     Conf2ScopeMappingContainer conf2ScopeMappingContainer = Mock()
     PomDependenciesConverter pomDependenciesConverterStub = Mock()

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportDeployWagonTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportDeployWagonTest.groovy
@@ -33,7 +33,7 @@ import spock.lang.Specification
 class RepositoryTransportDeployWagonTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider testDirectory = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectory = new TestNameTestDirectoryProvider(getClass())
 
     def "wagon connections attempts should set a repository and signal session opening events"() {
         setup:

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -54,7 +54,7 @@ import spock.lang.Unroll
 
 class DefaultMavenPublicationTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     MutableMavenProjectIdentity module
     NotationParser<Object, MavenArtifact> notationParser = Mock(NotationParser)

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
@@ -38,7 +38,7 @@ import static org.gradle.util.CollectionUtils.toSet
 
 class ValidatingMavenPublisherTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
 
     def delegate = Mock(MavenPublisher)
     def publisher = new ValidatingMavenPublisher(delegate)

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGeneratorTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGeneratorTest.groovy
@@ -47,7 +47,7 @@ import spock.lang.Unroll
 
 class MavenPomFileGeneratorTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
     def projectIdentity = new ReadableMavenProjectIdentity("group-id", "artifact-id", "1.0")
     def rangeMapper = Stub(VersionRangeMapper)
     def strategy = Stub(VersionMappingStrategyInternal) {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ConventionAwareHelperTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ConventionAwareHelperTest.java
@@ -44,7 +44,7 @@ public class ConventionAwareHelperTest {
     TestTask testTask;
 
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
 
     @Before public void setUp() {
         testTask = TestUtil.create(temporaryFolder).task(TestTask.class);

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AbstractClassGeneratorSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AbstractClassGeneratorSpec.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 abstract class AbstractClassGeneratorSpec extends Specification {
     @ClassRule
     @Shared
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     abstract ClassGenerator getGenerator()
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -106,7 +106,7 @@ import static org.junit.Assert.fail;
 
 public class AsmBackedClassGeneratorTest {
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     final ClassGenerator generator = AsmBackedClassGenerator.decorateAndInject(Collections.emptyList(), Collections.emptyList(), new TestCrossBuildInMemoryCacheFactory(), 0);
 
     private <T> T newInstance(Class<T> clazz, Object... args) throws Exception {

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/model/internal/fixture/ProjectRegistrySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/model/internal/fixture/ProjectRegistrySpec.groovy
@@ -41,7 +41,7 @@ class ProjectRegistrySpec extends AbstractProjectBuilderSpec {
     public static final StructBindingsStore STRUCT_BINDINGS_STORE
 
     @ClassRule
-    public static final TestNameTestDirectoryProvider SERVICES_TEST_DIRECTORY = TestNameTestDirectoryProvider.newInstance()
+    public static final TestNameTestDirectoryProvider SERVICES_TEST_DIRECTORY = TestNameTestDirectoryProvider.newInstance(getClass())
 
     static {
         def services = TestUtil.create(SERVICES_TEST_DIRECTORY.testDirectory).rootProject().services

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
@@ -30,7 +30,7 @@ import java.nio.file.LinkOption
 import java.nio.file.attribute.BasicFileAttributeView
 
 class CommonFileSystemTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def fs = NativeServicesTestFixture.instance.get(FileSystem)
 

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7SymlinkTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7SymlinkTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.util.WindowsSymbolicLinkUtil.createWindowsSymbolicLink
 
 class Jdk7SymlinkTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     @Requires(TestPrecondition.SYMLINKS)
     def 'on symlink supporting system, it will return true for supported symlink'() {

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/PosixJdk7FilePermissionHandlerTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/PosixJdk7FilePermissionHandlerTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 @Requires(TestPrecondition.NOT_WINDOWS)
 class PosixJdk7FilePermissionHandlerTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def "test chmod on non windows platforms with JDK7"() {
         setup:

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/AbstractFileMetadataAccessorTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Specification
 @UsesNativeServices
 abstract class AbstractFileMetadataAccessorTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     abstract FileMetadataAccessor getAccessor()
 
     abstract long lastModified(File file)

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/UnsupportedFilePermissionsTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/UnsupportedFilePermissionsTest.groovy
@@ -27,7 +27,7 @@ class UnsupportedFilePermissionsTest extends Specification {
 
     def outputEventListener = new TestOutputEventListener()
     @Rule ConfigureLogging logging = new ConfigureLogging(outputEventListener)
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def permissions = new UnsupportedFilePermissions()
 
     def "warns on first attempt to stat a file"() {

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/jansi/JansiStorageLocatorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/jansi/JansiStorageLocatorTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 class JansiStorageLocatorTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def locator = new JansiStorageLocator()
     def factory = Mock(JansiLibraryFactory)

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/processenvironment/ProcessEnvironmentTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/processenvironment/ProcessEnvironmentTest.groovy
@@ -25,7 +25,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class ProcessEnvironmentTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Rule final SetSystemProperties systemProperties = new SetSystemProperties()
     final ProcessEnvironment env = NativeServicesTestFixture.getInstance().get(ProcessEnvironment)
 

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/internal/normalization/java/ApiClassExtractorTestSupport.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/internal/normalization/java/ApiClassExtractorTestSupport.groovy
@@ -104,7 +104,7 @@ class ApiClassExtractorTestSupport extends Specification {
     public JavaCompiler compiler = ToolProvider.systemJavaCompiler
 
     @Rule
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     protected ApiContainer toApi(Map<String, String> sources) {
         toApi('1.7', [], sources)

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -55,7 +55,7 @@ import static org.gradle.performance.regression.inception.GradleInceptionPerform
 class GradleBuildPerformanceTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     @Rule
     TestName testName = new TestName()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractCacheCleanupTest.groovy
@@ -24,7 +24,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class AbstractCacheCleanupTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def cacheDir = temporaryFolder.file("cache-dir").createDir()
     def cleanableStore = Mock(CleanableStore) {
         getBaseDir() >> cacheDir

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
@@ -39,7 +39,7 @@ import static org.gradle.cache.FileLockManager.LockMode.Shared
 
 abstract class AbstractFileLockManagerTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def metaDataProvider = Mock(ProcessMetaDataProvider)
     def generator = Stub(IdGenerator)
     def contentionHandler = Stub(FileLockContentionHandler)

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/CompositeCleanupActionTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/CompositeCleanupActionTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class CompositeCleanupActionTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def cleanableStore = Stub(CleanableStore) {
         getBaseDir() >> temporaryFolder.getTestDirectory()
         getDisplayName() >> "My Cache"

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
@@ -40,7 +40,7 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 class DefaultCacheAccessTest extends ConcurrentSpec {
     private static final BaseSerializerFactory SERIALIZER_FACTORY = new BaseSerializerFactory()
 
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final FileLockManager lockManager = Mock()
     final CacheInitializationAction initializationAction = Mock()
     final CacheCleanupAction cleanupAction = Mock()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheFactoryTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheFactoryTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 
 class DefaultCacheFactoryTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final Action<?> opened = Mock()
     final Action<?> closed = Mock()
     final ProcessMetaDataProvider metaDataProvider = Mock()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheRepositoryTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheRepositoryTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 
 class DefaultCacheRepositoryTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     private final TestFile homeDir = tmpDir.createDir("home")
     private final TestFile sharedCacheDir = homeDir.file("caches")
     private final Map<String, ?> properties = [a: "value", b: "value2"]

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionTest.groovy
@@ -37,7 +37,7 @@ import static org.gradle.cache.FileLockManager.LockMode.Shared
 
 class DefaultFileLockManagerContentionTest extends ConcurrentSpec {
     @Rule
-    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     FileLockContentionHandler contentionHandler = new DefaultFileLockContentionHandler(executorFactory, new InetAddressFactory())
     FileLockContentionHandler contentionHandler2 = new DefaultFileLockContentionHandler(executorFactory, new InetAddressFactory())
     FileLockManager manager = new DefaultFileLockManager(Stub(ProcessMetaDataProvider), 2000, contentionHandler, new LongIdGenerator())

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
 
     @Rule
-    def TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    def TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def cacheDir = tmpDir.file("dir")
     def metaDataProvider = new DefaultProcessMetaDataProvider(NativeServicesTestFixture.getInstance().get(ProcessEnvironment));
     def lockManager = new DefaultFileLockManager(metaDataProvider, new NoOpFileLockContentionHandler())

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -38,7 +38,7 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 class DefaultPersistentDirectoryStoreTest extends Specification {
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
 
     def cacheDir = tmpDir.file("dir")
     def cleanupAction = Mock(CleanupAction)

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Subject
 import java.util.concurrent.TimeUnit
 
 class LeastRecentlyUsedCacheCleanupTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def cacheDir = temporaryFolder.file("cache-dir").createDir()
     def cleanableStore = Stub(CleanableStore) {
         getBaseDir() >> cacheDir

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/NonReservedFileFilterTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/NonReservedFileFilterTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class NonReservedFileFilterTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def "does not accept reserved files"() {
         given:

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/OnDemandFileAccessTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/OnDemandFileAccessTest.groovy
@@ -30,7 +30,7 @@ class OnDemandFileAccessTest extends Specification {
     final FileLockManager manager = Mock()
     final FileLock targetLock = Mock()
 
-    @Rule TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider(getClass())
     OnDemandFileAccess lock
     File file
 

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/SimpleStateCacheTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/SimpleStateCacheTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.cache.internal.DefaultFileLockManagerTestHelper.unlockU
 
 class SimpleStateCacheTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final FileAccess fileAccess = Mock()
     final Chmod chmod = Mock()
     final File file = tmpDir.file("state.bin")

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/SingleDepthFilesFinderTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/SingleDepthFilesFinderTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class SingleDepthFilesFinderTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     @Unroll
     def "finds files for depth #depth"() {

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/UnusedVersionsCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/UnusedVersionsCacheCleanupTest.groovy
@@ -31,7 +31,7 @@ class UnusedVersionsCacheCleanupTest extends Specification {
 
     static final String CACHE_NAME = "cache"
 
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def usedGradleVersions = Stub(UsedGradleVersions)
     def progressMonitor = Mock(CleanupProgressMonitor)

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BTreePersistentIndexedCacheTest.java
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/BTreePersistentIndexedCacheTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 
 public class BTreePersistentIndexedCacheTest {
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     private final Serializer<String> stringSerializer = new DefaultSerializer<String>();
     private final Serializer<Integer> integerSerializer = new DefaultSerializer<Integer>();
     private BTreePersistentIndexedCache<String, Integer> cache;

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/ByteInputTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/ByteInputTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class ByteInputTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     RandomAccessFile file
     ByteInput input
 

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/ByteOutputTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/ByteOutputTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class ByteOutputTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     RandomAccessFile file
     ByteOutput output
 

--- a/subprojects/platform-base/src/test/groovy/org/gradle/language/base/internal/tasks/StaleOutputCleanerTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/language/base/internal/tasks/StaleOutputCleanerTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class StaleOutputCleanerTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     Deleter deleter = TestFiles.deleter()
 
     def "deletes all previous output files"() {

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/BuildableComponentSpecTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/BuildableComponentSpecTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class BuildableComponentSpecTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def element = new TestBuildableComponentSpec(Stub(ComponentSpecIdentifier))
     def dependedOn1 = Stub(Task)

--- a/subprojects/platform-base/src/testFixtures/groovy/org/gradle/platform/base/PlatformBaseSpecification.groovy
+++ b/subprojects/platform-base/src/testFixtures/groovy/org/gradle/platform/base/PlatformBaseSpecification.groovy
@@ -34,7 +34,7 @@ import spock.lang.Specification
 
 abstract class PlatformBaseSpecification extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
 
     final def project = TestUtil.create(testDir).rootProject()
     @Rule SetRuleContext setContext = new SetRuleContext()

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestMergeSpecTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestMergeSpecTest.groovy
@@ -29,7 +29,7 @@ class DefaultManifestMergeSpecTest extends Specification {
 
     DefaultManifestMergeSpec mergeSpec = new DefaultManifestMergeSpec()
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def from() {
         expect:
@@ -41,7 +41,7 @@ class DefaultManifestMergeSpecTest extends Specification {
     def mergeWithFileAndObjectManifest() {
         def fileResolver = Mock(FileResolver)
         DefaultManifest baseManifest = new DefaultManifest(fileResolver)
-        def baseMap = baseManifest.attributes + ([key1: 'value1', key2: 'value2', key3: 'value3'] as LinkedHashMap) 
+        def baseMap = baseManifest.attributes + ([key1: 'value1', key2: 'value2', key3: 'value3'] as LinkedHashMap)
         def baseSectionMap = [keysec1: 'valueSec1', keysec2: 'valueSec2', keysec3: 'valueSec3']
         baseManifest.attributes(baseMap)
         baseManifest.attributes(baseSectionMap, 'section')

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestTest.groovy
@@ -33,7 +33,7 @@ class DefaultManifestTest extends Specification {
     DefaultManifest gradleManifest = new DefaultManifest(fileResolver)
 
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def testInitWithFileResolver() {
         expect:

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/DefaultJavaInstallationRegistryTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class DefaultJavaInstallationRegistryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def probe = Mock(JavaInstallationProbe)
     def registry = new DefaultJavaInstallationRegistry(probe, TestUtil.providerFactory(), TestFiles.fileCollectionFactory(), TestFiles.fileFactory())
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/CompilerOutputFileNamingSchemeTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/CompilerOutputFileNamingSchemeTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class CompilerOutputFileNamingSchemeTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     def resolver = Mock(RelativeFilePathResolver)
     def compilerOutputFileNamingScheme = new CompilerOutputFileNamingSchemeFactory(resolver).create()

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultNativeExecutableBinarySpecTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultNativeExecutableBinarySpecTest.groovy
@@ -35,7 +35,7 @@ import spock.lang.Specification
 
 class DefaultNativeExecutableBinarySpecTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     final testUtil = TestUtil.create(tmpDir)
     def namingScheme = DefaultBinaryNamingScheme.component("bigOne").withBinaryType("executable")

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultSharedLibraryBinarySpecTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultSharedLibraryBinarySpecTest.groovy
@@ -37,7 +37,7 @@ import spock.lang.Specification
 
 class DefaultSharedLibraryBinarySpecTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def namingScheme = DefaultBinaryNamingScheme.component("main").withBinaryType("sharedLibrary")
     final toolChain = Stub(NativeToolChainInternal)
     final platform = Stub(NativePlatform)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpecTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpecTest.groovy
@@ -40,7 +40,7 @@ import spock.lang.Specification
 
 class DefaultStaticLibraryBinarySpecTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final library = BaseComponentFixtures.createNode(NativeLibrarySpec, DefaultNativeLibrarySpec, new DefaultComponentSpecIdentifier("path", "libName"))
     def namingScheme = DefaultBinaryNamingScheme.component("main").withBinaryType("staticLibrary")
     def toolChain = Stub(NativeToolChainInternal)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/configure/NativeBinaryRulesTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/configure/NativeBinaryRulesTest.groovy
@@ -33,7 +33,7 @@ import spock.lang.Specification
 
 class NativeBinaryRulesTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
 
     def project = Mock(Project)
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/tasks/LinkSharedLibraryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/tasks/LinkSharedLibraryTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 class LinkSharedLibraryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def link = TestUtil.createRootProject(tmpDir.testDirectory).tasks.create("link", LinkSharedLibrary)
 
     def "has no default import library location when platform does not produce one"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistryTest.groovy
@@ -30,7 +30,7 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class DefaultNativeToolChainRegistryTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
 
     def project = TestUtil.create(testDir).rootProject()
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/NativeCompilerTest.groovy
@@ -42,7 +42,7 @@ import spock.lang.Unroll
 import java.util.concurrent.Executor
 
 abstract class NativeCompilerTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     protected CompilerOutputFileNamingSchemeFactory compilerOutputFileNamingSchemeFactory = new CompilerOutputFileNamingSchemeFactory(TestFiles.resolver(tmpDirProvider.root))
     private static final String O_EXT = ".o"

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/OutputCleaningCompilerTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 class OutputCleaningCompilerTest extends Specification {
 
     @Rule
-    final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     TestFile outputDir = tmpDirProvider.createDir("objs")
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/PCHUtilsTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/PCHUtilsTest.groovy
@@ -26,7 +26,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class PCHUtilsTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     def "generates a prefix header file" () {
         def headers = Lists.newArrayList()

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ClangToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ClangToolChainTest.groovy
@@ -35,7 +35,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class ClangToolChainTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
     final FileResolver fileResolver = Mock(FileResolver)
     final Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
     final toolChain = new ClangToolChain("clang", Stub(BuildOperationExecutor), Stub(OperatingSystem), fileResolver, Stub(ExecActionFactory), Stub(CompilerOutputFileNamingSchemeFactory), Stub(CompilerMetaDataProviderFactory), Stub(SystemLibraryDiscovery), instantiator, Stub(WorkerLeaseService))

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccLinkerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccLinkerTest.groovy
@@ -39,7 +39,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class GccLinkerTest extends Specification {
     public static final String LOG_LOCATION = "<log location>"
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     def operationLogger =  Mock(BuildOperationLogger)
     def executable = new File("executable")

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccOptionsFileArgsWriterTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccOptionsFileArgsWriterTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 import spock.lang.Unroll
 
 class GccOptionsFileArgsWriterTest extends OptionsFileArgsWriterTest {
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     OptionsFileArgsWriter getArgsWriter() {
         new GccOptionsFileArgsWriter(tmpDirProvider.getTestDirectory())

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccToolChainTest.groovy
@@ -34,7 +34,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class GccToolChainTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
     final FileResolver fileResolver = Mock(FileResolver)
     Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProviderTest.groovy
@@ -169,7 +169,7 @@ End of search list.
 """
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def execActionFactory = Mock(ExecActionFactory)
 
     @Unroll

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultUcrtLocatorTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Specification
 import static org.gradle.nativeplatform.toolchain.internal.msvcpp.AbstractWindowsKitComponentLocator.PLATFORMS
 
 class DefaultUcrtLocatorTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final WindowsRegistry windowsRegistry = Stub(WindowsRegistry)
     final WindowsComponentLocator ucrtLocator = new DefaultUcrtLocator(windowsRegistry)
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/DefaultVisualStudioLocatorTest.groovy
@@ -36,7 +36,7 @@ import spock.lang.Unroll
 import static org.gradle.nativeplatform.toolchain.internal.msvcpp.ArchitectureDescriptorBuilder.*
 
 class DefaultVisualStudioLocatorTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final VisualStudioVersionLocator commandLineLocator = Mock(VisualStudioVersionLocator)
     final VisualStudioVersionLocator windowsRegistryLocator = Mock(VisualStudioVersionLocator)
     final VisualStudioVersionLocator systemPathLocator = Mock(VisualStudioVersionLocator)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LegacyWindowsSdkLocatorTest.groovy
@@ -26,7 +26,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class LegacyWindowsSdkLocatorTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final WindowsRegistry windowsRegistry = Stub(WindowsRegistry)
     final OperatingSystem operatingSystem = Stub(OperatingSystem) {
         isWindows() >> true

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LinkExeLinkerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/LinkExeLinkerTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class LinkExeLinkerTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def argsTransformer = new LinkExeLinker.LinkerArgsTransformer()
 
     def "generates linker args for shared library"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppOptionsFileArgsWriterTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppOptionsFileArgsWriterTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 
 class VisualCppOptionsFileArgsWriterTest extends OptionsFileArgsWriterTest {
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     OptionsFileArgsWriter getArgsWriter() {
         new VisualCppOptionsFileArgsWriter(tmpDirProvider.getTestDirectory())

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppToolChainTest.groovy
@@ -37,7 +37,7 @@ import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class VisualCppToolChainTest extends Specification {
-    TestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
     final FileResolver fileResolver = Mock(FileResolver)
     final ExecActionFactory execActionFactory = Mock(ExecActionFactory)
     final CompilerOutputFileNamingSchemeFactory compilerOutputFileNamingSchemeFactory = Mock(CompilerOutputFileNamingSchemeFactory)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/WindowsKitWindowsSdkLocatorTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 import static org.gradle.nativeplatform.toolchain.internal.msvcpp.AbstractWindowsKitComponentLocator.PLATFORMS
 
 class WindowsKitWindowsSdkLocatorTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final WindowsRegistry windowsRegistry = Stub(WindowsRegistry)
     final WindowsComponentLocator<WindowsKitSdkInstall> windowsSdkLocator = new WindowsKitWindowsSdkLocator(windowsRegistry)
 

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/DefaultVisualCppMetadataProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/DefaultVisualCppMetadataProviderTest.groovy
@@ -24,7 +24,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultVisualCppMetadataProviderTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def windowsRegistry = Mock(WindowsRegistry)
     def metadataProvider = new DefaultVisualCppMetadataProvider(windowsRegistry)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/SystemPathVersionLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/SystemPathVersionLocatorTest.groovy
@@ -23,7 +23,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class SystemPathVersionLocatorTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def os = Mock(OperatingSystem)
     def versionDeterminer = Mock(VisualStudioMetaDataProvider)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/VisualStudioVersionDeterminerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/VisualStudioVersionDeterminerTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.nativeplatform.toolchain.internal.msvcpp.version.Visual
 
 
 class VisualStudioVersionDeterminerTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def commandLineLocator = Mock(VisualStudioVersionLocator)
     def windowsRegistryLocator = Mock(VisualStudioVersionLocator)
     def visualCppMetadataProvider = Mock(VisualCppMetadataProvider)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/VswhereSpec.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/VswhereSpec.groovy
@@ -24,7 +24,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class VswhereSpec extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     File vswhere
     def localRoot = tmpDir.createDir("root")
     def programFiles = localRoot.createDir("Program Files")

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/WindowsRegistryVersionLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/version/WindowsRegistryVersionLocatorTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.nativeplatform.toolchain.internal.msvcpp.version.Visual
 class WindowsRegistryVersionLocatorTest extends Specification {
     public static final String SOFTWARE_KEY = "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VC7"
     public static final String SOFTWARE_WOW6432_KEY = "SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7"
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def windowsRegistry = Mock(WindowsRegistry)
     def locator = new WindowsRegistryVersionLocator(windowsRegistry)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftDepsHandlerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftDepsHandlerTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Subject
 @Requires(TestPrecondition.NOT_WINDOWS)
 class SwiftDepsHandlerTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     File moduleSwiftDeps
     File barSource

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/SwiftLinkerTest.groovy
@@ -40,7 +40,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class SwiftLinkerTest extends Specification {
     public static final String LOG_LOCATION = "<log location>"
-    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDirProvider = new TestNameTestDirectoryProvider(getClass())
 
     def operationLogger =  Mock(BuildOperationLogger)
     def executable = new File("executable")

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/tools/ToolSearchPathTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/tools/ToolSearchPathTest.groovy
@@ -25,7 +25,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class ToolSearchPathTest extends Specification {
-    @Rule def TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule def TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def os = Stub(OperatingSystem)
     def registry = new ToolSearchPath(os)
 

--- a/subprojects/platform-play/src/test/groovy/org/gradle/play/tasks/PlayRunTest.groovy
+++ b/subprojects/platform-play/src/test/groovy/org/gradle/play/tasks/PlayRunTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class PlayRunTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     PlayApplication runnerToken = Mock(PlayApplication)
     PlayToolProvider playToolProvider = Mock(PlayToolProvider)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/StartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/StartScriptGeneratorTest.groovy
@@ -38,7 +38,7 @@ class StartScriptGeneratorTest extends Specification {
     ScriptGenerator windowsStartScriptGenerator = Mock()
     StartScriptGenerator.UnixFileOperation unixFileOperation = Mock()
     StartScriptGenerator startScriptGenerator = new StartScriptGenerator(unixStartScriptGenerator, windowsStartScriptGenerator, unixFileOperation)
-    @Rule TestNameTestDirectoryProvider temporaryFolder
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def setup() {
         populateStartScriptGenerator()

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultGroovySourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultGroovySourceSetTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.api.reflect.TypeOf.typeOf
 
 class DefaultGroovySourceSetTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def sourceSet = new DefaultGroovySourceSet("<name>", "<display-name>", TestUtil.objectFactory(tmpDir.testDirectory))
 
     void defaultValues() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
@@ -36,7 +36,7 @@ import static org.hamcrest.CoreMatchers.nullValue
 import static org.junit.Assert.assertThat
 
 class DefaultSourceSetTest extends Specification {
-    public @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     private final TaskResolver taskResolver = [resolveTask: {name -> [getName: {name}] as Task}] as TaskResolver
     private final TaskDependencyFactory taskDependencyFactory = Stub(TaskDependencyFactory) {
         _ * configurableDependency() >> new DefaultTaskDependency(taskResolver)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultBasePluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultBasePluginConventionTest.groovy
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertEquals
 
 class DefaultBasePluginConventionTest {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     private ProjectInternal project = TestUtil.create(temporaryFolder).rootProject()
     private File testDir = project.projectDir

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertThat
 
 class DefaultJavaPluginConventionTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.create(tmpDir).rootProject()
     def objectFactory = project.services.get(ObjectFactory)
     private JavaPluginConvention convention

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/GroovyBasePluginTest.groovy
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue
 
 class GroovyBasePluginTest {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
     private ProjectInternal project
 
     @Before

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/UploadTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/UploadTest.groovy
@@ -24,9 +24,9 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class UploadTest extends Specification {
-    
+
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def "can create task"() {
         when:

--- a/subprojects/process-services/src/test/groovy/org/gradle/process/internal/health/memory/DefaultOsMemoryInfoTest.groovy
+++ b/subprojects/process-services/src/test/groovy/org/gradle/process/internal/health/memory/DefaultOsMemoryInfoTest.groovy
@@ -26,7 +26,7 @@ import spock.lang.Specification
 
 @UsesNativeServices
 class DefaultOsMemoryInfoTest extends Specification {
-    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def "getTotalPhysicalMemory only throws when memory management methods are unavailable"() {
         expect:

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -65,7 +65,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     }
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def buildId = UniqueId.generate()
     def id = DefaultModuleVersionIdentifier.newId("group", "module", "1.2")
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/BuildDashboardGeneratorSpec.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/BuildDashboardGeneratorSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 class BuildDashboardGeneratorSpec extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     File outputFile
     BuildDashboardGenerator generator = new BuildDashboardGenerator()

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReportTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReportTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class TaskGeneratedSingleDirectoryReportTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "can attach a convention mapping for output directory location"() {
         def report = TestUtil.objectFactory(tmpDir.testDirectory).newInstance(TaskGeneratedSingleDirectoryReport, "report", Stub(Task), "entryPoint")

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleFileReportTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleFileReportTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class TaskGeneratedSingleFileReportTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "can attach a convention mapping for output file location"() {
         def report = TestUtil.objectFactory(tmpDir.testDirectory).newInstance(TaskGeneratedSingleFileReport, "report", Stub(Task))

--- a/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/GcsClientIntegrationTest.groovy
+++ b/subprojects/resources-gcs/src/integTest/groovy/org/gradle/integtests/resource/gcs/GcsClientIntegrationTest.groovy
@@ -37,7 +37,7 @@ class GcsClientIntegrationTest extends Specification {
     final String bucketName = 'org.gradle.artifacts'
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     @Rule
     final GcsServer server = new GcsServer(temporaryFolder)

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
@@ -50,7 +50,7 @@ class S3ClientIntegrationTest extends Specification {
     final String bucketName = 'org.gradle.artifacts'
 
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     @Shared
     DefaultAwsCredentials awsCredentials = new DefaultAwsCredentials()

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/DownloadedUriTextResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/DownloadedUriTextResourceTest.groovy
@@ -32,7 +32,7 @@ class DownloadedUriTextResourceTest extends Specification {
     private TextResource underTest
 
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
 
     def setup() {
         testDir = tmpDir.createDir('dir')

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/UriTextResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/UriTextResourceTest.groovy
@@ -34,7 +34,7 @@ class UriTextResourceTest extends Specification {
     private File file;
     private URI fileUri;
     @Rule
-    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
 
     def setup() {
         testDir = tmpDir.createDir('dir');

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/DefaultLocallyAvailableResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/DefaultLocallyAvailableResourceTest.groovy
@@ -21,7 +21,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultLocallyAvailableResourceTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "uses value from origin file"() {
         given:

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/LocalFileStandInExternalResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/LocalFileStandInExternalResourceTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
 
 class LocalFileStandInExternalResourceTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "can apply ContentAction to file contents"() {
         def file = tmpDir.createFile("content")

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/ModificationTimeFileAccessTimeJournalTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/ModificationTimeFileAccessTimeJournalTest.groovy
@@ -25,7 +25,7 @@ class ModificationTimeFileAccessTimeJournalTest extends Specification {
 
     static final long FIXED_TIMESTAMP = 42_000
 
-    @Rule TestNameTestDirectoryProvider tmpDir
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     @Subject ModificationTimeFileAccessTimeJournal journal = new ModificationTimeFileAccessTimeJournal()
 
     def "updates modification time"() {

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/SingleDepthFileAccessTrackerTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/local/SingleDepthFileAccessTrackerTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class SingleDepthFileAccessTrackerTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     TestFile baseDir = tmpDir.file("base")
     FileAccessTimeJournal journal = Mock(FileAccessTimeJournal)
 

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/transfer/AccessorBackedExternalResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/transfer/AccessorBackedExternalResourceTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Specification
 
 class AccessorBackedExternalResourceTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def resourceAccessor = Mock(ExternalResourceAccessor)
     def resourceUploader = Mock(ExternalResourceUploader)
     def resourceLister = Mock(ExternalResourceLister)

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/transfer/UrlExternalResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/transfer/UrlExternalResourceTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 class UrlExternalResourceTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def "can read file"() {
         def file = tmpDir.createFile("content")

--- a/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/DefaultScalaSourceSetTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/DefaultScalaSourceSetTest.groovy
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.instanceOf
 import static org.junit.Assert.assertThat
 
 class DefaultScalaSourceSetTest {
-    public @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     private final DefaultScalaSourceSet sourceSet = new DefaultScalaSourceSet("<set-display-name>", TestUtil.objectFactory(tmpDir.testDirectory))
 

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
@@ -39,7 +39,7 @@ import static org.junit.Assert.*
 
 class ScalaBasePluginTest {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     private final Project project = TestUtil.create(temporaryFolder).rootProject()
 
     @Before

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPluginTest.groovy
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue
 
 class ScalaPluginTest {
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     private final Project project = TestUtil.create(temporaryFolder).rootProject()
     private final ScalaPlugin scalaPlugin = new ScalaPlugin()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -32,7 +32,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
     protected static final List<String> TESTED_AGP_VERSIONS = AGP_VERSIONS.getLatestsFromMinorPlusNightly("3.6")
 
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     TestFile homeDir
 
     def setup() {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Specification
 @CleanupTestDirectory
 class PathNormalizationStrategyTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     private StringInterner stringInterner = new StringInterner()
 

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterTest.groovy
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 @UsesNativeServices
 class DirectorySnapshotterTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     def fileHasher = new TestFileHasher()
     def directorySnapshotter = new DirectorySnapshotter(fileHasher, new StringInterner())

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -38,7 +38,7 @@ import spock.lang.Specification
 @CleanupTestDirectory
 class FileSystemSnapshotFilterTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
+    final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
 
     VirtualFileSystem virtualFileSystem = TestFiles.virtualFileSystem()
     FileSystem fileSystem = TestFiles.fileSystem()

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractVirtualFileSystemTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractVirtualFileSystemTest.groovy
@@ -42,7 +42,7 @@ import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 @CleanupTestDirectory
 abstract class AbstractVirtualFileSystemTest extends Specification {
     @Rule
-    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def fileHasher = new AllowingHasher(TestFiles.fileHasher())
     def stat = new AllowingStat(TestFiles.fileSystem())

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 
 class DefaultSnapshotHierarchyTest extends Specification {
-    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     private static final SnapshotHierarchy EMPTY = DefaultSnapshotHierarchy.empty(CASE_SENSITIVE)
 

--- a/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/resolve/DependencyResolutionStressTest.groovy
@@ -40,7 +40,7 @@ import java.util.zip.ZipOutputStream
 
 @Category(SoakTest)
 class DependencyResolutionStressTest extends Specification {
-    @Rule TestNameTestDirectoryProvider workspace = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider workspace = new TestNameTestDirectoryProvider(getClass())
     GradleDistribution distribution = new UnderDevelopmentGradleDistribution()
     @Rule StressHttpServer server = new StressHttpServer()
     @Rule ConcurrentTestUtil concurrent = new ConcurrentTestUtil()

--- a/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/DefaultGradleRunnerTest.groovy
+++ b/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/DefaultGradleRunnerTest.groovy
@@ -33,7 +33,7 @@ class DefaultGradleRunnerTest extends Specification {
     @Rule
     SetSystemProperties sysProp = new SetSystemProperties()
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
     GradleExecutor gradleExecutor = Mock(GradleExecutor)
     TestKitDirProvider testKitDirProvider = Mock(TestKitDirProvider)
     File workingDir = new File('my/tests')

--- a/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/TempTestKitDirProviderTest.groovy
+++ b/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/TempTestKitDirProviderTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 class TempTestKitDirProviderTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
 
     def "can create temporary directory"() {
         def systemProperties = Mock(SystemProperties) {

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -37,7 +37,7 @@ import spock.lang.Unroll
 
 class Binary2JUnitXmlReportGeneratorSpec extends Specification {
 
-    @Rule private TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule private TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
     private resultsProvider = Mock(TestResultsProvider)
     BuildOperationExecutor buildOperationExecutor
     Binary2JUnitXmlReportGenerator generator

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestResultSerializerTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/TestResultSerializerTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 
 class TestResultSerializerTest extends Specification {
     @Rule
-    private TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    private TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     def "can write and read results"() {
         def class1 = new TestClassResult(1, 'Class1', 1234)

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/DefaultTestReportTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/report/DefaultTestReportTest.groovy
@@ -39,7 +39,7 @@ import spock.lang.Unroll
 
 class DefaultTestReportTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     BuildOperationExecutor buildOperationExecutor
     DefaultTestReport report
     final TestFile reportDir = tmpDir.file('report')

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.api.tasks.testing.TestResult.ResultType.SKIPPED
 
 class JUnitTestClassProcessorTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider(getClass())
 
     def processor = Mock(TestResultProcessor)
     def spec = new JUnitSpec([] as Set, [] as Set, [] as Set, [] as Set, [] as Set)

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
@@ -41,7 +41,7 @@ import spock.lang.Subject
 
 class TestNGTestClassProcessorTest extends Specification {
 
-    @Rule TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider()
+    @Rule TestNameTestDirectoryProvider dir = new TestNameTestDirectoryProvider(getClass())
 
     def processor = Mock(TestResultProcessor)
 

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Specification
 
 class DefaultCppTestSuiteTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     def testSuite = project.objects.newInstance(DefaultCppTestSuite, "test")
 

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
@@ -33,7 +33,7 @@ import spock.lang.Specification
 @UsesNativeServices
 class CppUnitTestPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("someApp").build()
 

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cunit/CUnitTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cunit/CUnitTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.model.internal.type.ModelTypes.modelMap
 
 class CUnitTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
     final def project = TestUtil.create(testDir).rootProject();
 
     def "creates a test suite for each library under test"() {

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.model.internal.type.ModelTypes.modelMap
 
 class GoogleTestTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
     final def project = TestUtil.create(testDir).rootProject();
 
     def "creates a test suite for each library under test"() {

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/internal/DefaultNativeTestSuiteBinarySpecTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/internal/DefaultNativeTestSuiteBinarySpecTest.groovy
@@ -28,7 +28,7 @@ import spock.lang.Specification
 
 class DefaultNativeTestSuiteBinarySpecTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())
     final def testUtil = TestUtil.create(testDir)
 
     def tasks = new DefaultNativeTestSuiteBinarySpec.DefaultTasksCollection(new DefaultBinaryTasksCollection(null, null, CollectionCallbackActionDecorator.NOOP))

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/plugins/NativeTestingBasePluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/plugins/NativeTestingBasePluginTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 
 class NativeTestingBasePluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testSuite").build()
 

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
@@ -31,7 +31,7 @@ import spock.lang.Specification
 
 class DefaultSwiftXCTestSuiteTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
     def testSuite = project.objects.newInstance(DefaultSwiftXCTestSuite, "test")
 

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -37,7 +37,7 @@ import spock.lang.Specification
 
 class XCTestConventionPluginTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     def projectDir = tmpDir.createDir("project")
     def project = ProjectBuilder.builder().withProjectDir(projectDir).withName("testApp").build()
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/AutoTestedSamplesToolingApiTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/AutoTestedSamplesToolingApiTest.groovy
@@ -25,7 +25,7 @@ import spock.lang.Specification
 
 public class AutoTestedSamplesToolingApiTest extends Specification {
 
-    @Rule public final TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider()
+    @Rule public final TestNameTestDirectoryProvider temp = new TestNameTestDirectoryProvider(getClass())
 
     void runSamples() {
         expect:

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -51,7 +51,7 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 class ConcurrentToolingApiIntegrationSpec extends Specification {
 
     @Rule final ConcurrentTestUtil concurrent = new ConcurrentTestUtil()
-    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     final GradleDistribution dist = new UnderDevelopmentGradleDistribution()
     final ToolingApi toolingApi = new ToolingApi(dist, temporaryFolder)
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
@@ -32,7 +32,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class DistributionFactoryTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final ProgressLoggerFactory progressLoggerFactory = Mock()
     final ProgressLogger progressLogger = Mock()
     final BuildCancellationToken cancellationToken = Mock()

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoaderTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoaderTest.groovy
@@ -67,7 +67,7 @@ import spock.lang.Specification
 
 class DefaultToolingImplementationLoaderTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     Distribution distribution = Mock()
     ProgressLoggerFactory loggerFactory = Mock()
     InternalBuildProgressListener progressListener = Mock()

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -74,7 +74,7 @@ abstract class ToolingApiSpecification extends Specification {
         return targetDist.version.baseVersion.version
     }
 
-    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     final GradleDistribution dist = new UnderDevelopmentGradleDistribution()
     final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
     private static final ThreadLocal<GradleDistribution> VERSION = new ThreadLocal<GradleDistribution>()

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -79,7 +79,7 @@ abstract class ToolingApiSpecification extends Specification {
     final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
     private static final ThreadLocal<GradleDistribution> VERSION = new ThreadLocal<GradleDistribution>()
 
-    TestDistributionDirectoryProvider temporaryDistributionFolder = new TestDistributionDirectoryProvider();
+    TestDistributionDirectoryProvider temporaryDistributionFolder = new TestDistributionDirectoryProvider(getClass())
     final ToolingApi toolingApi = new ToolingApi(targetDist, temporaryFolder)
 
     @Rule

--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -36,7 +36,7 @@ class GitVersionControlSystemSpec extends Specification {
     private RevCommit c1
     private RevCommit c2
 
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     GitFileRepository repo = new GitFileRepository(tmpDir.getTestDirectory())
     GitFileRepository repo2 = new GitFileRepository(tmpDir.getTestDirectory().file('other'))
     GitFileRepository submoduleRepo = new GitFileRepository("submodule", tmpDir.testDirectory)

--- a/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/WorkerProcessClassPathProviderTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/WorkerProcessClassPathProviderTest.groovy
@@ -25,7 +25,7 @@ import org.junit.Rule
 import spock.lang.Specification
 
 class WorkerProcessClassPathProviderTest extends Specification {
-    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final CacheRepository cacheRepository = Mock()
     final ModuleRegistry moduleRegistry = Mock()
     final WorkerProcessClassPathProvider provider = new WorkerProcessClassPathProvider(cacheRepository, moduleRegistry)

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorTest.groovy
@@ -43,7 +43,7 @@ class DefaultWorkerExecutorTest extends Specification {
     @Rule
     RedirectStdOutAndErr output = new RedirectStdOutAndErr()
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def workerDaemonFactory = Mock(WorkerFactory)
     def inProcessWorkerFactory = Mock(WorkerFactory)

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -31,7 +31,7 @@ class WorkerExecutorFixture {
     def outputFileDir
     def outputFileDirPath
     def list = [ 1, 2, 3 ]
-    private final TestNameTestDirectoryProvider temporaryFolder
+    private final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     final WorkParameterClass testParameterType
     final WorkActionClass workActionThatCreatesFiles
     final WorkActionClass workActionThatFails
@@ -117,7 +117,7 @@ class WorkerExecutorFixture {
                         additionalParameters.call(parameters)
                     }
                 }
-                
+
                 ${workerMethodTranslation}
             }
         """
@@ -174,7 +174,7 @@ class WorkerExecutorFixture {
             } finally {
                 getParameters().getOutputDir().mkdirs();
                 new File(getParameters().getOutputDir(), "finished").createNewFile();
-            } 
+            }
         """
         return workerClass
     }
@@ -246,12 +246,12 @@ class WorkerExecutorFixture {
     String getFileHelperClass() {
         return """
             package org.gradle.test;
-            
+
             import java.io.File;
             import java.io.PrintWriter;
             import java.io.BufferedWriter;
             import java.io.FileWriter;
-            
+
             public class FileHelper {
                 public static void write(String id, File outputFile) {
                     PrintWriter out = null;
@@ -442,10 +442,10 @@ class WorkerExecutorFixture {
                     ${extraFields}
 
                     @javax.inject.Inject
-                    public ${name.capitalize()}(${constructorArgs}) { 
+                    public ${name.capitalize()}(${constructorArgs}) {
                         ${constructorAction}
                     }
-                    
+
                     public void execute() {
                         ${action}
                     }

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/DownloadTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/DownloadTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 class DownloadTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
 
     def "downloads file"() {
         given:

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/ExclusiveFileAccessManagerTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/ExclusiveFileAccessManagerTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class ExclusiveFileAccessManagerTest extends Specification {
     @Rule
-    public TestNameTestDirectoryProvider temporaryDirectory = new TestNameTestDirectoryProvider()
+    public TestNameTestDirectoryProvider temporaryDirectory = new TestNameTestDirectoryProvider(getClass())
     private manager = new ExclusiveFileAccessManager(1000, 10)
 
     def 'If the directory for the lock file cannot be created then we get a good error message'() {

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
@@ -37,7 +37,7 @@ class InstallTest extends Specification {
     PathAssembler pathAssembler = Mock()
     PathAssembler.LocalDistribution localDistribution = Mock()
     @Rule
-    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider();
+    public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass());
 
     public void setup() {
         downloadCalled = false

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/SystemPropertiesHandlerTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/SystemPropertiesHandlerTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 @CleanupTestDirectory
 class SystemPropertiesHandlerTest extends Specification {
     @Rule
-    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def parsesPropertiesFile() {
         TestFile propFile = temporaryFolder.file('props')

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class WrapperExecutorTest extends Specification {
     @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider();
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
     final Install install = Mock()
     final BootstrapMainStarter start = Mock()
     TestFile projectDir;


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-private/issues/2988

This PR adds `className` to `AbstractTestDirectoryProvider` so there'll be no more `unknown-test-class`.

Please check out 007d4e484dc25538b1e8e04fba991cb690deabc9 to see the real change: other file changes are all noise.