### PR TITLE
Let instant execution load `gradle.properties` from the settings dir

### DIFF
--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -110,11 +110,6 @@ class DefaultInstantExecution internal constructor(
         }
         else -> {
 
-            // TODO - should load properties from settings file directory
-            gradlePropertiesController.loadGradlePropertiesFrom(
-                startParameter.rootDirectory
-            )
-
             val fingerprintChangedReason = checkFingerprint()
             when {
                 fingerprintChangedReason != null -> {
@@ -236,7 +231,20 @@ class DefaultInstantExecution internal constructor(
     }
 
     private
-    fun checkFingerprint(): InvalidationReason? =
+    fun checkFingerprint(): InvalidationReason? {
+        loadGradleProperties()
+        return checkInstantExecutionFingerprintFile()
+    }
+
+    private
+    fun loadGradleProperties() {
+        gradlePropertiesController.loadGradlePropertiesFrom(
+            startParameter.settingsDirectory
+        )
+    }
+
+    private
+    fun checkInstantExecutionFingerprintFile(): InvalidationReason? =
         withReadContextFor(instantExecutionFingerprintFile) {
             withHostIsolate {
                 instantExecutionFingerprintChecker().run {

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/initialization/InstantExecutionStartParameter.kt
@@ -27,6 +27,9 @@ class InstantExecutionStartParameter(
     private val startParameter: StartParameter
 ) {
 
+    val settingsDirectory: File
+        get() = buildLayout.settingsDir
+
     val rootDirectory: File
         get() = buildLayout.rootDirectory
 


### PR DESCRIPTION
And be compatible with the `master/settings.gradle` project layout.

