### PR TITLE
Do not smoke test AspectJ plugin against JDK14 due to incompatible dependency

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -130,6 +130,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK12_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_12
     }),
+    JDK13_OR_EARLIER({
+        JavaVersion.current() <= JavaVersion.VERSION_13
+    }),
     JDK7_POSIX({
         NOT_WINDOWS.fulfilled
     }),

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyPluginsSmokeTest.groovy
@@ -138,7 +138,7 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
             plugins {
                 id '${pluginId}' version '${version}'
             }
-            
+
             repositories {
                 ${jcenterRepository()}
             }
@@ -561,6 +561,8 @@ class ThirdPartyPluginsSmokeTest extends AbstractSmokeTest {
         result.task(":compileJava").outcome == UP_TO_DATE
     }
 
+    // Latest AspectJ 1.9.5 is not compatible with JDK14
+    @Requires(TestPrecondition.JDK13_OR_EARLIER)
     @Issue('https://plugins.gradle.org/plugin/io.freefair.aspectj')
     def 'freefair aspectj plugin'() {
         given:


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/10248

Latest AspectJ 1.9.5 is not compatible with JDK14.
