### PR TITLE
Alternative lock file format

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -27,7 +27,8 @@ public class FeaturePreviews {
      */
     public enum Feature {
         GRADLE_METADATA(false),
-        GROOVY_COMPILATION_AVOIDANCE(true);
+        GROOVY_COMPILATION_AVOIDANCE(true),
+        DEPENDENCY_LOCKING_IMPROVED_FORMAT(true);
 
         public static Feature withName(String name) {
             try {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -28,7 +28,7 @@ public class FeaturePreviews {
     public enum Feature {
         GRADLE_METADATA(false),
         GROOVY_COMPILATION_AVOIDANCE(true),
-        DEPENDENCY_LOCKING_IMPROVED_FORMAT(true);
+        ONE_LOCKFILE_PER_PROJECT(true);
 
         public static Feature withName(String name) {
             try {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/FeaturePreviewsActivationFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/FeaturePreviewsActivationFixture.groovy
@@ -19,11 +19,17 @@ package org.gradle.api.internal
 class FeaturePreviewsActivationFixture {
 
     static def activeFeatures() {
-        EnumSet.of(FeaturePreviews.Feature.GROOVY_COMPILATION_AVOIDANCE)
+        EnumSet<FeaturePreviews.Feature> active = EnumSet.noneOf(FeaturePreviews.Feature)
+        for (FeaturePreviews.Feature feature : FeaturePreviews.Feature.values()) {
+            if (feature.isActive()) {
+                active.add(feature)
+            }
+        }
+        active
     }
 
     static def inactiveFeatures() {
-        def features = EnumSet.allOf(FeaturePreviews.Feature.class)
+        def features = EnumSet.allOf(FeaturePreviews.Feature)
         features.removeAll(activeFeatures())
         features
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
@@ -36,10 +36,14 @@ abstract class AbstractLockingIntegrationTest extends AbstractDependencyResoluti
 
     abstract LockMode lockMode()
 
-    def 'succeeds when lock file does not conflict from declared versions'() {
+    @Unroll
+    def 'succeeds when lock file does not conflict from declared versions (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -61,7 +65,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
 
         def constraintVersion = lockMode() == LockMode.LENIENT ? "1.0" : "{strictly 1.0}"
         def extraReason = lockMode() == LockMode.LENIENT ? " (update/lenient mode)" : ""
@@ -79,12 +83,19 @@ dependencies {
                 }
             }
         }
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
-    def 'does not write-locks for not locked configuration'() {
+    @Unroll
+    def 'does not write-locks for not locked configuration (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 repositories {
     maven {
@@ -105,82 +116,55 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.expectLegacyMissing('unlockedConf')
+        lockfileFixture.expectLockStateMissing('unlockedConf', unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
-    def 'writes dependency lock file when requested'() {
-        mavenRepo.module('org', 'foo', '1.0').publish()
-        mavenRepo.module('org', 'bar', '1.0').publish()
-
-        FeaturePreviewsFixture.enableDependencyLockingImprovedFormat(settingsFile)
-        buildFile << """
-dependencyLocking {
-    lockAllConfigurations()
-    lockMode = LockMode.${lockMode()}
-}
-
-repositories {
-    maven {
-        name 'repo'
-        url '${mavenRepo.uri}'
-    }
-}
-configurations {
-    lockedConf
-}
-
-dependencies {
-    lockedConf 'org:foo:1.+'
-    lockedConf 'org:bar:1.+'
-}
-"""
-
-        when:
-        succeeds'dependencies', '--write-locks', '--refresh-dependencies'
-
-        then:
-        lockfileFixture.verifyLockfile(['org:foo:1.0=lockedConf', 'org:bar:1.0=lockedConf'])
-
-    }
-
-    @ToBeFixedForInstantExecution
-    def 'writes dependency lock file when requested (legacy)'() {
-        mavenRepo.module('org', 'foo', '1.0').publish()
-        mavenRepo.module('org', 'bar', '1.0').publish()
-
-        buildFile << """
-dependencyLocking {
-    lockAllConfigurations()
-    lockMode = LockMode.${lockMode()}
-}
-
-repositories {
-    maven {
-        name 'repo'
-        url '${mavenRepo.uri}'
-    }
-}
-configurations {
-    lockedConf
-}
-
-dependencies {
-    lockedConf 'org:foo:1.+'
-    lockedConf 'org:bar:1.+'
-}
-"""
-
-        when:
-        succeeds'dependencies', '--write-locks', '--refresh-dependencies'
-
-        then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
-
-    }
-
     @Unroll
+    def 'writes dependency lock file when requested (unique: #unique)'() {
+        mavenRepo.module('org', 'foo', '1.0').publish()
+        mavenRepo.module('org', 'bar', '1.0').publish()
+
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+    lockMode = LockMode.${lockMode()}
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf 'org:foo:1.+'
+    lockedConf 'org:bar:1.+'
+}
+"""
+
+        when:
+        succeeds'dependencies', '--write-locks', '--refresh-dependencies'
+
+        then:
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'], unique)
+
+        where:
+        unique << [true, false]
+    }
+
     @ToBeFixedForInstantExecution
+    @Unroll
     def "writes dependency lock file for resolved version #version"() {
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
@@ -213,7 +197,7 @@ dependencies {
         succeeds'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ["org:bar:${resolved}"])
+        lockfileFixture.verifyLockfile('lockedConf', ["org:bar:${resolved}"], false)
 
         where:
         version     | resolved
@@ -226,7 +210,8 @@ dependencies {
     }
 
     @ToBeFixedForInstantExecution
-    def "does not lock a configuration that is marked with deactivateDependencyLocking"() {
+    @Unroll
+    def "does not lock a configuration that is marked with deactivateDependencyLocking (unique: #unique)"() {
         ['foo', 'foz', 'bar', 'baz'].each { artifact ->
             mavenRepo.module('org', artifact, '1.0').publish()
             mavenRepo.module('org', artifact, '1.1').publish()
@@ -234,6 +219,9 @@ dependencies {
             mavenRepo.module('org', artifact, '2.0').publish()
         }
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockMode = LockMode.${lockMode()}
@@ -278,16 +266,23 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockEnabledConf', ['org:bar:1.2', 'org:baz:2.0', 'org:foo:1.1', 'org:foz:2.0'])
-        lockfileFixture.expectLegacyMissing('secondLockEnabledConf')
+        lockfileFixture.verifyLockfile([lockEnabledConf: ['org:bar:1.2', 'org:baz:2.0', 'org:foo:1.1', 'org:foz:2.0'], conf: ['org:bar:1.2', 'org:baz:2.0', 'org:foo:1.1', 'org:foz:2.0']], unique)
+        lockfileFixture.expectLockStateMissing('secondLockEnabledConf', unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
-    def 'upgrades lock file'() {
+    @Unroll
+    def 'upgrades lock file (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
         mavenRepo.module('org', 'foo', '2.0').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -310,56 +305,26 @@ dependencies {
 """
 
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ["org:foo:1.0"])
+        lockfileFixture.createLockfile('lockedConf', ["org:foo:1.0"], unique)
 
         when:
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
-    def 'counts dependencies with multiple paths as one instance'() {
+    def 'does not write duplicates in the lockfile (unique: #unique)'() {
         def foo = mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.0').dependsOn(foo).publish()
 
-        buildFile << """
-dependencyLocking {
-    lockAllConfigurations()
-    lockMode = LockMode.${lockMode()}
-}
-
-repositories {
-    maven {
-        name 'repo'
-        url '${mavenRepo.uri}'
-    }
-}
-configurations {
-    lockedConf
-}
-
-dependencies {
-    lockedConf 'org:foo:1.+'
-    lockedConf 'org:bar:1.+'
-}
-"""
-
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0', 'org:bar:1.0'])
-
-        when:
-        succeeds 'dependencies'
-
-        then:
-        outputContains("org:foo:1.0")
-    }
-
-    @ToBeFixedForInstantExecution
-    def 'does not write duplicates in the lockfile'() {
-        def foo = mavenRepo.module('org', 'foo', '1.0').publish()
-        mavenRepo.module('org', 'bar', '1.0').dependsOn(foo).publish()
-
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -386,14 +351,21 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def 'includes transitive dependencies in the lock file'() {
         def dep = mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.0').dependsOn(dep).publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -419,18 +391,25 @@ dependencies {
         succeeds 'dependencies', '--configuration', 'lockedConf', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
-    def 'updates part of the lockfile'() {
+    @Unroll
+    def 'updates part of the lockfile (unique: #unique)'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'], unique)
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -457,18 +436,25 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def 'updates part of the lockfile using wildcard'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'], unique)
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -495,18 +481,25 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:f*'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def 'updates but ignores irrelevant modules'() {
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'], unique)
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -533,10 +526,14 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo,org:baz'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.1'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.1'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def 'updates multiple parts of the lockfile'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
@@ -547,8 +544,11 @@ dependencies {
         mavenRepo.module('org', 'baz', '1.0').dependsOn(bar10).publish()
         mavenRepo.module('org', 'baz', '1.1').dependsOn(bar11).publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0', 'org:baz:1.0', 'org:buz:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0', 'org:baz:1.0', 'org:buz:1.0'], unique)
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -576,11 +576,18 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo,org:baz'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1', 'org:baz:1.1', 'org:buz:1.0'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1', 'org:baz:1.1', 'org:buz:1.0'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
-    def 'writes an empty lock file for an empty configuration'() {
+    @Unroll
+    def 'writes an empty lock file for an empty configuration (unique: #unique)'() {
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -601,11 +608,18 @@ configurations {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', [])
+        lockfileFixture.verifyLockfile('lockedConf', [], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
-    def 'overwrites a not empty lock file with an empty one when configuration no longer has dependencies'() {
+    @Unroll
+    def 'overwrites a not empty lock file with an empty one when configuration no longer has dependencies (unique: #unique)'() {
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -622,13 +636,16 @@ configurations {
     lockedConf
 }
 """
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', [])
+        lockfileFixture.verifyLockfile('lockedConf', [], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
@@ -60,7 +60,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         def constraintVersion = lockMode() == LockMode.LENIENT ? "1.0" : "{strictly 1.0}"
         def extraReason = lockMode() == LockMode.LENIENT ? " (update/lenient mode)" : ""
@@ -104,7 +104,7 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.expectMissing('unlockedConf')
+        lockfileFixture.expectLegacyMissing('unlockedConf')
     }
 
     @ToBeFixedForInstantExecution
@@ -138,7 +138,7 @@ dependencies {
         succeeds'dependencies', '--write-locks', '--refresh-dependencies'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
 
     }
 
@@ -176,7 +176,7 @@ dependencies {
         succeeds'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ["org:bar:${resolved}"])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ["org:bar:${resolved}"])
 
         where:
         version     | resolved
@@ -241,8 +241,8 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockEnabledConf', ['org:bar:1.2', 'org:baz:2.0', 'org:foo:1.1', 'org:foz:2.0'])
-        lockfileFixture.expectMissing('secondLockEnabledConf')
+        lockfileFixture.verifyLegacyLockfile('lockEnabledConf', ['org:bar:1.2', 'org:baz:2.0', 'org:foo:1.1', 'org:foz:2.0'])
+        lockfileFixture.expectLegacyMissing('secondLockEnabledConf')
     }
 
     @ToBeFixedForInstantExecution
@@ -273,13 +273,13 @@ dependencies {
 """
 
 
-        lockfileFixture.createLockfile('lockedConf', ["org:foo:1.0"])
+        lockfileFixture.createLegacyLockfile('lockedConf', ["org:foo:1.0"])
 
         when:
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1'])
     }
 
     @ToBeFixedForInstantExecution
@@ -309,7 +309,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0', 'org:bar:1.0'])
 
         when:
         succeeds 'dependencies'
@@ -349,7 +349,7 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
     }
 
     @ToBeFixedForInstantExecution
@@ -382,7 +382,7 @@ dependencies {
         succeeds 'dependencies', '--configuration', 'lockedConf', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
     }
 
     @ToBeFixedForInstantExecution
@@ -392,7 +392,7 @@ dependencies {
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
 
         buildFile << """
 dependencyLocking {
@@ -420,7 +420,7 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'])
     }
 
     @ToBeFixedForInstantExecution
@@ -430,7 +430,7 @@ dependencies {
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0'])
 
         buildFile << """
 dependencyLocking {
@@ -458,7 +458,7 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:f*'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.0'])
     }
 
     @ToBeFixedForInstantExecution
@@ -468,7 +468,7 @@ dependencies {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
 
         buildFile << """
 dependencyLocking {
@@ -496,7 +496,7 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo,org:baz'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.1'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.1'])
     }
 
     @ToBeFixedForInstantExecution
@@ -510,7 +510,7 @@ dependencies {
         mavenRepo.module('org', 'baz', '1.0').dependsOn(bar10).publish()
         mavenRepo.module('org', 'baz', '1.1').dependsOn(bar11).publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0', 'org:baz:1.0', 'org:buz:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0', 'org:bar:1.0', 'org:baz:1.0', 'org:buz:1.0'])
 
         buildFile << """
 dependencyLocking {
@@ -539,7 +539,7 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo,org:baz'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1', 'org:baz:1.1', 'org:buz:1.0'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1', 'org:baz:1.1', 'org:buz:1.0'])
     }
 
     @ToBeFixedForInstantExecution
@@ -564,7 +564,7 @@ configurations {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', [])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', [])
     }
 
     @ToBeFixedForInstantExecution
@@ -585,13 +585,13 @@ configurations {
     lockedConf
 }
 """
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', [])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', [])
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractValidatingLockingIntegrationTest.groovy
@@ -50,7 +50,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         fails 'checkDeps'
@@ -88,7 +88,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         fails 'checkDeps'
@@ -125,7 +125,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'])
 
         when:
         fails 'checkDeps'
@@ -162,7 +162,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         fails 'checkDeps'
@@ -190,7 +190,7 @@ configurations {
     lockedConf
 }
 """
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         fails 'checkDeps'
@@ -229,7 +229,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         run 'dependencies'
@@ -271,7 +271,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
 
         when:
         run 'dependencies'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -54,7 +54,7 @@ dependencies {
         succeeds 'dependencies'
 
         then:
-        lockfileFixture.expectMissing('unlockedConf')
+        lockfileFixture.expectLegacyMissing('unlockedConf')
     }
 
     def "version selector combinations are resolved equally for locked and unlocked configurations"() {
@@ -134,7 +134,7 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1'])
     }
 
     @ToBeFixedForInstantExecution
@@ -158,7 +158,7 @@ configurations {
         succeeds 'dependencies'
 
         then:
-        lockfileFixture.expectMissing('lockedConf')
+        lockfileFixture.expectLegacyMissing('lockedConf')
     }
 
     def 'attempting to change lock mode after a configuration has been resolved is invalid'() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.api.artifacts.dsl.LockMode
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import spock.lang.Unroll
 
 class DependencyLockingIntegrationTest extends AbstractValidatingLockingIntegrationTest {
 
@@ -27,9 +29,13 @@ class DependencyLockingIntegrationTest extends AbstractValidatingLockingIntegrat
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def 'succeeds without lock file present and does not create one'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -54,9 +60,13 @@ dependencies {
         succeeds 'dependencies'
 
         then:
-        lockfileFixture.expectLegacyMissing('unlockedConf')
+        lockfileFixture.expectLockStateMissing('unlockedConf', unique)
+
+        where:
+        unique << [true, false]
     }
 
+    @Unroll
     def "version selector combinations are resolved equally for locked and unlocked configurations"() {
         ['foo', 'foz', 'bar', 'baz'].each { artifact ->
             mavenRepo.module('org', artifact, '1.0').publish()
@@ -65,6 +75,9 @@ dependencies {
             mavenRepo.module('org', artifact, '2.0').publish()
         }
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 repositories {
     maven {
@@ -100,15 +113,22 @@ task check {
 
         expect:
         succeeds 'check'
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def 'writes a new lock file if update done without lockfile present'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.1').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -134,11 +154,18 @@ dependencies {
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1', 'org:bar:1.1'], unique)
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
+    @Unroll
     def 'does not write an empty lock file for an empty configuration if not requested'() {
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -158,7 +185,10 @@ configurations {
         succeeds 'dependencies'
 
         then:
-        lockfileFixture.expectLegacyMissing('lockedConf')
+        lockfileFixture.expectLockStateMissing('lockedConf', unique)
+
+        where:
+        unique << [true, false]
     }
 
     def 'attempting to change lock mode after a configuration has been resolved is invalid'() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
@@ -54,7 +54,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         succeeds 'checkDeps'
@@ -99,7 +99,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         succeeds 'checkDeps'
@@ -144,7 +144,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'])
 
         when:
         succeeds 'checkDeps'
@@ -188,7 +188,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         succeeds 'checkDeps'
@@ -225,7 +225,7 @@ configurations {
     lockedConf
 }
 """
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         succeeds 'checkDeps'
@@ -268,7 +268,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
 
         when:
         run 'dependencies'
@@ -310,7 +310,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
 
         when:
         run 'dependencies'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.api.artifacts.dsl.LockMode
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForInstantExecution
+import spock.lang.Unroll
 
 class DependencyLockingLenientModeIntegrationTest extends AbstractLockingIntegrationTest {
     @Override
@@ -25,11 +27,15 @@ class DependencyLockingLenientModeIntegrationTest extends AbstractLockingIntegra
         return LockMode.LENIENT
     }
 
+    @Unroll
     def 'does not fail when lock file conflicts with declared strict constraint'() {
         given:
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -54,7 +60,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -70,13 +76,20 @@ dependencies {
                 }
             }
         }
+
+        where:
+        unique << [true, false]
     }
 
+    @Unroll
     def 'does not fail when lock file conflicts with declared version constraint'() {
         given:
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -99,7 +112,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -115,14 +128,21 @@ dependencies {
                 }
             }
         }
+
+        where:
+        unique << [true, false]
     }
 
+    @Unroll
     def 'does not fail when lock file contains entry that is not in resolution result'() {
 
         given:
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.0').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -144,7 +164,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -159,13 +179,20 @@ dependencies {
                 }
             }
         }
+
+        where:
+        unique << [true, false]
     }
 
+    @Unroll
     def 'does not fail when lock file does not contain entry for module in resolution result'() {
         given:
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.0').publish()
 
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -188,7 +215,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -204,11 +231,19 @@ dependencies {
                 }
             }
         }
+
+        where:
+        unique << [true, false]
     }
 
+    @Unroll
     def 'does not fail when resolution result is empty and lock file contains entries'() {
         given:
         mavenRepo.module('org', 'foo', '1.0').publish()
+
+        if (unique) {
+            FeaturePreviewsFixture.enableOneLockfilePerProject(settingsFile)
+        }
         buildFile << """
 dependencyLocking {
     lockAllConfigurations()
@@ -225,7 +260,7 @@ configurations {
     lockedConf
 }
 """
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -237,6 +272,9 @@ configurations {
                 // Empty result
             }
         }
+
+        where:
+        unique << [true, false]
     }
 
     @ToBeFixedForInstantExecution
@@ -268,7 +306,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], false)
 
         when:
         run 'dependencies'
@@ -310,7 +348,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'], false)
 
         when:
         run 'dependencies'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingStrictModeIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingStrictModeIntegrationTest.groovy
@@ -55,8 +55,8 @@ dependencies {
         fails 'dependencies'
 
         then:
-        failureHasCause("Locking strict mode: Configuration ':lockedConf' is locked but does not have a lockfile.")
-        lockfileFixture.expectLegacyMissing('unlockedConf')
+        failureHasCause("Locking strict mode: Configuration ':lockedConf' is locked but does not have lock state.")
+        lockfileFixture.expectLockStateMissing('unlockedConf', false)
     }
 
     @ToBeFixedForInstantExecution
@@ -92,8 +92,8 @@ dependencies {
         fails 'dependencies', '--update-locks', 'org:foo'
 
         then:
-        failureHasCause("Locking strict mode: Configuration ':lockedConf' is locked but does not have a lockfile.")
-        lockfileFixture.expectLegacyMissing('unlockedConf')
+        failureHasCause("Locking strict mode: Configuration ':lockedConf' is locked but does not have lock state.")
+        lockfileFixture.expectLockStateMissing('unlockedConf', false)
     }
 
     @ToBeFixedForInstantExecution

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingStrictModeIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingStrictModeIntegrationTest.groovy
@@ -56,7 +56,7 @@ dependencies {
 
         then:
         failureHasCause("Locking strict mode: Configuration ':lockedConf' is locked but does not have a lockfile.")
-        lockfileFixture.expectMissing('unlockedConf')
+        lockfileFixture.expectLegacyMissing('unlockedConf')
     }
 
     @ToBeFixedForInstantExecution
@@ -93,7 +93,7 @@ dependencies {
 
         then:
         failureHasCause("Locking strict mode: Configuration ':lockedConf' is locked but does not have a lockfile.")
-        lockfileFixture.expectMissing('unlockedConf')
+        lockfileFixture.expectLegacyMissing('unlockedConf')
     }
 
     @ToBeFixedForInstantExecution

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -55,7 +55,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0'], false)
 
         when:
         succeeds 'dependencies'
@@ -94,7 +94,7 @@ dependencies {
 
         then:
         outputContains('my-dep-1.0')
-        lockfileFixture.verifyLegacyLockfile('lockedConf', [])
+        lockfileFixture.verifyLockfile('lockedConf', [], false)
     }
 
     @Unroll
@@ -128,7 +128,7 @@ dependencies {
         if (level == 'integration') {
             version += '-SNAPSHOT'
         }
-        lockfileFixture.createLegacyLockfile('lockedConf', ["org:bar:$version".toString()])
+        lockfileFixture.createLockfile('lockedConf', ["org:bar:$version".toString()], false)
 
         when:
         succeeds 'dependencies'
@@ -180,7 +180,7 @@ dependencies {
         outputContains("org:bar:$version -> $expectedVersion")
 
         and:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ["org:bar:$expectedVersion"])
+        lockfileFixture.verifyLockfile('lockedConf', ["org:bar:$expectedVersion"], false)
 
         where:
         version              | expectedVersion
@@ -222,7 +222,7 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:bar:1.0-SNAPSHOT'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0-SNAPSHOT'], false)
         outputContains('Dependency lock state for configuration \':lockedConf\' contains changing modules: [org:bar:1.0-SNAPSHOT]. This means that dependencies content may still change over time.')
 
         when:
@@ -263,13 +263,13 @@ dependencies {
     lockedConf 'org:foo:$version'
 }
 """
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', 'org:foo:1.0'], false)
 
         when:
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', "org:foo:$expectedVersion"])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', "org:foo:$expectedVersion"], false)
 
         where:
         version              | expectedVersion
@@ -313,7 +313,7 @@ task copyFiles(type: Copy) {
         succeeds 'copyFiles', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0'], false)
 
         and:
         succeeds 'copyFiles'
@@ -325,7 +325,7 @@ task copyFiles(type: Copy) {
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:test:1.1'])
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], false)
 
         buildFile << """
 dependencyLocking {
@@ -369,7 +369,7 @@ task resolve {
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:test:1.1'])
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], false)
 
         buildFile << """
 dependencyLocking {
@@ -413,7 +413,7 @@ task resolve {
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:test:1.1'])
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'], false)
 
         buildFile << """
 dependencyLocking {
@@ -457,7 +457,7 @@ task resolve {
     @ToBeFixedForInstantExecution(because = "composite builds")
     def "ignores the lock entry that matches a composite"() {
         given:
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:composite:1.1'])
+        lockfileFixture.createLockfile('lockedConf', ['org:composite:1.1'], false)
 
         file("composite/settings.gradle") << """
 rootProject.name = 'composite'
@@ -505,7 +505,7 @@ task resolve {
         mavenHttpRepo.module('org', 'foo', '2.0').publish()
         def bar10 = mavenHttpRepo.module('org', 'bar', '1.0').dependsOn('org', 'foo', '[1.0,2.0)').publish()
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'], false)
 
         buildFile << """
 dependencyLocking {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -55,7 +55,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0'])
 
         when:
         succeeds 'dependencies'
@@ -94,7 +94,7 @@ dependencies {
 
         then:
         outputContains('my-dep-1.0')
-        lockfileFixture.verifyLockfile('lockedConf', [])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', [])
     }
 
     @Unroll
@@ -128,7 +128,7 @@ dependencies {
         if (level == 'integration') {
             version += '-SNAPSHOT'
         }
-        lockfileFixture.createLockfile('lockedConf', ["org:bar:$version".toString()])
+        lockfileFixture.createLegacyLockfile('lockedConf', ["org:bar:$version".toString()])
 
         when:
         succeeds 'dependencies'
@@ -180,7 +180,7 @@ dependencies {
         outputContains("org:bar:$version -> $expectedVersion")
 
         and:
-        lockfileFixture.verifyLockfile('lockedConf', ["org:bar:$expectedVersion"])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ["org:bar:$expectedVersion"])
 
         where:
         version              | expectedVersion
@@ -222,7 +222,7 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0-SNAPSHOT'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:bar:1.0-SNAPSHOT'])
         outputContains('Dependency lock state for configuration \':lockedConf\' contains changing modules: [org:bar:1.0-SNAPSHOT]. This means that dependencies content may still change over time.')
 
         when:
@@ -263,13 +263,13 @@ dependencies {
     lockedConf 'org:foo:$version'
 }
 """
-        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', 'org:foo:1.0'])
 
         when:
         succeeds 'dependencies', '--update-locks', 'org:foo'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', "org:foo:$expectedVersion"])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:baz:1.0', "org:foo:$expectedVersion"])
 
         where:
         version              | expectedVersion
@@ -313,7 +313,7 @@ task copyFiles(type: Copy) {
         succeeds 'copyFiles', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         and:
         succeeds 'copyFiles'
@@ -325,7 +325,7 @@ task copyFiles(type: Copy) {
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:test:1.1'])
 
         buildFile << """
 dependencyLocking {
@@ -369,7 +369,7 @@ task resolve {
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:test:1.1'])
 
         buildFile << """
 dependencyLocking {
@@ -413,7 +413,7 @@ task resolve {
         mavenRepo.module('org', 'test', '1.0').publish()
         mavenRepo.module('org', 'test', '1.1').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:test:1.1'])
 
         buildFile << """
 dependencyLocking {
@@ -457,7 +457,7 @@ task resolve {
     @ToBeFixedForInstantExecution(because = "composite builds")
     def "ignores the lock entry that matches a composite"() {
         given:
-        lockfileFixture.createLockfile('lockedConf', ['org:composite:1.1'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:composite:1.1'])
 
         file("composite/settings.gradle") << """
 rootProject.name = 'composite'
@@ -505,7 +505,7 @@ task resolve {
         mavenHttpRepo.module('org', 'foo', '2.0').publish()
         def bar10 = mavenHttpRepo.module('org', 'bar', '1.0').dependsOn('org', 'foo', '[1.0,2.0)').publish()
 
-        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
 
         buildFile << """
 dependencyLocking {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
@@ -52,7 +52,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], false)
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
@@ -94,7 +94,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], false)
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
@@ -129,7 +129,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], false)
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
@@ -169,6 +169,6 @@ dependencies {
         succeeds 'dependencies', '--configuration', 'lockedConf', '--write-locks'
 
         then:
-        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1'])
+        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1'], false)
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
@@ -42,7 +42,7 @@ configurations {
     lockedConf {
         resolutionStrategy.activateDependencyLocking()
     }
-    
+
     unlockedConf
 }
 
@@ -52,7 +52,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
@@ -85,7 +85,7 @@ configurations {
     lockedConf {
         resolutionStrategy.activateDependencyLocking()
     }
-    
+
     unlockedConf.extendsFrom lockedConf
 }
 
@@ -94,7 +94,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
@@ -129,7 +129,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
@@ -169,6 +169,6 @@ dependencies {
         succeeds 'dependencies', '--configuration', 'lockedConf', '--write-locks'
 
         then:
-        lockfileFixture.verifyLockfile('lockedConf', ['org:foo:1.1'])
+        lockfileFixture.verifyLegacyLockfile('lockedConf', ['org:foo:1.1'])
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
@@ -57,7 +57,7 @@ project(':second') {
     }
 }
 """
-        firstLockFileFixture.createLegacyLockfile('compileClasspath', ['org:foo:1.0'])
+        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], false)
 
         when:
         succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
@@ -99,7 +99,7 @@ project(':second') {
     }
 }
 """
-        firstLockFileFixture.createLegacyLockfile('compileClasspath', ['org:foo:1.0'])
+        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'], false)
 
         when:
         succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
@@ -147,6 +147,6 @@ project(':second') {
 
         then:
         outputContains('Persisted dependency lock state for configuration \':first:compileClasspath\'')
-        firstLockFileFixture.verifyLegacyLockfile('compileClasspath', ['org:foo:1.1'])
+        firstLockFileFixture.verifyLockfile('compileClasspath', ['org:foo:1.1'], false)
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
@@ -57,7 +57,7 @@ project(':second') {
     }
 }
 """
-        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'])
+        firstLockFileFixture.createLegacyLockfile('compileClasspath', ['org:foo:1.0'])
 
         when:
         succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
@@ -99,7 +99,7 @@ project(':second') {
     }
 }
 """
-        firstLockFileFixture.createLockfile('compileClasspath', ['org:foo:1.0'])
+        firstLockFileFixture.createLegacyLockfile('compileClasspath', ['org:foo:1.0'])
 
         when:
         succeeds ':first:dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo'
@@ -147,6 +147,6 @@ project(':second') {
 
         then:
         outputContains('Persisted dependency lock state for configuration \':first:compileClasspath\'')
-        firstLockFileFixture.verifyLockfile('compileClasspath', ['org:foo:1.1'])
+        firstLockFileFixture.verifyLegacyLockfile('compileClasspath', ['org:foo:1.1'])
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
@@ -54,7 +54,7 @@ buildscript {
 }
 """
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0'])
+        lockFile.createLegacyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0'])
 
         when:
         succeeds 'buildEnvironment'
@@ -113,7 +113,7 @@ task resolve {
 }
 """
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0'])
+        lockFile.createLegacyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0'])
 
         when:
         succeeds 'resolve'
@@ -187,7 +187,7 @@ plugins {
 }
 """
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
+        lockFile.createLegacyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
 
         when:
         succeeds 'buildEnvironment'
@@ -239,7 +239,7 @@ plugins {
 
         then:
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.verifyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
+        lockFile.verifyLegacyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
     }
 
     def 'fails to resolve if lock state present but no dependencies remain'() {
@@ -257,7 +257,7 @@ buildscript {
 }
 """
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0'])
+        lockFile.createLegacyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0'])
 
         when:
         fails 'buildEnvironment'
@@ -310,8 +310,8 @@ dependencies {
         succeeds 'buildEnvironment', 'dependencies', '--write-locks'
 
         then:
-        lockFile.verifyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1'])
-        lockFile.verifyLockfile('classpath', ['org.foo:foo:1.1'])
+        lockFile.verifyLegacyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1'])
+        lockFile.verifyLegacyLockfile('classpath', ['org.foo:foo:1.1'])
     }
 
     def addPlugin() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -33,6 +33,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
+import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer;
@@ -554,8 +555,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingHandler.class, configurationContainer, dependencyLockingProvider);
         }
 
-        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules) {
-            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules());
+        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules, FeaturePreviews featurePreviews) {
+            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), featurePreviews);
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, NamedObjectInstantiator namedObjectInstantiator, PlatformSupport platformSupport) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -562,7 +562,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             listenerManager.addListener(new InternalBuildFinishedListener() {
                 @Override
                 public void buildFinished(GradleInternal gradle) {
-                    dependencyLockingProvider.buildFinished(gradle);
+                    dependencyLockingProvider.buildFinished();
                 }
             });
             return dependencyLockingProvider;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
+import org.gradle.api.internal.GradleInternal;
 
 import java.util.Set;
 
@@ -30,4 +31,6 @@ public interface DependencyLockingProvider {
     LockMode getLockMode();
 
     void setLockMode(LockMode mode);
+
+    void buildFinished(GradleInternal gradle);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
-import org.gradle.api.internal.GradleInternal;
 
 import java.util.Set;
 
@@ -32,5 +31,5 @@ public interface DependencyLockingProvider {
 
     void setLockMode(LockMode mode);
 
-    void buildFinished(GradleInternal gradle);
+    void buildFinished();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.FeaturePreviews;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
@@ -191,7 +190,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     }
 
     @Override
-    public void buildFinished(GradleInternal gradle) {
+    public void buildFinished() {
         if (uniqueLockStateEnabled && uniqueLockStateLoaded && lockFileReaderWriter.canWrite()) {
             lockFileReaderWriter.writeUniqueLockfile(allLockState);
             LOGGER.lifecycle("Persisted dependency lock state for project '{}' (buildscript: {})", context.getProjectPath(), context.isScript());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
@@ -18,6 +18,6 @@ package org.gradle.internal.locking;
 
 public class InvalidLockFileException extends RuntimeException {
     public InvalidLockFileException(String name, Exception cause) {
-        super("Invalid lock file content for " + name, cause);
+        super("Invalid lock state for " + name, cause);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.locking;
 
 public class InvalidLockFileException extends RuntimeException {
-    public InvalidLockFileException(String configurationName, Exception cause) {
-        super("Invalid lock file content for configuration '" + configurationName + "'", cause);
+    public InvalidLockFileException(String name, Exception cause) {
+        super("Invalid lock file content for " + name, cause);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -47,7 +47,8 @@ public class LockFileReaderWriter {
     static final String DEPENDENCY_LOCKING_FOLDER = "gradle/dependency-locks";
     static final Charset CHARSET = StandardCharsets.UTF_8;
     static final List<String> LOCKFILE_HEADER_LIST = ImmutableList.of("# This is a Gradle generated file for dependency locking.", "# Manual edits can break the build and are not advised.", "# This file is expected to be part of source control.");
-    public static final String EMPTY_CONFIGURATIONS_ENTRY = "empty=";
+    static final String EMPTY_CONFIGURATIONS_ENTRY = "empty=";
+    static final String BUILD_SCRIPT_PREFIX = "buildscript-";
 
     private final Path lockFilesRoot;
     private final DomainObjectContext context;
@@ -107,7 +108,7 @@ public class LockFileReaderWriter {
 
     private String decorate(String configurationName) {
         if (context.isScript()) {
-            return "buildscript-" + configurationName;
+            return BUILD_SCRIPT_PREFIX + configurationName;
         } else {
             return configurationName;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
@@ -18,6 +18,6 @@ package org.gradle.internal.locking;
 
 public class MissingLockStateException extends RuntimeException {
     public MissingLockStateException(String configurationName) {
-        super("Locking strict mode: Configuration '" + configurationName + "' is locked but does not have a lockfile.");
+        super("Locking strict mode: Configuration '" + configurationName + "' is locked but does not have lock state.");
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -18,7 +18,6 @@ package org.gradle.internal.locking;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 
@@ -57,7 +56,7 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     }
 
     @Override
-    public void buildFinished(GradleInternal gradle) {
+    public void buildFinished() {
         // No-op
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -18,6 +18,7 @@ package org.gradle.internal.locking;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.dsl.LockMode;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 
@@ -53,5 +54,10 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     @Override
     public void setLockMode(LockMode mode) {
         throw new IllegalStateException("Should not be invoked on the no-op instance");
+    }
+
+    @Override
+    public void buildFinished(GradleInternal gradle) {
+        // No-op
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -81,7 +81,7 @@ org:foo:1.0
         given:
         lockDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME) << "empty=conf"
         startParameter.isWriteDependencyLocks() >> true
-        featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+        featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
         provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         def modules = [module('org', 'foo', '1.0'), module('org','bar','1.3')] as Set
         provider.loadLockState('conf')
@@ -103,7 +103,7 @@ empty=
     def 'can load lockfile as strict constraints (Unique: #unique)'() {
         given:
         if (unique) {
-            featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+            featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
             provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         }
         writeLockFile(['org:bar:1.3', 'org:foo:1.0'], unique)
@@ -126,7 +126,7 @@ empty=
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org:foo']
         if (unique) {
-            featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+            featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
         }
         provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         writeLockFile(['org:bar:1.3', 'org:foo:1.0'], unique)
@@ -149,7 +149,7 @@ empty=
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org:*']
         if (unique) {
-            featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+            featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
         }
         provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         writeLockFile(['org:bar:1.3', 'org:foo:1.0'], unique)
@@ -172,7 +172,7 @@ empty=
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org.*:foo']
         if (unique) {
-            featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+            featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
         }
         provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         writeLockFile(['org.bar:foo:1.3', 'com:foo:1.0'], unique)
@@ -200,7 +200,7 @@ empty=
             }
         }
         if (unique) {
-            featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+            featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
         }
         provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         writeLockFile(['org:bar:1.1', 'org:foo:1.1'], unique)
@@ -219,7 +219,7 @@ empty=
     def 'fails with invalid content in lock file (Unique: #unique)'() {
         given:
         if (unique) {
-            featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+            featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
         }
         provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         writeLockFile(["invalid"], unique)
@@ -245,7 +245,7 @@ empty=
     def 'fails with missing lockfile in strict mode (Unique: #unique)'() {
         given:
         if (unique) {
-            featurePreviews.enableFeature(FeaturePreviews.Feature.DEPENDENCY_LOCKING_IMPROVED_FORMAT)
+            featurePreviews.enableFeature(FeaturePreviews.Feature.ONE_LOCKFILE_PER_PROJECT)
         }
         provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, dependencySubstitutionRules, featurePreviews)
         provider.setLockMode(LockMode.STRICT)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -256,7 +256,7 @@ empty=
         then:
         def ex = thrown(MissingLockStateException)
         1 * context.identityPath('conf') >> Path.path(':conf')
-        ex.message == 'Locking strict mode: Configuration \':conf\' is locked but does not have a lockfile.'
+        ex.message == 'Locking strict mode: Configuration \':conf\' is locked but does not have lock state.'
 
         where:
         unique << [true, false]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -82,7 +82,7 @@ line2"""
 
     def 'reads a unique lock file'() {
         given:
-        lockDir.file('all_locks.singlelockfile') << """#ignored
+        lockDir.file('project.lockfile') << """#ignored
 bar=a,c
 foo=a,b,c
 empty=d
@@ -143,7 +143,7 @@ line2"""
         given:
         context.isScript() >> true
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
-        lockDir.file('buildscript-all_locks.singlelockfile') << """#ignored
+        lockDir.file('buildscript-project.lockfile') << """#ignored
 bar=a,c
 foo=a,b,c
 empty=d

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -67,6 +67,20 @@ line2"""
         result == ['line1', 'line2']
     }
 
+    def 'reads a unique lock file'() {
+        given:
+        lockDir.file('all_locks.singlelockfile') << """#ignored
+bar=a,c
+foo=a,b,c
+empty=d"""
+
+        when:
+        def result = lockFileReaderWriter.readSingleLockFile()
+
+        then:
+        result == [a: ['bar', 'foo'], b: ['foo'], c: ['bar', 'foo'], d: []]
+    }
+
     def 'writes a legacy lock file with prefix on persist'() {
         when:
         context.isScript() >> true

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -43,7 +43,7 @@ class LockFileReaderWriterTest extends Specification {
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
     }
 
-    def 'writes a lock file on persist'() {
+    def 'writes a legacy lock file on persist'() {
         when:
         lockFileReaderWriter.writeLockFile('conf', ['line1', 'line2'])
 
@@ -53,7 +53,7 @@ line2
 """
     }
 
-    def 'reads a lock file'() {
+    def 'reads a legacy lock file'() {
         given:
         lockDir.file('conf.lockfile') << """#Ignored
 line1
@@ -67,7 +67,7 @@ line2"""
         result == ['line1', 'line2']
     }
 
-    def 'writes a lock file with prefix on persist'() {
+    def 'writes a legacy lock file with prefix on persist'() {
         when:
         context.isScript() >> true
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
@@ -79,7 +79,7 @@ line2
 """
     }
 
-    def 'reads a lock file with prefix'() {
+    def 'reads a legacy lock file with prefix'() {
         given:
         context.isScript() >> true
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
@@ -95,7 +95,7 @@ line2"""
         result == ['line1', 'line2']
     }
 
-    def 'fails to read a lockfile if root could not be determined'() {
+    def 'fails to read a legacy lockfile if root could not be determined'() {
         FileResolver resolver = Mock()
         resolver.canResolveRelativePath() >> false
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
@@ -110,7 +110,7 @@ line2"""
         ex.getMessage().contains('foo')
     }
 
-    def 'fails to write a lockfile if root could not be determined'() {
+    def 'fails to write a legacy lockfile if root could not be determined'() {
         FileResolver resolver = Mock()
         resolver.canResolveRelativePath() >> false
         lockFileReaderWriter = new LockFileReaderWriter(resolver, context)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
@@ -23,14 +23,14 @@ class LockfileFixture {
 
     TestFile testDirectory
 
-    def createLockfile(String configurationName, List<String> modules) {
+    def createLegacyLockfile(String configurationName, List<String> modules) {
         def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, "$configurationName$LockFileReaderWriter.FILE_SUFFIX")
         def lines = [LockFileReaderWriter.LOCKFILE_HEADER]
         lines.addAll modules
         lockFile.writelns(lines.sort())
     }
 
-    void verifyLockfile(String configurationName, List<String> expectedModules) {
+    void verifyLegacyLockfile(String configurationName, List<String> expectedModules) {
         def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, "$configurationName$LockFileReaderWriter.FILE_SUFFIX")
         assert lockFile.exists()
         def lockedModules = []
@@ -43,7 +43,7 @@ class LockfileFixture {
         assert lockedModules as Set == expectedModules as Set
     }
 
-    void expectMissing(String configurationName) {
+    void expectLegacyMissing(String configurationName) {
         def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, "$configurationName$LockFileReaderWriter.FILE_SUFFIX")
         assert !lockFile.exists()
     }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
@@ -23,12 +23,30 @@ class LockfileFixture {
 
     TestFile testDirectory
 
-    def createLockfile(List<String> entries, String empty = 'empty=') {
+    def createLockfile(List<String> entries, String empty = '') {
         def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
         def lines = [LockFileReaderWriter.LOCKFILE_HEADER]
         lines.addAll entries.sort()
-        lines.add empty
+        lines.add 'empty=' + empty
         lockFile.writelns(lines)
+    }
+
+    void verifyLockfile(List<String> entries, String empty = '') {
+        def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+        assert lockFile.exists()
+        def lockedModules = []
+        lockFile.eachLine { String line ->
+            if (!line.startsWith('#')) {
+                lockedModules << line
+            }
+        }
+
+        List<String> expectedModules = new ArrayList<>()
+        expectedModules.addAll(entries)
+        expectedModules.sort()
+        expectedModules.add('empty=' + empty)
+
+        assert lockedModules == expectedModules
     }
 
     def createLegacyLockfile(String configurationName, List<String> modules) {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
@@ -25,7 +25,7 @@ class LockfileFixture {
 
     def createLockfile(List<String> entries, String empty = '') {
         def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
-        def lines = [LockFileReaderWriter.LOCKFILE_HEADER]
+        def lines = new ArrayList(LockFileReaderWriter.LOCKFILE_HEADER_LIST)
         lines.addAll entries.sort()
         lines.add 'empty=' + empty
         lockFile.writelns(lines)
@@ -51,7 +51,7 @@ class LockfileFixture {
 
     def createLegacyLockfile(String configurationName, List<String> modules) {
         def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, "$configurationName$LockFileReaderWriter.FILE_SUFFIX")
-        def lines = [LockFileReaderWriter.LOCKFILE_HEADER]
+        def lines = new ArrayList(LockFileReaderWriter.LOCKFILE_HEADER_LIST)
         lines.addAll modules
         lockFile.writelns(lines.sort())
     }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
@@ -23,6 +23,14 @@ class LockfileFixture {
 
     TestFile testDirectory
 
+    def createLockfile(List<String> entries, String empty = 'empty=') {
+        def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+        def lines = [LockFileReaderWriter.LOCKFILE_HEADER]
+        lines.addAll entries.sort()
+        lines.add empty
+        lockFile.writelns(lines)
+    }
+
     def createLegacyLockfile(String configurationName, List<String> modules) {
         def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, "$configurationName$LockFileReaderWriter.FILE_SUFFIX")
         def lines = [LockFileReaderWriter.LOCKFILE_HEADER]

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -468,7 +468,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0'])
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
@@ -517,7 +517,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -468,7 +468,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:bar:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0'], false)
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
@@ -517,7 +517,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLegacyLockfile('lockedConf', ['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], false)
 
         when:
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
@@ -23,4 +23,10 @@ class FeaturePreviewsFixture {
 enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
 """
     }
+
+    static void enableDependencyLockingImprovedFormat(File settings) {
+        settings << """
+enableFeaturePreview('DEPENDENCY_LOCKING_IMPROVED_FORMAT')
+"""
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
@@ -24,7 +24,7 @@ enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
 """
     }
 
-    static void enableDependencyLockingImprovedFormat(File settings) {
+    static void enableOneLockfilePerProject(File settings) {
         settings << """
 enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
 """

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
@@ -26,7 +26,7 @@ enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
 
     static void enableDependencyLockingImprovedFormat(File settings) {
         settings << """
-enableFeaturePreview('DEPENDENCY_LOCKING_IMPROVED_FORMAT')
+enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
 """
     }
 }


### PR DESCRIPTION
This PR introduces an alternative lock file format, so that only one file per project is needed.

TODO:
- [ ] Increase integration test coverage
- [ ] Add documentation