### PR TITLE
Deprecate certain usages of 'default' and 'archives' configurations

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/TaskFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/TaskFilePropertiesIntegrationTest.groovy
@@ -26,7 +26,7 @@ class TaskFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             import java.nio.file.Path
             import java.nio.file.Files
-            
+
             class TransformTask extends DefaultTask {
                 @InputFile
                 Path inputFile
@@ -36,14 +36,14 @@ class TaskFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
                 Path outputFile
                 @OutputDirectory
                 Path outputDir
-                
+
                 @TaskAction
                 def go() {
                     outputFile.toFile().text = inputFile.toFile().text
                     inputDir.toFile().listFiles().each { f -> outputDir.resolve(f.name).toFile().text = f.text }
                 }
             }
-            
+
             task transform(type: TransformTask) {
                 inputFile = file("file1.txt").toPath()
                 inputDir = file("dir1").toPath()
@@ -92,7 +92,7 @@ class TaskFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             import java.nio.file.Path
             import java.nio.file.Files
-            
+
             task transform {
                 def inputFile = file("file1.txt").toPath()
                 def inputDir = file("dir1").toPath()
@@ -175,8 +175,13 @@ task otherJar(type: Jar) {
     destinationDirectory = buildDir
 }
 
-configurations { archives }
-dependencies { archives files('b.jar') { builtBy jar } }
+configurations {
+    deps
+    archives {
+        extendsFrom deps
+    }
+}
+dependencies { deps files('b.jar') { builtBy jar } }
 artifacts { archives otherJar }
 '''
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -38,21 +38,20 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
             .publish()
 
         buildFile << """
-            apply plugin: "base"
-
             repositories {
                 maven { url "${mavenHttpRepo.uri}" }
             }
 
             configurations {
-                resolveArchives.extendsFrom(archives)
+                base { canBeResolved = false; canBeConsumed = false }
+                path { extendsFrom(base) }
             }
 
             dependencies {
-              archives "org.utils:impl:1.3"
+                base "org.utils:impl:1.3"
             }
 
-            println configurations.resolveArchives.files
+            println configurations.path.files
         """
 
         mavenHttpRepo.server.chunkedTransfer = chunked
@@ -74,7 +73,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':resolveArchives'
+        artifactsOps[0].details.configurationPath == ':path'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -92,7 +91,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':resolveArchives'
+        artifactsOps2[0].details.configurationPath == ':path'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -119,8 +118,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         dir.allowGet()
 
         buildFile << """
-            apply plugin: "base"
-
             repositories {
                 maven {
                     url "${emptyRepo.uri}"
@@ -139,14 +136,15 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
             }
 
             configurations {
-                resolveArchives.extendsFrom(archives)
+                base { canBeResolved = false; canBeConsumed = false }
+                path { extendsFrom(base) }
             }
 
             dependencies {
-              archives "org.utils:impl:1.+"
+              base "org.utils:impl:1.+"
             }
 
-            println configurations.resolveArchives.files
+            println configurations.path.files
         """
 
         when:
@@ -173,7 +171,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':resolveArchives'
+        artifactsOps[0].details.configurationPath == ':path'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -203,7 +201,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':resolveArchives'
+        artifactsOps2[0].details.configurationPath == ':path'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -221,8 +219,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
         dir.allowGet()
 
         buildFile << """
-            apply plugin: "base"
-
             repositories {
                 maven {
                     url "${mavenHttpRepo.uri}"
@@ -233,15 +229,16 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
                 }
             }
 
-            dependencies {
-              archives "org.utils:impl:1.+"
-            }
-
             configurations {
-                resolveArchives.extendsFrom(archives)
+                base { canBeResolved = false; canBeConsumed = false }
+                path { extendsFrom(base) }
             }
 
-            println configurations.resolveArchives.files
+            dependencies {
+              base "org.utils:impl:1.+"
+            }
+
+            println configurations.path.files
         """
 
         when:
@@ -265,7 +262,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':resolveArchives'
+        artifactsOps[0].details.configurationPath == ':path'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -292,7 +289,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':resolveArchives'
+        artifactsOps2[0].details.configurationPath == ':path'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -306,24 +303,23 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
             .publish()
 
         buildFile << """
-            apply plugin: "base"
-
             repositories {
                 maven { url "${mavenHttpRepo.uri}" }
             }
 
-            dependencies {
-              archives "org.utils:impl:1.3"
-            }
-
             configurations {
-                primaryArchives { extendsFrom archives }
-                moreArchives { extendsFrom archives }
+                base { canBeResolved = false; canBeConsumed = false }
+                primary { extendsFrom base }
+                more { extendsFrom base }
             }
 
-            println configurations.primaryArchives.files
-            println configurations.primaryArchives.files
-            println configurations.moreArchives.files
+            dependencies {
+              base "org.utils:impl:1.3"
+            }
+
+            println configurations.primary.files
+            println configurations.primary.files
+            println configurations.more.files
         """
 
         when:
@@ -341,9 +337,9 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 3
-        artifactsOps[0].details.configurationPath == ':primaryArchives'
-        artifactsOps[1].details.configurationPath == ':primaryArchives'
-        artifactsOps[2].details.configurationPath == ':moreArchives'
+        artifactsOps[0].details.configurationPath == ':primary'
+        artifactsOps[1].details.configurationPath == ':primary'
+        artifactsOps[2].details.configurationPath == ':more'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -363,9 +359,9 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 3
-        artifactsOps2[0].details.configurationPath == ':primaryArchives'
-        artifactsOps2[1].details.configurationPath == ':primaryArchives'
-        artifactsOps2[2].details.configurationPath == ':moreArchives'
+        artifactsOps2[0].details.configurationPath == ':primary'
+        artifactsOps2[1].details.configurationPath == ':primary'
+        artifactsOps2[2].details.configurationPath == ':more'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -43,12 +43,16 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
             repositories {
                 maven { url "${mavenHttpRepo.uri}" }
             }
-            
+
+            configurations {
+                resolveArchives.extendsFrom(archives)
+            }
+
             dependencies {
               archives "org.utils:impl:1.3"
             }
-            
-            println configurations.archives.files
+
+            println configurations.resolveArchives.files
         """
 
         mavenHttpRepo.server.chunkedTransfer = chunked
@@ -70,7 +74,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':archives'
+        artifactsOps[0].details.configurationPath == ':resolveArchives'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -88,7 +92,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':archives'
+        artifactsOps2[0].details.configurationPath == ':resolveArchives'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -125,7 +129,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
                         artifact()
                     }
                 }
-                maven { 
+                maven {
                     url "${mavenHttpRepo.uri}"
                     metadataSources {
                         mavenPom()
@@ -133,12 +137,16 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
                     }
                 }
             }
-            
+
+            configurations {
+                resolveArchives.extendsFrom(archives)
+            }
+
             dependencies {
               archives "org.utils:impl:1.+"
             }
-            
-            println configurations.archives.files
+
+            println configurations.resolveArchives.files
         """
 
         when:
@@ -165,7 +173,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':archives'
+        artifactsOps[0].details.configurationPath == ':resolveArchives'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -195,7 +203,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':archives'
+        artifactsOps2[0].details.configurationPath == ':resolveArchives'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -216,7 +224,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
             apply plugin: "base"
 
             repositories {
-                maven { 
+                maven {
                     url "${mavenHttpRepo.uri}"
                     metadataSources {
                         mavenPom()
@@ -224,12 +232,16 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
                     }
                 }
             }
-            
+
             dependencies {
               archives "org.utils:impl:1.+"
             }
-            
-            println configurations.archives.files
+
+            configurations {
+                resolveArchives.extendsFrom(archives)
+            }
+
+            println configurations.resolveArchives.files
         """
 
         when:
@@ -253,7 +265,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':archives'
+        artifactsOps[0].details.configurationPath == ':resolveArchives'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -280,7 +292,7 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':archives'
+        artifactsOps2[0].details.configurationPath == ':resolveArchives'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -299,17 +311,18 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
             repositories {
                 maven { url "${mavenHttpRepo.uri}" }
             }
-            
+
             dependencies {
               archives "org.utils:impl:1.3"
             }
-            
+
             configurations {
+                primaryArchives { extendsFrom archives }
                 moreArchives { extendsFrom archives }
             }
-            
-            println configurations.archives.files
-            println configurations.archives.files
+
+            println configurations.primaryArchives.files
+            println configurations.primaryArchives.files
             println configurations.moreArchives.files
         """
 
@@ -328,8 +341,8 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 3
-        artifactsOps[0].details.configurationPath == ':archives'
-        artifactsOps[1].details.configurationPath == ':archives'
+        artifactsOps[0].details.configurationPath == ':primaryArchives'
+        artifactsOps[1].details.configurationPath == ':primaryArchives'
         artifactsOps[2].details.configurationPath == ':moreArchives'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
@@ -350,8 +363,8 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 3
-        artifactsOps2[0].details.configurationPath == ':archives'
-        artifactsOps2[1].details.configurationPath == ':archives'
+        artifactsOps2[0].details.configurationPath == ':primaryArchives'
+        artifactsOps2[1].details.configurationPath == ':primaryArchives'
         artifactsOps2[2].details.configurationPath == ':moreArchives'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -439,6 +439,9 @@ subprojects {
     configurations {
         'default'
         other
+        path {
+            extendsFrom configurations.'default'
+        }
     }
     task jar(type: Jar)
     artifacts {
@@ -455,18 +458,18 @@ project('a') {
         dependsOn configurations.default
         dependsOn configurations.other
         doFirst {
-            def jars = configurations.default.collect { it.name } as Set
+            def jars = configurations.path.collect { it.name } as Set
             assert jars == ['a.jar', 'b.jar', 'c.jar'] as Set
 
             jars = configurations.other.collect { it.name } as Set
             assert jars == ['a.jar', 'b.jar', 'c.jar'] as Set
 
             // Check type of root component
-            def defaultResult = configurations.default.incoming.resolutionResult
+            def defaultResult = configurations.path.incoming.resolutionResult
             def defaultRootId = defaultResult.root.id
             assert defaultRootId instanceof ProjectComponentIdentifier
 
-            def otherResult = configurations.default.incoming.resolutionResult
+            def otherResult = configurations.other.incoming.resolutionResult
             def otherRootId = otherResult.root.id
             assert otherRootId instanceof ProjectComponentIdentifier
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -333,8 +333,11 @@ allprojects {
 }
 
 project(":a") {
-    configurations { 'default' {} }
-    dependencies { 'default' 'group:externalA:1.5' }
+    configurations {
+        deps
+        'default' { extendsFrom deps }
+    }
+    dependencies { deps 'group:externalA:1.5' }
     task xJar(type: Jar) { archiveBaseName='x' }
     task yJar(type: Jar) { archiveBaseName='y' }
     artifacts { 'default' xJar, yJar }
@@ -437,10 +440,10 @@ project(':b') {
 subprojects {
     apply plugin: 'base'
     configurations {
-        'default'
+        first
         other
-        path {
-            extendsFrom configurations.'default'
+        'default' {
+            extendsFrom first
         }
     }
     task jar(type: Jar)
@@ -451,21 +454,21 @@ subprojects {
 
 project('a') {
     dependencies {
-        'default' project(':b')
+        first project(':b')
         other project(':b')
     }
     task listJars {
-        dependsOn configurations.default
+        dependsOn configurations.first
         dependsOn configurations.other
         doFirst {
-            def jars = configurations.path.collect { it.name } as Set
+            def jars = configurations.first.collect { it.name } as Set
             assert jars == ['a.jar', 'b.jar', 'c.jar'] as Set
 
             jars = configurations.other.collect { it.name } as Set
             assert jars == ['a.jar', 'b.jar', 'c.jar'] as Set
 
             // Check type of root component
-            def defaultResult = configurations.path.incoming.resolutionResult
+            def defaultResult = configurations.first.incoming.resolutionResult
             def defaultRootId = defaultResult.root.id
             assert defaultRootId instanceof ProjectComponentIdentifier
 
@@ -478,13 +481,13 @@ project('a') {
 
 project('b') {
     dependencies {
-        'default' project(':c')
+        first project(':c')
     }
 }
 
 project('c') {
     dependencies {
-        'default' project(':a')
+        first project(':a')
     }
 }
 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
@@ -119,7 +119,6 @@ project(':child2') {
         compileOnly 'org.test.ignore-me:1.0'
         testImplementation 'org.test.ignore-me:1.0'
         testRuntimeOnly 'org.test.ignore-me:1.0'
-        "default" 'org.test.ignore-me:1.0'
     }
 }
 """
@@ -209,11 +208,10 @@ project(':child2') {
     dependencies {
         implementation 'org.test:m1:1.0'
         runtimeOnly 'org.test:m2:1.0'
-        
+
         compileOnly 'org.test:ignore-me:1.0'
         testImplementation 'org.test:ignore-me:1.0'
         testRuntimeOnly 'org.test:ignore-me:1.0'
-        "default" 'org.test:ignore-me:1.0'
     }
 }
 """

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -66,7 +66,12 @@ Gradle will continue building your projects on the affected systems, but without
 
 === Deprecations
 
-There were no deprecations between Gradle 6.2 and 6.3.
+==== Resolving default and archives configuration
+
+Almost every Gradle project has the _default_ and _archives_ configurations which are added by the _base_ plugin.
+These configurations are no longer used in modern Gradle builds that use <<variant_model.adoc#,variant aware dependency management>> and the <<publishing_setup.adoc#,new publishing plugins>>.
+While the configurations will stay in Gradle for backwards compatibility for now, resolving them is now deprecated.
+Resolving these configurations was never an intended use case and only possible because in earlier gradle versions _every_ configuration was resolvable.
 
 [[changes_6.2]]
 == Upgrading from 6.1

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -66,12 +66,13 @@ Gradle will continue building your projects on the affected systems, but without
 
 === Deprecations
 
-==== Resolving default and archives configuration
+==== Using default and archives configurations
 
 Almost every Gradle project has the _default_ and _archives_ configurations which are added by the _base_ plugin.
 These configurations are no longer used in modern Gradle builds that use <<variant_model.adoc#,variant aware dependency management>> and the <<publishing_setup.adoc#,new publishing plugins>>.
-While the configurations will stay in Gradle for backwards compatibility for now, resolving them is now deprecated.
-Resolving these configurations was never an intended use case and only possible because in earlier gradle versions _every_ configuration was resolvable.
+While the configurations will stay in Gradle for backwards compatibility for now, using them to declare dependencies or to resolve dependencies is now deprecated.
+Resolving these configurations was never an intended use case and only possible because in earlier Gradle versions _every_ configuration was resolvable.
+For dependency declaration, please use the configurations provided by the plugins you use, for example by the <<java_library_plugin.adoc#sec:java_library_configurations_graph,Java Library plugin>>.
 
 [[changes_6.2]]
 == Upgrading from 6.1

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
@@ -225,21 +225,17 @@ project(':c') {
         testFile("settings.gradle") << "include 'a', 'b'"
         testFile("build.gradle") << """
 allprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
 
     java {
         withSourcesJar()
-    }
-
-    artifacts {
-        archives sourcesJar
     }
 }
 
 project(':a') {
     dependencies { implementation project(':b') }
     compileJava.doFirst {
-        assert classpath.collect { it.name } == ['b.jar']
+        assert classpath.collect { it.name } == ['main']
     }
 }
 
@@ -255,7 +251,7 @@ interface Person { }
 """
 
         def result = inTestDirectory().withTasks("a:classes").run()
-        result.assertTasksExecuted(":b:compileJava", ":b:processResources", ":b:classes", ":b:jar", ":a:compileJava", ":a:processResources", ":a:classes")
+        result.assertTasksExecuted(":b:compileJava", ":a:compileJava", ":a:processResources", ":a:classes")
     }
 
     @Test

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyLocalPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyLocalPublishIntegrationTest.groovy
@@ -206,6 +206,7 @@ task ivyXml(type: Upload) {
         published.assertIsCopyOf(file('someDir/a'))
     }
 
+    @ToBeFixedForInstantExecution
     def "fails gracefully if trying to publish a directory with ivy"() {
 
         given:

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -168,6 +168,8 @@ public class BasePlugin implements Plugin<Project> {
 
         archivesConfiguration.deprecateForResolution(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
         defaultConfiguration.deprecateForResolution(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        archivesConfiguration.deprecateForDeclaration(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, JavaPlugin.API_CONFIGURATION_NAME);
+        defaultConfiguration.deprecateForDeclaration(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, JavaPlugin.API_CONFIGURATION_NAME);
 
         configurations.all(new Action<Configuration>() {
             @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -40,6 +40,7 @@ import org.gradle.api.tasks.Upload;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.internal.Describables;
+import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -155,15 +156,18 @@ public class BasePlugin implements Plugin<Project> {
         ConfigurationContainer configurations = project.getConfigurations();
         project.setStatus("integration");
 
-        final Configuration archivesConfiguration = configurations.maybeCreate(Dependency.ARCHIVES_CONFIGURATION).
+        final DeprecatableConfiguration archivesConfiguration = (DeprecatableConfiguration) configurations.maybeCreate(Dependency.ARCHIVES_CONFIGURATION).
             setDescription("Configuration for archive artifacts.");
 
-        configurations.maybeCreate(Dependency.DEFAULT_CONFIGURATION).
+        final DeprecatableConfiguration defaultConfiguration = (DeprecatableConfiguration) configurations.maybeCreate(Dependency.DEFAULT_CONFIGURATION).
             setDescription("Configuration for default artifacts.");
 
         final DefaultArtifactPublicationSet defaultArtifacts = project.getExtensions().create(
             "defaultArtifacts", DefaultArtifactPublicationSet.class, archivesConfiguration.getArtifacts()
         );
+
+        archivesConfiguration.deprecateForResolution(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+        defaultConfiguration.deprecateForResolution(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
 
         configurations.all(new Action<Configuration>() {
             @Override

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaCustomizedLayoutIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaCustomizedLayoutIntegrationTest.groovy
@@ -39,11 +39,11 @@ class SamplesJavaCustomizedLayoutIntegrationTest extends AbstractSampleIntegrati
 
     @Unroll
     @UsesSample('java/customizedLayout')
-    def "can build and upload jar with #dsl dsl"() {
+    def "can build jar with #dsl dsl"() {
         TestFile javaprojectDir = sample.dir.file(dsl)
 
         // Build and test projects
-        executer.inDirectory(javaprojectDir).withTasks('clean', 'build', 'uploadArchives').run()
+        executer.inDirectory(javaprojectDir).withTasks('clean', 'build').run()
 
         // Check tests have run
         def result = new DefaultTestExecutionResult(javaprojectDir)


### PR DESCRIPTION
Fixes #12379 

Note: I added the 'Java Library plugin' configurations as suggested replacements as I assume that would be the most likely things users wanted when the (accidentally) used these configurations for dependency declaration/resolving.