### PR TITLE
Polish `WrapperPropertiesLoaderCrossVersionTest`

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/IgnoreVersions.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/IgnoreVersions.java
@@ -20,6 +20,9 @@ import groovy.lang.Closure;
 
 import java.lang.annotation.*;
 
+/**
+ * @see CrossVersionTestRunner
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TargetVersions.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TargetVersions.java
@@ -17,6 +17,9 @@ package org.gradle.integtests.fixtures;
 
 import java.lang.annotation.*;
 
+/**
+ * @see CrossVersionTestRunner
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperCrossVersionIntegrationTest.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.integtests
+package org.gradle.integtests.wrapper
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperPropertiesLoaderCrossVersionTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperPropertiesLoaderCrossVersionTest.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.integtests
+package org.gradle.integtests.wrapper
 
 import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperPropertiesLoaderCrossVersionTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperPropertiesLoaderCrossVersionTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.integtests.wrapper
 
 import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
-import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
@@ -26,7 +25,6 @@ import spock.lang.Issue
 import static org.junit.Assume.assumeTrue
 
 @SuppressWarnings("IntegrationTestFixtures")
-@TargetVersions("6.2.2+")
 class WrapperPropertiesLoaderCrossVersionTest extends CrossVersionIntegrationSpec {
 
     @Issue('https://github.com/gradle/gradle/issues/11173')

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperPropertiesLoaderCrossVersionTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/WrapperPropertiesLoaderCrossVersionTest.groovy
@@ -15,15 +15,15 @@
  */
 package org.gradle.integtests
 
-
 import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.util.GradleVersion
-import org.junit.Assume
 import spock.lang.Issue
+
+import static org.junit.Assume.assumeTrue
 
 @SuppressWarnings("IntegrationTestFixtures")
 @TargetVersions("6.2.2+")
@@ -34,8 +34,8 @@ class WrapperPropertiesLoaderCrossVersionTest extends CrossVersionIntegrationSpe
         given:
         GradleDistribution wrapperVersion = previous
         GradleDistribution executionVersion = current
-        Assume.assumeTrue("skipping $wrapperVersion as its wrapper cannot execute version ${executionVersion.version.version}", wrapperVersion.wrapperCanExecute(executionVersion.version))
-        Assume.assumeTrue("skipping execute version ${executionVersion.version.version} as it is <6.0", executionVersion.version >= GradleVersion.version("6.0"))
+        assumeTrue "skipping $wrapperVersion as its wrapper cannot execute version $executionVersion.version.version", wrapperVersion.wrapperCanExecute(executionVersion.version)
+        assumeTrue "skipping execute version $executionVersion.version.version as it is <6.0", executionVersion.version >= GradleVersion.version("6.0")
 
         requireOwnGradleUserHomeDir()
 
@@ -80,7 +80,7 @@ class WrapperPropertiesLoaderCrossVersionTest extends CrossVersionIntegrationSpe
 
         when:
         GradleExecuter executer = version(wrapperVersion).requireIsolatedDaemons()
-        String output =  executer.usingExecutable('gradlew').withTasks('hello').run().output
+        String output = executer.usingExecutable('gradlew').withTasks('hello').run().output
 
         then:
         output.contains('system_property_available in buildSrc:                 true')


### PR DESCRIPTION
- Move `wrapper` cross version tests to `*.wrapper` subpackage
- Remove `@TargetVersions` from `WrapperPropertiesLoaderCrossVersionTest`
- Improve javadoc of cross version test annotations