### PR TITLE
Enable dependency verification and buildSrc checks in instant execution dogfooding smoke test

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
@@ -82,7 +82,6 @@ class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
     private static final String[] GRADLE_BUILD_TEST_ARGS = [
         "-PbuildTimestamp=" + newTimestamp(),
         "-PbuildSrcCheck=false", // TODO:instant-execution remove once fixed
-        "--dependency-verification=off" // TODO:instant-execution remove once handled
     ]
 
     private static String newTimestamp() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildInstantExecutionSmokeTest.groovy
@@ -80,8 +80,7 @@ class GradleBuildInstantExecutionSmokeTest extends AbstractSmokeTest {
     }
 
     private static final String[] GRADLE_BUILD_TEST_ARGS = [
-        "-PbuildTimestamp=" + newTimestamp(),
-        "-PbuildSrcCheck=false", // TODO:instant-execution remove once fixed
+        "-PbuildTimestamp=" + newTimestamp()
     ]
 
     private static String newTimestamp() {


### PR DESCRIPTION
Now that they work!
