### PR TITLE
Revert "Deactivate log level propagation to java.util.Logging for now"

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/JavaUtilLoggingSystemIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/JavaUtilLoggingSystemIntegrationTest.groovy
@@ -17,7 +17,6 @@
 
 package org.gradle.internal.logging
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 /**
@@ -61,7 +60,6 @@ class JavaUtilLoggingSystemIntegrationTest extends AbstractIntegrationSpec {
         succeeds('isLoggable')
     }
 
-    @NotYetImplemented
     def 'JUL logger.isLoggable corresponds to gradle log level for --warn'() {
         given:
         buildFile << """
@@ -87,7 +85,6 @@ class JavaUtilLoggingSystemIntegrationTest extends AbstractIntegrationSpec {
         succeeds('isLoggable')
     }
 
-    @NotYetImplemented
     def 'JUL logger.isLoggable corresponds to gradle log level for --info'() {
         given:
         buildFile << """
@@ -113,7 +110,6 @@ class JavaUtilLoggingSystemIntegrationTest extends AbstractIntegrationSpec {
         succeeds('isLoggable')
     }
 
-    @NotYetImplemented
     def 'JUL logger.isLoggable corresponds to gradle log level for LIFECYCLE'() {
         given:
         buildFile << """
@@ -139,7 +135,6 @@ class JavaUtilLoggingSystemIntegrationTest extends AbstractIntegrationSpec {
         succeeds('isLoggable')
     }
 
-    @NotYetImplemented
     def 'JUL logger.isLoggable corresponds to gradle log level for --quiet'() {
         given:
         buildFile << """

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/source/JavaUtilLoggingSystem.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/source/JavaUtilLoggingSystem.java
@@ -101,14 +101,13 @@ public class JavaUtilLoggingSystem implements LoggingSourceSystem {
     }
 
     private void install(Level level) {
-        if (installed) {
-            return;
+        if (!installed) {
+            LogManager.getLogManager().reset();
+            SLF4JBridgeHandler.install();
+            installed = true;
         }
 
-        LogManager.getLogManager().reset();
-        SLF4JBridgeHandler.install();
         logger.setLevel(level);
-        installed = true;
     }
 
     private static class SnapshotImpl implements Snapshot {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/source/JavaUtilLoggingSystem.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/source/JavaUtilLoggingSystem.java
@@ -40,16 +40,11 @@ public class JavaUtilLoggingSystem implements LoggingSourceSystem {
     // SLF4JBridgeHandler which is installed by this logging system.
     static {
         LOG_LEVEL_MAPPING.put(LogLevel.DEBUG, Level.FINE);
-        LOG_LEVEL_MAPPING.put(LogLevel.INFO, Level.FINE);
-        LOG_LEVEL_MAPPING.put(LogLevel.LIFECYCLE, Level.FINE);
-        LOG_LEVEL_MAPPING.put(LogLevel.WARN, Level.FINE);
-        LOG_LEVEL_MAPPING.put(LogLevel.QUIET, Level.FINE);
-        LOG_LEVEL_MAPPING.put(LogLevel.ERROR, Level.FINE);
-        //LOG_LEVEL_MAPPING.put(LogLevel.INFO, Level.CONFIG);
-        //LOG_LEVEL_MAPPING.put(LogLevel.LIFECYCLE, Level.WARNING);
-        //LOG_LEVEL_MAPPING.put(LogLevel.WARN, Level.WARNING);
-        //LOG_LEVEL_MAPPING.put(LogLevel.QUIET, Level.SEVERE);
-        //LOG_LEVEL_MAPPING.put(LogLevel.ERROR, Level.SEVERE);
+        LOG_LEVEL_MAPPING.put(LogLevel.INFO, Level.CONFIG);
+        LOG_LEVEL_MAPPING.put(LogLevel.LIFECYCLE, Level.WARNING);
+        LOG_LEVEL_MAPPING.put(LogLevel.WARN, Level.WARNING);
+        LOG_LEVEL_MAPPING.put(LogLevel.QUIET, Level.SEVERE);
+        LOG_LEVEL_MAPPING.put(LogLevel.ERROR, Level.SEVERE);
     }
 
     private final Logger logger;

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/source/JavaUtilLoggingSystemTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/source/JavaUtilLoggingSystemTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.logging.source
 
-import groovy.transform.NotYetImplemented
+
 import org.gradle.api.logging.LogLevel
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.logging.TestOutputEventListener
@@ -42,7 +42,6 @@ class JavaUtilLoggingSystemTest extends Specification {
         outputEventListener.toString() == '[[INFO] [test] info message][[ERROR] [test] error message]'
     }
 
-    @NotYetImplemented
     def routesJulToListenerWithCorrectLevel() {
         when:
         configurer.setLevel(LogLevel.INFO)


### PR DESCRIPTION
This reverts commit 9aba91121c2a88d158ac8d60ac692ece78a749f7.

It appears that the JUL logs have all been turned to ~~11~~ `FINE` by @jjohannes a while ago to fix some flakiness in the logging tests. It's unclear if we still need this, though.

Let's check if we can make things pass by reverting this as it would be important to have proper JUL log level mapping to make https://github.com/gradle/native-platform/issues/128 work.